### PR TITLE
test(resilience): flush microtasks after failure for OPEN observability (closes #448)

### DIFF
--- a/tests/resilience/backoff-strategies.test.ts
+++ b/tests/resilience/backoff-strategies.test.ts
@@ -652,6 +652,8 @@ describe('Integration Tests', () => {
     } catch (error) {
       // Expected failure
     }
+    // Flush microtasks to ensure OPEN transition is observable
+    await Promise.resolve();
 
     // Verify circuit is open
     const stats = httpClient.getHealthStats();


### PR DESCRIPTION
After the first request fails and opens the circuit, flush microtasks (await Promise.resolve()) so getHealthStats() immediately observes OPEN. This avoids timing edges with fake timers/microtasks. This should close #448.