### PR TITLE
Server: OpenAPI auto‑wiring + basic route tests

### DIFF
--- a/scripts/verify/execute-contracts.ts
+++ b/scripts/verify/execute-contracts.ts
@@ -48,7 +48,6 @@ async function main() {
           if (openapiPath.endsWith('.json')) {
             try {
               const oas = JSON.parse(txt);
-              // Prefer deriving from components.schemas
               const schemas = oas.components?.schemas || {};
               const names = Object.keys(schemas);
               const seen = new Set<string>();
@@ -91,7 +90,6 @@ async function main() {
               if (names.length > 0) {
                 input = synth((schemas as any)[names[0]]);
               } else {
-                // Fallback: pick first path+op and build an object with the path only
                 const paths = oas.paths ? Object.keys(oas.paths) : [];
                 if (paths.length > 0) input = { path: paths[0] };
               }

--- a/src/contracts/conditions.ts
+++ b/src/contracts/conditions.ts
@@ -1,11 +1,40 @@
-// Pre/Post conditions (skeleton)
-// Derive from formal properties over time (e.g., no negative stock, idempotency)
+// Pre/Post conditions (heuristic, endpoint-agnostic)
+// Uses schemas when possible; otherwise returns true (non-blocking skeleton).
+import {
+  CreateReservationInputSchema,
+  InventorySchema,
+  ReservationSchema,
+  ReservationsIdDeleteInput,
+  InventorySkuGetInput,
+} from './schemas'
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v)
+}
 
 export function pre(input: unknown): boolean {
+  if (!isObject(input)) return true
+  // Try to recognize input shape by keys and validate with schemas
+  if ('sku' in input && 'quantity' in input && 'orderId' in input) {
+    return CreateReservationInputSchema.safeParse(input).success
+  }
+  if ('id' in input && Object.keys(input).length === 1) {
+    return ReservationsIdDeleteInput.safeParse(input).success
+  }
+  if ('sku' in input && !('quantity' in input)) {
+    return InventorySkuGetInput.safeParse(input).success
+  }
   return true
 }
 
 export function post(input: unknown, output: unknown): boolean {
+  if (!isObject(output)) return true
+  // Validate known domain objects if present
+  if ('stock' in output && 'sku' in output) {
+    return InventorySchema.safeParse(output).success
+  }
+  if ('status' in output && 'id' in output && 'sku' in output && 'quantity' in output && 'orderId' in output) {
+    return ReservationSchema.safeParse(output).success
+  }
   return true
 }
-


### PR DESCRIPTION
- Auto-registers routes from artifacts/codex/openapi.(yaml|json) if present; falls back to static wiring.\n- Adds vitest for minimal route handlers using contracts-injected skeletons.\n- No breaking changes; improves dev UX and ensures scaffolds respond with expected status codes.