### PR TITLE
Hotfix: agent:complete timeout + echo fallback + reliable cassette key

### DIFF
--- a/src/commands/agent/complete.ts
+++ b/src/commands/agent/complete.ts
@@ -2,23 +2,60 @@ import { loadLLM } from '../../providers/index.js';
 import { withRecorder } from '../../providers/recorder.js';
 
 export async function agentComplete(prompt: string, system?: string, flags?: { record?: boolean; replay?: boolean; dir?: string }) {
+  // Enhanced flag interpretation
+  const mode = process.env.AE_RECORDER_MODE; // record|replay|off
+  
+  // Error if both --record and --replay are specified
+  if (flags?.record && flags?.replay) {
+    console.error('Error: Cannot specify both --record and --replay flags');
+    process.exit(1);
+  }
+  
+  // Priority: explicit flags > environment variable
+  let wantReplay = false;
+  let wantRecord = false;
+  
+  if (flags?.replay) {
+    wantReplay = true;
+  } else if (flags?.record) {
+    wantRecord = true;
+  } else if (mode === 'replay') {
+    wantReplay = true;
+  } else if (mode === 'record') {
+    wantRecord = true;
+  }
+  
+  // Use default cassette directory if not specified
+  const cassetteDir = flags?.dir ?? 'artifacts/cassettes';
+  
+  // Start execution log with prompt summary
+  const promptSummary = prompt.length > 100 ? `${prompt.slice(0, 100)}...` : prompt;
+  console.log(`[ae][agent] Starting completion: "${promptSummary}"`);
+  
+  if (wantRecord) {
+    console.log(`[ae][agent] Mode: RECORD (cassettes -> ${cassetteDir})`);
+  } else if (wantReplay) {
+    console.log(`[ae][agent] Mode: REPLAY (cassettes <- ${cassetteDir})`);
+  } else {
+    console.log(`[ae][agent] Mode: LIVE`);
+  }
+  
   try {
-    const mode = process.env.AE_RECORDER_MODE; // record|replay|off
-    const wantReplay = flags?.replay ?? (mode === 'replay');
-    const wantRecord = flags?.record ?? (mode === 'record');
-    
     let llm = await loadLLM();
     
     if (wantReplay || wantRecord) {
-      llm = withRecorder(llm, { dir: flags?.dir, replay: wantReplay });
+      llm = withRecorder(llm, { dir: cassetteDir, replay: wantReplay });
     }
     
-    console.log(`Using LLM provider: ${llm.name}`);
+    console.log(`[ae][agent] Provider: ${llm.name}`);
     
     const output = await llm.complete({ prompt, system });
+    
+    // End execution log with character count
+    console.log(`[ae][agent] Completed: ${output.length} characters`);
     console.log(`[${llm.name}]`, output);
   } catch (error) {
-    console.error('LLM completion failed:', error instanceof Error ? error.message : 'Unknown error');
+    console.error('[ae][agent] LLM completion failed:', error instanceof Error ? error.message : 'Unknown error');
     process.exit(1);
   }
 }

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -7,10 +7,37 @@ export interface LLM {
   }): Promise<string>;
 }
 
+function withTimeout(llm: LLM, timeoutMs: number = 5000): LLM {
+  return {
+    name: llm.name,
+    async complete(input) {
+      const timeoutPromise = new Promise<string>((_, reject) => {
+        setTimeout(() => reject(new Error('LLM timeout')), timeoutMs);
+      });
+      
+      try {
+        return await Promise.race([llm.complete(input), timeoutPromise]);
+      } catch (error) {
+        if (error instanceof Error && error.message === 'LLM timeout') {
+          console.warn(`[${llm.name}] Timed out after ${timeoutMs}ms, falling back to echo`);
+          const echoProvider = (await import('./llm-echo.js')).default;
+          return await echoProvider.complete(input);
+        }
+        
+        // For other errors, also fallback to echo
+        console.warn(`[${llm.name}] Failed with error, falling back to echo:`, error instanceof Error ? error.message : 'Unknown error');
+        const echoProvider = (await import('./llm-echo.js')).default;
+        return await echoProvider.complete(input);
+      }
+    }
+  };
+}
+
 export async function loadLLM(): Promise<LLM> {
   if (process.env.ANTHROPIC_API_KEY) {
     try {
-      return (await import('./llm-anthropic.js')).default;
+      const llm = (await import('./llm-anthropic.js')).default;
+      return withTimeout(llm);
     } catch (error) {
       console.warn('Anthropic SDK not available, falling back to echo');
     }
@@ -18,7 +45,8 @@ export async function loadLLM(): Promise<LLM> {
   
   if (process.env.OPENAI_API_KEY) {
     try {
-      return (await import('./llm-openai.js')).default;
+      const llm = (await import('./llm-openai.js')).default;
+      return withTimeout(llm);
     } catch (error) {
       console.warn('OpenAI SDK not available, falling back to echo');
     }
@@ -26,7 +54,8 @@ export async function loadLLM(): Promise<LLM> {
   
   if (process.env.GEMINI_API_KEY) {
     try {
-      return (await import('./llm-gemini.js')).default;
+      const llm = (await import('./llm-gemini.js')).default;
+      return withTimeout(llm);
     } catch (error) {
       console.warn('Gemini SDK not available, falling back to echo');
     }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,6 +1,7 @@
 import type { LLM } from './index.js';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import path from 'node:path';
+import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
 
 export function withRecorder(base: LLM, opts?: { dir?: string; replay?: boolean }) : LLM {
   const dir = opts?.dir ?? 'artifacts/cassettes';
@@ -11,28 +12,56 @@ export function withRecorder(base: LLM, opts?: { dir?: string; replay?: boolean 
     async complete(input) {
       await mkdir(dir, { recursive: true });
       
-      const key = `${(input.system ?? '').slice(0,24)}__${input.prompt.slice(0,48)}`
+      // Generate hash-based key for better reliability
+      const hashKey = createHash('sha1')
+        .update(JSON.stringify({ system: input.system, prompt: input.prompt }))
+        .digest('hex')
+        .slice(0, 16);
+      
+      // Legacy key format for backward compatibility
+      const legacyKey = `${(input.system ?? '').slice(0,24)}__${input.prompt.slice(0,48)}`
         .replace(/\W+/g,'_')
         .replace(/^_+|_+$/g,'');
-      const file = path.join(dir, `${key}.json`);
+      
+      const hashFile = path.join(dir, `${hashKey}.json`);
+      const legacyFile = path.join(dir, `${legacyKey}.json`);
       
       if (replay) {
         try {
+          // Try hash-based file first
+          let file = hashFile;
+          try {
+            await access(hashFile);
+          } catch {
+            // Fall back to legacy file if hash file doesn't exist
+            file = legacyFile;
+          }
+          
           const hit = JSON.parse(await readFile(file, 'utf8'));
           return hit.output;
         } catch (error) {
           if (error && typeof error === 'object' && 'code' in error && (error as any).code === 'ENOENT') {
-            throw new Error(`Cassette not found: ${file}. Run with --record first.`);
+            throw new Error(`Cassette not found: ${hashFile} or ${legacyFile}. Run with --record first.`);
           } else if (error instanceof SyntaxError) {
-            throw new Error(`Cassette file is invalid JSON: ${file}.`);
+            throw new Error(`Cassette file is invalid JSON.`);
           } else {
             throw error;
           }
         }
       }
       
-      const out = await base.complete(input);
-      await writeFile(file, JSON.stringify({ input, output: out }, null, 2));
+      let out: string;
+      try {
+        out = await base.complete(input);
+      } catch (error) {
+        // If base provider fails (including timeout), use echo as fallback
+        console.warn(`[recorder] Base provider failed, using echo fallback:`, error instanceof Error ? error.message : 'Unknown error');
+        const echoProvider = (await import('./llm-echo.js')).default;
+        out = await echoProvider.complete(input);
+      }
+      
+      // Always save with hash-based filename for new recordings
+      await writeFile(hashFile, JSON.stringify({ input, output: out }, null, 2));
       return out;
     }
   };


### PR DESCRIPTION
## Summary
- **5s Timeout Protection**: LLM providers now have 5-second timeout with automatic echo fallback
- **Hash-based Cassette Keys**: Replace unreliable string-based keys with SHA1 hash for better consistency
- **Enhanced Flag Handling**: Improved --record/--replay flag interpretation with clear error messages
- **Robust Logging**: Detailed start/end logs with prompt summaries and execution status

## Key Changes

### 1. LLM Timeout & Fallback (`src/providers/index.ts`)
```typescript
function withTimeout(llm: LLM, timeoutMs: number = 5000): LLM {
  // Promise.race with timeout + automatic echo fallback
  // Applied to all API providers (Anthropic, OpenAI, Gemini)
}
```

### 2. Hash-based Cassette Keys (`src/providers/recorder.ts`) 
```typescript
const hashKey = createHash('sha1')
  .update(JSON.stringify({ system: input.system, prompt: input.prompt }))
  .digest('hex')
  .slice(0, 16);
```
- Backward compatibility with legacy format
- New recordings always use hash-based filenames

### 3. Enhanced Flag Interpretation (`src/commands/agent/complete.ts`)
- Priority: `--record`/`--replay` flags > `AE_RECORDER_MODE` env var  
- Error on conflicting flags: `--record` + `--replay`
- Default cassette directory: `artifacts/cassettes`
- Detailed execution logging with mode indicators

### 4. Resilient Error Handling
- Timeout/error fallback preserves cassette consistency during recording
- All providers wrapped with timeout protection
- Clear warning messages for debugging

## Test Plan
- [x] 5s timeout works and falls back to echo provider
- [x] Hash-based cassette keys generated consistently  
- [x] Backward compatibility with existing cassette files
- [x] Flag validation prevents conflicting --record/--replay
- [x] Default cassette directory used when --cassette-dir not specified
- [x] Detailed logging shows execution flow and status
- [x] Recording mode preserves echo fallback outputs in cassettes

🤖 Generated with [Claude Code](https://claude.ai/code)