### PR TITLE
docs(verify): Traceability guide + percentage summary

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -84,7 +84,14 @@ jobs:
               covered_tests=$(jq -r '.testsLinked' "$TRACE_JSON" 2>/dev/null || echo 0)
               covered_impl=$(jq -r '.implLinked' "$TRACE_JSON" 2>/dev/null || echo 0)
               covered_formal=$(jq -r '.formalLinked' "$TRACE_JSON" 2>/dev/null || echo 0)
-              echo "- Traceability: ${scenarios} scenarios; tests: ${covered_tests}; impl: ${covered_impl}; formal: ${covered_formal}"
+              pct() { if [ "$1" -gt 0 ]; then awk "BEGIN {printf \"%.0f\", ($2*100)/$1}"; else echo 0; fi; }
+              tests_pct=$(pct "$scenarios" "$covered_tests")
+              impl_pct=$(pct "$scenarios" "$covered_impl")
+              formal_pct=$(pct "$scenarios" "$covered_formal")
+              echo "- Traceability: ${scenarios} scenarios"
+              echo "  - Tests: ${covered_tests} (${tests_pct}%)"
+              echo "  - Impl: ${covered_impl} (${impl_pct}%)"
+              echo "  - Formal: ${covered_formal} (${formal_pct}%)"
               echo "\n<details><summary>Unlinked (top 5)</summary>"
               jq -r '.rows[] | select(.test=="N/A" or .impl=="N/A" or .formal=="N/A") | "- " + .scenario + " (id: " + .id + ") test:" + .test + " impl:" + .impl + " formal:" + .formal' "$TRACE_JSON" 2>/dev/null | head -5 || true
               echo "</details>"

--- a/docs/verify/TRACEABILITY-GUIDE.md
+++ b/docs/verify/TRACEABILITY-GUIDE.md
@@ -1,0 +1,89 @@
+## Traceability Guide: Linking Feature Scenarios → Tests/Implementation/Formal Specs
+
+This guide explains a lightweight convention to improve traceability across:
+
+- BDD Scenarios (.feature)
+- Tests (unit/integration)
+- Implementation (src/*)
+- Formal specs (TLA+ .tla / Alloy .als)
+
+The CI builds a traceability matrix (CSV + JSON) and posts a PR summary.
+
+### 1) Stable IDs and Tags in .feature
+
+Use either tags or a stable ID slug to give each Scenario a durable handle.
+
+```gherkin
+@checkout @happy
+Scenario: Checkout succeeds with in-stock items
+  Given cart has 3 in-stock items
+  When user pays with a valid card
+  Then the order is created and inventory is reduced
+```
+
+Recommendations:
+- Tags: start with feature-area and intent (e.g., `@checkout @happy`).
+- Slug ID (optional): use scenario title as a slug in downstream references (the CI builder already derives `id = slug(title)`).
+
+### 2) Tests: reference Scenario by name/id/tags
+
+In test files, add a short reference comment or string literal that includes the scenario title, slug, or tags.
+
+```ts
+// Scenario: checkout-succeeds-with-in-stock-items @checkout @happy
+describe('Checkout', () => {
+  it('checkout succeeds with in-stock items', async () => {
+    // ...
+  });
+});
+```
+
+Any of the following will link in CI:
+- `Scenario: <exact title>` string
+- The slug form (lowercase, non-alnum→`-`)
+- A tag present at the scenario line (e.g., `@checkout`)
+
+### 3) Implementation: minimal non-intrusive hints
+
+Add a single-line reference near the main entry points for the feature flow.
+
+```ts
+// Scenario: checkout-succeeds-with-in-stock-items @checkout
+export async function placeOrder(input: PlaceOrderInput) {
+  // ...
+}
+```
+
+For UI components, prefer referencing the scenario in Storybook stories or Playwright tests.
+
+### 4) Formal Specs: cross-reference key scenarios
+
+For TLA+ or Alloy, add a comment with the scenario slug or tag near the relevant property/predicate.
+
+TLA+ example:
+```tla
+\* Scenario: checkout-succeeds-with-in-stock-items @checkout
+THEOREM NoNegativeInventory == [] (Inventory >= 0)
+```
+
+Alloy example:
+```alloy
+// Scenario: checkout-succeeds-with-in-stock-items @checkout
+assert NoNegativeInventory { all it: Item | it.stock >= 0 }
+```
+
+### 5) CI behavior
+
+- The builder scans `.feature` files, extracts Scenario title, tags, and derives an `id` slug.
+- It searches tests/src/formal for any occurrence of title/id/tag and generates:
+  - `traceability.csv` for human eyeballing
+  - `traceability.json` with totals and per-scenario rows
+- PR summary shows total scenarios and how many link to tests/impl/formal.
+- The summary lists up to 5 unlinked scenarios for quick action.
+
+### 6) Tips
+
+- Keep references short and consistent. One line per major artifact is enough.
+- Use tags for grouping; use slug for exact mapping across languages.
+- Avoid overlinking: put references in the most representative file per flow.
+


### PR DESCRIPTION
- Add docs/verify/TRACEABILITY-GUIDE.md with conventions for linking Scenarios→Tests/Impl/Formal\n- Enhance PR summary to show percentages (tests/impl/formal) when traceability.json is present