### PR TITLE
chore(formal): aggregate reports + artifact upload

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -36,6 +36,15 @@ jobs:
         run: node scripts/formal/verify-conformance.mjs
       - name: Validate trace schema (sample)
         run: node scripts/formal/trace-validate.mjs
+      - name: Aggregate formal summaries (local)
+        run: node scripts/formal/aggregate-formal.mjs
+      - name: Upload formal reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: formal-reports
+          path: |
+            hermetic-reports/
 
   verify-alloy:
     name: verify:alloy (stub)

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -10,6 +10,7 @@ CLI stubs (to be wired)
 - `pnpm run verify:tla -- --engine=apalache|tlc` — prints stub
 - `pnpm run verify:smt -- --solver=z3|cvc5` — prints stub
 - `pnpm run verify:formal` — 上記4種の連続実行（ローカル確認用）
+  - 集計: `hermetic-reports/formal/summary.json` に要約を出力
 
 Conformance sample (quick demo)
 - `pnpm run conformance:sample` — サンプルのルール/設定/データ/コンテキストを生成

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "verify:alloy": "node scripts/formal/verify-alloy.mjs",
     "verify:tla": "node scripts/formal/verify-tla.mjs",
     "verify:smt": "node scripts/formal/verify-smt.mjs",
-    "verify:formal": "node scripts/formal/verify-conformance.mjs && node scripts/formal/verify-alloy.mjs && node scripts/formal/verify-tla.mjs --engine=tlc && node scripts/formal/verify-smt.mjs --solver=z3",
+    "verify:formal": "node scripts/formal/verify-conformance.mjs && node scripts/formal/verify-alloy.mjs && node scripts/formal/verify-tla.mjs --engine=tlc && node scripts/formal/verify-smt.mjs --solver=z3 && node scripts/formal/aggregate-formal.mjs",
     "conformance:sample": "tsx src/cli/index.ts conformance sample --rules samples/conformance/sample-rules.json --config samples/conformance/sample-config.json --data samples/conformance/sample-data.json --context samples/conformance/sample-context.json",
     "conformance:verify:sample": "tsx src/cli/index.ts conformance verify -i samples/conformance/sample-data.json --context-file samples/conformance/sample-context.json --rules samples/conformance/sample-rules.json --format json --output hermetic-reports/conformance/sample-results.json",
     "tools:formal:check": "node scripts/formal/tools-check.mjs",

--- a/scripts/formal/aggregate-formal.mjs
+++ b/scripts/formal/aggregate-formal.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Aggregate formal reports into hermetic-reports/formal/summary.json
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const formalDir = path.join(repoRoot, 'hermetic-reports', 'formal');
+const confDir = path.join(repoRoot, 'hermetic-reports', 'conformance');
+fs.mkdirSync(formalDir, { recursive: true });
+
+function readJsonSafe(p){ try { return JSON.parse(fs.readFileSync(p,'utf8')); } catch { return undefined; } }
+
+const conformance = readJsonSafe(path.join(confDir, 'summary.json'));
+const smt = readJsonSafe(path.join(formalDir, 'smt-summary.json'));
+const alloy = readJsonSafe(path.join(formalDir, 'alloy-summary.json'));
+
+const summary = {
+  timestamp: new Date().toISOString(),
+  present: {
+    conformance: !!conformance,
+    smt: !!smt,
+    alloy: !!alloy,
+    tla: false
+  },
+  conformance: conformance || null,
+  smt: smt || null,
+  alloy: alloy || null
+};
+
+const outFile = path.join(formalDir, 'summary.json');
+fs.writeFileSync(outFile, JSON.stringify(summary, null, 2));
+console.log(`Formal summary written: ${path.relative(repoRoot, outFile)}`);
+process.exit(0);
+


### PR DESCRIPTION
- Add scripts/formal/aggregate-formal.mjs\n- Append aggregation to verify:formal\n- In formal-verify (conformance job), run aggregation and upload hermetic-reports as artifact\n- Docs: formal-runbook mentions summary path\n\nLabel-gated, non-blocking, informational only.