### PR TITLE
feat: P1-A Property-Based Testing helpers

### DIFF
--- a/src/testing/fc-assert.ts
+++ b/src/testing/fc-assert.ts
@@ -1,0 +1,6 @@
+import fc from 'fast-check';
+
+export function aeAssert<T>(prop: fc.IProperty<T>, opts?: Partial<fc.Parameters<T>>) {
+  const seedEnv = process.env.AE_SEED ? Number(process.env.AE_SEED) : undefined;
+  return fc.assert(prop, { seed: seedEnv ?? 12345, verbose: true, endOnFailure: true, ...opts });
+}

--- a/src/testing/properties.ts
+++ b/src/testing/properties.ts
@@ -1,0 +1,18 @@
+import fc from 'fast-check';
+
+export const arbEmail = fc.oneof(
+  fc.emailAddress(), // 正例
+  fc.string()        // ノイズ（負例）
+);
+
+export function multiset<T>(arr: T[]) {
+  const m = new Map<T, number>();
+  for (const x of arr) m.set(x, (m.get(x) ?? 0) + 1);
+  return m;
+}
+
+export function expectMultisetEqual<T>(a: T[], b: T[]) {
+  const ma = multiset(a), mb = multiset(b);
+  if (ma.size !== mb.size) throw new Error('multiset size differs');
+  for (const [k,v] of ma) if (mb.get(k) !== v) throw new Error(`count differs for ${String(k)}`);
+}

--- a/tests/examples/pbt.multiset.test.ts
+++ b/tests/examples/pbt.multiset.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'vitest';
+import fc from 'fast-check';
+import { aeAssert } from '../../src/testing/fc-assert';
+import { expectMultisetEqual } from '../../src/testing/properties';
+
+test('sort preserves multiset', () => {
+  aeAssert(fc.property(fc.array(fc.integer()), (arr) => {
+    const sorted = [...arr].sort((a,b)=>a-b);
+    expectMultisetEqual(arr, sorted);
+  }));
+});


### PR DESCRIPTION
## Summary
- Add Property-Based Testing helpers with fast-check integration
- Implement `aeAssert` with deterministic seeding via `AE_SEED`
- Add metamorphic testing utilities (`multiset`, `expectMultisetEqual`)
- Include example test demonstrating sort preservation property

## Changes
- **src/testing/fc-assert.ts**: Seeded fast-check assertion wrapper
- **src/testing/properties.ts**: Multiset utilities for metamorphic testing
- **tests/examples/pbt.multiset.test.ts**: Example property-based test

## AE_SEED による再現手順

### デフォルトシード実行
```bash
npm test tests/examples/pbt.multiset.test.ts
```

### 特定シードで再現
```bash
AE_SEED=42 npm test tests/examples/pbt.multiset.test.ts
```

### シード確認
テストでは以下の優先順位でシードが決定されます：
1. `AE_SEED` 環境変数 (存在する場合)  
2. デフォルト値 `12345`

🤖 Generated with [Claude Code](https://claude.ai/code)