### PR TITLE
ci(verify): clickable linked examples

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -98,7 +98,23 @@ jobs:
               jq -r '.rows[] | select(.test=="N/A" or .impl=="N/A" or .formal=="N/A") | "- " + .scenario + " (id: " + .id + ") test:" + .test + " impl:" + .impl + " formal:" + .formal' "$TRACE_JSON" 2>/dev/null | head -5 || true
               echo "</details>"
               echo "\n<details><summary>Linked examples (up to 3)</summary>"
-              jq -r '.rows[] | select(.test!="N/A" and .impl!="N/A" and .formal!="N/A") | "- " + .scenario + " test:" + .test + " impl:" + .impl + " formal:" + .formal' "$TRACE_JSON" 2>/dev/null | head -3 || true
+              PR_SHA=$(jq -r '.pull_request.head.sha // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")
+              REPO="$GITHUB_REPOSITORY"
+              if [ -f "$TRACE_JSON" ]; then
+                idx=0
+                while IFS= read -r row && [ $idx -lt 3 ]; do
+                  scenario=$(echo "$row" | jq -r '.scenario')
+                  testp=$(echo "$row" | jq -r '.test')
+                  implp=$(echo "$row" | jq -r '.impl')
+                  formp=$(echo "$row" | jq -r '.formal')
+                  testlink="$testp"; impllink="$implp"; formlink="$formp"
+                  if [ -n "$PR_SHA" ] && [ "$testp" != "N/A" ]; then testlink="[$testp](https://github.com/$REPO/blob/$PR_SHA/$testp)"; fi
+                  if [ -n "$PR_SHA" ] && [ "$implp" != "N/A" ]; then impllink="[$implp](https://github.com/$REPO/blob/$PR_SHA/$implp)"; fi
+                  if [ -n "$PR_SHA" ] && [ "$formp" != "N/A" ]; then formlink="[$formp](https://github.com/$REPO/blob/$PR_SHA/$formp)"; fi
+                  echo "- $scenario test: $testlink impl: $impllink formal: $formlink"
+                  idx=$((idx+1))
+                done < <(jq -c '.rows[] | select(.test!="N/A" and .impl!="N/A" and .formal!="N/A")' "$TRACE_JSON" 2>/dev/null)
+              fi
               echo "</details>"
               echo "\n<details><summary>Hit basis (tests/formal)</summary>"
               thit_title=$(jq '[.rows[] | select(.testHit == .scenario)] | length' "$TRACE_JSON" 2>/dev/null || echo 0)


### PR DESCRIPTION
- Linked examples now render as markdown links to the PR head SHA (when available)