### PR TITLE
chore(quality): a11y enforcement opt-in + /enforce-a11y

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -41,12 +41,12 @@ jobs:
             const header = '<!-- AE-ADAPTER-A11Y -->\n';
             const body = [
               header,
-              '### Accessibility (report-only)',
+              '### Accessibility',
               '',
               `Violations: critical=${{ steps.a11y.outputs.critical }}, serious=${{ steps.a11y.outputs.serious }}, moderate=${{ steps.a11y.outputs.moderate }}, minor=${{ steps.a11y.outputs.minor }}`,
               `Passes: ${{ steps.a11y.outputs.passes }}, Components tested: ${{ steps.a11y.outputs.components }}`,
               '',
-              '_Non-blocking. Use label `run-adapters` to trigger, enforcement planned via `enforce-a11y`._',
+              `${{ contains(github.event.pull_request.labels.*.name, 'enforce-a11y') && 'Policy: enforced (label: enforce-a11y)' || 'Policy: report-only' }}`,
               'Docs: docs/quality/adapter-thresholds.md'
             ].join('\n');
             const { owner, repo, number } = context.issue;
@@ -57,4 +57,12 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
             }
-
+      - name: Enforce a11y thresholds (critical/serious==0)
+        if: steps.a11y.outputs.present == 'true' && contains(github.event.pull_request.labels.*.name, 'enforce-a11y')
+        run: |
+          crit=${{ steps.a11y.outputs.critical }}
+          seri=${{ steps.a11y.outputs.serious }}
+          if [ "$crit" -gt 0 ] || [ "$seri" -gt 0 ]; then
+            printf "%s\n" "::error::a11y violations exceed threshold (critical=$crit, serious=$seri)"
+            exit 1
+          fi

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -190,6 +190,10 @@ jobs:
                 await addLabels(['run-adapters']);
                 return reply('Label `run-adapters` added. Adapter thresholds (report-only) will run.');
               }
+              case '/enforce-a11y': {
+                await addLabels(['enforce-a11y']);
+                return reply('Label `enforce-a11y` added. Adapter thresholds will be enforced (a11y critical/serious=0).');
+              }
               case '/run-formal': {
                 await addLabels(['run-formal']);
                 return reply('Label `run-formal` added. Formal jobs will run (non-blocking, opt-in).');

--- a/docs/quality/adapter-thresholds.md
+++ b/docs/quality/adapter-thresholds.md
@@ -9,6 +9,10 @@ Proposal
   - `enforce-a11y`, `enforce-perf`, `enforce-lh` — turn results into gates
   - `a11y:<score>`, `perf:<score>` — override thresholds ad hoc
 
+Current wiring (a11y minimal)
+- `run-adapters`: runs adapter-thresholds.yml to summarize `reports/a11y-results.json` on PR (non-blocking)
+- `enforce-a11y`: enforces minimal thresholds (critical=0, serious=0). Job fails if violated.
+
 Phasing
 - Phase 1: Reporting only (post PR comments/artifacts)
 - Phase 2: Label-gated enforcement
@@ -16,4 +20,4 @@ Phasing
 
 Notes
 - See `quality-gates-centralized.yml` for central jobs and consider adding thresholds as follow-up.
-
+ - File: `.github/workflows/adapter-thresholds.yml`


### PR DESCRIPTION
- adapter-thresholds.yml:  ラベル時にしきい値(critical=0, serious=0)を強制\n- agent-commands.yml:  を追加（ラベル付与）\n- docs: adapter-thresholds.md に運用を追記\n\n運用\n- 基本は  でreport-only\n- 厳格化は  で明示的に（段階導入）\n