### PR TITLE
docs(formal): samples + PR summary enhancement

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -173,6 +173,16 @@ jobs:
                 lines.push(`• Contract/E2E templates: ${s.files} files (dir: ${s.outDir})`);
               }
             } catch {}
+            // PBT/BDD counts (lightweight)
+            try {
+              const { execSync } = require('child_process');
+              let pbtCount = 0, bddCount = 0;
+              try { pbtCount = parseInt(execSync("bash -lc 'ls tests/property/*.test.ts 2>/dev/null | wc -l'", {stdio:['ignore','pipe','ignore']}).toString().trim()) || 0; } catch {}
+              try { bddCount = parseInt(execSync("bash -lc 'rg -n "^Feature:" tests 2>/dev/null | wc -l'", {stdio:['ignore','pipe','ignore']}).toString().trim()) || 0; } catch {}
+              if (!isNaN(pbtCount) || !isNaN(bddCount)) {
+                lines.push(`• Tests: PBT files=${pbtCount || 0}, BDD features=${bddCount || 0}`);
+              }
+            } catch {}
             if (lines.length === 0) {
               lines.push('No CodeX artifacts found to summarize.');
             }

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -9,6 +9,7 @@ CLI stubs (to be wired)
 - `pnpm run verify:alloy` — prints stub
 - `pnpm run verify:tla -- --engine=apalache|tlc` — prints stub
 - `pnpm run verify:smt -- --solver=z3|cvc5` — prints stub
+ - `pnpm run verify:formal` — 上記4種の連続実行（ローカル確認用）
 
 Specs/Artifacts
 - TLA+: `spec/tla/` (README with skeleton)
@@ -16,7 +17,10 @@ Specs/Artifacts
 - Trace schema: `observability/trace-schema.yaml`
 - Reports (planned): `hermetic-reports/`
 
+Samples
+- TLA+: `spec/tla/DomainSpec.tla`（最小の安全性不変と遷移の例）
+- Alloy: `spec/alloy/Domain.als`（最小の安全性アサーションの例）
+
 Roadmap Fit (Issue #493)
 - Non‑blocking, label‑gated CI first
 - Wire real engines behind the above stubs incrementally
-

--- a/spec/alloy/Domain.als
+++ b/spec/alloy/Domain.als
@@ -1,0 +1,16 @@
+module Domain
+
+// Minimal Alloy skeleton for illustration. Replace with domain model.
+
+sig State {
+  onHand: Int,
+  allocated: Int
+}
+
+pred Init[s: State] { s.onHand = 0 and s.allocated = 0 }
+
+pred Invariant[s: State] { s.onHand >= 0 and s.allocated <= s.onHand }
+
+assert Safety { all s: State | Invariant[s] }
+
+check Safety for 5 Int, 3 State

--- a/spec/tla/DomainSpec.tla
+++ b/spec/tla/DomainSpec.tla
@@ -1,0 +1,17 @@
+------------------------------ MODULE DomainSpec ------------------------------
+EXTENDS Naturals, Sequences
+
+(* Minimal skeleton for illustration. Replace with domain-specific spec. *)
+
+VARIABLES state
+
+Init == state = [ onHand |-> 0, allocated |-> 0 ]
+
+Next == 
+  \/ \E qty \in Nat : qty > 0 /\ state' = [state EXCEPT !.onHand = @ + qty]
+  \/ \E qty \in Nat : qty > 0 /\ state.allocated + qty <= state.onHand /\ state' = [state EXCEPT !.allocated = @ + qty]
+  \/ \E qty \in Nat : qty > 0 /\ qty <= state.allocated /\ state' = [state EXCEPT !.allocated = @ - qty, !.onHand = @ - qty]
+
+Invariant == state.onHand \geq 0 /\ state.allocated \leq state.onHand
+
+=============================================================================


### PR DESCRIPTION
Low-impact additions:\n\n- Add minimal samples: spec/tla/DomainSpec.tla, spec/alloy/Domain.als\n- Update formal-runbook with samples and verify:formal\n- PR summary: add lightweight PBT/BDD counts (no blocking)\n\nNo behavior change in core; only docs/CI summary display updated.