### PR TITLE
feat(verify): TLC failure list + traceability hit types

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -109,6 +109,9 @@ jobs:
               total=$(jq '(.tlc.results | length) + 0' "$MODEL_FILE" 2>/dev/null || echo 0)
               if [ "$total" -gt 0 ]; then pct=$(awk "BEGIN {printf \"%.0f\", ($ok*100)/$total}"); else pct=0; fi
               echo "- Model Check (TLC): ${ok}/${total} (${pct}%) modules ok"
+              echo "\n<details><summary>Non-OK modules (top 5)</summary>"
+              jq -r '.tlc.results[] | select(.ok!=true) | "- " + .module + ( .log? // "" | " (log: " + . + ")" )' "$MODEL_FILE" 2>/dev/null | head -5 || true
+              echo "</details>"
             else
               echo "- Model Check: (no summary artifact)"
             fi

--- a/scripts/verify/build-traceability.mjs
+++ b/scripts/verify/build-traceability.mjs
@@ -61,10 +61,10 @@ async function firstMatch(files, needles) {
   for (const p of files) {
     const text = await readFileSafe(p);
     for (const n of needles) {
-      if (n && text.includes(n)) return path.relative(repoRoot, p);
+      if (n && text.includes(n)) return { file: path.relative(repoRoot, p), hit: n };
     }
   }
-  return 'N/A';
+  return { file: 'N/A', hit: '' };
 }
 
 async function main() {
@@ -86,10 +86,10 @@ async function main() {
     const test = await firstMatch(testFiles, needles);
     const impl = await firstMatch(implFiles, needles);
     const formal = await firstMatch(tlaFiles, needles);
-    if (test !== 'N/A') coveredTests++;
-    if (impl !== 'N/A') coveredImpl++;
-    if (formal !== 'N/A') coveredFormal++;
-    rows.push({ scenario: sc.name, id: sc.id, tags: (sc.tags || []).join(' '), test, impl, formal });
+    if (test.file !== 'N/A') coveredTests++;
+    if (impl.file !== 'N/A') coveredImpl++;
+    if (formal.file !== 'N/A') coveredFormal++;
+    rows.push({ scenario: sc.name, id: sc.id, tags: (sc.tags || []).join(' '), test: test.file, impl: impl.file, formal: formal.file, testHit: test.hit, implHit: impl.hit, formalHit: formal.hit });
   }
 
   const csvLines = ['Scenario,Id,Tags,Test,Implementation,Formal'];


### PR DESCRIPTION
- Post-summary now lists non-OK TLC modules (top 5) with log paths\n- Traceability builder records which key matched (title/id/tag) for test/impl/formal