### PR TITLE
feat(resilience): fast-fail when circuit OPEN (part of #448)

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -536,6 +536,10 @@ export class ResilientHttpClient {
     url: string,
     options: RequestInit = {}
   ): Promise<T> {
+    // If circuit is already OPEN, fail fast to match expectations that next request fails immediately
+    if (this.circuitBreaker && this.circuitBreaker.getStats().state === CircuitState.OPEN) {
+      return new Promise<never>((_, reject) => setTimeout(() => reject(new Error(`Circuit breaker is OPEN for HTTP ${options.method || 'GET'} ${url}`)), 0));
+    }
     const attemptOperation = async (): Promise<T> => {
       // Rate limiting per attempt
       if (this.rateLimiter) {


### PR DESCRIPTION
When CircuitBreaker is already OPEN, fast-fail HTTP requests immediately with a deferred rejection.\n\n- Aligns with test expectation that subsequent requests fail immediately while OPEN.\n- Uses next-tick rejection to avoid unhandled rejection warnings in test environments.\n\nScope: minimal change in ResilientHttpClient.request. No merge yet; awaiting review.