### PR TITLE
chore(quality): perf summary + enforcement (label-gated)

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -66,3 +66,67 @@ jobs:
             printf "%s\n" "::error::a11y violations exceed threshold (critical=$crit, serious=$seri)"
             exit 1
           fi
+
+  summarize-perf:
+    if: contains(github.event.pull_request.labels.*.name, 'run-adapters')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Summarize perf results (report-only)
+        id: perf
+        run: |
+          set -e
+          FILE="reports/perf-results.json"
+          if [ ! -f "$FILE" ]; then
+            printf "%s\n" "present=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          score=$(jq -r '.score // .performance // .lighthouse.performance // empty' "$FILE" 2>/dev/null || printf "\n")
+          [ -z "$score" ] && score=$(jq -r '.metrics.score // empty' "$FILE" 2>/dev/null || printf "\n")
+          # Normalize to number 0..100 if possible
+          if printf '%s\n' "$score" | rg -q '^[0-9]+(\.[0-9]+)?$'; then :; else score=""; fi
+          printf "%s\n" "present=true" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "score=${score:-}" >> "$GITHUB_OUTPUT"
+      - name: Comment PR with perf summary
+        if: steps.perf.outputs.present == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const header = '<!-- AE-ADAPTER-PERF -->\n';
+            const score = '${{ steps.perf.outputs.score }}' || 'n/a';
+            const enforced = ${{ contains(github.event.pull_request.labels.*.name, 'enforce-perf') && 'true' || 'false' }};
+            const labels = context.payload.pull_request.labels.map(l=>l.name);
+            const perfLbl = labels.find(n=>/^perf:\\d{1,3}$/.test(n));
+            const threshold = perfLbl ? Number(perfLbl.split(':')[1]) : (Number(process.env.PERF_DEFAULT_THRESHOLD||75));
+            const body = [
+              header,
+              '### Performance (report-only)',
+              '',
+              `Score: ${score}`,
+              `Policy: ${enforced==='true' ? 'enforced (label: enforce-perf)' : 'report-only'}; Threshold: ${threshold}%`,
+              '',
+              'Docs: docs/quality/adapter-thresholds.md'
+            ].join('\n');
+            const { owner, repo, number } = context.issue;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
+            const mine = comments.data.find(c => c.body && c.body.startsWith(header));
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+            }
+        env:
+          PERF_DEFAULT_THRESHOLD: ${{ vars.PERF_DEFAULT_THRESHOLD }}
+      - name: Enforce perf threshold
+        if: steps.perf.outputs.present == 'true' && contains(github.event.pull_request.labels.*.name, 'enforce-perf')
+        run: |
+          score='${{ steps.perf.outputs.score }}'
+          thresh='${{ vars.PERF_DEFAULT_THRESHOLD }}'
+          # label perf:<n> overrides
+          lbl=$(jq -r '.pull_request.labels[]?.name | select(test("^perf:[0-9]{1,3}$"))' "$GITHUB_EVENT_PATH" | head -1 || true)
+          if [ -n "$lbl" ]; then thresh=${lbl#perf:}; fi
+          if [ -z "$score" ]; then
+            printf "%s\n" "::error::perf score not found in reports/perf-results.json"
+            exit 1
+          fi
+          awk 'BEGIN{ if ('"${score}"' + 0 < '"${thresh}"' + 0) exit 1 }' || { printf "%s\n" "::error::perf score ${score}% below threshold ${thresh}%"; exit 1; }

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -190,6 +190,23 @@ jobs:
                 await addLabels(['run-adapters']);
                 return reply('Label `run-adapters` added. Adapter thresholds (report-only) will run.');
               }
+              case '/enforce-perf': {
+                await addLabels(['enforce-perf']);
+                return reply('Label `enforce-perf` added. Performance threshold enforcement may apply.');
+              }
+              case '/perf': {
+                const v = (arg || '').trim();
+                if (v.toLowerCase() === 'clear') {
+                  await removeLabelsByPrefix('perf:');
+                  return reply('Cleared perf:* labels.');
+                }
+                if (!/^\d{1,3}$/.test(v)) return reply('Usage: `/perf <pct|clear>` (e.g., `/perf 75`)');
+                const n = Number(v);
+                if (n < 0 || n > 100) return reply('Perf percent must be 0..100');
+                await removeLabelsByPrefix('perf:');
+                await addLabels([`perf:${n}`]);
+                return reply(`Label \`perf:${n}\` set. Performance check will use this threshold.`);
+              }
               case '/enforce-a11y': {
                 await addLabels(['enforce-a11y']);
                 return reply('Label `enforce-a11y` added. Adapter thresholds will be enforced (a11y critical/serious=0).');

--- a/docs/quality/adapter-thresholds.md
+++ b/docs/quality/adapter-thresholds.md
@@ -13,6 +13,11 @@ Current wiring (a11y minimal)
 - `run-adapters`: runs adapter-thresholds.yml to summarize `reports/a11y-results.json` on PR (non-blocking)
 - `enforce-a11y`: enforces minimal thresholds (critical=0, serious=0). Job fails if violated.
 
+Perf (proposal → minimal wiring)
+- `reports/perf-results.json` が存在する場合にスコアを要約（非ブロッキング）
+- `enforce-perf` ラベルでしきい値を強制（`perf:<score>` ラベルで上書き。既定は `vars.PERF_DEFAULT_THRESHOLD` または 75）
+- Slash Commands: `/enforce-perf`, `/perf <pct|clear>`
+
 Phasing
 - Phase 1: Reporting only (post PR comments/artifacts)
 - Phase 2: Label-gated enforcement


### PR DESCRIPTION
- adapter-thresholds.yml:  があればスコア要約をPRコメント（非ブロッキング）\n-  ラベルでしきい値を強制（ ラベルで上書き、既定は  か 75）\n- agent-commands: ,  を追加\n- docs: adapter-thresholds.md に perf 運用を追記\n\n運用\n- 基本は  でreport-only\n- 厳格化は  +  で明示的に（段階導入）\n