### PR TITLE
ci/docs: label-gating policy + detailed PR summary support

### DIFF
--- a/.github/workflows/pr-summary-comment.yml
+++ b/.github/workflows/pr-summary-comment.yml
@@ -8,6 +8,14 @@ permissions:
 jobs:
   summarize:
     runs-on: ubuntu-latest
+      - name: Determine summary mode
+        id: mode
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
+            const detailed = labels.includes("pr-summary:detailed");
+            core.setOutput("mode", detailed ? "detailed" : "digest");
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -17,6 +25,10 @@ jobs:
         run: |
           if npm run -s | grep -q "artifacts:aggregate"; then npm run artifacts:aggregate || true; fi
       - name: Generate Markdown summary
+        env:
+          SUMMARY_MODE: ${{ steps.mode.outputs.mode }}
+        run: |
+          if [ -f scripts/summary/render-pr-summary.mjs ]; then node scripts/summary/render-pr-summary.mjs; else echo "No renderer; keeping inline"; fi
         run: |
           if [ -f scripts/summary/render-pr-summary.mjs ]; then node scripts/summary/render-pr-summary.mjs; else echo "No renderer; keeping inline"; fi
         id: gen

--- a/docs/ci/label-gating.md
+++ b/docs/ci/label-gating.md
@@ -1,0 +1,18 @@
+# CI Label Gating Policy
+
+Purpose
+- Enable gradual tightening of CI by toggling gates per PR using labels. Default remains non‑blocking to avoid disruption.
+
+Labels
+- `enforce-artifacts`: make artifacts validation (ajv) blocking
+- `enforce-testing`: make testing scripts (property/replay/BDD lint) blocking
+- `trace:<id>`: set TRACE_ID for focused runs in property/replay scripts
+- `pr-summary:detailed`: render a more detailed PR summary (vs. digest)
+
+Workflows
+- validate-artifacts-ajv.yml: reads `enforce-artifacts` and toggles `continue-on-error`
+- testing-ddd-scripts.yml: reads `enforce-testing` and toggles `continue-on-error`; reads `trace:<id>` to focus runs
+- pr-summary-comment.yml: reads `pr-summary:detailed` to switch summary mode
+
+Notes
+- These controls are per‑PR. Organization/branch‑wide enforcement can be added later (e.g., always blocking on main) once agreed.

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -1,19 +1,27 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 function r(p){ try { return JSON.parse(fs.readFileSync(p,'utf-8')); } catch { return undefined; } }
+const mode = process.env.SUMMARY_MODE === 'detailed' ? 'detailed' : 'digest';
 const c = r('artifacts/summary/combined.json') || {};
-const adapters=(c.adapters||[]).map(a=>`  - ${a.adapter||a.name}: ${a.summary} (${a.status})`).join('\n');
+const adaptersArr = (c.adapters||[]);
+const adaptersLine = adaptersArr.map(a=>`${a.adapter||a.name}: ${a.summary} (${a.status})`).join(', ');
+const adaptersList = adaptersArr.map(a=>`  - ${a.adapter||a.name}: ${a.summary} (${a.status})`).join('\n');
 const formalObj = c.formal || r('formal/summary.json') || {};
 const formal = formalObj.result || 'n/a';
 const replay = c.replay || r('artifacts/domain/replay.summary.json') || {};
 const props = c.properties ? (Array.isArray(c.properties) ? c.properties : [c.properties]) : (r('artifacts/properties/summary.json') ? [r('artifacts/properties/summary.json')] : []);
 const traceIds = new Set();
-for (const a of c.adapters||[]) if (a?.traceId) traceIds.add(a.traceId);
+for (const a of adaptersArr) if (a?.traceId) traceIds.add(a.traceId);
 if (formalObj?.traceId) traceIds.add(formalObj.traceId);
 if (replay?.traceId) traceIds.add(replay.traceId);
 for (const p of props) if (p?.traceId) traceIds.add(p.traceId);
 const replayLine = replay.totalEvents!==undefined ? `Replay: ${replay.totalEvents} events, ${(replay.violatedInvariants||[]).length} violations` : 'Replay: n/a';
-const md = `## Quality Summary\n- Adapters:\n${adapters}\n- Formal: ${formal}\n- ${replayLine}\n- Trace IDs: ${Array.from(traceIds).join(', ')}`;
+let md;
+if (mode === 'digest') {
+  md = `Quality: n/a | Formal: ${formal} | ${replayLine} | Adapters: ${adaptersLine} | Trace: ${Array.from(traceIds).join(', ')}`;
+} else {
+  md = `## Quality Summary\n- Adapters:\n${adaptersList}\n- Formal: ${formal}\n- ${replayLine}\n- Trace IDs: ${Array.from(traceIds).join(', ')}`;
+}
 fs.mkdirSync('artifacts/summary',{recursive:true});
 fs.writeFileSync('artifacts/summary/PR_SUMMARY.md', md);
 console.log(md);


### PR DESCRIPTION
Adds docs/ci/label-gating.md, supports pr-summary:detailed to switch PR summary mode, and wires SUMMARY_MODE into the PR summary workflow.