### PR TITLE
chore(formal): friendlier file_not_found messages + docs tip

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -98,4 +98,5 @@ Alloy CLI（環境がある場合）
 Tips（出力・色・抑制）
 - コンソール要約は色分け表示。色を無効化するには `NO_COLOR=1` を指定（CI等）
 - 実行ログのサマリは `hermetic-reports/formal/summary.json` でも確認可能
- - PRサマリにも Formal summary を1行で表示（サマリが生成されている場合）
+- PRサマリにも Formal summary を1行で表示（サマリが生成されている場合）
+ - `file_not_found`: `--file` の指定パスを確認（SMT/TLA/Alloy）

--- a/scripts/formal/verify-alloy.mjs
+++ b/scripts/formal/verify-alloy.mjs
@@ -40,6 +40,7 @@ let output = '';
 
 if (!fs.existsSync(absFile)){
   status = 'file_not_found';
+  output = `Alloy file not found: ${absFile}`;
 } else if (has('alloy')) {
   output = sh(`bash -lc 'alloy ${absFile.replace(/'/g, "'\\''")} 2>&1 || true'`);
   ran = true; status = 'ran';

--- a/scripts/formal/verify-smt.mjs
+++ b/scripts/formal/verify-smt.mjs
@@ -42,6 +42,7 @@ if (!file) {
   status = 'no_file';
 } else if (!fs.existsSync(file)) {
   status = 'file_not_found';
+  output = `SMT-LIB file not found: ${file}`;
 } else if (solver === 'z3' && has('z3')) {
   output = sh(`bash -lc 'z3 -smt2 ${file.replace(/'/g, "'\\''")} 2>&1 || true'`);
   status = 'ran'; ran = true;

--- a/scripts/formal/verify-tla.mjs
+++ b/scripts/formal/verify-tla.mjs
@@ -42,6 +42,7 @@ let output = '';
 
 if (!fs.existsSync(absFile)){
   status = 'file_not_found';
+  output = `TLA file not found: ${absFile}`;
 } else if (engine === 'apalache'){
   if (has('apalache-mc')){
     output = sh(`bash -lc 'apalache-mc check --inv=Invariant ${absFile.replace(/'/g, "'\\''")} 2>&1 || true'`);


### PR DESCRIPTION
- Alloy/TLA/SMT runners now print file_not_found with path\n- Runbook: add tip for file_not_found\n\nNon-blocking; improves diagnostics.