### PR TITLE
Docs+scripts: add server start commands and Quick Start run section

### DIFF
--- a/docs/getting-started/QUICK-START-GUIDE.md
+++ b/docs/getting-started/QUICK-START-GUIDE.md
@@ -245,6 +245,21 @@ Implementation time estimate: 2 hours
 Risk assessment: Low risk
 ```
 
+### ▶️ Run the Sample Server
+
+You can run a minimal Fastify server that wires the scaffolded endpoints:
+
+```bash
+pnpm install
+pnpm run start:server
+# Server listens on http://localhost:3000
+
+# Example calls:
+# POST /reservations       -> expects { sku, quantity>=1, orderId }
+# DELETE /reservations/:id -> cancels a reservation
+# GET /inventory/:sku      -> returns { sku, stock>=0 }
+```
+
 #### Scenario 2: Legacy System Partial Modernization
 
 ```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "ae-server": "./dist/src/cli/server-runner.js"
   },
   "scripts": {
+    "start:server": "tsx src/server.ts",
+    "dev:server": "tsx watch src/server.ts",
     "dev": "tsx watch src/index.ts",
     "dev:web": "pnpm --filter @ae-framework/web dev",
     "dev:storybook": "pnpm --filter @ae-framework/storybook dev",


### PR DESCRIPTION
Adds `start:server`/`dev:server` scripts and a Quick Start section showing how to run the Fastify sample server and try endpoints. No functional changes to core; incremental docs and scripts only.