### PR TITLE
ci(verify): linked examples in PR summary

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -97,6 +97,9 @@ jobs:
               echo "\n<details><summary>Unlinked (top 5)</summary>"
               jq -r '.rows[] | select(.test=="N/A" or .impl=="N/A" or .formal=="N/A") | "- " + .scenario + " (id: " + .id + ") test:" + .test + " impl:" + .impl + " formal:" + .formal' "$TRACE_JSON" 2>/dev/null | head -5 || true
               echo "</details>"
+              echo "\n<details><summary>Linked examples (up to 3)</summary>"
+              jq -r '.rows[] | select(.test!="N/A" or .impl!="N/A" or .formal!="N/A") | "- " + .scenario + " test:" + .test + " impl:" + .impl + " formal:" + .formal' "$TRACE_JSON" 2>/dev/null | head -3 || true
+              echo "</details>"
               echo "\n<details><summary>Hit basis (tests/formal)</summary>"
               thit_title=$(jq '[.rows[] | select(.testHit == .scenario)] | length' "$TRACE_JSON" 2>/dev/null || echo 0)
               thit_id=$(jq '[.rows[] | select(.testHit == .id)] | length' "$TRACE_JSON" 2>/dev/null || echo 0)


### PR DESCRIPTION
- Post-summary now shows up to 3 linked examples from traceability.json (scenario with test/impl/formal paths)\n- Kept under a collapsible details block