### PR TITLE
CI: Phase B/C gating (qa-bench/security) + pnpm install fallback

### DIFF
--- a/.github/workflows/ae-ci.yml
+++ b/.github/workflows/ae-ci.yml
@@ -6,7 +6,22 @@ on:
   pull_request:
 
 jobs:
+  qa_gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.set.outputs.run }}
+    steps:
+      - uses: actions/github-script@v7
+        id: set
+        with:
+          script: |
+            const isPR = context.eventName === 'pull_request';
+            const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
+            const shouldRun = !isPR || labels.includes('run-qa');
+            core.setOutput('run', String(shouldRun));
   qa-bench:
+    needs: qa_gate
+    if: ${{ needs.qa_gate.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking') }}
     steps:
@@ -18,7 +33,7 @@ jobs:
       - name: Enable corepack
         run: corepack enable
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
       - name: Build
         run: pnpm run build
       - name: Bin smoke check

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,10 +20,24 @@ permissions:
   actions: read
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run_security: ${{ steps.lbl.outputs.run_security }}
+    steps:
+      - uses: actions/github-script@v7
+        id: lbl
+        with:
+          script: |
+            const isPR = context.eventName === 'pull_request';
+            const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
+            const runSecurity = !isPR || labels.includes('run-security');
+            core.setOutput('run_security', String(runSecurity));
   security-scan:
+    needs: gate
+    if: ${{ needs.gate.outputs.run_security == 'true' }}
     name: Security Scanning
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || contains(join(fromJSON(toJSON(github.event.pull_request.labels)).*.name, ','), 'run-security')
     continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking') }}
     
     steps:
@@ -59,6 +73,8 @@ jobs:
           retention-days: 30
 
   dependency-audit:
+    needs: gate
+    if: ${{ needs.gate.outputs.run_security == 'true' }}
     name: Dependency Audit
     runs-on: ubuntu-latest
     


### PR DESCRIPTION
- qa-bench を 'run-qa' ラベルで実行（PRはデフォルト非実行）\n- security系ジョブを 'run-security' ラベルで実行（PRはデフォルト非実行）\n- pnpm install を --frozen-lockfile 失敗時に --no-frozenlockfile フォールバック\n- Verify Lite のみ必須を維持しつつ、重い/任意ジョブを赤要因から分離\n\n関連Issue: #536, #537