### PR TITLE
chore: update workflows to support pnpm v10

### DIFF
--- a/.github/workflows/codegen-drift-check.yml
+++ b/.github/workflows/codegen-drift-check.yml
@@ -37,9 +37,9 @@ jobs:
           cache: 'pnpm'
           
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
-          version: 8
+          version: 10
           
       - name: Install dependencies
         run: |
@@ -216,9 +216,9 @@ jobs:
           cache: 'pnpm'
           
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
-          version: 8
+          version: 10
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -269,9 +269,9 @@ jobs:
           cache: 'pnpm'
           
       - name: Setup pnpm  
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
-          version: 8
+          version: 10
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/fail-fast-spec-validation.yml
+++ b/.github/workflows/fail-fast-spec-validation.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   NODE_VERSION: '20'
-  PNPM_VERSION: '8'
+  PNPM_VERSION: '10'
 
 jobs:
   fail-fast-validation:
@@ -39,7 +39,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: ${{ env.PNPM_VERSION }}
 


### PR DESCRIPTION
## Summary
- Updates pnpm/action-setup from v4 to v5 for pnpm v10 compatibility
- Updates pnpm version from 8 to 10 in workflow configurations  
- Ensures future-proofing for pnpm v10 features and improvements

## Changed Files
- `.github/workflows/codegen-drift-check.yml`
- `.github/workflows/fail-fast-spec-validation.yml`

## Test Plan
- [ ] Verify workflow compatibility with pnpm v10
- [ ] Check that existing functionality remains intact
- [ ] Confirm no breaking changes in CI/CD pipelines

🤖 Generated with [Claude Code](https://claude.ai/code)