### PR TITLE
verify+alloy: warn on invalid ALLOY_CMD_JSON; hit-basis in summary

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -97,6 +97,16 @@ jobs:
               echo "\n<details><summary>Unlinked (top 5)</summary>"
               jq -r '.rows[] | select(.test=="N/A" or .impl=="N/A" or .formal=="N/A") | "- " + .scenario + " (id: " + .id + ") test:" + .test + " impl:" + .impl + " formal:" + .formal' "$TRACE_JSON" 2>/dev/null | head -5 || true
               echo "</details>"
+              echo "\n<details><summary>Hit basis (tests/formal)</summary>"
+              thit_title=$(jq '[.rows[] | select(.testHit == .scenario)] | length' "$TRACE_JSON" 2>/dev/null || echo 0)
+              thit_id=$(jq '[.rows[] | select(.testHit == .id)] | length' "$TRACE_JSON" 2>/dev/null || echo 0)
+              thit_tag=$(jq '[.rows[] | select(.testHit | type=="string" and startswith("@"))] | length' "$TRACE_JSON" 2>/dev/null || echo 0)
+              fhit_title=$(jq '[.rows[] | select(.formalHit == .scenario)] | length' "$TRACE_JSON" 2>/dev/null || echo 0)
+              fhit_id=$(jq '[.rows[] | select(.formalHit == .id)] | length' "$TRACE_JSON" 2>/dev/null || echo 0)
+              fhit_tag=$(jq '[.rows[] | select(.formalHit | type=="string" and startswith("@"))] | length' "$TRACE_JSON" 2>/dev/null || echo 0)
+              echo "- Test hits: title=${thit_title} id=${thit_id} tag=${thit_tag}"
+              echo "- Formal hits: title=${fhit_title} id=${fhit_id} tag=${fhit_tag}"
+              echo "</details>"
             elif [ -f "$TRACE_FILE" ]; then
               total=$(wc -l < "$TRACE_FILE")
               scenarios=$((total-1))

--- a/scripts/verify/run-model-checks.mjs
+++ b/scripts/verify/run-model-checks.mjs
@@ -126,7 +126,11 @@ async function main() {
                 try {
                   const arr = JSON.parse(addArgsJson);
                   if (Array.isArray(arr)) args.push(...arr.map(String));
-                } catch {}
+                } catch (err) {
+                  console.warn(`[run-model-checks] Warning: Invalid JSON in ALLOY_CMD_JSON: ${addArgsJson}`);
+                  console.warn(`[run-model-checks] Error: ${err?.message ?? String(err)}`);
+                  console.warn('[run-model-checks] Falling back to ALLOY_CMD_ARGS or no extra arguments.');
+                }
               } else if (addArgs) {
                 // Fallback: simple whitespace split (avoid quotes/escaping); prefer ALLOY_CMD_JSON
                 args.push(...addArgs.split(/\s+/));


### PR DESCRIPTION
- Add console warnings when ALLOY_CMD_JSON is invalid, fallback to ALLOY_CMD_ARGS\n- Enhance PR summary to show hit basis (title/id/tag) counts for tests/formal