### PR TITLE
docs(formal): mini flow + spec check scripts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ Claude CodeやMCPとの統合
 - **[formal-gates.md](./quality/formal-gates.md)** ⭐ フォーマル品質ゲート（v0.2 DoD）
 - [formal-runbook.md](./quality/formal-runbook.md) - 実行・運用手順（ラベルゲート/手動実行）
 - [formal-tools-setup.md](./quality/formal-tools-setup.md) - ローカル環境セットアップ（Apalache/TLC/Z3/cvc5）
+ - [formal-mini-flow.md](./quality/formal-mini-flow.md) - 反例→失敗テスト→修正→緑の最小フロー
 
 ### 📐 [spec/](./spec/) - 仕様レジストリ
 仕様の配置と規約

--- a/docs/quality/formal-mini-flow.md
+++ b/docs/quality/formal-mini-flow.md
@@ -1,0 +1,31 @@
+# Formal Mini Flow: 反例 → 失敗テスト → 修正 → 緑
+
+目的
+- 形式仕様と実装の“接着”を小さいループで回すための最小手順。
+
+流れ（例）
+1) 仕様/期待を定義（TLA+/Alloy/不変）
+   - TLA+ 最小: `spec/tla/DomainSpec.tla`（Invariant を定義）
+   - Alloy 最小: `spec/alloy/Domain.als`（Safety アサーション）
+   - 実装側の不変: onHand>=0, allocated<=onHand（verify:conformance でチェック）
+2) 実行で反例が出る
+   - `pnpm run spec:check:tla` ／ Alloy IDEで `Domain.als` を `check` 実行
+   - `pnpm run verify:conformance -i <events.json>`
+3) 反例をテスト化（Red）
+   - 反例となるイベント列/入力を `tests/` に最小再現として追加
+4) 実装を最小修正（Green）
+   - 失敗テストが通るように、小さく修正
+5) リファクタリング（Refactor）
+   - 仕様と実装の重複/複雑性を整理
+
+補助コマンド
+- TLA+ チェック: `pnpm run spec:check:tla`（Apalache または TLC がある場合に実行）
+- Alloy チェック: `pnpm run spec:check:alloy`（CLIがなければガイダンスを表示）
+- トレース検証: `pnpm run trace:validate`（スキーマ整合の軽量チェック）
+- Conformance: `pnpm run verify:conformance [-i file --disable-invariants ...]`
+
+Tips
+- まずは「不変（safety）」から始め、小さいループで回す
+- CIは `run-formal` ラベルで起動（非ブロッキング）
+- 詳細は `docs/quality/formal-runbook.md` と `docs/quality/formal-gates.md`
+

--- a/package.json
+++ b/package.json
@@ -226,6 +226,8 @@
     "conformance:verify:sample": "tsx src/cli/index.ts conformance verify -i samples/conformance/sample-data.json --context-file samples/conformance/sample-context.json --rules samples/conformance/sample-rules.json --format json --output hermetic-reports/conformance/sample-results.json",
     "tools:formal:check": "node scripts/formal/tools-check.mjs",
     "trace:validate": "node scripts/formal/trace-validate.mjs samples/conformance/sample-traces.json",
+    "spec:check:tla": "node scripts/formal/spec-check-tla.mjs spec/tla/DomainSpec.tla",
+    "spec:check:alloy": "node scripts/formal/spec-check-alloy.mjs spec/alloy/Domain.als",
     "quality:policy": "tsx src/cli/index.ts quality policy",
     "quality:validate": "tsx src/cli/index.ts quality validate",
     "quality:report": "tsx src/cli/index.ts quality report",

--- a/scripts/formal/spec-check-alloy.mjs
+++ b/scripts/formal/spec-check-alloy.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+// Lightweight Alloy checker placeholder: prints guidance (Alloy 6 CLI may not be present).
+console.log('Alloy check placeholder — open spec/alloy/Domain.als in Alloy IDE or use Alloy 6 CLI if available.');
+process.exit(0);
+

--- a/scripts/formal/spec-check-tla.mjs
+++ b/scripts/formal/spec-check-tla.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Lightweight TLA+ checker: prefers Apalache if installed; otherwise tries TLC via TLA_TOOLS_JAR.
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+
+function has(cmd) { try { execSync(`bash -lc 'command -v ${cmd}'`, {stdio:'ignore'}); return true; } catch { return false; } }
+function run(cmd) { try { console.log(`$ ${cmd}`); execSync(cmd, { stdio: 'inherit' }); return 0; } catch (e) { return 1; } }
+
+const spec = process.argv[2] || 'spec/tla/DomainSpec.tla';
+if (!fs.existsSync(spec)) { console.log(`Spec not found: ${spec} (skipping)`); process.exit(0); }
+
+if (has('apalache-mc')) {
+  process.exit(run(`bash -lc 'apalache-mc check --inv=Invariant ${spec}'`) ? 0 : 0);
+} else if (process.env.TLA_TOOLS_JAR) {
+  const jar = process.env.TLA_TOOLS_JAR;
+  process.exit(run(`bash -lc 'java -cp ${jar} tlc2.TLC ${spec}'`) ? 0 : 0);
+} else {
+  console.log('No Apalache or TLA_TOOLS_JAR set. Use tools:formal:check and see formal-tools-setup.md');
+  process.exit(0);
+}
+


### PR DESCRIPTION
Add a concise guide for the Red-Green-Refactor mini flow and lightweight spec check scripts.\n\n- docs/quality/formal-mini-flow.md\n- scripts: spec:check:tla (Apalache/TLC if present), spec:check:alloy (placeholder guidance)\n- npm scripts: spec:check:tla, spec:check:alloy\n\nNon-blocking and purely additive.