### PR TITLE
fix(resilience): stop retries on 'Circuit breaker is OPEN' (part of #448)

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -179,6 +179,10 @@ export class BackoffStrategy {
    * Default retry condition - determines if error is retryable
    */
   private isRetryableError(error: Error): boolean {
+    // Circuit breaker explicitly OPEN should not be retried
+    if (typeof error.message === 'string' && error.message.includes('Circuit breaker is OPEN')) {
+      return false;
+    }
     // Network errors
     if (error.message.includes('ECONNRESET') ||
         error.message.includes('ENOTFOUND') ||


### PR DESCRIPTION
Extend isRetryableError to treat 'Circuit breaker is OPEN' as non-retryable. Ensures first request fails immediately once CB transitions to OPEN as expected by integration tests. Awaiting review.