### PR TITLE
chore(quality/agents): Lighthouse summary+enforcement (label-gated)

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -130,3 +130,76 @@ jobs:
             exit 1
           fi
           awk 'BEGIN{ if ('"${score}"' + 0 < '"${thresh}"' + 0) exit 1 }' || { printf "%s\n" "::error::perf score ${score}% below threshold ${thresh}%"; exit 1; }
+
+  summarize-lh:
+    if: contains(github.event.pull_request.labels.*.name, 'run-adapters')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Summarize Lighthouse results (report-only)
+        id: lh
+        run: |
+          set -e
+          FILE=""
+          for f in reports/lighthouse-results.json reports/lh-results.json; do
+            if [ -f "$f" ]; then FILE="$f"; break; fi
+          done
+          if [ -z "$FILE" ]; then
+            printf "%s\n" "present=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Try multiple paths: categories.performance.score (0..1) or .performance (0..100)
+          raw=$(jq -r '.categories.performance.score // .performance // .score // empty' "$FILE" 2>/dev/null || printf "\n")
+          score=""
+          if [ -n "$raw" ]; then
+            if printf '%s\n' "$raw" | rg -q '^[0-1](\.[0-9]+)?$'; then
+              # normalize 0..1 -> 0..100
+              score=$(awk 'BEGIN{printf "%d", ('"$raw"')*100}')
+            elif printf '%s\n' "$raw" | rg -q '^[0-9]+(\.[0-9]+)?$'; then
+              score=$(printf "%s\n" "$raw" | cut -d. -f1)
+            fi
+          fi
+          printf "%s\n" "present=true" >> "$GITHUB_OUTPUT"
+          printf "%s\n" "score=${score:-}" >> "$GITHUB_OUTPUT"
+      - name: Comment PR with Lighthouse summary
+        if: steps.lh.outputs.present == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const header = '<!-- AE-ADAPTER-LH -->\n';
+            const score = '${{ steps.lh.outputs.score }}' || 'n/a';
+            const enforced = ${{ contains(github.event.pull_request.labels.*.name, 'enforce-lh') && 'true' || 'false' }};
+            const labels = context.payload.pull_request.labels.map(l=>l.name);
+            const lhLbl = labels.find(n=>/^lh:\\d{1,3}$/.test(n));
+            const threshold = lhLbl ? Number(lhLbl.split(':')[1]) : (Number(process.env.LH_DEFAULT_THRESHOLD||80));
+            const body = [
+              header,
+              '### Lighthouse Performance (report-only)',
+              '',
+              `Score: ${score}`,
+              `Policy: ${enforced==='true' ? 'enforced (label: enforce-lh)' : 'report-only'}; Threshold: ${threshold}%`,
+              '',
+              'Docs: docs/quality/adapter-thresholds.md'
+            ].join('\n');
+            const { owner, repo, number } = context.issue;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
+            const mine = comments.data.find(c => c.body && c.body.startsWith(header));
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+            }
+        env:
+          LH_DEFAULT_THRESHOLD: ${{ vars.LH_DEFAULT_THRESHOLD }}
+      - name: Enforce Lighthouse threshold
+        if: steps.lh.outputs.present == 'true' && contains(github.event.pull_request.labels.*.name, 'enforce-lh')
+        run: |
+          score='${{ steps.lh.outputs.score }}'
+          thresh='${{ vars.LH_DEFAULT_THRESHOLD }}'
+          lbl=$(jq -r '.pull_request.labels[]?.name | select(test("^lh:[0-9]{1,3}$"))' "$GITHUB_EVENT_PATH" | head -1 || true)
+          if [ -n "$lbl" ]; then thresh=${lbl#lh:}; fi
+          if [ -z "$score" ]; then
+            printf "%s\n" "::error::lighthouse score not found in results file"
+            exit 1
+          fi
+          awk 'BEGIN{ if ('"${score}"' + 0 < '"${thresh}"' + 0) exit 1 }' || { printf "%s\n" "::error::lighthouse score ${score}% below threshold ${thresh}%"; exit 1; }

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -194,6 +194,10 @@ jobs:
                 await addLabels(['enforce-perf']);
                 return reply('Label `enforce-perf` added. Performance threshold enforcement may apply.');
               }
+              case '/enforce-lh': {
+                await addLabels(['enforce-lh']);
+                return reply('Label `enforce-lh` added. Lighthouse threshold enforcement may apply.');
+              }
               case '/perf': {
                 const v = (arg || '').trim();
                 if (v.toLowerCase() === 'clear') {
@@ -206,6 +210,19 @@ jobs:
                 await removeLabelsByPrefix('perf:');
                 await addLabels([`perf:${n}`]);
                 return reply(`Label \`perf:${n}\` set. Performance check will use this threshold.`);
+              }
+              case '/lh': {
+                const v = (arg || '').trim();
+                if (v.toLowerCase() === 'clear') {
+                  await removeLabelsByPrefix('lh:');
+                  return reply('Cleared lh:* labels.');
+                }
+                if (!/^\d{1,3}$/.test(v)) return reply('Usage: `/lh <pct|clear>` (e.g., `/lh 80`)');
+                const n = Number(v);
+                if (n < 0 || n > 100) return reply('Lighthouse percent must be 0..100');
+                await removeLabelsByPrefix('lh:');
+                await addLabels([`lh:${n}`]);
+                return reply(`Label \`lh:${n}\` set. Lighthouse check will use this threshold.`);
               }
               case '/enforce-a11y': {
                 await addLabels(['enforce-a11y']);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@
   - `/run-spec` … `run-spec` ラベル付与（Spec Fail-Fast 実行）
   - `/run-drift` … `run-drift` ラベル付与（Codegen Drift 検出 実行）
   - `/run-adapters` … `run-adapters` ラベル付与（Adapter Thresholds レポート実行）
+  - `/enforce-perf` … `enforce-perf` ラベル付与（Perf しきい値 enforcement）
+  - `/perf <pct|clear>` … `perf:<pct>` を設定（上書き）/ クリア
+  - `/enforce-lh` … `enforce-lh` ラベル付与（Lighthouse しきい値 enforcement）
+  - `/lh <pct|clear>` … `lh:<pct>` を設定（上書き）/ クリア
   - `/non-blocking` … `ci-non-blocking` ラベル付与（一部ジョブを continue-on-error）
   - `/blocking` … `ci-non-blocking` ラベル除去（通常のブロッキング設定へ）
   - `/ready` … `do-not-merge` ラベル除去（マージ待ち状態へ）

--- a/docs/quality/adapter-thresholds.md
+++ b/docs/quality/adapter-thresholds.md
@@ -18,6 +18,11 @@ Perf (proposal → minimal wiring)
 - `enforce-perf` ラベルでしきい値を強制（`perf:<score>` ラベルで上書き。既定は `vars.PERF_DEFAULT_THRESHOLD` または 75）
 - Slash Commands: `/enforce-perf`, `/perf <pct|clear>`
 
+Lighthouse (proposal → minimal wiring)
+- `reports/lighthouse-results.json`（または `reports/lh-results.json`）から performance スコアを要約（非ブロッキング）
+- `enforce-lh` ラベルでしきい値を強制（`lh:<score>` ラベルで上書き。既定は `vars.LH_DEFAULT_THRESHOLD` または 80）
+- Slash Commands: `/enforce-lh`, `/lh <pct|clear>`
+
 Phasing
 - Phase 1: Reporting only (post PR comments/artifacts)
 - Phase 2: Label-gated enforcement


### PR DESCRIPTION
- adapter-thresholds.yml: Lighthouse結果があればスコア要約をPRコメント（非ブロッキング）\n-  ラベルでしきい値を強制（ で上書き、既定は  か 80）\n- agent-commands: ,  を追加\n- docs/AGENTS: コマンド一覧に perf/lh を追記\n\n運用\n-  でreport-only、必要に応じて  +  で段階的に厳格化\n