### PR TITLE
chore(quality/agents): adapter-thresholds (report-only) + /run-adapters

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -1,0 +1,60 @@
+name: Adapter Thresholds (Report-Only)
+
+on:
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  summarize-a11y:
+    if: contains(github.event.pull_request.labels.*.name, 'run-adapters')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Summarize a11y results (report-only)
+        id: a11y
+        run: |
+          set -e
+          FILE="reports/a11y-results.json"
+          if [ ! -f "$FILE" ]; then
+            printf "%s\n" "present=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          critical=$(jq -r '.violations.critical // 0' "$FILE" 2>/dev/null || printf "0\n")
+          serious=$(jq -r '.violations.serious // 0' "$FILE" 2>/dev/null || printf "0\n")
+          moderate=$(jq -r '.violations.moderate // 0' "$FILE" 2>/dev/null || printf "0\n")
+          minor=$(jq -r '.violations.minor // 0' "$FILE" 2>/dev/null || printf "0\n")
+          passes=$(jq -r '.passes // 0' "$FILE" 2>/dev/null || printf "0\n")
+          comps=$(jq -r '.components_tested | length' "$FILE" 2>/dev/null || printf "0\n")
+          printf "%s\n" "present=true" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "critical=$critical" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "serious=$serious" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "moderate=$moderate" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "minor=$minor" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "passes=$passes" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "components=$comps" >> "$GITHUB_OUTPUT"
+      - name: Comment PR with a11y summary
+        if: steps.a11y.outputs.present == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const header = '<!-- AE-ADAPTER-A11Y -->\n';
+            const body = [
+              header,
+              '### Accessibility (report-only)',
+              '',
+              `Violations: critical=${{ steps.a11y.outputs.critical }}, serious=${{ steps.a11y.outputs.serious }}, moderate=${{ steps.a11y.outputs.moderate }}, minor=${{ steps.a11y.outputs.minor }}`,
+              `Passes: ${{ steps.a11y.outputs.passes }}, Components tested: ${{ steps.a11y.outputs.components }}`,
+              '',
+              '_Non-blocking. Use label `run-adapters` to trigger, enforcement planned via `enforce-a11y`._',
+              'Docs: docs/quality/adapter-thresholds.md'
+            ].join('\n');
+            const { owner, repo, number } = context.issue;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
+            const mine = comments.data.find(c => c.body && c.body.startsWith(header));
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+            }
+

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -186,6 +186,10 @@ jobs:
                 await addLabels(['qa-batch:agents']);
                 return reply('Label `qa-batch:agents` added. Agents tests will run in CI Fast (opt-in).');
               }
+              case '/run-adapters': {
+                await addLabels(['run-adapters']);
+                return reply('Label `run-adapters` added. Adapter thresholds (report-only) will run.');
+              }
               case '/run-formal': {
                 await addLabels(['run-formal']);
                 return reply('Label `run-formal` added. Formal jobs will run (non-blocking, opt-in).');


### PR DESCRIPTION
- 新規workflow: adapter-thresholds.yml（ラベル  で起動、a11y結果の要約をPRにコメント／非ブロッキング）\n- agent-commands:  を追加（ラベル付与）\n- 既存docsの運用方針に整合（段階導入、opt-in）\n\n検証\n- 構文: actionlint方針（echo→printf）に沿って記述\n- ローカル: types/build/test:fast に影響なし\n