### PR TITLE
chore(formal): aggregate shows Apalache status (ran/ok/version)

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -42,6 +42,8 @@ jobs:
           const apalacheSum = find(base, "formal-reports-apalache/apalache-summary.json");
           const confSum = find(base, "formal-reports-conformance/conformance-summary.json");
 
+          const apalache = apalacheSum ? rj(apalacheSum) : undefined;
+
           const lines = [];
           lines.push("## 🔎 Formal Reports Aggregate");
           lines.push("");
@@ -50,7 +52,15 @@ jobs:
           lines.push(tlaSum ? `- TLA summary file: ${path.basename(tlaSum)}` : "- TLA summary: n/a");
           lines.push(alloySum ? `- Alloy summary file: ${path.basename(alloySum)}` : "- Alloy summary: n/a");
           lines.push(smtSum ? `- SMT summary file: ${path.basename(smtSum)}` : "- SMT summary: n/a");
-          lines.push(apalacheSum ? `- Apalache summary file: ${path.basename(apalacheSum)}` : "- Apalache summary: n/a");
+          if (apalacheSum && apalache) {
+            const v = apalache.version || 'n/a';
+            const ok = apalache.ok; // may be boolean or null
+            const ran = apalache.ran;
+            const status = apalache.status;
+            lines.push(`- Apalache: ran=${ran? 'yes':'no'} ok=${ok==null? 'n/a': (ok? 'yes':'no')} status=${status||'n/a'} (v=${v})`);
+          } else {
+            lines.push("- Apalache summary: n/a");
+          }
           lines.push(confSum ? `- Conformance summary file: ${path.basename(confSum)}` : "- Conformance summary: n/a");
           lines.push("");
           lines.push("_Non-blocking. Add/remove label run-formal to control._");


### PR DESCRIPTION
- formal-aggregate: apalache-summary.json から ran/ok/status/version を抽出して表示\n- 既存のTLC/Alloy/SMT集約には影響なし（非ブロッキング、run-formal時のみ）\n\n検証\n- 既存スクリプトの型に依存せず単純JSON読込\n- ローカル: types/build/test:fast 影響なし\n