### PR TITLE
CI: pnpm fallback bulk + security gates + testing-ddd pnpm

### DIFF
--- a/.github/workflows/codegen-drift-check.yml
+++ b/.github/workflows/codegen-drift-check.yml
@@ -45,7 +45,7 @@ jobs:
           
       - name: Install dependencies
         run: |
-          pnpm install --frozen-lockfile
+          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
           
       - name: Build ae-framework
         run: |

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Enable corepack
         run: corepack enable
       - name: Install deps (pnpm)
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
       - name: Run coverage
         run: pnpm run coverage || true
       - name: Check coverage threshold

--- a/.github/workflows/flake-maintenance.yml
+++ b/.github/workflows/flake-maintenance.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
       - run: corepack enable
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
       
       - name: Install bc for calculations
         run: sudo apt-get update && sudo apt-get install -y bc

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -57,7 +57,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
 
       - name: Run security analyzer
         run: pnpm run security:scan
@@ -92,7 +92,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
 
       - name: Audit dependencies
         run: pnpm audit --audit-level=moderate || true
@@ -107,6 +107,8 @@ jobs:
           fi
 
   secrets-scan:
+    needs: gate
+    if: ${{ needs.gate.outputs.run_security == 'true' }}
     name: Secrets Scanning
     runs-on: ubuntu-latest
     
@@ -124,9 +126,11 @@ jobs:
           config-path: .gitleaks.toml
 
   codeql-analysis:
+    needs: gate
+    if: ${{ needs.gate.outputs.run_security == 'true' }}
     name: CodeQL Analysis
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule'
+    # schedule は別トリガーで動く
     
     permissions:
       security-events: write
@@ -157,6 +161,8 @@ jobs:
           category: "/language:${{matrix.language}}"
 
   license-check:
+    needs: gate
+    if: ${{ needs.gate.outputs.run_security == 'true' }}
     name: License Compliance
     runs-on: ubuntu-latest
     

--- a/.github/workflows/testing-ddd-scripts.yml
+++ b/.github/workflows/testing-ddd-scripts.yml
@@ -13,8 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: '20' }
-      - run: npm ci
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
       - name: Derive strict gate from labels
         id: gate
         uses: actions/github-script@v7
@@ -35,20 +38,20 @@ jobs:
         env:
           TRACE_ID: ${{ steps.trace.outputs.trace_id }}
         run: |
-          if [ -n "${TRACE_ID}" ]; then TRACE_ID=${TRACE_ID} npm run test:property:focus --silent || true; else npm run test:property --silent || true; fi
+          if [ -n "${TRACE_ID}" ]; then TRACE_ID=${TRACE_ID} pnpm run test:property:focus --silent || true; else pnpm run test:property --silent || true; fi
       - name: Replay runner (#411)
         env:
           TRACE_ID: ${{ steps.trace.outputs.trace_id }}
         run: |
-          if [ -n "${TRACE_ID}" ]; then TRACE_ID=${TRACE_ID} npm run test:replay:focus --silent || true; else npm run test:replay --silent || true; fi
+          if [ -n "${TRACE_ID}" ]; then TRACE_ID=${TRACE_ID} pnpm run test:replay:focus --silent || true; else pnpm run test:replay --silent || true; fi
       - name: BDD lint (#410)
         continue-on-error: ${{ github.ref != 'refs/heads/main' && steps.gate.outputs.strict != 'true' }}
-        run: npm run bdd:lint --silent || true
+        run: pnpm run bdd:lint --silent || true
       - name: Formal GWT format (#407)
         run: |
           if [ -f formal/summary.json ]; then node scripts/formal/format-counterexamples.mjs; fi
       - name: Aggregate artifacts (#408)
-        run: npm run artifacts:aggregate --silent || true
+        run: pnpm run artifacts:aggregate --silent || true
       - name: Upload artifacts (summary)
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
- security.yml: run-securityゲートを secrets/codeql/license にも適用\n- pnpm install のフォールバック（--no-frozen-lockfile）を複数ワークフローに導入\n- testing-ddd-scripts: npm→pnpm 化、corepack enable 追加\n\n関連Issue: #535, #536, #537