### PR TITLE
ci: testing+ddd scripts + ajv validation (non-blocking)

### DIFF
--- a/.github/workflows/testing-ddd-scripts.yml
+++ b/.github/workflows/testing-ddd-scripts.yml
@@ -1,0 +1,33 @@
+name: testing-ddd-scripts
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+permissions:
+  contents: read
+jobs:
+  testing-ddd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+      - name: Property harness (#406)
+        run: npm run test:property --silent || true
+      - name: Replay runner (#411)
+        run: npm run test:replay --silent || true
+      - name: BDD lint (#410)
+        run: npm run bdd:lint --silent || true
+      - name: Formal GWT format (#407)
+        run: |
+          if [ -f formal/summary.json ]; then node scripts/formal/format-counterexamples.mjs; fi
+      - name: Aggregate artifacts (#408)
+        run: npm run artifacts:aggregate --silent || true
+      - name: Upload artifacts (summary)
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-artifacts
+          path: |
+            artifacts/**
+            formal/summary.json

--- a/.github/workflows/validate-artifacts-ajv.yml
+++ b/.github/workflows/validate-artifacts-ajv.yml
@@ -1,0 +1,30 @@
+name: validate-artifacts-ajv
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+      - run: npm i -D ajv ajv-cli jq
+      - name: Validate adapter summaries
+        run: npx ajv -s docs/schemas/artifacts-adapter-summary.schema.json -d "artifacts/*/summary.json" --strict=false || true
+      - name: Validate formal summary
+        run: |
+          if [ -f formal/summary.json ]; then npx ajv -s docs/schemas/formal-summary.schema.json -d formal/summary.json --strict=false; fi
+      - name: Validate property summaries
+        run: |
+          if [ -f artifacts/properties/summary.json ]; then \
+            if jq -e 'type=="array"' artifacts/properties/summary.json >/dev/null; then \
+              jq -c '.[]' artifacts/properties/summary.json | while read -r item; do \
+                echo "$item" | npx ajv -s docs/schemas/artifacts-properties-summary.schema.json -d /dev/stdin --strict=false; \
+              done; \
+            else \
+              npx ajv -s docs/schemas/artifacts-properties-summary.schema.json -d artifacts/properties/summary.json --strict=false; \
+            fi; \
+          fi


### PR DESCRIPTION
Adds two GitHub Actions workflows:\n- testing-ddd-scripts: runs property/replay/bdd lint/formal format/aggregate and uploads artifacts (steps tolerant with `|| true`).\n- validate-artifacts-ajv: validates normalized artifacts with ajv (non-blocking).\nNo core code changes.