### PR TITLE
feat(spec-compiler): package CLI --relaxed/--desc-max; lenient enum/invariant normalization; docs update

### DIFF
--- a/docs/development/spec-validation.md
+++ b/docs/development/spec-validation.md
@@ -132,6 +132,32 @@ Default quality gates:
 - **Warnings**: 10 (more than 10 warnings fails validation)
 - **Info**: unlimited
 
+## Lenient Mode (Development)
+
+To accelerate early iteration, a lenient validation profile is available:
+
+- Env flag: `AE_SPEC_RELAXED=1` downgrades strict schema errors to warnings.
+- Root CLI: `ae-framework spec validate --relaxed` enables lenient mode.
+- Package CLI: `ae-spec validate --relaxed` also supported.
+- Increase warning tolerance for local runs with `--max-warnings 999` or via `.ae/spec-validation.config.json`.
+
+Configurable limits (via environment variables):
+- `AE_SPEC_DESC_MIN` / `AE_SPEC_DESC_MAX`: common description length (default 10/500)
+- `AE_SPEC_FIELD_DESC_MAX` / `AE_SPEC_DOMAIN_DESC_MAX` / `AE_SPEC_INVARIANT_DESC_MAX`
+- `AE_SPEC_GLOSSARY_DESC_MAX`
+- API-related: `AE_SPEC_API_SUMMARY_MAX`, `AE_SPEC_API_PARAM_DESC_MAX`, `AE_SPEC_API_ERROR_DESC_MAX`
+- Constraint length: `AE_SPEC_CONSTRAINT_MAX`
+
+CLI overrides:
+- Root CLI: `ae-framework spec validate --relaxed --desc-max 2000`
+- Package CLI: `ae-spec compile --relaxed --desc-max 2000`
+
+Lenient normalizations:
+- Field type hints like `enum: a|b` are coerced to `string` in lenient mode.
+- Invariant ID auto-fallback: non-UUID IDs are replaced with generated UUIDv4 in lenient mode.
+
+Note: CI should continue using the strict profile by default.
+
 ## Usage Scenarios
 
 ### 1. Developer Workflow

--- a/packages/spec-compiler/src/cli.ts
+++ b/packages/spec-compiler/src/cli.ts
@@ -19,8 +19,20 @@ program
   .option('-o, --output <file>', 'Output JSON file (default: stdout)')
   .option('--no-validate', 'Skip validation during compilation')
   .option('--source-map', 'Include source location information')
+  .option('--relaxed', 'Relax strict schema errors to warnings (AE_SPEC_RELAXED=1)')
+  .option('--desc-max <n>', 'Override description max length (e.g., 1000)')
   .action(async (options) => {
     try {
+      if (options.relaxed) process.env.AE_SPEC_RELAXED = '1';
+      if (options.descMax) {
+        const n = parseInt(String(options.descMax), 10);
+        if (Number.isFinite(n) && n > 0) {
+          process.env.AE_SPEC_DESC_MAX = String(n);
+          process.env.AE_SPEC_INVARIANT_DESC_MAX = String(n);
+          process.env.AE_SPEC_DOMAIN_DESC_MAX = String(n);
+          process.env.AE_SPEC_FIELD_DESC_MAX = String(n);
+        }
+      }
       const compiler = new AESpecCompiler();
       const ir = await compiler.compile({
         inputPath: resolve(options.input),
@@ -100,11 +112,23 @@ program
   .requiredOption('-i, --input <file>', 'Input markdown file')
   .option('--max-errors <n>', 'Maximum allowed errors', parseInt, 0)
   .option('--max-warnings <n>', 'Maximum allowed warnings', parseInt, 10)
+  .option('--relaxed', 'Relax strict schema errors to warnings (AE_SPEC_RELAXED=1)')
+  .option('--desc-max <n>', 'Override description max length (e.g., 1000)')
   .action(async (options) => {
     try {
       console.log(`🔍 Validating ${options.input}...`);
       
       const compiler = new AESpecCompiler();
+      if (options.relaxed) process.env.AE_SPEC_RELAXED = '1';
+      if (options.descMax) {
+        const n = parseInt(String(options.descMax), 10);
+        if (Number.isFinite(n) && n > 0) {
+          process.env.AE_SPEC_DESC_MAX = String(n);
+          process.env.AE_SPEC_INVARIANT_DESC_MAX = String(n);
+          process.env.AE_SPEC_DOMAIN_DESC_MAX = String(n);
+          process.env.AE_SPEC_FIELD_DESC_MAX = String(n);
+        }
+      }
       const ir = await compiler.compile({
         inputPath: resolve(options.input),
         validate: false, // We'll lint separately for better reporting


### PR DESCRIPTION
Summary
Follow-up for lenient AE‑Spec schema: add package-level CLI flags, implement enum/invariant lenient normalization, and document relaxed mode.

Changes
- Package CLI (packages/spec-compiler/src/cli.ts)
  - compile/validate: add `--relaxed` (sets AE_SPEC_RELAXED=1)
  - compile/validate: add `--desc-max <n>` (overrides description-related limits via env)
- Lenient normalizations (packages/spec-compiler/src/compiler.ts)
  - Field type hints like `enum: a|b` are coerced to `string` in relaxed mode
  - Invariant ID fallback: non-UUID IDs are replaced with UUIDv4 in relaxed mode
- Docs (docs/development/spec-validation.md)
  - Add section for relaxed mode, env-driven limits, CLI usage

Validation
- Built the package; ran `ae-spec validate --relaxed --max-warnings 999 -i spec/EncryptedChat.ae-spec.md` successfully (errors=0, warnings present).

Notes
- Strict profile unchanged by default; relaxed is opt-in.
- Further schema relaxations (if needed) can be layered without breaking strict mode.

