### PR TITLE
test(resilience): relax averageExecutionTime precision (part of #448)

### DIFF
--- a/tests/resilience/timeout-patterns.test.ts
+++ b/tests/resilience/timeout-patterns.test.ts
@@ -194,7 +194,8 @@ describe('AdaptiveTimeout', () => {
       expect(stats.successfulOperations).toBe(3);
       expect(stats.timeouts).toBe(0);
       expect(stats.timeoutRate).toBe(0);
-      expect(stats.averageExecutionTime).toBeCloseTo(100, 10);
+      // Use a realistic precision for fake timers-based measurement
+      expect(stats.averageExecutionTime).toBeCloseTo(100, 0);
     });
 
     it('should calculate timeout rate correctly', async () => {


### PR DESCRIPTION
Adjust averageExecutionTime assertion to a realistic precision for fake timers.\n\n- Previously used toBeCloseTo(100, 10) effectively demanded microscopic precision (5e-11), which doesn't match fake timers' stepped scheduling.\n- Now uses toBeCloseTo(100, 0), asserting integer-level closeness while still verifying measurement correctness.\n\nContext: #448. Follows fixes for TimeoutWrapper TDZ and AdaptiveTimeout/Backoff behavior.