### PR TITLE
ci(typecov): add label-gated threshold check (60%)

### DIFF
--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -78,6 +78,12 @@ jobs:
               issue_number: context.issue.number,
               body
             });
+  type-coverage-threshold:
+    if: github.event_name == 'pull_request' && contains(join(fromJSON(toJSON(github.event.pull_request.labels)).*.name, ','), 'enforce-typecov')
+    uses: ./.github/workflows/common/ci-core.yml
+    with:
+      node-version: '20'
+      run-script: typecov:check
   types-tests:
     uses: ./.github/workflows/common/ci-core.yml
     with:

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:phase3.2:core": "vitest run tests/testing/playwright-integration.test.ts tests/testing/visual-regression.test.ts",
     "test:types": "tsd --files types/**/*.test-d.ts",
     "typecov": "type-coverage -p tsconfig.verify.json --ignore-catch",
+    "typecov:check": "type-coverage -p tsconfig.verify.json --ignore-catch --threshold 60",
     "coverage": "vitest run --coverage",
     "bdd": "cucumber-js",
     "pbt": "vitest run -c tests/property/vitest.config.ts",


### PR DESCRIPTION
Add a label-gated type coverage threshold check (60%) to the quality gates workflow.\n- Use label  on PRs to enable gating\n- Always comment coverage percentage (existing job)\n- Adds script  to package.json\n\nThis implements a non-disruptive step toward T4; we can later make it required or increase the threshold.