### PR TITLE
ci/docs: PR summary formal counts + formal-verify trace-validate

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -32,6 +32,8 @@ jobs:
           node-version: '20'
       - name: Run verify:conformance stub
         run: node scripts/formal/verify-conformance.mjs
+      - name: Validate trace schema (sample)
+        run: node scripts/formal/trace-validate.mjs
 
   verify-alloy:
     name: verify:alloy (stub)

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -184,6 +184,14 @@ jobs:
                 lines.push(`• Tests: PBT files=${pbtCount || 0}, BDD features=${bddCount || 0}`);
               }
             } catch {}
+            // Formal specs counts (TLA/Alloy)
+            try {
+              const { execSync } = require('child_process');
+              let tlaCount = 0, alsCount = 0;
+              try { tlaCount = parseInt(execSync("bash -lc 'ls spec/tla/*.tla 2>/dev/null | wc -l'", {stdio:['ignore','pipe','ignore']}).toString().trim()) || 0; } catch {}
+              try { alsCount = parseInt(execSync("bash -lc 'ls spec/alloy/*.als 2>/dev/null | wc -l'", {stdio:['ignore','pipe','ignore']}).toString().trim()) || 0; } catch {}
+              lines.push(`• Formal specs: TLA=${tlaCount}, Alloy=${alsCount}`);
+            } catch {}
             if (lines.length === 0) {
               lines.push('No CodeX artifacts found to summarize.');
             }

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -28,6 +28,7 @@ Samples
 Tools
 - ローカル確認: `pnpm run tools:formal:check`（インストール済みツールを一覧）
 - セットアップ手順: [formal-tools-setup.md](./formal-tools-setup.md)
+- トレース検証（軽量）: `pnpm run trace:validate`（サンプルイベントのスキーマ整合を確認）
 
 Roadmap Fit (Issue #493)
 - Non‑blocking, label‑gated CI first


### PR DESCRIPTION
Low-impact improvements:\n\n- PR summary: add Formal specs counts (TLA/Alloy)\n- Formal Verify workflow: run trace-validate (sample) in verify-conformance job\n- Runbook: mention trace:validate command\n\nNon-blocking and label-gated; no impact to default CI.