### PR TITLE
docs: Req2Run environment setup + Health Check (2025-09) + Stable CI Profile

### DIFF
--- a/docs/benchmark/README.md
+++ b/docs/benchmark/README.md
@@ -67,6 +67,10 @@ pnpm run benchmark:list
 
 # Generate config
 pnpm run benchmark:init
+
+#### Environment Setup
+
+For repository location and CI preparation of the Req2Run benchmark, see `req2run-environment-setup.md`.
 ```
 
 ### Configuration

--- a/docs/benchmark/req2run-environment-setup.md
+++ b/docs/benchmark/req2run-environment-setup.md
@@ -1,0 +1,81 @@
+# Req2Run Benchmark Integration — Environment Setup
+
+This guide explains how to set up and run the Req2Run benchmark integration with ae-framework on local machines and in CI.
+
+## Prerequisites
+- Node.js 20+
+- pnpm 8/10 via corepack (`corepack enable`)
+- Git installed
+
+Optional (local cloning mode):
+- Access to the Req2Run benchmark repository
+
+## Repository Location Options
+ae-framework can consume the Req2Run benchmark problems from:
+
+- Cloned repo directory (recommended for local debugging)
+  - Set `REQ2RUN_BENCHMARK_REPO=/path/to/req2run-benchmark`
+- Auto-managed temp directory (CI-friendly)
+  - If `REQ2RUN_BENCHMARK_REPO` is unset, the runner expects the repo at `/tmp/req2run-benchmark`. Use a CI step to clone into that path.
+
+Reference: `src/benchmark/req2run/runners/BenchmarkRunner.ts` uses `process.env.REQ2RUN_BENCHMARK_REPO || '/tmp/req2run-benchmark'`.
+
+## Install and Build
+```bash
+corepack enable
+pnpm install --frozen-lockfile
+pnpm run build
+```
+
+## Quick Run (Local)
+Basic integration run with default config and reports written under `reports/benchmark`:
+
+```bash
+# Option 1: use a local clone
+export REQ2RUN_BENCHMARK_REPO="$HOME/dev/req2run-benchmark"
+
+# Option 2: clone into the default path
+mkdir -p /tmp && git clone https://github.com/itdojp/req2run-benchmark.git /tmp/req2run-benchmark || true
+
+# Run basic suite
+pnpm benchmark:basic
+
+# Or list and run via CLI
+pnpm benchmark:list
+pnpm benchmark
+```
+
+Artifacts and reports:
+- JSON/Markdown/CSV reports under `reports/benchmark/`
+- CI examples: `src/benchmark/req2run/examples/`
+
+## CI Integration (Minimal)
+Add a step before running the benchmark to ensure the repository is present:
+
+```yaml
+- name: Prepare Req2Run repository
+  run: |
+    git clone --depth 1 https://github.com/itdojp/req2run-benchmark /tmp/req2run-benchmark || true
+    echo "REQ2RUN_BENCHMARK_REPO=/tmp/req2run-benchmark" >> $GITHUB_ENV
+
+- name: Run Req2Run benchmark (CI profile)
+  run: pnpm benchmark:ci
+```
+
+The CI profile writes results to `reports/benchmark` and shortens execution for pipeline stability. Tune depths, categories, and timeouts under `src/benchmark/req2run/config/default.ts` or by providing a config file.
+
+## Custom Configuration
+You can generate and pass a benchmark config file:
+
+```bash
+pnpm benchmark:init               # writes ./benchmark-config.json
+pnpm benchmark -- --config ./benchmark-config.json
+```
+
+In code, the default report directory is `./reports/benchmark` (see `config.default.ts`).
+
+## Troubleshooting
+- Repo not found: ensure `REQ2RUN_BENCHMARK_REPO` points to a valid path or clone into `/tmp/req2run-benchmark`.
+- Long runtimes: use the CI profile (`pnpm benchmark:ci`) or narrow the category/difficulty.
+- Missing reports: check job logs for `reports/benchmark` path; ensure the process has write permissions.
+

--- a/docs/ci/stable-profile.md
+++ b/docs/ci/stable-profile.md
@@ -1,0 +1,18 @@
+# Stable CI Test Profile
+
+This profile provides deterministic, faster test execution suitable for PR verification. Heavy or flaky suites are gated behind labels or nightly jobs.
+
+## Commands
+- Full CI config: `pnpm run test:ci`
+- Stable subset: `pnpm run test:ci:stable`
+
+`test:ci:stable` currently excludes:
+- `**/system-integration.test.ts`
+
+## Usage in Workflows
+- For PR workflows aiming for reliability and speed, run `test:ci:stable` or target explicit suites (`test:unit`, `test:int`, `test:a11y`, `test:coverage`).
+- Keep Playwright/E2E runs label-gated (`run-e2e`) or scheduled/nightly.
+
+## Evolution
+- As we identify more flaky suites, we will either stabilize them (preferred) or move them to label/nightly until fixed.
+

--- a/docs/quality/health-check-2025-09.md
+++ b/docs/quality/health-check-2025-09.md
@@ -1,0 +1,37 @@
+# Repository Health Check — 2025-09-05
+
+Scope: Types Gate, Verify, Bench, Flake, Branch Protection, and CI workflow hygiene.
+
+## Current Gates & Policies
+- PR Verify (pr-verify.yml)
+  - CodeX quickstart runs in tolerant mode via env: `CODEX_SKIP_QUALITY=1`, `CODEX_TOLERANT=1`.
+  - Summary/comments and artifacts are uploaded; job status remains green by design.
+- Quality Gates (quality-gates-centralized.yml)
+  - Triggered only on code changes via `paths` filters (`src/**`, `packages/**`, `apps/**`, `tests/**`, `configs/**`, `scripts/**`, `types/**`).
+- SBOM (sbom-generation.yml)
+  - Runs when manifests/code change; avoids docs-only PRs.
+- Security (security.yml)
+  - `paths-ignore` for docs/markdown to skip heavy scans on docs PRs.
+  - Container scan steps guarded by `hashFiles('docker/Dockerfile')` at step level.
+- Parallel Tests (parallel-test-execution.yml)
+  - E2E job on PR runs only with label `run-e2e`; always runs on push.
+  - Path filters identical to quality gates to reduce noise.
+- Spec Validation
+  - Reusable workflow is callable (`workflow_call`) and referenced by fail-fast pipelines.
+
+## Lint & Hygiene
+- actionlint: All workflows pass local `actionlint v1.7.1`.
+- workflow reuse: Reusable workflows expose `workflow_call` and optional inputs.
+
+## Types & Tests
+- Type strict mode env available (`AE_TYPES_STRICT=1`).
+- Stable CI test profile available: `pnpm run test:ci:stable` (excludes heavy system-integration tests). See `docs/ci/stable-profile.md`.
+
+## Branch Protection (suggested)
+- Require: actionlint, PR Verify, Quality Gates minimal, SBOM (manifests), Security (fast lanes), Spec Validation (if spec used).
+- Optional: E2E label-gated job not required.
+
+## Follow-ups
+- Document additional exclusions for the stable profile as we identify flaky suites.
+- Track CI duration metrics to refine path filters.
+


### PR DESCRIPTION
Implements #171 and #262 docs, and clarifies #306 approach.\n\n- New: docs/benchmark/req2run-environment-setup.md — prerequisites, REPO path, local/CI examples\n- New: docs/quality/health-check-2025-09.md — current CI gates, path filters, label gates, actionlint status\n- New: docs/ci/stable-profile.md — how to use \ and gating strategy\n- Updated: docs/benchmark/README.md links to environment setup\n\nThese additions help external contributors reproduce benchmarks and understand our current CI policy.