### PR TITLE
ci(verify): optional contracts enforcement

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -173,3 +173,16 @@ jobs:
         with:
           name: contracts-exec
           path: artifacts/contracts/contracts-exec.json
+      - name: Enforce contracts (optional)
+        if: ${{ env.CONTRACTS_ENFORCE == '1' }}
+        run: |
+          FILE=artifacts/contracts/contracts-exec.json
+          if [ ! -f "$FILE" ]; then echo "No contracts exec artifact found"; exit 1; fi
+          PARSE_IN=$(jq -r '.results.parseInOk // false' "$FILE")
+          PRE_OK=$(jq -r '.results.preOk // false' "$FILE")
+          POST_OK=$(jq -r '.results.postOk // false' "$FILE")
+          PARSE_OUT=$(jq -r '.results.parseOutOk // false' "$FILE")
+          if [ "$PARSE_IN" != "true" ] || [ "$PRE_OK" != "true" ] || [ "$POST_OK" != "true" ] || [ "$PARSE_OUT" != "true" ]; then
+            echo "Contracts enforcement failed: parseIn=$PARSE_IN pre=$PRE_OK post=$POST_OK parseOut=$PARSE_OUT"
+            exit 1
+          fi

--- a/docs/verify/RUNTIME-CONTRACTS.md
+++ b/docs/verify/RUNTIME-CONTRACTS.md
@@ -41,3 +41,7 @@ const generated = await agent.generateFromOpenAPI(openapi, {
 ```
 
 > This is an initial skeleton; future versions will extract specific properties.
+
+### Optional enforcement in CI
+
+Set `CONTRACTS_ENFORCE=1` in the environment to make the `contracts-exec` step fail the PR when minimal parse/pre/post checks fail. Default is report-only.


### PR DESCRIPTION
- Add optional enforcement to contracts-exec via CONTRACTS_ENFORCE=1\n- If enabled, fail when minimal parse/pre/post checks fail\n- Update RUNTIME-CONTRACTS.md