### PR TITLE
chore(formal): Apalache error extraction + aggregate details

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -57,7 +57,19 @@ jobs:
             const ok = apalache.ok; // may be boolean or null
             const ran = apalache.ran;
             const status = apalache.status;
-            lines.push(`- Apalache: ran=${ran? 'yes':'no'} ok=${ok==null? 'n/a': (ok? 'yes':'no')} status=${status||'n/a'} (v=${v})`);
+            const timeMs = apalache.timeMs || null;
+            const toolPath = apalache.toolPath || '';
+            const run = apalache.run || '';
+            lines.push(`- Apalache: ran=${ran? 'yes':'no'} ok=${ok==null? 'n/a': (ok? 'yes':'no')} status=${status||'n/a'} (v=${v}${timeMs?`, ${Math.round(timeMs/1000)}s`:''})`);
+            if (toolPath || run) {
+              lines.push(`  - ${toolPath?`tool: ${toolPath}`:''}${toolPath&&run?' | ':''}${run?`run: ${run}`:''}`);
+            }
+            if (ok === false && Array.isArray(apalache.errors) && apalache.errors.length > 0) {
+              lines.push('');
+              lines.push('<details><summary>Apalache errors (top)</summary>');
+              for (const e of apalache.errors.slice(0,5)) lines.push(`- ${e}`);
+              lines.push('</details>');
+            }
           } else {
             lines.push("- Apalache summary: n/a");
           }

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -66,6 +66,14 @@ if (!fs.existsSync(absFile)){
   toolPath = sh(`bash -lc 'command -v ${apalacheCmd} || true'`).trim();
 }
 
+function extractErrors(out){
+  const lines = (out || '').split(/\r?\n/);
+  const key = /error|violat|counterexample|fail/i;
+  const picked = [];
+  for (const l of lines) { if (key.test(l)) picked.push(l.trim()); if (picked.length>=5) break; }
+  return picked;
+}
+
 const summary = {
   tool: 'apalache',
   file: path.relative(repoRoot, absFile),
@@ -81,6 +89,7 @@ const summary = {
     ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
     : null,
   timestamp: new Date().toISOString(),
+  errors: ran ? extractErrors(output) : [],
   output: output.slice(0, 4000)
 };
 


### PR DESCRIPTION
- verify-apalache.mjs: 出力から error/violation/counterexample を抽出し errors[] に格納\n- formal-aggregate.yml: ok=false かつ errors がある場合に details 折りたたみで上位5件を表示\n- 既存の ran/ok/status/version/time/toolPath/run 表示は維持（非ブロッキング）\n\n検証\n- ローカル: types/build/test:fast 全てOK\n- 集約は  ラベル時のみ実行\n