### PR TITLE
T1: MinimalSpec for runner + typecov 65% (label-gated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:phase3.2:core": "vitest run tests/testing/playwright-integration.test.ts tests/testing/visual-regression.test.ts",
     "test:types": "tsd --files types/**/*.test-d.ts",
     "typecov": "type-coverage -p tsconfig.verify.json --ignore-catch",
-    "typecov:check": "type-coverage -p tsconfig.verify.json --ignore-catch --threshold 60",
+    "typecov:check": "type-coverage -p tsconfig.verify.json --ignore-catch --threshold 65",
     "coverage": "vitest run --coverage",
     "bdd": "cucumber-js",
     "pbt": "vitest run -c tests/property/vitest.config.ts",

--- a/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
+++ b/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
@@ -546,12 +546,12 @@ export class StandardizedBenchmarkRunner {
   }
 
   private extractConstraints(spec: unknown): Record<string, unknown> {
-    const s = spec as any;
+    const s = spec as MinimalSpec;
     return {
       technical: s.constraints?.allowed_packages || [],
       business: s.constraints?.disallowed_packages || [],
-      performance: s.requirements?.non_functional?.performance || {},
-      security: s.requirements?.non_functional?.security || {},
+      performance: (s.requirements?.non_functional as Record<string, unknown> | undefined)?.performance || {},
+      security: (s.requirements?.non_functional as Record<string, unknown> | undefined)?.security || {},
       platform: s.constraints?.platform || []
     };
   }


### PR DESCRIPTION
- StandardizedBenchmarkRunner: add MinimalSpec to replace internal  in normalize/build/extract paths\n- Replace NFR access with safe optional chaining and typed records\n- package.json: raise label-gated type coverage threshold to 65%\n\nNon-breaking tightening of types; coverage gating remains behind PR label.