### PR TITLE
T1: enforce no-explicit-any (verify+codegen) and remove residual any

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -75,4 +75,21 @@ export default ts.config(
       '@typescript-eslint/no-misused-promises': 'error',
     }
   }
+  },
+  // T1 escalation (file-specific): enforce no-explicit-any in cleaned files
+  {
+    files: [
+      'src/mcp-server/verify-server.ts',
+      'src/mcp-server/code-generation-server.ts',
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.verify.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    }
+  }
 );

--- a/src/mcp-server/code-generation-server.ts
+++ b/src/mcp-server/code-generation-server.ts
@@ -157,7 +157,7 @@ export class CodeGenerationServer {
         switch (request.params.name) {
           case 'generate_code_from_tests': {
             const parsed: GenerateCodeFromTestsArgs = parseOrThrow(GenerateCodeFromTestsArgsSchema, request.params.arguments);
-            const result = await this.agent.generateCodeFromTests(parsed as any);
+            const result = await this.agent.generateCodeFromTests(parsed as unknown as import('../agents/code-generation-agent.js').CodeGenerationRequest);
             return {
               content: [
                 {
@@ -193,7 +193,7 @@ export class CodeGenerationServer {
 
           case 'validate_code_against_tests': {
             const args: ValidateCodeAgainstTestsArgs = parseOrThrow(ValidateCodeAgainstTestsArgsSchema, request.params.arguments);
-            const results = await this.validateCodeAgainstTests(args.codeFiles as any[], args.testFiles as any[]);
+            const results = await this.validateCodeAgainstTests(args.codeFiles, args.testFiles);
             return {
               content: [
                 {

--- a/src/mcp-server/spec-synthesis-server.ts
+++ b/src/mcp-server/spec-synthesis-server.ts
@@ -93,7 +93,8 @@ async function start() {
       const { AEIR } = await import('../..//packages/spec-compiler/src/types.js');
       const { readFileSync } = await import('fs');
       const irPath = resolve(args.irPath);
-      const ir = JSON.parse(readFileSync(irPath, 'utf-8')) as any;
+      type IRLike = { domain?: unknown[]; api?: unknown[] };
+      const ir = JSON.parse(readFileSync(irPath, 'utf-8')) as unknown as IRLike;
       const { spawnSync } = await import('child_process');
       const outBase = args.outDir || 'generated';
       const run = (t: string, dir: string) => spawnSync(process.execPath, ['dist/src/cli/index.js','codegen','generate','-i', irPath, '-o', resolve(dir), '-t', t], { stdio: 'inherit' });
@@ -119,4 +120,3 @@ start().catch(err => {
   console.error('[mcp-spec] fatal:', err);
   process.exit(1);
 });
-

--- a/src/mcp-server/test-generation-server.ts
+++ b/src/mcp-server/test-generation-server.ts
@@ -501,7 +501,19 @@ class TestGenerationServer {
     };
   }
 
-  private formatTestGenerationResult(result: any): string {
+  private formatTestGenerationResult(result: {
+    testFile: string;
+    testCases: { name: string; type: string; priority: string; description: string }[];
+    coverage: {
+      functional: unknown[];
+      edgeCases: unknown[];
+      errorHandling: unknown[];
+      performance: unknown[];
+      security: unknown[];
+    };
+    recommendations: string[];
+    testContent: string;
+  }): string {
     let response = `# Generated Tests\n\n`;
     response += `**Test File**: ${result.testFile}\n\n`;
     

--- a/src/mcp-server/verify-server.ts
+++ b/src/mcp-server/verify-server.ts
@@ -489,7 +489,7 @@ export class VerifyMCPServer {
     };
   }
 
-  private async handleRunPerformanceTests(args: any) {
+  private async handleRunPerformanceTests(args: unknown) {
     const { projectPath, duration }: PerformanceTestsArgs = parseOrThrow(PerformanceTestsArgsSchema, args);
     const request = await this.buildVerificationRequest(projectPath, ['performance']);
     


### PR DESCRIPTION
- ESLint: add file-specific override to enforce no-explicit-any=error for verify-server.ts and code-generation-server.ts\n- Verify MCP: switch remaining handlers to unknown + schemas; type traceability formatters\n- CodeGen MCP: remove any from generate/validate paths\n- Spec Synthesis: replace JSON parse cast with IR-like typed alias\n- TestGen: type format result signature (no any)\n\nAdvances #238 T1 by cleaning residual any and enforcing at MCP hotspots.