### PR TITLE
ci: label-gated blocking + summary renderer (non-blocking by default)

### DIFF
--- a/.github/workflows/pr-summary-comment.yml
+++ b/.github/workflows/pr-summary-comment.yml
@@ -17,6 +17,8 @@ jobs:
         run: |
           if npm run -s | grep -q "artifacts:aggregate"; then npm run artifacts:aggregate || true; fi
       - name: Generate Markdown summary
+        run: |
+          if [ -f scripts/summary/render-pr-summary.mjs ]; then node scripts/summary/render-pr-summary.mjs; else echo "No renderer; keeping inline"; fi
         id: gen
         run: |
           node -e '

--- a/.github/workflows/testing-ddd-scripts.yml
+++ b/.github/workflows/testing-ddd-scripts.yml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   testing-ddd:
     runs-on: ubuntu-latest
+    outputs:
+      strict: ${{ steps.gate.outputs.strict }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,6 +17,13 @@ jobs:
       - run: npm ci
       - name: Derive TRACE_ID from PR labels
         id: trace
+        id: trace
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
+            const strict = labels.includes("enforce-testing");
+            core.setOutput("strict", String(strict));
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/validate-artifacts-ajv.yml
+++ b/.github/workflows/validate-artifacts-ajv.yml
@@ -4,7 +4,33 @@ on:
 permissions:
   contents: read
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      strict: ${{ steps.gate.outputs.strict }}
+    steps:
+      - uses: actions/github-script@v7
+        id: gate
+        with:
+          script: |
+            const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
+            const strict = labels.includes("enforce-artifacts");
+            core.setOutput("strict", String(strict));
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      strict: ${{ steps.gate.outputs.strict }}
+    steps:
+      - uses: actions/github-script@v7
+        id: gate
+        with:
+          script: |
+            const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
+            const strict = labels.includes("enforce-artifacts");
+            core.setOutput("strict", String(strict));
   validate:
+    needs: gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+function r(p){ try { return JSON.parse(fs.readFileSync(p,'utf-8')); } catch { return undefined; } }
+const c = r('artifacts/summary/combined.json') || {};
+const adapters=(c.adapters||[]).map(a=>`  - ${a.adapter||a.name}: ${a.summary} (${a.status})`).join('\n');
+const formalObj = c.formal || r('formal/summary.json') || {};
+const formal = formalObj.result || 'n/a';
+const replay = c.replay || r('artifacts/domain/replay.summary.json') || {};
+const props = c.properties ? (Array.isArray(c.properties) ? c.properties : [c.properties]) : (r('artifacts/properties/summary.json') ? [r('artifacts/properties/summary.json')] : []);
+const traceIds = new Set();
+for (const a of c.adapters||[]) if (a?.traceId) traceIds.add(a.traceId);
+if (formalObj?.traceId) traceIds.add(formalObj.traceId);
+if (replay?.traceId) traceIds.add(replay.traceId);
+for (const p of props) if (p?.traceId) traceIds.add(p.traceId);
+const replayLine = replay.totalEvents!==undefined ? `Replay: ${replay.totalEvents} events, ${(replay.violatedInvariants||[]).length} violations` : 'Replay: n/a';
+const md = `## Quality Summary\n- Adapters:\n${adapters}\n- Formal: ${formal}\n- ${replayLine}\n- Trace IDs: ${Array.from(traceIds).join(', ')}`;
+fs.mkdirSync('artifacts/summary',{recursive:true});
+fs.writeFileSync('artifacts/summary/PR_SUMMARY.md', md);
+console.log(md);


### PR DESCRIPTION
- validate-artifacts-ajv: gate job reads label enforce-artifacts; continue-on-error toggled by strict
- testing-ddd-scripts: gate reads label enforce-testing; continue-on-error toggled by strict
- pr-summary-comment: use renderer script if present