### PR TITLE
T1: reduce any in Req2Run types

### DIFF
--- a/src/benchmark/req2run/types/index.ts
+++ b/src/benchmark/req2run/types/index.ts
@@ -12,7 +12,7 @@ export interface RequirementSpec {
   requirements: string[];
   constraints: {
     business?: string[];
-    performance?: any;
+    performance?: unknown;
   };
   testCriteria: TestCriteria[];
   expectedOutput: ExpectedOutput;
@@ -111,8 +111,8 @@ export interface PhaseExecution {
   startTime: Date;
   endTime: Date;
   duration: number;
-  input: any;
-  output: any;
+  input: unknown;
+  output: unknown;
   success: boolean;
   errors?: string[];
 }
@@ -144,8 +144,8 @@ export interface TestCriteria {
 export interface ExpectedOutput {
   type: OutputType;
   format: string;
-  schema?: any;
-  examples: any[];
+  schema?: unknown;
+  examples: unknown[];
 }
 
 export enum BenchmarkCategory {
@@ -301,7 +301,7 @@ export enum ReportFormat {
 
 export interface ReportDestination {
   type: 'file' | 'github' | 'slack' | 'email' | 'webhook';
-  config: any;
+  config: Record<string, unknown>;
 }
 
 export interface DashboardConfig {
@@ -341,7 +341,7 @@ export interface ExecutionLog {
   level: 'debug' | 'info' | 'warn' | 'error';
   phase?: string;
   message: string;
-  context?: any;
+  context?: Record<string, unknown>;
 }
 
 export interface DocumentationArtifact {


### PR DESCRIPTION
Part of #238 T1.\n\n- src/benchmark/req2run/types/index.ts:\n  - constraints.performance: unknown\n  - PhaseExecution.input/output: unknown\n  - ExpectedOutput.schema/examples: unknown/unknown[]\n  - ReportDestination.config: Record<string, unknown>\n  - ExecutionLog.context: Record<string, unknown>\n\nFlexible yet safe types to eliminate explicit any without constraining data shapes.