### PR TITLE
docs(codex): stdio adapter, build prereqs, artifact dir/docs updates

### DIFF
--- a/docs/integrations/CODEX-ARTIFACTS.md
+++ b/docs/integrations/CODEX-ARTIFACTS.md
@@ -4,7 +4,7 @@ This document describes the machine-readable artifacts produced when running ae-
 
 ## Per-phase result files
 
-- Path: `artifacts/codex/result-<phase>.json`
+- Path: `artifacts/codex/result-<phase>.json` (or directory in `CODEX_ARTIFACTS_DIR` if set)
 - Format:
 ```jsonc
 {
@@ -34,7 +34,8 @@ Notes:
   "totalEntities": 1,
   "okEntities": 1,
   "files": ["apps/web/app/products/page.tsx", "apps/web/components/ProductForm.tsx"],
-  "dryRun": true
+  "dryRun": true,
+  "artifactDir": "/abs/path/to/artifacts/codex"
 }
 ```
 
@@ -65,4 +66,3 @@ The PR Verify workflow uploads:
 - `codex-model-check`: `artifacts/codex/model-check.json` (if present)
 
 Additionally, it posts a PR comment summarizing model check and UI scaffold results.
-

--- a/docs/integrations/CODEX-INTEGRATION.md
+++ b/docs/integrations/CODEX-INTEGRATION.md
@@ -6,7 +6,7 @@ This guide explains how to use ae-framework in the CodeX (agentic coding) enviro
 
 - Minimal: CLI bridge (PoC)
 - Recommended: MCP integration (reuse existing MCP servers)
-- Advanced: CodeX-specific task adapter (future work)
+- Adapter: CodeX Task Adapter via stdio bridge (JSON-in/JSON-out)
 
 ## 1) CLI Bridge (PoC)
 
@@ -87,20 +87,26 @@ Replace `${AE_FRAMEWORK_ROOT}` with your local path. Minimal JSON example:
 }
 ```
 
-## 3) CodeX Task Adapter (Future)
+## 3) CodeX Task Adapter (Stdio Bridge)
 
-Design a dedicated adapter that maps CodeX TODO/Plan/Tool calls to ae-framework phases.
+A dedicated adapter maps CodeX TODO/Plan/Tool calls to ae-framework phases. Use the stdio bridge for simple JSON I/O.
 
-### Planned scope
+### Current scope
 - Phase handlers: intent, formal, stories, validation, modeling, ui
-- Request/response contracts: reuse `src/agents/*-task-adapter.ts` patterns
-- Telemetry integration: reuse phase6 OpenTelemetry metrics
+- Request/response contracts: `TaskRequest` / `TaskResponse`
+- Artifacts: writes JSON summaries to `artifacts/codex/`
 
-### Current skeleton and behavior
-- File: `src/agents/codex-task-adapter.ts`
-- Phase routing: intent/stories/validation/modeling → delegates to existing adapters
-- Formal: delegates to `FormalAgent` (`tla+` generation + validation summary)
-- UI: uses `UIScaffoldGenerator` if `context.phaseState.entities` is provided; otherwise returns recommendations
+### Usage (stdio)
+- Script: `pnpm run codex:adapter`
+- Example:
+```bash
+echo '{"description":"Generate UI","subagent_type":"ui","context":{"phaseState":{"entities":{}}}}' | pnpm run codex:adapter
+```
+
+### Implementation notes
+- File: `src/agents/codex-task-adapter.ts` (core), `scripts/codex/adapter-stdio.mjs` (bridge)
+- UI: uses `UIScaffoldGenerator` when `context.phaseState.entities` is provided; otherwise dry-run
+- Formal: `FormalAgent` generates TLA+ and OpenAPI (best-effort model checking)
 
 ## Operational Considerations
 

--- a/docs/integrations/QUICK-START-CODEX.md
+++ b/docs/integrations/QUICK-START-CODEX.md
@@ -5,7 +5,7 @@ This guide shows the fastest way to use ae-framework from CodeX via CLI/MCP.
 ## Prerequisites
 - Node.js 20.11+
 - pnpm 9 (Corepack: `corepack enable`)
-- Repository built (`pnpm run build`)
+- Build the repo first (`pnpm run build`) — stdio/quickstart scripts load `dist/`
 
 ## 1) One-command PoC (Verify + Formal)
 To customize formal input, set `CODEX_FORMAL_REQ` to your requirement text (single line or escaped).
@@ -56,4 +56,10 @@ $env:CODEX_RUN_FORMAL="1"; pnpm run build; pnpm run codex:quickstart
 - cmd.exe:
 ```bat
 set CODEX_RUN_FORMAL=1 && pnpm run build && pnpm run codex:quickstart
+```
+## 4) Stdio Adapter (direct Task Adapter)
+Pipe a `TaskRequest` JSON to the stdio adapter and receive a `TaskResponse` JSON.
+```bash
+pnpm run build
+echo '{"description":"Generate UI","subagent_type":"ui","context":{"phaseState":{"entities":{}}}}' | pnpm run codex:adapter
 ```


### PR DESCRIPTION
- Update integration guide to include stdio adapter usage\n- Emphasize `pnpm run build` prerequisite (dist references)\n- Document artifacts dir env and ui-summary fields\n\nRefs #292, #291.