### PR TITLE
fix(resilience): AdaptiveTimeout immediate increase; Backoff non-retryable return (partial #448)

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -68,7 +68,14 @@ export class BackoffStrategy {
         
         // Check if we should retry
         if (attempt === this.options.maxRetries || !this.options.shouldRetry(lastError, attempt)) {
-          break;
+          // Do not retry: return failure immediately with actual attempts executed
+          return {
+            success: false,
+            error: lastError,
+            attempts: attempt + 1,
+            totalTime: Date.now() - startTime,
+            delays,
+          };
         }
 
         // Calculate delay with jitter
@@ -83,6 +90,7 @@ export class BackoffStrategy {
       }
     }
 
+    // Should not reach here due to early return on non-retryable or maxRetries
     return {
       success: false,
       error: lastError!,


### PR DESCRIPTION
Partial follow-up for #448:\n\n- AdaptiveTimeout: if a timeout occurs and history is insufficient, increase currentTimeoutMs by adaptationFactor (bounded by min/max).\n- BackoffStrategy: when shouldRetry(error) is false at any attempt, return failure immediately with attempts = attempt + 1 (no extra retries).\n\nNotes\n- This improves resilience tests stability. One statistical precision test still fails due to fake-timer drift (averageExecutionTime ~110ms vs expected 100ms @ 10 digits). Proposing to either adjust measurement to precise scheduled resolution timing or relax precision in tests; will address in a subsequent PR.\n- CircuitBreaker integration timing expectations remain to be tuned; planned next.\n