### PR TITLE
ci(formal): workflow inputs for ALLOY_JAR / TLA_TOOLS_JAR

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -17,6 +17,14 @@ on:
         description: "SMT solver (z3|cvc5)"
         required: false
         default: "z3"
+      alloyJar:
+        description: "Path to Alloy jar (optional)"
+        required: false
+        default: ""
+      tlaToolsJar:
+        description: "Path to TLA+ tla2tools.jar (optional)"
+        required: false
+        default: ""
 
 jobs:
   verify-conformance:
@@ -58,6 +66,8 @@ jobs:
         with:
           node-version: '20'
       - name: Run verify:alloy (sample)
+        env:
+          ALLOY_JAR: ${{ github.event_name == 'workflow_dispatch' && inputs.alloyJar || '' }}
         run: node scripts/formal/verify-alloy.mjs --file spec/alloy/Domain.als || true
 
   verify-tla:
@@ -74,6 +84,7 @@ jobs:
       - name: Run verify:tla stub
         env:
           TLA_ENGINE: ${{ github.event_name == 'workflow_dispatch' && inputs.engine || 'tlc' }}
+          TLA_TOOLS_JAR: ${{ github.event_name == 'workflow_dispatch' && inputs.tlaToolsJar || '' }}
         run: node scripts/formal/verify-tla.mjs --engine=$TLA_ENGINE --file spec/tla/DomainSpec.tla || true
 
   verify-smt:

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -3,6 +3,12 @@
 Usage
 - Label-gated CI: add PR label `run-formal` to run formal checks (stub initially)
 - Manual run: trigger `Formal Verify` via `workflow_dispatch`
+  - inputs:
+    - `target`: all|conformance|alloy|tla|smt
+    - `engine`: tlc|apalache（tla用）
+    - `solver`: z3|cvc5（smt用）
+    - `alloyJar`: Alloy jar のパス（任意）
+    - `tlaToolsJar`: tla2tools.jar のパス（任意）
 
 CLI stubs (to be wired)
 - `pnpm run verify:conformance` — prints stub; use `ae conformance verify` for real engine


### PR DESCRIPTION
- formal-verify.yml: add workflow_dispatch inputs alloyJar / tlaToolsJar\n- Pass inputs as env to verify-alloy / verify-tla jobs\n- Runbook: document available inputs\n\nLabel-gated, non-blocking.