### PR TITLE
feat(smt): verify-smt --file + sample + docs

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -29,6 +29,8 @@ Tools
 - ローカル確認: `pnpm run tools:formal:check`（インストール済みツールを一覧）
 - セットアップ手順: [formal-tools-setup.md](./formal-tools-setup.md)
 - トレース検証（軽量）: `pnpm run trace:validate`（サンプルイベントのスキーマ整合を確認）
+ - SMT サンプル: `spec/smt/sample.smt2`（動作確認用）
+ - 実行例: `pnpm run verify:smt -- --solver=z3 --file spec/smt/sample.smt2`
 
 verify:conformance オプション
 - `-i, --in <file>` 入力イベントJSON（既定: `samples/conformance/sample-traces.json`）

--- a/scripts/formal/verify-smt.mjs
+++ b/scripts/formal/verify-smt.mjs
@@ -1,6 +1,69 @@
 #!/usr/bin/env node
-// Stub runner for verify:smt
-const solverArg = process.argv.find(a => a.startsWith('--solver='));
-const solver = solverArg ? solverArg.slice('--solver='.length) : 'z3';
-console.log(`verify:smt stub — solver=${solver || 'z3'} (integration TBD)`);
+// Lightweight SMT runner: accepts --solver and --file, runs if available, writes a summary. Non-blocking.
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') args.help = true;
+    else if (a === '--file' && argv[i+1]) { args.file = argv[++i]; }
+    else if (a.startsWith('--file=')) { args.file = a.slice(7); }
+    else if (a.startsWith('--solver=')) { args.solver = a.slice(9); }
+    else { args._.push(a); }
+  }
+  return args;
+}
+
+function has(cmd) { try { execSync(`bash -lc 'command -v ${cmd}'`, {stdio:'ignore'}); return true; } catch { return false; } }
+function sh(cmd) { try { return execSync(cmd, { encoding: 'utf8' }); } catch (e) { return (e.stdout?.toString?.() || '') + (e.stderr?.toString?.() || ''); } }
+
+const args = parseArgs(process.argv);
+if (args.help) {
+  console.log(`Usage: node scripts/formal/verify-smt.mjs [--solver=z3|cvc5] [--file path/to/input.smt2]`);
+  process.exit(0);
+}
+
+const solver = (args.solver || 'z3').toLowerCase();
+const file = args.file;
+
+const repoRoot = path.resolve(process.cwd());
+const outDir = path.join(repoRoot, 'hermetic-reports', 'formal');
+const outFile = path.join(outDir, 'smt-summary.json');
+fs.mkdirSync(outDir, { recursive: true });
+
+let status = 'skipped';
+let output = '';
+let ran = false;
+
+if (!file) {
+  status = 'no_file';
+} else if (!fs.existsSync(file)) {
+  status = 'file_not_found';
+} else if (solver === 'z3' && has('z3')) {
+  output = sh(`bash -lc 'z3 -smt2 ${file.replace(/'/g, "'\\''")} 2>&1 || true'`);
+  status = 'ran'; ran = true;
+} else if (solver === 'cvc5' && has('cvc5')) {
+  output = sh(`bash -lc 'cvc5 --lang=smt2 ${file.replace(/'/g, "'\\''")} 2>&1 || true'`);
+  status = 'ran'; ran = true;
+} else {
+  status = 'solver_not_available';
+}
+
+const summary = {
+  solver,
+  file: file || null,
+  ran,
+  status,
+  timestamp: new Date().toISOString(),
+  output: output.slice(0, 4000)
+};
+
+fs.writeFileSync(outFile, JSON.stringify(summary, null, 2));
+console.log(`SMT summary written: ${path.relative(repoRoot, outFile)}`);
+console.log(`- solver=${solver} status=${status}${ran ? '' : ''}`);
+
+// Non-blocking
 process.exit(0);

--- a/spec/smt/sample.smt2
+++ b/spec/smt/sample.smt2
@@ -1,0 +1,5 @@
+(set-logic QF_LIA)
+(declare-const x Int)
+(assert (> x 0))
+(check-sat)
+(get-model)


### PR DESCRIPTION
- verify-smt.mjs: add --file option; run z3/cvc5 if available; write summary\n- Add spec/smt/sample.smt2\n- Update runbook with SMT example\n\nNon-blocking; informational only.