### PR TITLE
QA: add --light mode and use in CI

### DIFF
--- a/.github/workflows/ae-ci.yml
+++ b/.github/workflows/ae-ci.yml
@@ -38,8 +38,8 @@ jobs:
         run: pnpm run build
       - name: Bin smoke check
         run: node scripts/ci/check-bins.mjs
-      - name: QA
-        run: node dist/src/cli/index.js qa
+      - name: QA (light)
+        run: node dist/src/cli/index.js qa --light
       - name: Bench (seeded)
         run: AE_SEED=123 node dist/src/cli/index.js bench
       - name: Upload artifacts

--- a/src/runner/main.ts
+++ b/src/runner/main.ts
@@ -17,7 +17,8 @@ export async function main() {
     .action(benchRun);
   
   cli.command('qa', 'Run QA metrics')
-    .action(qaRun);
+    .option('--light', 'Run light suite (fast tests)')
+    .action((opts) => qaRun({ light: Boolean(opts.light) }));
   
   cli.command('qa:flake', 'Run tests multiple times to detect flakiness')
     .option('--times <n>', 'Repeat count', { default: 10 })


### PR DESCRIPTION
- qa コマンドに --light オプションを追加（vitestは test:fast を実行）\n- ae-ci で qa 実行時に --light を付与し、スピードと安定性を向上\n\n関連Issue: #536