### PR TITLE
ci(verify): contracts exec accepts OpenAPI JSON

### DIFF
--- a/docs/verify/RUNTIME-CONTRACTS.md
+++ b/docs/verify/RUNTIME-CONTRACTS.md
@@ -50,4 +50,4 @@ Set `CONTRACTS_ENFORCE=1` in the environment to make the `contracts-exec` step f
 
 Set `CONTRACTS_SAMPLE_INPUT=/path/to/input.json` to feed a JSON object as input to the runtime contracts execution. This helps validate schemas and pre/post on a realistic shape. When absent, `{}` is used.
 
-Alternatively, set `CONTRACTS_OPENAPI_PATH` (defaults to `artifacts/codex/openapi.yaml`) and the runner will try to extract the first JSON block it finds in the OpenAPI file as a sample input (best‑effort, optional).
+Alternatively, set `CONTRACTS_OPENAPI_PATH` (defaults to `artifacts/codex/openapi.yaml` or `openapi.json`) and the runner will try to derive a simple sample. For YAML it extracts the first JSON block; for JSON it picks the first path (best‑effort, optional).


### PR DESCRIPTION
- If CONTRACTS_SAMPLE_INPUT is absent, contracts-exec now checks openapi.json and picks the first path as a naive sample\n- YAML fallback remains (first JSON block)\n- Docs updated