### PR TITLE
docs/coverage+ci: operational steps + coverage-check note

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -42,7 +42,12 @@ jobs:
     steps:
       - name: Note
         run: |
-          printf "%s\n" "Coverage dry-run on main is non-blocking by default."
+          printf "%s\n" "Coverage policy:" \
+          && printf "%s\n" "- Enforce on main: ${COVERAGE_ENFORCE_MAIN:-0}" \
+          && printf "%s\n" "- Default threshold: ${COVERAGE_DEFAULT_THRESHOLD:-80} (override via coverage:<pct>)"
+        env:
+          COVERAGE_ENFORCE_MAIN: ${{ vars.COVERAGE_ENFORCE_MAIN }}
+          COVERAGE_DEFAULT_THRESHOLD: ${{ vars.COVERAGE_DEFAULT_THRESHOLD }}
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: '20' }

--- a/docs/quality/coverage-policy.md
+++ b/docs/quality/coverage-policy.md
@@ -18,7 +18,16 @@ Recommended operations
 - On PRs: use `/coverage <pct>` for ad-hoc thresholds and `/enforce-coverage` when you want blocking
 - On `main`: set `COVERAGE_ENFORCE_MAIN=1` and `COVERAGE_DEFAULT_THRESHOLD` in repository variables
 
+Step-by-step (enable on main)
+1) Settings → Variables → Repository variables に以下を追加します。
+   - `COVERAGE_ENFORCE_MAIN=1`
+   - `COVERAGE_DEFAULT_THRESHOLD`（例: 80）
+2) 必須化は段階導入を推奨します（まずはコメントでの報告→のちにRequired化）。
+3) PR では `/coverage <pct>` で個別しきい値、`/enforce-coverage` でブロッキングを選択できます。
+
+Notes
+- 変数が未設定でもPRコメントは出力されます（report-only）。
+
 References
 - Workflow: `.github/workflows/coverage-check.yml`
 - Slash commands: see `AGENTS.md` and `docs/ci-policy.md`
-


### PR DESCRIPTION
- docs: coverage-policy.md に main での有効化手順を追記（変数設定）\n- coverage-check.yml: Note ステップで Enforce/Threshold の変数状態を表示（report-only の場合も可視化）\n