### PR TITLE
T1: reduce explicit any in MCP (verify/codegen/container)

### DIFF
--- a/src/mcp-server/code-generation-server.ts
+++ b/src/mcp-server/code-generation-server.ts
@@ -224,7 +224,22 @@ export class CodeGenerationServer {
     });
   }
 
-  private async validateCodeAgainstTests(codeFiles: any[], testFiles: any[]): Promise<any> {
+  private async validateCodeAgainstTests(
+    codeFiles: { path: string; content: string }[],
+    testFiles: { path: string; content: string }[],
+  ): Promise<{
+    testResults: { file: string; status: 'pending' | 'passed' | 'failed'; coverage: number }[];
+    coverage: {
+      percentage: number;
+      details: {
+        lines: { covered: number; total: number };
+        functions: { covered: number; total: number };
+        branches: { covered: number; total: number };
+      }
+    };
+    suggestions: string[];
+    passing: boolean;
+  }> {
     // Basic validation implementation
     console.log(`Validating ${codeFiles.length} code files against ${testFiles.length} test files`);
     

--- a/src/mcp-server/container-server.ts
+++ b/src/mcp-server/container-server.ts
@@ -384,15 +384,15 @@ export class ContainerServer {
           default:
             throw new Error(`Unknown tool: ${name}`);
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         return {
           content: [
             {
               type: 'text',
               text: JSON.stringify({
                 success: false,
-                message: `Tool execution failed: ${error.message}`,
-                error: error.message,
+                message: `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`,
+                error: error instanceof Error ? error.message : String(error),
                 tool: name,
                 args,
               }, null, 2),

--- a/src/mcp-server/schemas.ts
+++ b/src/mcp-server/schemas.ts
@@ -51,6 +51,49 @@ export const SecurityScanArgsSchema = z.object({
 });
 export type SecurityScanArgs = z.infer<typeof SecurityScanArgsSchema>;
 
+// Additional Verify MCP schemas
+export const PerformanceTestsArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  duration: z.number().optional().default(30),
+});
+export type PerformanceTestsArgs = z.infer<typeof PerformanceTestsArgsSchema>;
+
+export const AccessibilityArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  standards: z.array(z.string()).optional().default(['WCAG2.1']),
+});
+export type AccessibilityArgs = z.infer<typeof AccessibilityArgsSchema>;
+
+export const VerifyContractsArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  contractPath: z.string().optional(),
+});
+export type VerifyContractsArgs = z.infer<typeof VerifyContractsArgsSchema>;
+
+export const VerifySpecificationsArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  specPaths: z.array(z.string()).optional().default([]),
+});
+export type VerifySpecificationsArgs = z.infer<typeof VerifySpecificationsArgsSchema>;
+
+export const MutationTestsArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  threshold: z.number().optional().default(80),
+});
+export type MutationTestsArgs = z.infer<typeof MutationTestsArgsSchema>;
+
+export const TraceabilityArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  outputFormat: z.enum(['json','html','csv']).optional().default('json'),
+});
+export type TraceabilityArgs = z.infer<typeof TraceabilityArgsSchema>;
+
+export const GetQualityMetricsArgsSchema = z.object({
+  projectPath: z.string().min(1),
+  includeHistory: z.boolean().optional().default(false),
+});
+export type GetQualityMetricsArgs = z.infer<typeof GetQualityMetricsArgsSchema>;
+
 export function parseOrThrow<T extends z.ZodTypeAny>(schema: T, input: unknown): z.infer<T> {
   const res = schema.safeParse(input);
   if (!res.success) {


### PR DESCRIPTION
Part of #238 T1.\n\n- Verify MCP: add schemas for perf/accessibility/contracts/specs/mutations/traceability/metrics; switch handlers to unknown-first\n- Verify MCP: type traceability formatters (HTML/CSV) to remove any\n- CodeGen MCP: type validateCodeAgainstTests inputs/outputs (remove any)\n- Container MCP: use unknown in catch and safe error stringification\n\nPrepares for future escalation of  in targeted files.