### PR TITLE
ci(verify): label-based contracts enforcement + traceability plumbing

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -161,6 +161,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Determine enforcement from labels
+        run: |
+          if [ -f "$GITHUB_EVENT_PATH" ]; then
+            if jq -e '.pull_request.labels[]?.name | select(.=="enforce-contracts")' "$GITHUB_EVENT_PATH" >/dev/null; then
+              echo "CONTRACTS_ENFORCE=1" >> $GITHUB_ENV
+            fi
+          fi
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
- contracts-exec: set CONTRACTS_ENFORCE=1 when PR has label 'enforce-contracts'\n- prepares post-summary for hit-basis (will follow with exact counts)