### PR TITLE
fix: ESM環境でのテレメトリモジュール初期化エラー修正 (Issue #98)

### DIFF
--- a/src/telemetry/enhanced-telemetry.ts
+++ b/src/telemetry/enhanced-telemetry.ts
@@ -363,6 +363,15 @@ if (process.env.DISABLE_ENHANCED_TELEMETRY !== 'true' && process.env.NODE_ENV !=
     await enhancedTelemetry.shutdown();
   };
   
-  process.on('SIGTERM', shutdownHandler);
-  process.on('SIGINT', shutdownHandler);
+  // Safe process event handler registration for different environments
+  try {
+    if (typeof process !== 'undefined' && process.on && typeof process.on === 'function') {
+      process.on('SIGTERM', shutdownHandler);
+      process.on('SIGINT', shutdownHandler);
+    }
+  } catch (error) {
+    // In some ESM environments, process.on may not be available
+    // This is not critical for telemetry functionality
+    console.warn('Process event handlers could not be registered:', error instanceof Error ? error.message : String(error));
+  }
 }


### PR DESCRIPTION
## Summary

ESM環境でのテレメトリモジュール初期化時の`TypeError: process.on is not a function`エラーを修正しました。

## Problem

- CLI実行時に`process.on('SIGTERM', shutdownHandler)`でランタイムエラーが発生
- ESM環境では`process.on`が利用できない場合がある
- 全CLIコマンドが実行不可となっていました

## Solution

### 1. 安全な process.on 呼び出し実装
```typescript
// Before
process.on('SIGTERM', shutdownHandler);
process.on('SIGINT', shutdownHandler);

// After  
try {
  if (typeof process !== 'undefined' && process.on && typeof process.on === 'function') {
    process.on('SIGTERM', shutdownHandler);
    process.on('SIGINT', shutdownHandler);
  }
} catch (error) {
  console.warn('Process event handlers could not be registered:', error.message);
}
```

### 2. 修正ファイル
- `src/telemetry/enhanced-telemetry.ts:366-377`
- `src/telemetry/telemetry-setup.ts:53-68`

### 3. エラーハンドリング強化
- TypeScript厳密型チェック対応
- ESM環境での graceful degradation

## Test Plan

- [x] テレメトリファイルの型チェック成功確認
- [x] process.on が利用できない環境での安全な動作
- [ ] CLI コマンド実行確認（Issue #99修正後に実行可能）

## Impact

✅ **修正前**: すべてのCLIコマンドでクラッシュ  
✅ **修正後**: テレメトリ機能は保持しつつ、ESM環境でも安全に動作

Fixes #98

🤖 Generated with [Claude Code](https://claude.ai/code)