### PR TITLE
ci(verify): contracts exec sample input + summary

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -75,10 +75,12 @@ jobs:
           MODEL_FILE=$(find artifacts_dl/model-check-results -name 'model-check.json' 2>/dev/null | head -1)
           TRACE_JSON=$(find artifacts_dl/traceability-matrix -name 'traceability.json' 2>/dev/null | head -1)
           CONTRACTS_JSON=$(find artifacts_dl/contracts-check -name 'contracts-check.json' 2>/dev/null | head -1)
+          CONTRACTS_EXEC=$(find artifacts_dl/contracts-exec -name 'contracts-exec.json' 2>/dev/null | head -1)
           echo "TRACE_FILE=$TRACE_FILE" >> $GITHUB_OUTPUT
           echo "MODEL_FILE=$MODEL_FILE" >> $GITHUB_OUTPUT
           echo "TRACE_JSON=$TRACE_JSON" >> $GITHUB_OUTPUT
           echo "CONTRACTS_JSON=$CONTRACTS_JSON" >> $GITHUB_OUTPUT
+          echo "CONTRACTS_EXEC=$CONTRACTS_EXEC" >> $GITHUB_OUTPUT
           {
             echo "### 🔍 Verification Summary"
             if [ -f "$TRACE_JSON" ]; then
@@ -153,6 +155,13 @@ jobs:
               echo "- Contracts: schemas=${haveSchemas} conditions=${haveConds} machine=${haveMachine}"
             else
               echo "- Contracts: (no check artifact)"
+            fi
+            if [ -f "$CONTRACTS_EXEC" ]; then
+              pin=$(jq -r '.results.parseInOk // false' "$CONTRACTS_EXEC" 2>/dev/null || echo false)
+              pre=$(jq -r '.results.preOk // false' "$CONTRACTS_EXEC" 2>/dev/null || echo false)
+              pst=$(jq -r '.results.postOk // false' "$CONTRACTS_EXEC" 2>/dev/null || echo false)
+              pout=$(jq -r '.results.parseOutOk // false' "$CONTRACTS_EXEC" 2>/dev/null || echo false)
+              echo "  - Contracts exec: parseIn=${pin} pre=${pre} post=${pst} parseOut=${pout}"
             fi
           } > pr-summary.md
           cat pr-summary.md

--- a/docs/verify/RUNTIME-CONTRACTS.md
+++ b/docs/verify/RUNTIME-CONTRACTS.md
@@ -45,3 +45,7 @@ const generated = await agent.generateFromOpenAPI(openapi, {
 ### Optional enforcement in CI
 
 Set `CONTRACTS_ENFORCE=1` in the environment to make the `contracts-exec` step fail the PR when minimal parse/pre/post checks fail. Default is report-only.
+
+### Supplying sample input
+
+Set `CONTRACTS_SAMPLE_INPUT=/path/to/input.json` to feed a JSON object as input to the runtime contracts execution. This helps validate schemas and pre/post on a realistic shape. When absent, `{}` is used.

--- a/scripts/verify/execute-contracts.ts
+++ b/scripts/verify/execute-contracts.ts
@@ -28,7 +28,17 @@ async function main() {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const conds = await import(path.join(repoRoot, 'src', 'contracts', 'conditions.ts'));
-      const input: unknown = {}; // minimal dummy input
+      // Prefer sample input via env if provided
+      let input: unknown = {};
+      const samplePath = process.env.CONTRACTS_SAMPLE_INPUT;
+      if (samplePath) {
+        try {
+          const txt = await fs.readFile(samplePath, 'utf8');
+          input = JSON.parse(txt);
+        } catch (e) {
+          console.warn(`[contracts-exec] Warning: failed to read CONTRACTS_SAMPLE_INPUT at ${samplePath}: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
       let preOk = true; let postOk = true; let parseInOk = true; let parseOutOk = true;
       try { schemas.InputSchema?.parse?.(input); } catch (e) { parseInOk = false; }
       try { preOk = !!conds.pre?.(input); } catch (e) { preOk = false; }
@@ -48,4 +58,3 @@ async function main() {
 }
 
 main().catch((e) => { console.error('contracts-exec failed:', e); process.exit(1); });
-


### PR DESCRIPTION
- contracts-exec reads CONTRACTS_SAMPLE_INPUT (JSON) as input when provided\n- post-summary shows parseIn/pre/post/parseOut booleans\n- docs updated