### PR TITLE
ci: actionlint sweep — fix reusable calls, syntax, contexts

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
     branches: [main, develop]
+  workflow_call:
+    # Allow release workflow to reuse this fast CI
 concurrency:
   group: ci-fast-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/hermetic-ci.yml
+++ b/.github/workflows/hermetic-ci.yml
@@ -107,8 +107,8 @@ jobs:
           pnpm run build
 
       - name: Bin smoke check (after first build)
-        run: node scripts/ci/check-bins.mjs
-
+        run: |
+          node scripts/ci/check-bins.mjs
           # Create checksum of build output
           find dist/ -type f -exec sha256sum {} \; | sort > build1.checksums
           
@@ -122,7 +122,8 @@ jobs:
           pnpm run build
 
       - name: Bin smoke check (after second build)
-        run: node scripts/ci/check-bins.mjs
+        run: |
+          node scripts/ci/check-bins.mjs
           # Create checksum of second build
           find dist/ -type f -exec sha256sum {} \; | sort > build2.checksums
           

--- a/.github/workflows/nightly-monitoring.yml
+++ b/.github/workflows/nightly-monitoring.yml
@@ -55,7 +55,7 @@ jobs:
           retention-days: 14
       
       - name: Notify Slack on failure
-        if: failure() && secrets.SLACK_WEBHOOK_URL != null
+        if: failure() && env.SLACK_WEBHOOK != null
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -122,11 +122,9 @@ jobs:
               if (fs.existsSync('artifacts/codex/ui-summary.json')) {
                 const s = JSON.parse(fs.readFileSync('artifacts/codex/ui-summary.json','utf8'));
                 let files = s.files || [];
-                const preview = files.slice(0, 5).map(f => `    - ${f}`).join('
-');
+                const preview = files.slice(0, 5).map(f => `    - ${f}`).join('\\n');
                 lines.push(`• UI Scaffold: ${s.okEntities}/${s.totalEntities} entities, Files: ${files.length}, Dry-run: ${!!s.dryRun}`);
-                if (files.length) lines.push('  Preview files (up to 5):
-' + preview);
+                if (files.length) lines.push('  Preview files (up to 5):\\n' + preview);
               }
             } catch {}
             // Stories summary
@@ -215,7 +213,7 @@ jobs:
           retention-days: 14
       
       - name: Notify Slack on failure
-        if: failure() && secrets.SLACK_WEBHOOK_URL != null
+        if: failure() && env.SLACK_WEBHOOK != null
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -10,6 +10,12 @@ on:
       - 'configs/**'
       - 'scripts/**'
       - 'types/**'
+  workflow_call:
+    # Allow reuse from other workflows (e.g., release)
+    inputs:
+      environment:
+        required: false
+        type: string
 permissions: read-all
 jobs:
   integration:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -203,16 +203,17 @@ jobs:
   container-security:
     name: Container Security
     runs-on: ubuntu-latest
-    if: hashFiles('docker/Dockerfile') != ''
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Build Docker image
+        if: hashFiles('docker/Dockerfile') != ''
         run: docker build -f docker/Dockerfile -t ae-framework:latest .
 
       - name: Run Trivy vulnerability scanner
+        if: hashFiles('docker/Dockerfile') != ''
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'ae-framework:latest'

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [main, develop]
     paths: ['spec/**', '.ae/**', 'docs/**']
+  workflow_call:
+    # Allow other workflows to call this validation
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes for #304 (actionlint).\n\n- Add workflow_call to reusable workflows (spec-validation, quality-gates, ci-fast)\n- Fix YAML syntax errors in pr-verify and hermetic-ci\n- Replace disallowed contexts in if conditions (use env for Slack webhook)\n- Move job-level hashFiles guard to step-level in security workflow\n\nValidated locally with actionlint v1.7.1.