### PR TITLE
ci: PR summary comment from combined artifacts

### DIFF
--- a/.github/workflows/pr-summary-comment.yml
+++ b/.github/workflows/pr-summary-comment.yml
@@ -1,0 +1,52 @@
+name: pr-summary-comment
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+      - name: Aggregate artifacts if present
+        run: |
+          if npm run -s | grep -q "artifacts:aggregate"; then npm run artifacts:aggregate || true; fi
+      - name: Generate Markdown summary
+        id: gen
+        run: |
+          node -e '
+          const fs=require("fs");
+          function r(p){ try { return JSON.parse(fs.readFileSync(p,"utf-8")); } catch { return undefined; } }
+          const c = r("artifacts/summary/combined.json") || {};
+          const adapters=(c.adapters||[]).map(a=>`  - ${a.adapter||a.name}: ${a.summary} (${a.status})`).join("\n");
+          const formal = c.formal ? (c.formal.result || "n/a") : "n/a";
+          const props = c.properties ? (Array.isArray(c.properties) ? c.properties : [c.properties]) : [];
+          const traceIds = new Set();
+          for (const a of c.adapters||[]) if (a?.traceId) traceIds.add(a.traceId);
+          if (c.formal?.traceId) traceIds.add(c.formal.traceId);
+          for (const p of props) if (p?.traceId) traceIds.add(p.traceId);
+          const md = `## Quality Summary\n- Adapters:\n${adapters}\n- Formal: ${formal}\n- Trace IDs: ${Array.from(traceIds).join(', ')}`;
+          fs.mkdirSync("artifacts/summary",{recursive:true});
+          fs.writeFileSync("artifacts/summary/PR_SUMMARY.md", md);
+          console.log(md);
+          '
+      - name: Post or update PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('artifacts/summary/PR_SUMMARY.md','utf-8');
+            const header = '<!-- AE-PR-SUMMARY -->\n' + body;
+            const { owner, repo, number } = context.issue;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
+            const mine = comments.data.find(c => c.body && c.body.startsWith('<!-- AE-PR-SUMMARY -->'));
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body: header });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: number, body: header });
+            }


### PR DESCRIPTION
Adds a lightweight workflow that aggregates artifacts (if available) and posts/updates a PR summary comment. Non-blocking; docs/scripts-only usage.