### PR TITLE
T1: stricter report types + typed gate thresholds

### DIFF
--- a/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
+++ b/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
@@ -851,7 +851,7 @@ Generated on: ${new Date().toISOString()}
     byCategory: Array<{ category: string; successRate: number; avgScore: number; avgTime: number }>;
     topPerformers: Array<{ problemId: string; score: number; time: number }>;
     worstPerformers: Array<{ problemId: string; score: number; time: number }>;
-    results: Array<{ problemId: string; success: boolean; score: number; time: number; phases: any[]; errors: string[] }>;
+    results: Array<{ problemId: string; success: boolean; score: number; time: number; phases: PhaseSummary[]; errors: string[] }>;
   }): string {
     return `# Standardized AE Framework Benchmark Report
 

--- a/src/quality/quality-gate-runner.ts
+++ b/src/quality/quality-gate-runner.ts
@@ -9,6 +9,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { QualityPolicyLoader, QualityGateResult, QualityReport, QualityGate } from './policy-loader.js';
 
+type CoverageThreshold = { lines?: number; functions?: number; branches?: number; statements?: number };
+type LintThreshold = { maxErrors?: number; maxWarnings?: number };
+type SecurityThreshold = { maxCritical?: number; maxHigh?: number; maxMedium?: number };
+type PerfThreshold = Record<string, number | undefined>;
+type A11yThreshold = Record<string, number | undefined>;
+
 // Mock telemetry for main branch compatibility
 type Attributes = Record<string, unknown>;
 const mockTelemetry = {
@@ -392,19 +398,19 @@ export class QualityGateRunner {
     // Parse based on gate category
     switch (gate.category) {
       case 'testing':
-        return this.parseCoverageResult(baseResult, result, threshold);
+        return this.parseCoverageResult(baseResult, result, threshold as CoverageThreshold);
       
       case 'code-quality':
-        return this.parseLintingResult(baseResult, result, threshold);
+        return this.parseLintingResult(baseResult, result, threshold as LintThreshold);
       
       case 'security':
-        return this.parseSecurityResult(baseResult, result, threshold);
+        return this.parseSecurityResult(baseResult, result, threshold as SecurityThreshold);
       
       case 'performance':
-        return this.parsePerformanceResult(baseResult, result, threshold);
+        return this.parsePerformanceResult(baseResult, result, threshold as PerfThreshold);
       
       case 'frontend':
-        return this.parseAccessibilityResult(baseResult, result, threshold);
+        return this.parseAccessibilityResult(baseResult, result, threshold as A11yThreshold);
       
       default:
         // Generic parsing


### PR DESCRIPTION
- Standardized runner: use PhaseSummary[] in enhanced report results\n- quality-gate-runner: add threshold type aliases and cast before category parsers\n\nIncremental type tightening without behavior changes.