### PR TITLE
docs(ci): testing+ddd scripts CI snippet + roadmap links

### DIFF
--- a/docs/roadmap/TESTING-DDD-INDEX.md
+++ b/docs/roadmap/TESTING-DDD-INDEX.md
@@ -42,3 +42,10 @@ Replay
 DDD IR
 - docs/ddd/ae-ir-ddd.md
 - docs/ddd/events.md
+
+Implementation (scripts)
+- scripts/testing/property-harness.mjs
+- scripts/testing/replay-runner.mjs
+- scripts/bdd/lint.mjs
+- scripts/formal/format-counterexamples.mjs
+- scripts/adapters/aggregate-artifacts.mjs

--- a/docs/roadmap/TESTING-DDD-ROADMAP.md
+++ b/docs/roadmap/TESTING-DDD-ROADMAP.md
@@ -59,3 +59,10 @@ English / 日本語 (summary)
 
 ## References
 - See also: docs/roadmap/TESTING-DDD-INDEX.md (reviewer quick links)
+
+## Implementation Scripts
+- Property: npm run test:property / :focus
+- Replay: npm run test:replay / :focus
+- BDD Lint: npm run bdd:lint
+- Formal GWT: node scripts/formal/format-counterexamples.mjs
+- Aggregate: npm run artifacts:aggregate

--- a/docs/templates/ci/testing-ddd-scripts.snippet.yml
+++ b/docs/templates/ci/testing-ddd-scripts.snippet.yml
@@ -1,0 +1,26 @@
+name: testing-ddd-scripts
+on: [push, pull_request]
+jobs:
+  testing-ddd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+      - name: Property harness (#406)
+        run: npm run test:property --silent || true
+      - name: Replay runner (#411)
+        run: npm run test:replay --silent || true
+      - name: BDD lint (#410)
+        run: npm run bdd:lint --silent || true
+      - name: Formal GWT format (#407)
+        run: |
+          if [ -f formal/summary.json ]; then node scripts/formal/format-counterexamples.mjs; fi
+      - name: Aggregate artifacts (#408)
+        run: npm run artifacts:aggregate --silent || true
+      - name: Upload artifacts (summary)
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-summary
+          path: artifacts/**


### PR DESCRIPTION
Adds docs/templates/ci/testing-ddd-scripts.snippet.yml tying together #406/#407/#408/#410/#411 scripts, and links them from the roadmap and index.