### PR TITLE
CI: Core pnpm fallback (--no-frozen-lockfile)

### DIFF
--- a/.github/workflows/common/ci-core.yml
+++ b/.github/workflows/common/ci-core.yml
@@ -21,5 +21,5 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: 'pnpm'
       - run: corepack enable
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
       - run: pnpm run ${{ inputs.run-script }}


### PR DESCRIPTION
- 共通ワークフロー(ci-core)にpnpmインストールのフォールバックを導入\n- PRヘッドのヘッドレス制約やロックファイル不在の検出誤差に対応\n\n関連Issue: #536