### PR TITLE
fix(resilience): remove pre-check fast-fail (part of #448)

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -543,11 +543,6 @@ export class ResilientHttpClient {
     url: string,
     options: RequestInit = {}
   ): Promise<T> {
-    // Fast-fail if circuit is already OPEN
-    if (this.circuitBreaker && this.circuitBreaker.getStats().state === CircuitState.OPEN) {
-      return new Promise<never>((_, reject) => Promise.resolve().then(() => reject(new Error(`Circuit breaker is OPEN for HTTP ${options.method || 'GET'} ${url}`))));
-    }
-
     let serverErrorCount = 0;
     const attemptOperation = async (): Promise<T> => {
       // Rate limiting per attempt


### PR DESCRIPTION
Defer OPEN handling to CircuitBreaker.execute so that recovery timeout allows HALF_OPEN/close as expected. Pre-check fast-fail caused false OPEN during integration scenario after timers advanced. Awaiting review.