### PR TITLE
ci/docs: PR formal file paths + jq examples

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -217,17 +217,20 @@ jobs:
                 if (f.smt) {
                   const st = f.smt.status;
                   const t = (st === 'ran') ? tag(true) : (st === 'solver_not_available' ? info : tag(false));
-                  parts.push(`${t} SMT: ${st}`);
+                  const file = f.smt.file ? ` (${f.smt.file})` : '';
+                  parts.push(`${t} SMT: ${st}${file}`);
                 }
                 if (f.alloy) {
                   const st = f.alloy.status;
                   const t = (st === 'ran') ? tag(true) : (st === 'tool_not_available' ? info : tag(false));
-                  parts.push(`${t} Alloy: ${st}`);
+                  const file = f.alloy.file ? ` (${f.alloy.file})` : '';
+                  parts.push(`${t} Alloy: ${st}${file}`);
                 }
                 if (f.tla) {
                   const st = f.tla.status;
                   const t = (st === 'ran') ? tag(true) : (st === 'tool_not_available' ? info : tag(false));
-                  parts.push(`${t} TLA: ${st} (${f.tla.engine})`);
+                  const file = f.tla.file ? ` ${f.tla.file}` : '';
+                  parts.push(`${t} TLA: ${st} (${f.tla.engine})${file}`);
                 }
                 if (parts.length) lines.push('• Formal summary: ' + parts.join('; '));
               }

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -127,3 +127,8 @@ Artifacts（Formal Reports）
 - `hermetic-reports/formal/alloy-summary.json`: Alloy ランナーの簡易要約（file/status/output）
 - `hermetic-reports/formal/smt-summary.json`: SMT ランナーの簡易要約（solver/file/status/output）
 - `hermetic-reports/conformance/summary.json`: Conformance 要約（events/schemaErrors/invariantViolations/violationRate/first/byType）
+
+Artifacts のクイック確認（jq）
+- 集約のpresence: `jq '.present' hermetic-reports/formal/summary.json`
+- Conformance byType: `jq '.conformance.byType' hermetic-reports/formal/summary.json`
+- 最初の不変違反: `jq '.conformance.firstInvariantViolation' hermetic-reports/formal/summary.json`


### PR DESCRIPTION
- PR summary now includes short file paths for SMT/Alloy/TLA when present\n- Runbook: add jq examples to inspect formal artifacts quickly\n\nNon-blocking; improves diagnostics.