### PR TITLE
ci(verify): contracts exec derive sample from OpenAPI (best-effort)

### DIFF
--- a/docs/verify/RUNTIME-CONTRACTS.md
+++ b/docs/verify/RUNTIME-CONTRACTS.md
@@ -49,3 +49,5 @@ Set `CONTRACTS_ENFORCE=1` in the environment to make the `contracts-exec` step f
 ### Supplying sample input
 
 Set `CONTRACTS_SAMPLE_INPUT=/path/to/input.json` to feed a JSON object as input to the runtime contracts execution. This helps validate schemas and pre/post on a realistic shape. When absent, `{}` is used.
+
+Alternatively, set `CONTRACTS_OPENAPI_PATH` (defaults to `artifacts/codex/openapi.yaml`) and the runner will try to extract the first JSON block it finds in the OpenAPI file as a sample input (best‑effort, optional).

--- a/scripts/verify/execute-contracts.ts
+++ b/scripts/verify/execute-contracts.ts
@@ -38,6 +38,16 @@ async function main() {
         } catch (e) {
           console.warn(`[contracts-exec] Warning: failed to read CONTRACTS_SAMPLE_INPUT at ${samplePath}: ${e instanceof Error ? e.message : String(e)}`);
         }
+      } else {
+        // Try to derive from OpenAPI YAML if available (very naive: find first JSON block)
+        const openapiPath = process.env.CONTRACTS_OPENAPI_PATH || path.join(repoRoot, 'artifacts', 'codex', 'openapi.yaml');
+        try {
+          const yamlTxt = await fs.readFile(openapiPath, 'utf8');
+          const jsonMatch = yamlTxt.match(/\{[\s\S]*?\}/);
+          if (jsonMatch) {
+            try { input = JSON.parse(jsonMatch[0]); } catch {}
+          }
+        } catch {}
       }
       let preOk = true; let postOk = true; let parseInOk = true; let parseOutOk = true;
       try { schemas.InputSchema?.parse?.(input); } catch (e) { parseInOk = false; }


### PR DESCRIPTION
- contracts-exec: if CONTRACTS_SAMPLE_INPUT is not set, try CONTRACTS_OPENAPI_PATH (default artifacts/codex/openapi.yaml) and extract the first JSON block as input (best-effort)\n- docs updated