### PR TITLE
P1-B: Branded types with runtime validation (Zod)

### DIFF
--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export type Brand<T, B extends string> = T & { readonly __brand: B };
+
+export function branded<T, B extends string>(
+  schema: z.ZodType<T>, brand: B, normalize?: (t: T) => T
+) {
+  return {
+    schema,
+    make(input: unknown): Brand<T, B> {
+      if (normalize && typeof input === 'string') {
+        input = normalize(input as T);
+      }
+      const v = schema.parse(input);
+      return v as Brand<T, B>;
+    },
+    is(u: unknown): u is Brand<T, B> {
+      try { 
+        schema.parse(u); 
+        return true; 
+      } catch { 
+        return false; 
+      }
+    }
+  };
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { branded, Brand } from './brand';
+
+const EmailSchema = z.string().email();
+export type Email = Brand<string, 'Email'>;
+
+export const Email = branded(
+  EmailSchema, 
+  'Email', 
+  (s) => s.trim().toLowerCase()
+);
+
+export function makeEmail(input: string): Email { 
+  return Email.make(input); 
+}

--- a/src/testing/fc-assert.ts
+++ b/src/testing/fc-assert.ts
@@ -1,0 +1,6 @@
+import fc from 'fast-check';
+
+export function aeAssert<T>(prop: fc.IProperty<T>, opts?: Partial<fc.Parameters<T>>) {
+  const seedEnv = process.env.AE_SEED ? Number(process.env.AE_SEED) : undefined;
+  return fc.assert(prop, { seed: seedEnv ?? 12345, verbose: true, endOnFailure: true, ...opts });
+}

--- a/src/testing/properties.ts
+++ b/src/testing/properties.ts
@@ -1,0 +1,18 @@
+import fc from 'fast-check';
+
+export const arbEmail = fc.oneof(
+  fc.emailAddress(), // 正例
+  fc.string()        // ノイズ（負例）
+);
+
+export function multiset<T>(arr: T[]) {
+  const m = new Map<T, number>();
+  for (const x of arr) m.set(x, (m.get(x) ?? 0) + 1);
+  return m;
+}
+
+export function expectMultisetEqual<T>(a: T[], b: T[]) {
+  const ma = multiset(a), mb = multiset(b);
+  if (ma.size !== mb.size) throw new Error('multiset size differs');
+  for (const [k,v] of ma) if (mb.get(k) !== v) throw new Error(`count differs for ${String(k)}`);
+}

--- a/tests/examples/pbt.multiset.test.ts
+++ b/tests/examples/pbt.multiset.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'vitest';
+import fc from 'fast-check';
+import { aeAssert } from '../../src/testing/fc-assert';
+import { expectMultisetEqual } from '../../src/testing/properties';
+
+test('sort preserves multiset', () => {
+  aeAssert(fc.property(fc.array(fc.integer()), (arr) => {
+    const sorted = [...arr].sort((a,b)=>a-b);
+    expectMultisetEqual(arr, sorted);
+  }));
+});

--- a/tests/lib/email.brand.test.ts
+++ b/tests/lib/email.brand.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest';
+import { makeEmail } from '../../src/lib/email';
+
+test('makeEmail normalizes and validates', () => {
+  expect(makeEmail('  Foo@Example.com ')).toBe('foo@example.com' as any);
+  expect(() => makeEmail('invalid')).toThrow();
+});


### PR DESCRIPTION
## 目的
ブランド型のユーティリティ（Zod統合）を導入し、Email の make 関数で正規化＋検証を一本化

## 変更内容

### 生成経路
1. **src/lib/brand.ts**: 汎用ブランド型ファクトリー
   - `Brand<T,B>` 型定義でタグ付き型を提供
   - `branded()` ファクトリーでZodスキーマ統合
   - オプション正規化関数サポート

2. **src/lib/email.ts**: Email ブランド型実装
   - `Email` 型でstring誤用防止
   - `makeEmail()` で trim + toLowerCase 正規化
   - Zodの email バリデーション統合

3. **tests/lib/email.brand.test.ts**: 単体テスト
   - 正規化動作の検証（空白削除、小文字化）
   - 不正メール形式での例外発生確認

### 不変条件
- Email 型は必ず有効なメール形式
- 正規化により一貫した形式（小文字、空白なし）
- ランタイム検証でタイプセーフティ保証

### 使い方
```typescript
import { makeEmail, Email } from './src/lib/email';

// 正規化 + 検証
const email: Email = makeEmail('  Foo@Example.com '); // "foo@example.com"

// 不正形式は例外
try {
  makeEmail('invalid');  
} catch (e) {
  // ZodError: Invalid email
}

// 型安全性
function sendEmail(to: Email) { /* ... */ }
sendEmail(email); // ✓ OK
sendEmail('string'); // ✗ Type error
```

### 例外メッセージ
- **ZodError**: `Invalid email` - 不正なメール形式時
- **Parse Error**: Zodによる詳細バリデーションエラー情報

## その他
- zod は既存依存関係として利用
- 既存の Email 型定義との競合なし（確認済み）
- vitest によるテスト実行で全テスト通過

🤖 Generated with [Claude Code](https://claude.ai/code)