### PR TITLE
ci/docs: coverage gating + auto-labels for coverage

### DIFF
--- a/.github/workflows/auto-labels.yml
+++ b/.github/workflows/auto-labels.yml
@@ -16,15 +16,16 @@ jobs:
             const pr = context.payload.pull_request;
             if (!pr) return;
             const toAdd = new Set();
-            // If base is main, suggest enforce-artifacts (we do not auto-enforce here; main default handles it)
-            if (pr.base && pr.base.ref === 'main') {
-              // no-op: main default already enforces artifacts
-            }
-            // Find trace:<id> in title
+            // trace:<id> in title
             const m = (pr.title||'').match(/trace:([A-Za-z0-9_.:-]+)/);
             if (m) toAdd.add(`trace:${m[1]}`);
-            // Switch to detailed summary if title/body contains [detailed]
+            // detailed mode marker
             if ((pr.title||'').includes('[detailed]') || (pr.body||'').includes('[detailed]')) toAdd.add('pr-summary:detailed');
+            // enforce-coverage marker
+            if ((pr.title||'').includes('[enforce-coverage]') || (pr.body||'').includes('[enforce-coverage]')) toAdd.add('enforce-coverage');
+            // coverage threshold [cov=85]
+            const m2 = (pr.title||'').match(/\[cov=(\d{2,3})\]/) || (pr.body||'').match(/\[cov=(\d{2,3})\]/);
+            if (m2) toAdd.add(`coverage:${m2[1]}`);
             if (toAdd.size) {
               await github.rest.issues.addLabels({ owner, repo, issue_number: number, labels: Array.from(toAdd) });
             }

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -1,0 +1,49 @@
+name: coverage-check
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      strict: ${{ steps.gate.outputs.strict }}
+      threshold: ${{ steps.th.outputs.threshold }}
+    steps:
+      - uses: actions/github-script@v7
+        id: gate
+        with:
+          script: |
+            const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
+            const strict = labels.includes('enforce-coverage');
+            core.setOutput('strict', String(strict));
+      - uses: actions/github-script@v7
+        id: th
+        with:
+          script: |
+            const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
+            const cov = labels.find(n => n.startsWith('coverage:'));
+            const val = cov ? Number(cov.split(':')[1]) : 80;
+            core.setOutput('threshold', String(isFinite(val) ? val : 80));
+  coverage:
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci
+      - name: Run coverage
+        run: npm run coverage --silent || true
+      - name: Check coverage threshold
+        env:
+          THRESHOLD: ${{ needs.gate.outputs.threshold }}
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then \
+            PCT=$(node -e "console.log((require('./coverage/coverage-summary.json').total.lines.pct)||0)"); \
+            echo "Coverage: ${PCT}% (threshold: ${THRESHOLD}%)"; \
+            awk 'BEGIN{ if ('"${PCT}"' + 0 < '"${THRESHOLD}"' + 0) exit 1 }'; \
+          else \
+            echo "No coverage-summary.json found; skipping check"; \
+          fi
+        continue-on-error: ${{ needs.gate.outputs.strict != 'true' }}

--- a/docs/ci/label-gating.md
+++ b/docs/ci/label-gating.md
@@ -19,3 +19,5 @@ Notes
 
 ## Automation
 - auto-labels workflow: adds `trace:<id>` from PR title, sets `pr-summary:detailed` when [detailed] is present.
+- `enforce-coverage`: make coverage threshold blocking (default 80%)
+- `coverage:<pct>`: set coverage threshold in percent (e.g., coverage:85)


### PR DESCRIPTION
- coverage-check: runs coverage and enforces threshold when label enforce-coverage; threshold via coverage:<pct> label (default 80)\n- auto-labels: parse [cov=NN] and [enforce-coverage] markers in PR title/body\nDocs updated in label-gating.md