### PR TITLE
fix: update packageManager to use semver format for pnpm@10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -358,5 +358,5 @@
   "engines": {
     "node": ">=20.11 <23"
   },
-  "packageManager": "pnpm@9"
+  "packageManager": "pnpm@10.0.0"
 }


### PR DESCRIPTION
## Summary
Fixes the "Invalid package manager specification in package.json (pnpm@9); expected a semver version" error by updating the packageManager field to use proper semver format.

## Problem
- Current `"packageManager": "pnpm@9"` causes error during `pnpm install`
- Corepack requires exact semver version specification

## Solution
- Update to `"packageManager": "pnpm@10.0.0"` with proper semver format
- Aligns with pnpm v10 support added in PR #274

## Test Plan
- [ ] Verify `pnpm install` works without errors
- [ ] Confirm Corepack properly detects pnpm@10.0.0
- [ ] Check CI workflows use correct pnpm version

Fixes the pnpm install error reported after PR #274 merge.

🤖 Generated with [Claude Code](https://claude.ai/code)