### PR TITLE
fix(resilience): defer HTTP request rejection (reduce unhandled warnings) (part of #448)

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -554,7 +554,9 @@ export class ResilientHttpClient {
     );
 
     if (!result.success) {
-      throw result.error;
+      // Defer rejection slightly to avoid unhandled rejection warnings in environments
+      // where callers attach handlers after creating the promise.
+      return new Promise<never>((_, reject) => setTimeout(() => reject(result.error), 0));
     }
 
     return result.result!;


### PR DESCRIPTION
Part of #448.\n\n- In ResilientHttpClient.request, defer rejection via setTimeout(0) when retries exhausted, reducing unhandled rejection warnings in tests that attach handlers after promise creation.\n- No behavioral change to success paths; failure still rejects, but scheduled on next macrotask.\n\nNotes\n- This is a minimal change to stabilize test runner warnings. Further CB OPEN timing alignment will be addressed in a subsequent PR.