### PR TITLE
docs(formal): byType + NO_COLOR; messages: friendlier tool hints

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -72,6 +72,7 @@ Roadmap Fit (Issue #493)
 - `schemaErrors`: スキーマ違反件数
 - `invariantViolations`: 不変違反件数（`violationRate` は events に対する比率）
 - `firstInvariantViolation`: 最初の違反（`type` と `index`）
+ - `byType(...)`: 不変タイプごとの件数（例: `onhand_min`, `allocated_le_onhand`）
 
 TLA+/Apalache/SMT コマンド例（ローカル）
 - TLA+ (TLC)
@@ -87,3 +88,7 @@ TLA+/Apalache/SMT コマンド例（ローカル）
 Alloy CLI（環境がある場合）
 - `pnpm run verify:alloy -- --file spec/alloy/Domain.als`
 - CLI が無い場合は `ALLOY_JAR=/path/to/alloy.jar` を設定し、`java -jar $ALLOY_JAR spec/alloy/Domain.als`
+
+Tips（出力・色・抑制）
+- コンソール要約は色分け表示。色を無効化するには `NO_COLOR=1` を指定（CI等）
+- 実行ログのサマリは `hermetic-reports/formal/summary.json` でも確認可能

--- a/scripts/formal/verify-alloy.mjs
+++ b/scripts/formal/verify-alloy.mjs
@@ -49,7 +49,7 @@ if (!fs.existsSync(absFile)){
   ran = true; status = 'ran';
 } else {
   status = 'tool_not_available';
-  output = 'Alloy CLI not found. Set ALLOY_JAR=/path/to/alloy.jar or install Alloy CLI.';
+  output = 'Alloy CLI not found. Set ALLOY_JAR=/path/to/alloy.jar or install Alloy CLI. See docs/quality/formal-tools-setup.md';
 }
 
 const summary = {

--- a/scripts/formal/verify-smt.mjs
+++ b/scripts/formal/verify-smt.mjs
@@ -50,6 +50,7 @@ if (!file) {
   status = 'ran'; ran = true;
 } else {
   status = 'solver_not_available';
+  output = `Solver '${solver}' not found. See docs/quality/formal-tools-setup.md`;
 }
 
 const summary = {


### PR DESCRIPTION
- Runbook: add byType(...) explanation and NO_COLOR tip\n- verify-alloy.mjs: append setup doc link in tool-not-available output\n- verify-smt.mjs: set output message when solver not available (doc link)\n\nNon-blocking; improves clarity and DX.