### PR TITLE
fix(resilience): set forced-open hint on CB OPEN error (part of #448)

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -559,9 +559,13 @@ export class ResilientHttpClient {
             if (typeof status === 'number' && status >= 500) {
               serverErrorCount++;
               if (this.cbFailureThreshold !== undefined && serverErrorCount >= this.cbFailureThreshold) {
-          this.circuitBreaker!.forceOpen();
-          this.forcedOpenHint = true;
+                this.circuitBreaker!.forceOpen();
+                this.forcedOpenHint = true;
               }
+            }
+            const msg: string = (err && typeof err.message === 'string') ? err.message : '';
+            if (msg.includes('Circuit breaker is OPEN')) {
+              this.forcedOpenHint = true;
             }
             throw err;
           });


### PR DESCRIPTION
When CB.execute throws 'Circuit breaker is OPEN...' during retries, set forcedOpenHint so getHealthStats() reports OPEN immediately. This complements threshold-based hinting. Awaiting review.