### PR TITLE
ci: add Slack alerts for workflow failures (#229)

### DIFF
--- a/.github/workflows/nightly-monitoring.yml
+++ b/.github/workflows/nightly-monitoring.yml
@@ -25,10 +25,10 @@ jobs:
           fi
       
       - name: Install
-        run: "${{ env.PM }}" install
+        run: ${{ env.PM }} install
       
       - name: Build
-        run: "${{ env.PM }}" run build
+        run: ${{ env.PM }} run build
       
       - name: Flake (30x)
         run: node dist/cli.js qa:flake --times 30 --timeoutMs 240000 --workers 50% --pattern "tests/**"
@@ -56,3 +56,14 @@ jobs:
           name: nightly-artifacts
           path: artifacts/
           retention-days: 14
+      
+      - name: Notify Slack on failure
+        if: failure() && secrets.SLACK_WEBHOOK_URL != null
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_MESSAGE: |
+            🚨 ${{ github.workflow }} failed on ${{ github.ref }}
+            • run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            • artifacts: (see workflow page)
+          SLACK_COLOR: "#E01E5A"

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -29,10 +29,10 @@ jobs:
           fi
       
       - name: Install
-        run: "${{ env.PM }}" install
+        run: ${{ env.PM }} install
       
       - name: Build
-        run: "${{ env.PM }}" run build
+        run: ${{ env.PM }} run build
       
       - name: Verify
         run: node dist/cli.js verify
@@ -46,3 +46,14 @@ jobs:
           name: ae-artifacts
           path: artifacts/
           retention-days: 14
+      
+      - name: Notify Slack on failure
+        if: failure() && secrets.SLACK_WEBHOOK_URL != null
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_MESSAGE: |
+            🚨 ${{ github.workflow }} failed on ${{ github.ref }}
+            • run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            • artifacts: (see workflow page)
+          SLACK_COLOR: "#E01E5A"

--- a/README.md
+++ b/README.md
@@ -321,6 +321,14 @@ Built with:
 - Nightly: `nightly-monitoring` runs flake(×30) and compares two seeded benches (≤5%) at JST 04:15.
 - Replay policy: PR=**replay** by default, main/nightly may record separately if needed.
 - Required check: set **PR Verify / verify** as a required status in branch protection.
+- Slack alerts: verify/nightly failures notify Slack (requires `SLACK_WEBHOOK_URL` secret).
+
+#### Slack Alerts Setup
+1. Go to repository **Settings** → **Secrets and variables** → **Actions**
+2. Click **New repository secret**
+3. Name: `SLACK_WEBHOOK_URL`, Value: your Slack webhook URL
+4. Save - failures will now trigger Slack notifications
+5. If secret is not set, notification step is automatically skipped
 
 ---
 


### PR DESCRIPTION
## Summary
- Add conditional Slack notifications for workflow failures in both verify and nightly workflows
- Notifications only trigger when SLACK_WEBHOOK_URL secret is configured
- Graceful fallback when secret is not set (step automatically skipped)

## Changes
- Add Slack notification steps to pr-verify.yml and nightly-monitoring.yml workflows
- Update README.md with Slack alerts setup instructions  
- Use conditional execution with secrets.SLACK_WEBHOOK_URL != null check

## Test plan
- [ ] Verify workflows run without errors when SLACK_WEBHOOK_URL is not configured
- [ ] Test Slack notifications when secret is properly configured and workflow fails
- [ ] Confirm step is automatically skipped when secret is missing

Fixes #229

🤖 Generated with [Claude Code](https://claude.ai/code)