### PR TITLE
feat(mcp): T2 unknown-first validation (TDD + Container)

### DIFF
--- a/src/mcp-server/container-server.ts
+++ b/src/mcp-server/container-server.ts
@@ -11,6 +11,21 @@ import {
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { ContainerAgent, ContainerAgentConfig } from '../agents/container-agent.js';
+import {
+  BuildVerificationImageArgsSchema,
+  CancelJobArgsSchema,
+  CleanupArgsSchema,
+  GetJobStatusArgsSchema,
+  ListJobsArgsSchema,
+  RunContainerVerificationArgsSchema,
+  parseOrThrow,
+  type BuildVerificationImageArgs,
+  type CancelJobArgs,
+  type CleanupArgs,
+  type GetJobStatusArgs,
+  type ListJobsArgs,
+  type RunContainerVerificationArgs,
+} from './schemas.js';
 
 export class ContainerServer {
   private server: Server;
@@ -253,7 +268,8 @@ export class ContainerServer {
           }
 
           case 'run_container_verification': {
-            const result = await this.agent.runVerification(args as any);
+            const parsed: RunContainerVerificationArgs = parseOrThrow(RunContainerVerificationArgsSchema, args);
+            const result = await this.agent.runVerification(parsed as any);
             return {
               content: [
                 {
@@ -265,7 +281,8 @@ export class ContainerServer {
           }
 
           case 'build_verification_image': {
-            const result = await this.agent.buildVerificationImage(args as any);
+            const parsed: BuildVerificationImageArgs = parseOrThrow(BuildVerificationImageArgsSchema, args);
+            const result = await this.agent.buildVerificationImage(parsed as any);
             return {
               content: [
                 {
@@ -277,7 +294,7 @@ export class ContainerServer {
           }
 
           case 'get_verification_job_status': {
-            const { jobId } = args as any;
+            const { jobId }: GetJobStatusArgs = parseOrThrow(GetJobStatusArgsSchema, args);
             const result = await this.agent.getJobStatus(jobId);
             return {
               content: [
@@ -290,7 +307,8 @@ export class ContainerServer {
           }
 
           case 'list_verification_jobs': {
-            const result = await this.agent.listJobs(args as any);
+            const parsed: ListJobsArgs = parseOrThrow(ListJobsArgsSchema, args);
+            const result = await this.agent.listJobs(parsed as any);
             return {
               content: [
                 {
@@ -302,7 +320,7 @@ export class ContainerServer {
           }
 
           case 'cancel_verification_job': {
-            const { jobId } = args as any;
+            const { jobId }: CancelJobArgs = parseOrThrow(CancelJobArgsSchema, args);
             const result = await this.agent.cancelJob(jobId);
             return {
               content: [
@@ -327,7 +345,8 @@ export class ContainerServer {
           }
 
           case 'cleanup_container_resources': {
-            const result = await this.agent.cleanup(args as any);
+            const parsed: CleanupArgs = parseOrThrow(CleanupArgsSchema, args);
+            const result = await this.agent.cleanup(parsed as any);
             return {
               content: [
                 {

--- a/src/mcp-server/schemas.ts
+++ b/src/mcp-server/schemas.ts
@@ -132,3 +132,76 @@ export const AnalyzeCoverageArgsSchema = z.object({
   projectPath: z.string().optional().default('.'),
 });
 export type AnalyzeCoverageArgs = z.infer<typeof AnalyzeCoverageArgsSchema>;
+
+// ---------- Container MCP Schemas ----------
+export const LanguageEnum = z.enum(['rust', 'elixir', 'multi']);
+
+export const RunContainerVerificationArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  language: LanguageEnum,
+  tools: z.array(z.string()).min(1),
+  jobName: z.string().optional(),
+  timeout: z.number().optional(),
+  buildImages: z.boolean().optional().default(false),
+  environment: z.record(z.string()).optional().default({}),
+});
+export type RunContainerVerificationArgs = z.infer<typeof RunContainerVerificationArgsSchema>;
+
+export const BuildVerificationImageArgsSchema = z.object({
+  language: LanguageEnum,
+  tools: z.array(z.string()).min(1),
+  baseImage: z.string().optional(),
+  tag: z.string().optional(),
+  push: z.boolean().optional().default(false),
+  buildArgs: z.record(z.string()).optional().default({}),
+});
+export type BuildVerificationImageArgs = z.infer<typeof BuildVerificationImageArgsSchema>;
+
+export const GetJobStatusArgsSchema = z.object({ jobId: z.string().min(1) });
+export type GetJobStatusArgs = z.infer<typeof GetJobStatusArgsSchema>;
+
+export const ListJobsArgsSchema = z.object({
+  status: z.enum(['pending', 'running', 'completed', 'failed']).optional(),
+  language: LanguageEnum.optional(),
+});
+export type ListJobsArgs = z.infer<typeof ListJobsArgsSchema>;
+
+export const CancelJobArgsSchema = z.object({ jobId: z.string().min(1) });
+export type CancelJobArgs = z.infer<typeof CancelJobArgsSchema>;
+
+export const CleanupArgsSchema = z.object({
+  maxAge: z.number().optional().default(3600),
+  keepCompleted: z.number().optional().default(10),
+  force: z.boolean().optional().default(false),
+});
+export type CleanupArgs = z.infer<typeof CleanupArgsSchema>;
+
+// ---------- TDD MCP Schemas ----------
+export const AnalyzeTDDArgsSchema = z.object({
+  path: z.string().optional().default(process.cwd()),
+  phase: z.string().optional(),
+});
+export type AnalyzeTDDArgs = z.infer<typeof AnalyzeTDDArgsSchema>;
+
+export const GuideTDDArgsSchema = z.object({
+  feature: z.string().min(1),
+  currentStep: z.string().optional(),
+});
+export type GuideTDDArgs = z.infer<typeof GuideTDDArgsSchema>;
+
+export const ValidateTestFirstArgsSchema = z.object({
+  sourceFiles: z.array(z.string()).optional().default([]),
+});
+export type ValidateTestFirstArgs = z.infer<typeof ValidateTestFirstArgsSchema>;
+
+export const RedGreenCycleArgsSchema = z.object({
+  testCommand: z.string().optional().default('npm test'),
+  expectRed: z.boolean().optional().default(false),
+});
+export type RedGreenCycleArgs = z.infer<typeof RedGreenCycleArgsSchema>;
+
+export const SuggestTestStructureArgsSchema = z.object({
+  codeFile: z.string().min(1),
+  framework: z.string().optional().default('vitest'),
+});
+export type SuggestTestStructureArgs = z.infer<typeof SuggestTestStructureArgsSchema>;


### PR DESCRIPTION
Continues #238 Type Safety work.\n\n- Add schemas to  for TDD and Container MCP tool args\n- Switch handlers in  and  to  and parse via Zod\n- Preserve defaults at schema-level; structured errors on invalid inputs\n\nThis follows the previously merged Verify/TestGen changes and expands unknown-first validation across more MCP servers.