### PR TITLE
ci: P0 readiness — stabilize PR experience (tolerant quickstart, path filters)

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -33,7 +33,8 @@ jobs:
         env:
           AE_TYPES_STRICT: "1"
           CODEX_RUN_FORMAL: "1"
-        continue-on-error: true
+          CODEX_SKIP_QUALITY: "1"   # keep informative but non-blocking
+          CODEX_TOLERANT: "1"       # force success regardless of phase results
       - name: Upload CodeX quickstart summary
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -1,6 +1,15 @@
 name: Quality Gates
 on:
   pull_request:
+    # Run quality gates only when code paths change
+    paths:
+      - 'src/**'
+      - 'packages/**'
+      - 'apps/**'
+      - 'tests/**'
+      - 'configs/**'
+      - 'scripts/**'
+      - 'types/**'
 permissions: read-all
 jobs:
   integration:

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -5,6 +5,13 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
+    # Run SBOM only when dependency or code manifests change
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'packages/**'
+      - 'apps/**'
+      - 'src/**'
   schedule:
     # Run daily at 2 AM UTC
     - cron: '0 2 * * *'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
+    # Avoid running heavy scans for docs-only changes
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   schedule:
     # Run security scan daily at 2 AM UTC
     - cron: '0 2 * * *'


### PR DESCRIPTION
P0 set focusing on public‑friendly PR experience.

Changes:
- PR Verify: Make CodeX quickstart tolerant via env (`CODEX_SKIP_QUALITY=1`, `CODEX_TOLERANT=1`) and remove `continue-on-error` reliance (#307)
- Quality Gates: Run only on code changes via paths filter (#305)
- SBOM: Trigger on manifests/code only (#305)
- Security: Ignore docs‑only PRs (#305)

Rationale:
- Reduce CI load and red noise on docs/infra PRs
- Keep quickstart informative but non‑blocking

Next (separate PRs):
- actionlint sweep across workflows (#304)
- vitest stable profile adoption where applicable (#306)
