### PR TITLE
ci(quality): add Types Gate (types:check + type tests)

### DIFF
--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -23,6 +23,11 @@ jobs:
     with:
       node-version: '20'
       run-script: test:int
+  types:
+    uses: ./.github/workflows/common/ci-core.yml
+    with:
+      node-version: '20'
+      run-script: types:check
   a11y:
     uses: ./.github/workflows/common/ci-core.yml
     with:
@@ -33,3 +38,8 @@ jobs:
     with:
       node-version: '20'
       run-script: test:coverage
+  types-tests:
+    uses: ./.github/workflows/common/ci-core.yml
+    with:
+      node-version: '20'
+      run-script: test:types


### PR DESCRIPTION
Implements #238 T1 groundwork by adding a Types Gate to CI.\n\n- Add  job running  (tsc with tsconfig.verify)\n- Add  job running  (tsd)\n- Respects existing path filters to avoid docs-only runs\n\nThis keeps failures visible early without changing lint severities yet (soft landing).