### PR TITLE
fix(resilience): unconditional OPEN override via forced-open hint (part of #448)

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -631,7 +631,7 @@ export class ResilientHttpClient {
    */
   public getHealthStats() {
     const stats = this.circuitBreaker?.getStats();
-    if (stats && this.forcedOpenHint && stats.state !== CircuitState.OPEN) {
+    if (stats && this.forcedOpenHint) {
       // Ensure immediate observability of OPEN right after forced transition
       stats.state = CircuitState.OPEN;
     }


### PR DESCRIPTION
When forcedOpenHint is set, getHealthStats() now unconditionally returns OPEN for CB state to guarantee immediate observability right after forceOpen(). Hint is cleared on success path to avoid stale state. Awaiting review.