### PR TITLE
feat(mcp-verify): T2 unknown-first arg validation with Zod

### DIFF
--- a/src/mcp-server/schemas.ts
+++ b/src/mcp-server/schemas.ts
@@ -60,3 +60,75 @@ export function parseOrThrow<T extends z.ZodTypeAny>(schema: T, input: unknown):
   return res.data;
 }
 
+// ---------- Test Generation MCP Schemas ----------
+export const TestFrameworkEnum = z.enum(['vitest', 'jest', 'mocha']);
+
+export const GenerateFromRequirementsArgsSchema = z.object({
+  feature: z.string().min(1),
+  requirements: z.array(z.string()).optional().default([]),
+  testFramework: TestFrameworkEnum.optional().default('vitest'),
+});
+export type GenerateFromRequirementsArgs = z.infer<typeof GenerateFromRequirementsArgsSchema>;
+
+export const GenerateFromCodeArgsSchema = z.object({
+  codeFile: z.string().min(1),
+});
+export type GenerateFromCodeArgs = z.infer<typeof GenerateFromCodeArgsSchema>;
+
+const InputParamSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1),
+  constraints: z.array(z.string()).optional().default([]),
+});
+
+export const PropertyTestsArgsSchema = z.object({
+  functionName: z.string().min(1),
+  inputs: z.array(InputParamSchema).min(1),
+  outputs: z
+    .object({ type: z.string().min(1) })
+    .optional()
+    .default({ type: 'any' }),
+  invariants: z.array(z.string()).min(1),
+});
+export type PropertyTestsArgs = z.infer<typeof PropertyTestsArgsSchema>;
+
+export const BDDArgsSchema = z.object({
+  title: z.string().min(1),
+  asA: z.string().min(1),
+  iWant: z.string().min(1),
+  soThat: z.string().min(1),
+  acceptanceCriteria: z.array(z.string()).optional().default([]),
+});
+export type BDDArgs = z.infer<typeof BDDArgsSchema>;
+
+const AnyObj = z.object({}).passthrough();
+
+export const PlanIntegrationArgsSchema = z.object({
+  services: z.array(z.union([AnyObj, z.string()])).min(1),
+  dataFlow: z.array(AnyObj).optional().default([]),
+});
+export type PlanIntegrationArgs = z.infer<typeof PlanIntegrationArgsSchema>;
+
+export const SecurityTestsArgsSchema = z.object({
+  endpoint: z.object({
+    method: z.string().min(1),
+    path: z.string().min(1),
+  }),
+});
+export type SecurityTestsArgs = z.infer<typeof SecurityTestsArgsSchema>;
+
+export const PerformanceSLAInput = z.object({
+  responseTime: z.number().optional(),
+  throughput: z.number().optional(),
+  concurrentUsers: z.number().optional(),
+  availability: z.number().optional(),
+});
+export const DesignPerformanceArgsSchema = z.object({
+  sla: PerformanceSLAInput,
+});
+export type DesignPerformanceArgs = z.infer<typeof DesignPerformanceArgsSchema>;
+
+export const AnalyzeCoverageArgsSchema = z.object({
+  projectPath: z.string().optional().default('.'),
+});
+export type AnalyzeCoverageArgs = z.infer<typeof AnalyzeCoverageArgsSchema>;

--- a/src/mcp-server/schemas.ts
+++ b/src/mcp-server/schemas.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+export const VerificationTypeEnum = z.enum([
+  'tests',
+  'coverage',
+  'linting',
+  'typechecking',
+  'security',
+  'performance',
+  'accessibility',
+  'contracts',
+  'specifications',
+  'mutations',
+]);
+
+export const FullVerificationArgsSchema = z.object({
+  projectPath: z.string().min(1, 'projectPath is required'),
+  verificationTypes: z.array(VerificationTypeEnum).min(1, 'at least one verification type required'),
+  strictMode: z.boolean().optional().default(false),
+});
+export type FullVerificationArgs = z.infer<typeof FullVerificationArgsSchema>;
+
+export const TestTypeEnum = z.enum(['unit', 'integration', 'e2e', 'property', 'contract']);
+export const RunTestsArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  testTypes: z.array(TestTypeEnum).optional().default(['unit', 'integration', 'e2e']),
+});
+export type RunTestsArgs = z.infer<typeof RunTestsArgsSchema>;
+
+export const CoverageArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  threshold: z.number().optional().default(80),
+});
+export type CoverageArgs = z.infer<typeof CoverageArgsSchema>;
+
+export const LintingArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  fix: z.boolean().optional().default(false),
+});
+export type LintingArgs = z.infer<typeof LintingArgsSchema>;
+
+export const TypeCheckingArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  strict: z.boolean().optional().default(true),
+});
+export type TypeCheckingArgs = z.infer<typeof TypeCheckingArgsSchema>;
+
+export const SecurityScanArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  includeDevDeps: z.boolean().optional().default(true),
+});
+export type SecurityScanArgs = z.infer<typeof SecurityScanArgsSchema>;
+
+export function parseOrThrow<T extends z.ZodTypeAny>(schema: T, input: unknown): z.infer<T> {
+  const res = schema.safeParse(input);
+  if (!res.success) {
+    const msg = res.error.issues.map(i => `${i.path.join('.') || '(root)'}: ${i.message}`).join('; ');
+    throw new Error(`Invalid arguments: ${msg}`);
+  }
+  return res.data;
+}
+

--- a/src/mcp-server/verify-server.ts
+++ b/src/mcp-server/verify-server.ts
@@ -10,6 +10,21 @@ import {
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { VerifyAgent, VerificationRequest, VerificationType } from '../agents/verify-agent.js';
+import {
+  CoverageArgsSchema,
+  FullVerificationArgsSchema,
+  LintingArgsSchema,
+  RunTestsArgsSchema,
+  SecurityScanArgsSchema,
+  TypeCheckingArgsSchema,
+  parseOrThrow,
+  type CoverageArgs,
+  type FullVerificationArgs,
+  type LintingArgs,
+  type RunTestsArgs,
+  type SecurityScanArgs,
+  type TypeCheckingArgs,
+} from './schemas.js';
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
 import * as path from 'path';
 
@@ -356,8 +371,8 @@ export class VerifyMCPServer {
     });
   }
 
-  private async handleFullVerification(args: any) {
-    const { projectPath, verificationTypes, strictMode = false } = args;
+  private async handleFullVerification(args: unknown) {
+    const { projectPath, verificationTypes, strictMode }: FullVerificationArgs = parseOrThrow(FullVerificationArgsSchema, args);
     const request = await this.buildVerificationRequest(projectPath, verificationTypes);
     request.strictMode = strictMode;
     
@@ -373,8 +388,8 @@ export class VerifyMCPServer {
     };
   }
 
-  private async handleRunTests(args: any) {
-    const { projectPath, testTypes = ['unit', 'integration', 'e2e'] } = args;
+  private async handleRunTests(args: unknown) {
+    const { projectPath, testTypes }: RunTestsArgs = parseOrThrow(RunTestsArgsSchema, args);
     const request = await this.buildVerificationRequest(projectPath, ['tests']);
     
     // Filter test files by type
@@ -392,8 +407,8 @@ export class VerifyMCPServer {
     };
   }
 
-  private async handleCheckCoverage(args: any) {
-    const { projectPath, threshold = 80 } = args;
+  private async handleCheckCoverage(args: unknown) {
+    const { projectPath, threshold }: CoverageArgs = parseOrThrow(CoverageArgsSchema, args);
     const request = await this.buildVerificationRequest(projectPath, ['coverage']);
     
     const result = await this.verifyAgent.checkCoverage(request);
@@ -409,8 +424,8 @@ export class VerifyMCPServer {
     };
   }
 
-  private async handleRunLinting(args: any) {
-    const { projectPath, fix = false } = args;
+  private async handleRunLinting(args: unknown) {
+    const { projectPath, fix }: LintingArgs = parseOrThrow(LintingArgsSchema, args);
     const request = await this.buildVerificationRequest(projectPath, ['linting']);
     
     const result = await this.verifyAgent.runLinting(request);
@@ -426,8 +441,8 @@ export class VerifyMCPServer {
     };
   }
 
-  private async handleRunTypeChecking(args: any) {
-    const { projectPath, strict = true } = args;
+  private async handleRunTypeChecking(args: unknown) {
+    const { projectPath, strict }: TypeCheckingArgs = parseOrThrow(TypeCheckingArgsSchema, args);
     const request = await this.buildVerificationRequest(projectPath, ['typechecking']);
     
     const result = await this.verifyAgent.runTypeChecking(request);
@@ -443,8 +458,8 @@ export class VerifyMCPServer {
     };
   }
 
-  private async handleRunSecurityScan(args: any) {
-    const { projectPath, includeDevDeps = true } = args;
+  private async handleRunSecurityScan(args: unknown) {
+    const { projectPath, includeDevDeps }: SecurityScanArgs = parseOrThrow(SecurityScanArgsSchema, args);
     const request = await this.buildVerificationRequest(projectPath, ['security']);
     
     const result = await this.verifyAgent.runSecurityChecks(request);


### PR DESCRIPTION
Implements part of #238 (Type Safety).\n\n- Add  with Zod schemas for Verify MCP tool inputs\n- Change handlers to  and parse via schemas (unknown-first)\n- Keep behavior: defaults via schema ; on invalid args, return error with details\n\nScope: focused on Verify MCP server (incremental). Next steps: extend schemas to other MCP servers and key boundaries (CLI/env).