### PR TITLE
T1: escalate unsafe TS rules (MCP) + add type-coverage job

### DIFF
--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -38,6 +38,11 @@ jobs:
     with:
       node-version: '20'
       run-script: test:coverage
+  type-coverage:
+    uses: ./.github/workflows/common/ci-core.yml
+    with:
+      node-version: '20'
+      run-script: typecov
   types-tests:
     uses: ./.github/workflows/common/ci-core.yml
     with:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,5 +52,27 @@ export default ts.config(
       '@typescript-eslint/no-unsafe-member-access': 'error',
       '@typescript-eslint/no-unsafe-return': 'error',
     }
+  },
+  // T1 escalation (targeted): strengthen unsafe rules for MCP servers
+  {
+    files: [
+      'src/mcp-server/**/*.ts',
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.verify.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Keep no-explicit-any as warn for now (soft landing),
+      // but escalate unsafe operations to error in MCP boundaries
+      '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
+      '@typescript-eslint/no-unsafe-return': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+    }
   }
 );


### PR DESCRIPTION
Part of #238 T1.\n\n- ESLint: For , escalate  and promise rules to error (keep  at warn for soft landing).\n- CI: Add  job (runs ) to centralized quality gates, non-blocking for now.\n\nRationale: tighten I/O boundary safety where schemas are in place, and surface overall type coverage to guide next steps.