### PR TITLE
CLI: adopt safeExit (wave 4)

### DIFF
--- a/src/cli/ae-fix-cli.ts
+++ b/src/cli/ae-fix-cli.ts
@@ -15,6 +15,7 @@ import { validateFailureArtifact, validateFailureArtifactCollection, FailureArti
 import { AutoFixEngine } from '../cegis/auto-fix-engine.js';
 import type { AutoFixOptions } from '../cegis/auto-fix-engine.js';
 import { toMessage } from '../utils/error-utils.js';
+import { safeExit } from '../utils/safe-exit.js';
 
 const program = new Command();
 
@@ -39,7 +40,7 @@ program
       await executeAutoFix(options);
     } catch (error: unknown) {
       console.error(chalk.red('❌ Auto-fix failed:'), toMessage(error));
-      process.exit(1);
+      safeExit(1);
     }
   });
 
@@ -55,7 +56,7 @@ program
       await executeAnalysis(options);
     } catch (error: unknown) {
       console.error(chalk.red('❌ Analysis failed:'), toMessage(error));
-      process.exit(1);
+      safeExit(1);
     }
   });
 
@@ -75,7 +76,7 @@ program
       await createFailureArtifact(options);
     } catch (error: unknown) {
       console.error(chalk.red('❌ Failed to create artifact:'), toMessage(error));
-      process.exit(1);
+      safeExit(1);
     }
   });
 
@@ -89,7 +90,7 @@ program
       await validateArtifacts(options);
     } catch (error: unknown) {
       console.error(chalk.red('❌ Validation failed:'), toMessage(error));
-      process.exit(1);
+      safeExit(1);
     }
   });
 
@@ -103,7 +104,7 @@ program
       await showFixHistory(options);
     } catch (error: unknown) {
       console.error(chalk.red('❌ Failed to show history:'), toMessage(error));
-      process.exit(1);
+      safeExit(1);
     }
   });
 
@@ -338,7 +339,7 @@ async function validateArtifacts(options: any): Promise<void> {
     }
   } catch (error: unknown) {
     console.error(chalk.red('❌ Validation failed:'), toMessage(error));
-    process.exit(1);
+    safeExit(1);
   }
 }
 

--- a/src/cli/enhanced-state-cli.ts
+++ b/src/cli/enhanced-state-cli.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import { EnhancedStateManager } from '../utils/enhanced-state-manager.js';
 import type { FailureArtifact } from '../utils/enhanced-state-manager.js';
 import { toMessage } from '../utils/error-utils.js';
+import { safeExit } from '../utils/safe-exit.js';
 import type { AEIR } from '@ae-framework/spec-compiler';
 import * as fs from 'fs/promises';
 import type * as path from 'path';
@@ -70,7 +71,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to save SSOT: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -100,7 +101,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to load SSOT: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -128,7 +129,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to list versions: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -151,7 +152,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to create snapshot: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -177,7 +178,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to load snapshot: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -220,7 +221,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to simulate failure: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -235,7 +236,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to run garbage collection: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -259,7 +260,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to show statistics: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -306,7 +307,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Transaction test failed: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 
@@ -324,7 +325,7 @@ export class EnhancedStateCLI {
       
     } catch (error: unknown) {
       console.error(chalk.red(`❌ Failed to export state: ${toMessage(error)}`));
-      process.exit(1);
+      safeExit(1);
     }
   }
 

--- a/src/cli/slash-cli.ts
+++ b/src/cli/slash-cli.ts
@@ -8,6 +8,7 @@ import { Command } from 'commander';
 import { SlashCommandManager } from '../commands/slash-command-manager.js';
 import chalk from 'chalk';
 import { toMessage } from '../utils/error-utils.js';
+import { safeExit } from '../utils/safe-exit.js';
 import * as readline from 'readline';
 
 const program = new Command();
@@ -45,7 +46,7 @@ program
       }
   } catch (error: unknown) {
     console.error(chalk.red(`❌ Error: ${toMessage(error)}`));
-    process.exit(1);
+    safeExit(1);
   }
   });
 
@@ -96,7 +97,7 @@ program
       console.log(chalk.blue(`\n📊 Results: ${successCount}/${results.length} successful`));
   } catch (error: unknown) {
     console.error(chalk.red(`❌ Error: ${toMessage(error)}`));
-    process.exit(1);
+    safeExit(1);
   }
   });
 
@@ -210,7 +211,7 @@ program
     });
     
     rl.on('close', () => {
-      process.exit(0);
+      safeExit(0);
     });
   });
 

--- a/src/commands/adapt/jest.ts
+++ b/src/commands/adapt/jest.ts
@@ -132,6 +132,7 @@ export async function adaptJest(thresholds?: { statements: number; branches: num
 
   } catch (error) {
     console.error(chalk.red(`❌ Jest adaptation failed: ${error instanceof Error ? error.message : 'Unknown error'}`));
-    process.exit(1);
+    const { safeExit } = await import('../../utils/safe-exit.js');
+    safeExit(1);
   }
 }

--- a/src/commands/adapt/vitest.ts
+++ b/src/commands/adapt/vitest.ts
@@ -165,6 +165,7 @@ export async function adaptVitest(thresholds?: { statements: number; branches: n
 
   } catch (error) {
     console.error(chalk.red(`❌ Vitest adaptation failed: ${error instanceof Error ? error.message : 'Unknown error'}`));
-    process.exit(1);
+    const { safeExit } = await import('../../utils/safe-exit.js');
+    safeExit(1);
   }
 }


### PR DESCRIPTION
- safeExit を ae-fix/slash/enhanced-state のCLIおよび adaptors(jest/vitest) に適用\n- さらなるテスト・CI安全性の向上