### PR TITLE
chore(formal): color console summary (NO_COLOR aware)

### DIFF
--- a/scripts/formal/print-summary.mjs
+++ b/scripts/formal/print-summary.mjs
@@ -10,6 +10,18 @@ if (!fs.existsSync(p)) {
   process.exit(0);
 }
 const f = JSON.parse(fs.readFileSync(p,'utf8'));
+
+// Color helpers (respect NO_COLOR)
+const useColor = process.stdout.isTTY && !process.env.NO_COLOR;
+const c = {
+  green: (s) => useColor ? `\u001b[32m${s}\u001b[0m` : s,
+  yellow: (s) => useColor ? `\u001b[33m${s}\u001b[0m` : s,
+  red: (s) => useColor ? `\u001b[31m${s}\u001b[0m` : s,
+  cyan: (s) => useColor ? `\u001b[36m${s}\u001b[0m` : s,
+  gray: (s) => useColor ? `\u001b[90m${s}\u001b[0m` : s,
+  bold: (s) => useColor ? `\u001b[1m${s}\u001b[0m` : s,
+};
+
 const lines = [];
 if (f.conformance) {
   const ce = f.conformance.schemaErrors ?? 'n/a';
@@ -20,18 +32,31 @@ if (f.conformance) {
     const fv = f.conformance.firstInvariantViolation;
     if (fv && (fv.index !== undefined) && fv.type) first = `, first=${fv.type}@${fv.index}`;
   } catch {}
-  lines.push(`Conformance: schemaErrors=${ce}, invariantViolations=${iv}, rate=${vr}${first}`);
+  const conformanceLine = `Conformance: schemaErrors=${ce}, invariantViolations=${iv}, rate=${vr}${first}`;
+  const colored = (iv === 0 && ce === 0) ? c.green(conformanceLine) : c.yellow(conformanceLine);
+  lines.push(colored);
 }
-if (f.smt) lines.push(`SMT: ${f.smt.status}`);
-if (f.alloy) lines.push(`Alloy: ${f.alloy.status}`);
-if (f.tla) lines.push(`TLA: ${f.tla.status} (${f.tla.engine})`);
+if (f.smt) {
+  const st = f.smt.status;
+  const smtLine = `SMT: ${st}`;
+  lines.push(st === 'ran' ? c.green(smtLine) : (st === 'solver_not_available' ? c.gray(smtLine) : c.yellow(smtLine)));
+}
+if (f.alloy) {
+  const st = f.alloy.status;
+  const alloyLine = `Alloy: ${st}`;
+  lines.push(st === 'ran' ? c.green(alloyLine) : (st === 'tool_not_available' ? c.gray(alloyLine) : c.yellow(alloyLine)));
+}
+if (f.tla) {
+  const st = f.tla.status;
+  const tlaLine = `TLA: ${st} (${f.tla.engine})`;
+  lines.push(st === 'ran' ? c.green(tlaLine) : (st === 'tool_not_available' ? c.gray(tlaLine) : c.yellow(tlaLine)));
+}
 
 if (lines.length) {
-  console.log('--- Formal Summary ---');
+  console.log(c.bold('--- Formal Summary ---'));
   for (const l of lines) console.log(l);
-  console.log('----------------------');
+  console.log(c.bold('----------------------'));
 } else {
   console.log('Formal summary is empty');
 }
 process.exit(0);
-


### PR DESCRIPTION
- Colorize print-summary output for quick visual scan (green/yellow/gray)\n- Respects NO_COLOR and non-TTY\n\nNon-blocking; developer UX only.