### PR TITLE
chore(formal): verify echo + color legend

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -29,6 +29,11 @@ TLA: tool_not_available (tlc)
 ----------------------
 ```
 
+色の意味（コンソール要約）
+- 緑: OK（実行成功・違反なし）
+- 黄: 注意（違反やスキップなど）
+- 灰: ツール未検出など情報のみ
+
 Conformance sample (quick demo)
 - `pnpm run conformance:sample` — サンプルのルール/設定/データ/コンテキストを生成
 - `pnpm run conformance:verify:sample` — 生成データで検証を実行（JSONレポート出力）

--- a/scripts/formal/verify-conformance.mjs
+++ b/scripts/formal/verify-conformance.mjs
@@ -116,7 +116,12 @@ const summary = {
 
 writeJson(outFile, summary);
 console.log(`Conformance summary written: ${path.relative(repoRoot, outFile)}`);
+console.log(`- input=${path.relative(repoRoot, dataPath)} schema=${path.relative(repoRoot, schemaPath)}`);
 console.log(`- events=${summary.events} schemaErrors=${summary.schemaErrors} invariantViolations=${summary.invariantViolations}`);
+if (args.disable || args.onhandMin !== undefined) {
+  const disableList = (args.disable || '').split(',').map(s=>s.trim()).filter(Boolean).join(',') || 'none';
+  console.log(`- options: disable=[${disableList}] onhandMin=${onhandMin}`);
+}
 
 // Non-blocking (label-gated workflow); always exit 0
 process.exit(0);


### PR DESCRIPTION
- verify-conformance: echo input/schema/options alongside output path\n- runbook: add color legend for console summary (green/yellow/gray)\n\nNon-blocking; improves DX and clarity.