### PR TITLE
chore(formal): aggregate Apalache time/toolPath/run

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -57,7 +57,13 @@ jobs:
             const ok = apalache.ok; // may be boolean or null
             const ran = apalache.ran;
             const status = apalache.status;
-            lines.push(`- Apalache: ran=${ran? 'yes':'no'} ok=${ok==null? 'n/a': (ok? 'yes':'no')} status=${status||'n/a'} (v=${v})`);
+            const timeMs = apalache.timeMs || null;
+            const toolPath = apalache.toolPath || '';
+            const run = apalache.run || '';
+            lines.push(`- Apalache: ran=${ran? 'yes':'no'} ok=${ok==null? 'n/a': (ok? 'yes':'no')} status=${status||'n/a'} (v=${v}${timeMs?`, ${Math.round(timeMs/1000)}s`:''})`);
+            if (toolPath || run) {
+              lines.push(`  - ${toolPath?`tool: ${toolPath}`:''}${toolPath&&run?' | ':''}${run?`run: ${run}`:''}`);
+            }
           } else {
             lines.push("- Apalache summary: n/a");
           }


### PR DESCRIPTION
- formal-aggregate: Apalache の summary から timeMs/toolPath/run を追加表示\n- 非ブロッキング、 ラベル時のみ集約\n