### PR TITLE
feat(codex): OpenAPI→contract/E2E test generator + quickstart skip/tolerant modes; docs/CI updates

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -91,6 +91,14 @@ jobs:
           else
             echo 'No ui-summary.json found.'
           fi
+      - name: Show contract/E2E templates summary (if present)
+        if: always()
+        run: |
+          if [ -f artifacts/codex/openapi-contract-tests.json ]; then
+            node -e "const s=require('./artifacts/codex/openapi-contract-tests.json'); console.log('Contract/E2E templates:', s.files, 'dir:', s.outDir);"
+          else
+            echo 'No openapi-contract-tests.json found.'
+          fi
 
       - name: Comment summary on PR
         if: github.event_name == 'pull_request'
@@ -159,6 +167,13 @@ jobs:
             const hasOas = fs.existsSync('artifacts/codex/openapi.yaml');
             if (hasTla) lines.push('• Formal: TLA+ generated (artifacts/codex/formal.tla)');
             if (hasOas) lines.push('• OpenAPI: artifacts/codex/openapi.yaml');
+            // Contract/E2E templates
+            try {
+              if (fs.existsSync('artifacts/codex/openapi-contract-tests.json')) {
+                const s = JSON.parse(fs.readFileSync('artifacts/codex/openapi-contract-tests.json','utf8'));
+                lines.push(`• Contract/E2E templates: ${s.files} files (dir: ${s.outDir})`);
+              }
+            } catch {}
             if (lines.length === 0) {
               lines.push('No CodeX artifacts found to summarize.');
             }

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ sample-*.json
 invalid-sample-*.json
 clean-sample-*.json
 artifacts/cassettes/
+artifacts/codex/
+artifacts/codex-quickstart-summary.md
+tests/api/generated/
 
 # Generated files
 traceability.csv

--- a/docs/changes/2025-08-31-codex-contract-templates.md
+++ b/docs/changes/2025-08-31-codex-contract-templates.md
@@ -1,0 +1,28 @@
+# CodeX: OpenAPI → Contract/E2E Templates, Quickstart Quality Controls (2025-08-31)
+
+This change adds contract/E2E test template generation from OpenAPI and improves the CodeX quickstart developer experience.
+
+## Highlights
+- Contract/E2E templates generator:
+  - Script: `scripts/codex/generate-contract-tests.mjs`
+  - Input: OpenAPI (`.yaml` or `.json`)
+  - Output: `tests/api/generated/*.test.ts` (skipped test templates)
+  - Summary: `artifacts/codex/openapi-contract-tests.json`
+- Quickstart improvements:
+  - `CODEX_SKIP_QUALITY=1` to skip quality gates
+  - `CODEX_TOLERANT=1` to always exit 0 (non-blocking demo)
+  - Enrich OpenAPI with minimal `/health` endpoint when `paths` is empty
+- CI/Docs updates:
+  - PR verify prints template counts when present
+  - Integration docs list new env vars and artifacts
+
+## Related
+- Closes #292 (Docs: Update CodeX integration to reflect current adapter status and build prerequisites)
+- Refs #295 (Generate contract/E2E test templates from OpenAPI in CodeX flow)
+
+## Usage
+```bash
+pnpm run build
+CODEX_SKIP_QUALITY=1 CODEX_RUN_FORMAL=1 pnpm run codex:quickstart
+# Generated tests in tests/api/generated/, summary in artifacts/codex/openapi-contract-tests.json
+```

--- a/docs/integrations/CODEX-ARTIFACTS.md
+++ b/docs/integrations/CODEX-ARTIFACTS.md
@@ -57,6 +57,29 @@ Notes:
   }
   ```
 
+## Generated contract/E2E test templates
+
+When the quickstart runs with `CODEX_RUN_FORMAL=1` and an OpenAPI is produced, a generator creates Vitest templates:
+
+- Tests directory: `tests/api/generated/`
+- One file per operationId: `<operationId>.test.ts`
+- Tests are `it.skip(...)` by default (safe templates to customize)
+- Machine-readable summary: `artifacts/codex/openapi-contract-tests.json`
+
+Example summary:
+```json
+{
+  "openapi": "artifacts/codex/quickstart-openapi.yaml",
+  "outDir": "tests/api/generated",
+  "files": 12,
+  "operations": [
+    { "operationId": "getUser", "method": "get", "path": "/users/{id}", "file": "tests/api/generated/getUser.test.ts" }
+  ],
+  "mode": "templates",
+  "ts": "2025-01-01T00:00:00.000Z"
+}
+```
+
 ## CI collection
 
 The PR Verify workflow uploads:

--- a/docs/integrations/CODEX-INTEGRATION.md
+++ b/docs/integrations/CODEX-INTEGRATION.md
@@ -18,10 +18,12 @@ Run ae-framework commands from CodeX tasks. This requires file write permissions
 # Build first
 pnpm run build
 
-# Run PoC (verify, optionally UI scaffold with CODEX_RUN_UI=1)
+# Run PoC (verify; optional UI scaffold and formal generation)
 pnpm run codex:quickstart
 
-# Or: CODEX_RUN_UI=1 pnpm run codex:quickstart
+# Examples:
+#   UI scaffold demo: CODEX_RUN_UI=1 pnpm run codex:quickstart
+#   Formal + OpenAPI + contract templates: CODEX_RUN_FORMAL=1 pnpm run codex:quickstart
 ```
 
 Artifacts (logs, summaries) will be written under `artifacts/`.
@@ -29,6 +31,7 @@ Artifacts (logs, summaries) will be written under `artifacts/`.
 ### Notes
 - The quickstart finds the CLI at `dist/src/cli/index.js` (or `dist/cli.js` as fallback).
 - Non-zero exit codes fail the step, enabling clear feedback in CodeX.
+ - Build prerequisites: Node.js >= 20.11 (<23) and pnpm 10 (use Corepack: `corepack enable`).
 
 ### Minimal Phase 6 sample (for UI scaffold)
 
@@ -107,13 +110,25 @@ echo '{"description":"Generate UI","subagent_type":"ui","context":{"phaseState":
 - File: `src/agents/codex-task-adapter.ts` (core), `scripts/codex/adapter-stdio.mjs` (bridge)
 - UI: uses `UIScaffoldGenerator` when `context.phaseState.entities` is provided; otherwise dry-run
 - Formal: `FormalAgent` generates TLA+ and OpenAPI (best-effort model checking)
+- Validation: runtime schema validation (Zod) for `context.phaseState` blocks on invalid inputs with actionable messages.
+ - Contract/E2E templates: when OpenAPI is available in quickstart, `scripts/codex/generate-contract-tests.mjs` scaffolds tests under `tests/api/generated/` and writes `artifacts/codex/openapi-contract-tests.json`.
 
 ## Operational Considerations
 
-- Environment: Node 20.11+, pnpm 9 (Corepack).
+- Environment: Node >= 20.11 (<23), pnpm 10 (Corepack recommended: `corepack enable`).
 - Artifacts: prefer JSON/Markdown outputs for CodeX UI consumption.
 - Security: keep CLI/file permissions aligned with CodeX sandbox settings.
 - E2E dependencies (Playwright/LHCI): optional; introduce in CI/local first.
+
+### Environment variables
+- `CODEX_ARTIFACTS_DIR`: override adapter artifact output dir (defaults to `./artifacts/codex`).
+- `CODEX_RUN_UI`: `1` to enable Phase 6 UI scaffold in quickstart.
+- `CODEX_PHASE_STATE_FILE`: path to phase state JSON for UI scaffold.
+- `CODEX_UI_DRY_RUN`: `1` (default) to simulate, `0` to write files for UI scaffold.
+- `CODEX_RUN_FORMAL`: `1` to enable formal generation in quickstart.
+- `CODEX_FORMAL_REQ`: requirement text for formal/OpenAPI generation when `CODEX_RUN_FORMAL=1`.
+- `CODEX_SKIP_QUALITY`: `1` to skip running quality gates in quickstart.
+- `CODEX_TOLERANT`: `1` to force quickstart to exit 0 even if steps fail (non-blocking demo mode).
 
 ## Acceptance Criteria (incremental)
 
@@ -157,6 +172,13 @@ pnpm run build
 CODEX_RUN_UI=1 CODEX_PHASE_STATE_FILE=samples/phase-state.example.json pnpm run codex:quickstart
 
 # Dry-run is enabled by default; set CODEX_UI_DRY_RUN=0 to write files
+
+Skip quality gates or run in tolerant mode (optional):
+```bash
+CODEX_SKIP_QUALITY=1 pnpm run codex:quickstart
+# or
+CODEX_TOLERANT=1 pnpm run codex:quickstart
+```
 ```
 
 ## Machine-readable artifacts

--- a/docs/integrations/QUICK-START-CODEX.md
+++ b/docs/integrations/QUICK-START-CODEX.md
@@ -4,7 +4,7 @@ This guide shows the fastest way to use ae-framework from CodeX via CLI/MCP.
 
 ## Prerequisites
 - Node.js 20.11+
-- pnpm 9 (Corepack: `corepack enable`)
+- pnpm 10 (Corepack recommended: `corepack enable`)
 - Build the repo first (`pnpm run build`) — stdio/quickstart scripts load `dist/`
 
 ## 1) One-command PoC (Verify + Formal)
@@ -18,6 +18,16 @@ Outputs under `artifacts/`:
 - `artifacts/codex/openapi.yaml` (OpenAPI)
 - `artifacts/codex/model-check.json` (model checking)
 - `artifacts/codex/result-formal.json` (per-phase JSON)
+- If OpenAPI is present, contract/E2E templates are scaffolded under `tests/api/generated/` and summarized in `artifacts/codex/openapi-contract-tests.json`.
+
+Optional flags for smoother local runs:
+```bash
+# Skip quality gates entirely
+CODEX_SKIP_QUALITY=1 pnpm run codex:quickstart
+
+# Tolerant mode: always exit 0 even if steps fail
+CODEX_TOLERANT=1 pnpm run codex:quickstart
+```
 
 ## 2) UI Scaffold (Phase 6)
 Use the included sample Phase State:
@@ -30,6 +40,7 @@ pnpm run codex:quickstart
 ```
 - Dry-run by default. Set `CODEX_UI_DRY_RUN=0` to write files.
 - UI summary is saved as `artifacts/codex/ui-summary.json`.
+ - To change where artifacts are written, set `CODEX_ARTIFACTS_DIR` (adapter) or run quickstart from the repo root.
 
 ## 3) MCP Integration
 Start MCP servers and connect from CodeX:

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "container:demo": "tsx -e \"import { ContainerAgent } from './src/agents/container-agent.js'; console.log('Container verification demo ready');\"",
     "codex:quickstart": "node scripts/codex/quickstart.mjs",
     "codex:adapter": "node scripts/codex/adapter-stdio.mjs",
+    "codex:generate:contracts": "node scripts/codex/generate-contract-tests.mjs",
     "codex:mcp:intent": "tsx src/mcp-server/intent-server.ts",
     "codex:mcp:test": "tsx src/mcp-server/test-generation-server.ts",
     "codex:mcp:verify": "tsx src/mcp-server/verify-server.ts",

--- a/scripts/codex/generate-contract-tests.mjs
+++ b/scripts/codex/generate-contract-tests.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Generate Vitest contract/E2E test templates from an OpenAPI spec.
+// - Default mode creates skipped test templates (safe for CI)
+// - Writes a machine-readable summary to artifacts/codex/openapi-contract-tests.json
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import yaml from 'yaml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function parseArgs(argv) {
+  const args = { outDir: 'tests/api/generated', mode: 'templates' };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--openapi') args.openapi = argv[++i];
+    else if (a === '--outDir') args.outDir = argv[++i];
+    else if (a === '--mode') args.mode = argv[++i];
+  }
+  if (!args.openapi) throw new Error('Missing --openapi <path/to/openapi.yaml>');
+  return args;
+}
+
+function ensureDir(p) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function readOpenAPI(p) {
+  const raw = fs.readFileSync(p, 'utf8');
+  const doc = /\.(ya?ml)$/i.test(p) ? yaml.parse(raw) : JSON.parse(raw);
+  if (!doc || !doc.paths || typeof doc.paths !== 'object') {
+    throw new Error('Invalid OpenAPI: missing paths');
+  }
+  return doc;
+}
+
+function sanitize(name) {
+  return name.replace(/[^a-zA-Z0-9_-]+/g, '_');
+}
+
+function inferOperationId(pathKey, method, op) {
+  return op.operationId || `${method}_${pathKey}`.replace(/[^a-zA-Z0-9]+/g, '_');
+}
+
+function genTestTemplate({ operationId, method, pathKey, summary, hasRequestBody, hasResponses }) {
+  const title = summary ? `${operationId} - ${summary}` : operationId;
+  // Use skipped tests to avoid failing CI until developers implement them.
+  return `import { describe, it, expect } from 'vitest';
+
+describe('${title}', () => {
+  it.skip('contract: request/response schema validation', async () => {
+    // TODO: Implement contract validation against OpenAPI schemas
+    // - Validate request shape${hasRequestBody ? ' (requestBody is defined)' : ''}
+    // - Validate response shape${hasResponses ? ' (responses are defined)' : ''}
+    // Suggested approach: use Ajv with JSON Schema or zod adapters.
+    expect(true).toBe(true);
+  });
+
+  it.skip('e2e: endpoint behavior (integration)', async () => {
+    // TODO: Implement E2E/integration test
+    // - Start app/server
+    // - Perform ${method.toUpperCase()} ${pathKey}
+    // - Assert status code and payload
+    expect(true).toBe(true);
+  });
+});
+`;
+}
+
+function writeSummary(summary) {
+  const root = process.cwd();
+  const outDir = path.join(root, 'artifacts', 'codex');
+  ensureDir(outDir);
+  const p = path.join(outDir, 'openapi-contract-tests.json');
+  fs.writeFileSync(p, JSON.stringify(summary, null, 2), 'utf8');
+  return p;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const root = process.cwd();
+  const specPath = path.resolve(args.openapi);
+  const outDir = path.resolve(args.outDir);
+
+  const oas = readOpenAPI(specPath);
+  ensureDir(outDir);
+
+  let files = 0;
+  const operations = [];
+  for (const [pathKey, pathItem] of Object.entries(oas.paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+    for (const method of ['get','post','put','patch','delete','options','head','trace']) {
+      const op = pathItem[method];
+      if (!op) continue;
+      const operationId = inferOperationId(pathKey, method, op);
+      const testName = sanitize(operationId) + '.test.ts';
+      const hasRequestBody = !!op.requestBody;
+      const hasResponses = !!op.responses && Object.keys(op.responses).length > 0;
+      const content = genTestTemplate({ operationId, method, pathKey, summary: op.summary, hasRequestBody, hasResponses });
+      const target = path.join(outDir, testName);
+      fs.writeFileSync(target, content, 'utf8');
+      files += 1;
+      operations.push({ operationId, method, path: pathKey, file: path.relative(root, target) });
+    }
+  }
+
+  const summary = {
+    openapi: path.relative(root, specPath),
+    outDir: path.relative(root, outDir),
+    files, operations,
+    mode: args.mode,
+    ts: new Date().toISOString(),
+  };
+  const summaryPath = writeSummary(summary);
+  console.log(`Generated ${files} contract/E2E test templates → ${path.relative(root, outDir)}`);
+  console.log(`Summary: ${path.relative(root, summaryPath)}`);
+}
+
+main().catch(err => {
+  console.error('[codex] generate-contract-tests failed:', err);
+  process.exit(1);
+});
+

--- a/scripts/codex/quickstart.mjs
+++ b/scripts/codex/quickstart.mjs
@@ -40,9 +40,16 @@ async function main() {
   ensureDir(artifactsDir);
   const summaryPath = path.join(artifactsDir, `codex-quickstart-summary.md`);
 
-  // 1) Verify gates
-  console.log('[codex] Running ae verify ...');
-  const verifyCode = runNode([cli, 'verify'], { env: { AE_TYPES_STRICT: '1' } });
+  // 1) Quality gates (skippable)
+  let verifyCode = 0;
+  let verifyLabel = 'skipped';
+  if (process.env.CODEX_SKIP_QUALITY === '1') {
+    console.log('[codex] Skipping quality gates (CODEX_SKIP_QUALITY=1)');
+  } else {
+    console.log('[codex] Running ae quality run ...');
+    verifyCode = runNode([cli, 'quality', 'run'], { env: { AE_TYPES_STRICT: '1' } });
+    verifyLabel = String(verifyCode);
+  }
 
   // 2) Optional UI scaffold
   let uiCode = 0;
@@ -63,6 +70,9 @@ async function main() {
   let formalCode = 0;
   let formalOut = '';
   let formalMC = '';
+  let openapiPath = '';
+  let contractsSummaryPath = '';
+  let contractsCount = 0;
   if (process.env.CODEX_RUN_FORMAL === '1') {
     try {
       console.log('[codex] Generating formal spec + OpenAPI ...');
@@ -76,7 +86,44 @@ async function main() {
       fs.writeFileSync(tlaPath, spec.content, 'utf8');
       try {
         const openapi = await agent.createAPISpecification(reqText, 'openapi', { includeExamples: true, generateContracts: true });
-        fs.writeFileSync(path.join(codexDir, 'quickstart-openapi.yaml'), openapi.content, 'utf8');
+        openapiPath = path.join(codexDir, 'quickstart-openapi.yaml');
+        fs.writeFileSync(openapiPath, openapi.content, 'utf8');
+        // Enrich with minimal endpoint if no paths are present
+        try {
+          const { default: yaml } = await import('yaml');
+          const doc = yaml.parse(fs.readFileSync(openapiPath, 'utf8')) || {};
+          const hasPaths = doc.paths && Object.keys(doc.paths).length > 0;
+          if (!hasPaths) {
+            doc.openapi = doc.openapi || '3.0.3';
+            doc.info = doc.info || { title: 'Quickstart API', version: '1.0.0' };
+            doc.paths = {
+              '/health': {
+                get: {
+                  operationId: 'healthCheck',
+                  summary: 'Health check endpoint',
+                  responses: {
+                    '200': {
+                      description: 'OK',
+                      content: {
+                        'application/json': {
+                          schema: {
+                            type: 'object',
+                            properties: { status: { type: 'string' } },
+                            required: ['status']
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            };
+            fs.writeFileSync(openapiPath, yaml.stringify(doc), 'utf8');
+            console.log('[codex] OpenAPI enriched with /health endpoint');
+          }
+        } catch (e) {
+          console.warn('[codex] Failed to enrich OpenAPI:', e?.message || e);
+        }
       } catch {}
       try {
         const mc = await agent.runModelChecking(spec, []);
@@ -85,6 +132,25 @@ async function main() {
       } catch { formalMC = 'failed'; }
       formalOut = tlaPath;
       formalCode = 0;
+
+      // If we have an OpenAPI spec, generate contract/E2E test templates
+      if (openapiPath && fs.existsSync(openapiPath)) {
+        console.log('[codex] Generating contract/E2E test templates from OpenAPI ...');
+        const genArgs = [path.resolve('scripts/codex/generate-contract-tests.mjs'), '--openapi', openapiPath, '--outDir', 'tests/api/generated'];
+        const rc = runNode(genArgs);
+        // Read summary file if available
+        try {
+          const sPath = path.join(codexDir, 'openapi-contract-tests.json');
+          if (fs.existsSync(sPath)) {
+            const s = JSON.parse(fs.readFileSync(sPath, 'utf8'));
+            contractsSummaryPath = sPath;
+            contractsCount = s.files || 0;
+          }
+        } catch {}
+        if (rc !== 0) {
+          console.warn('[codex] Contract test generation exited with non-zero status');
+        }
+      }
     } catch (e) {
       console.error('[codex] Formal generation failed:', e);
       formalCode = 1;
@@ -94,15 +160,20 @@ async function main() {
   const summary = [
     '# CodeX Quickstart Summary',
     '',
-    `- Verify exit code: ${verifyCode}`,
+    process.env.CODEX_SKIP_QUALITY === '1' ? '- Quality gates: skipped' : `- Quality gates exit code: ${verifyCode}`,
     process.env.CODEX_RUN_UI === '1' ? `- UI scaffold exit code: ${uiCode}${process.env.CODEX_PHASE_STATE_FILE ? ' (state file provided)' : ''}` : '- UI scaffold: skipped',
     process.env.CODEX_RUN_FORMAL === '1' ? `- Formal generation: ${formalCode === 0 ? 'ok' : 'failed'}${formalOut ? ` (${path.relative(root, formalOut)})` : ''}${formalMC ? `, model-check: ${formalMC}` : ''}` : '- Formal generation: skipped',
+    process.env.CODEX_RUN_FORMAL === '1' && openapiPath ? `- OpenAPI: ${path.relative(root, openapiPath)}${contractsSummaryPath ? ` → Generated contract/E2E templates: ${contractsCount}` : ''}` : '',
     '',
     'Artifacts generated under artifacts/ as applicable.',
   ].join('\n');
   fs.writeFileSync(summaryPath, summary, 'utf8');
   console.log(`[codex] Wrote summary: ${summaryPath}`);
 
+  if (process.env.CODEX_TOLERANT === '1') {
+    // Tolerant mode: never fail quickstart
+    process.exit(0);
+  }
   if (verifyCode !== 0 || uiCode !== 0) {
     process.exit(1);
   }


### PR DESCRIPTION
概要:
- OpenAPI から契約/E2E テンプレート生成（scripts/codex/generate-contract-tests.mjs）
- Quickstart 強化: CODEX_SKIP_QUALITY=1, CODEX_TOLERANT=1、OpenAPI 空時に /health を追加
- CI: PR Verify でテンプレート件数を出力・要約
- Docs: 新しい環境変数・成果物を反映

使い方:
- pnpm run build
- CODEX_SKIP_QUALITY=1 CODEX_RUN_FORMAL=1 pnpm run codex:quickstart

成果物:
- tests/api/generated/*.test.ts（雛形、it.skip）
- artifacts/codex/openapi-contract-tests.json

関連:
- Closes #292
- Refs #295
