### PR TITLE
fix(contracts): resolve merge markers; domain-aware pre/post + endpoint schemas

### DIFF
--- a/src/contracts/conditions.ts
+++ b/src/contracts/conditions.ts
@@ -26,11 +26,6 @@ export function pre(input: unknown): boolean {
   if ('sku' in input && !('quantity' in input)) {
     return InventorySkuGetInput.safeParse(input).success
   }
->>>>>>> e2a347e (verify: add OpenAPI sample, contracts skeleton, TLC Spec fix, traceability links (refs #381))
-// Pre/Post conditions (skeleton)
-// Derive from formal properties over time (e.g., no negative stock, idempotency)
-
-export function pre(input: unknown): boolean {
   return true
 }
 
@@ -61,7 +56,3 @@ export function post(input: unknown, output: unknown): boolean {
   }
   return true
 }
->>>>>>> e2a347e (verify: add OpenAPI sample, contracts skeleton, TLC Spec fix, traceability links (refs #381))
-  return true
-}
-

--- a/src/contracts/schemas.ts
+++ b/src/contracts/schemas.ts
@@ -33,8 +33,3 @@ export const ReservationsIdDeleteOutput = z.object({}).optional()
 
 export const InventorySkuGetInput = z.object({ sku: z.string() })
 export const InventorySkuGetOutput = InventorySchema
->>>>>>> e2a347e (verify: add OpenAPI sample, contracts skeleton, TLC Spec fix, traceability links (refs #381))
-// Minimal skeleton schemas; refine per domain as needed
-export const InputSchema = z.any()
-export const OutputSchema = z.any()
-


### PR DESCRIPTION
Resolve leftover merge conflict markers in contracts module.\n- Keep domain-aware pre/post conditions (inventory non-negative, reservation echo, schema validation).\n- Keep endpoint-specific schemas/aliases derived from OpenAPI.\n\nThis cleans types/build on feature branch.