### PR TITLE
T1: reduce any in core/infra/api (db/telemetry/api server)

### DIFF
--- a/src/api/fastify-augment.d.ts
+++ b/src/api/fastify-augment.d.ts
@@ -1,0 +1,10 @@
+import 'fastify';
+import type { Span } from '@opentelemetry/api';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    span?: Span;
+    startTime?: number;
+  }
+}
+

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -36,8 +36,8 @@ export async function createServer(): Promise<FastifyInstance> {
       },
     });
     
-    (request as any).span = span;
-    (request as any).startTime = Date.now();
+    request.span = span;
+    request.startTime = Date.now();
     enhancedTelemetry.recordCounter('api.requests.total', 1, {
       method: request.method,
       endpoint: request.url,
@@ -46,11 +46,11 @@ export async function createServer(): Promise<FastifyInstance> {
 
   // Add response timing hook
   app.addHook('onResponse', async (request, reply) => {
-    const span = (request as any).span;
+    const span = request.span;
     if (span) {
       span.setAttributes({
         'http.status_code': reply.statusCode,
-        [TELEMETRY_ATTRIBUTES.DURATION_MS]: Date.now() - (request as any).startTime || 0,
+        [TELEMETRY_ATTRIBUTES.DURATION_MS]: Date.now() - (request.startTime || 0),
       });
       
       if (reply.statusCode >= 400) {
@@ -108,7 +108,7 @@ export async function createServer(): Promise<FastifyInstance> {
       return reply.code(200).send(healthData);
     } catch (error) {
       timer.end({ endpoint: '/health', result: 'error' });
-      const span = (req as any).span;
+      const span = req.span;
       if (span) {
         span.recordException(error as Error);
       }
@@ -155,7 +155,7 @@ export async function createServer(): Promise<FastifyInstance> {
         runtimeGuard.recordBusinessRuleViolation(
           'max_quantity_limit',
           `Quantity ${quantity} exceeds maximum allowed (100)`,
-          'medium' as any,
+          'medium' as const,
           { orderId, itemId, quantity }
         );
         
@@ -200,7 +200,7 @@ export async function createServer(): Promise<FastifyInstance> {
       return reply.code(201).send(responseData);
     } catch (error) {
       timer.end({ endpoint: '/reservations', result: 'error' });
-      const span = (req as any).span;
+      const span = req.span;
       if (span) {
         span.recordException(error as Error);
       }
@@ -218,7 +218,7 @@ export async function createServer(): Promise<FastifyInstance> {
         timestamp: new Date().toISOString(),
       });
     } catch (error) {
-      const span = (req as any).span;
+      const span = req.span;
       if (span) {
         span.recordException(error as Error);
       }

--- a/src/infra/db.ts
+++ b/src/infra/db.ts
@@ -14,7 +14,7 @@ export class Database {
     });
   }
 
-  async query(text: string, params?: any[]) {
+  async query(text: string, params?: ReadonlyArray<unknown>) {
     const client = await this.pool.connect();
     try {
       return await client.query(text, params);

--- a/src/infra/telemetry.ts
+++ b/src/infra/telemetry.ts
@@ -26,7 +26,7 @@ export function initTelemetry(serviceName: string = 'inventory-api') {
     metricReader: new PeriodicExportingMetricReader({
       exporter: metricExporter,
       exportIntervalMillis: 10000,
-    }) as any,
+    }),
     instrumentations: [
       getNodeAutoInstrumentations({
         '@opentelemetry/instrumentation-fs': {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
       "@ae-framework/spec-compiler/*": ["./packages/spec-compiler/dist/*"]
     }
   },
-  "include": ["src/**/*.ts", "types/**/*.d.ts", "packages/**/*"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "types/**/*.d.ts", "packages/**/*"],
   "exclude": [
     "node_modules", 
     "dist", 


### PR DESCRIPTION
Part of #238 T1 outside MCP.\n\n- src/infra/db.ts: params typed as ReadonlyArray<unknown> (drop any[])\n- src/infra/telemetry.ts: remove unnecessary any cast for metricReader\n- src/api/server.ts: add Fastify request span/startTime types and replace (req as any) with typed fields; use 'medium' as const\n- src/api/fastify-augment.d.ts: FastifyRequest augmentation (Span/startTime)\n- tsconfig.json: include src/**/*.d.ts for declaration merging\n\nSafe, localized changes improving type safety without behavior changes.