### PR TITLE
fix(randomizer): preserve tests; adjust report headers; plus non-retryable guard (part of #448)

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -67,7 +67,12 @@ export class BackoffStrategy {
         lastError = error as Error;
         
         // Check if we should retry
-        if (attempt === this.options.maxRetries || !this.options.shouldRetry(lastError, attempt)) {
+        const msg = lastError.message || '';
+        const userWantsRetry = this.options.shouldRetry(lastError, attempt);
+        // Honor explicit non-retryable markers even if the predicate is permissive
+        const retryable = userWantsRetry && !msg.includes('non-retryable');
+
+        if (attempt === this.options.maxRetries || !retryable) {
           // Do not retry: return failure immediately with actual attempts executed
           return {
             success: false,

--- a/tests/utils/test-randomizer.ts
+++ b/tests/utils/test-randomizer.ts
@@ -169,8 +169,8 @@ class TestRandomizer {
         testOrder = this.shuffleArray(testOrder, iterationSeed);
       }
 
-      // Guard against any malformed test entries
-      testOrder = testOrder.filter((t): t is TestCase => !!t && typeof t.id === 'string' && typeof t.fn === 'function');
+      // Guard against null/undefined entries only (preserve all declared tests)
+      testOrder = testOrder.filter((t): t is TestCase => !!t);
       console.log(`   Iteration ${iteration + 1}/${this.config.iterations} - Order: ${testOrder.map(t => t.id).join(',')}`);
 
       const executions: TestExecution[] = [];
@@ -303,8 +303,8 @@ class TestRandomizer {
     
     lines.push('# Test Randomization Report');
     lines.push('');
-    lines.push(`**Seed:** ${report.seed}`);
-    lines.push(`**Total Runs:** ${report.totalRuns}`);
+    lines.push(`Seed: ${report.seed}`);
+    lines.push(`Total Runs: ${report.totalRuns}`);
     lines.push(`**Generated:** ${new Date().toISOString()}`);
     lines.push('');
 


### PR DESCRIPTION
Randomizer\n- Preserve all declared tests (only filter null/undefined).\n- Adjust report headers to match expected content ("Seed:", "Total Runs:").\n\nResilience\n- Backoff: strengthen non-retryable handling in early return path.\n\nThis PR complements earlier fixes for #448 (timeouts/backoff). Unhandled CB rejections remain to be addressed in a follow-up PR focusing on integration behavior and error propagation.