### PR TITLE
chore(formal): Apalache raw output artifact + verify.yml fix

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -162,3 +162,4 @@ jobs:
           name: formal-reports-apalache
           path: |
             hermetic-reports/formal/apalache-summary.json
+            hermetic-reports/formal/apalache-output.txt

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -114,17 +114,10 @@ jobs:
               if [ -f "$TRACE_JSON" ]; then
                 idx=0
               while IFS= read -r row && [ $idx -lt 3 ]; do
-<<<<<<< HEAD
                   scenario=$(printf "%s\n" "$row" | jq -r '.scenario')
                   testp=$(printf "%s\n" "$row" | jq -r '.test')
                   implp=$(printf "%s\n" "$row" | jq -r '.impl')
                   formp=$(printf "%s\n" "$row" | jq -r '.formal')
-=======
-                  scenario=$(printf "%s\n" "$row" | jq -r '.scenario')
-                  testp=$(printf "%s\n" "$row" | jq -r '.test')
-                  implp=$(printf "%s\n" "$row" | jq -r '.impl')
-                  formp=$(printf "%s\n" "$row" | jq -r '.formal')
->>>>>>> origin/main
                   testdisp=$( [ "$testp" != "N/A" ] && shortp "$testp" || printf "N/A\n" )
                   impldisp=$( [ "$implp" != "N/A" ] && shortp "$implp" || printf "N/A\n" )
                   formdisp=$( [ "$formp" != "N/A" ] && shortp "$formp" || printf "N/A\n" )
@@ -132,11 +125,7 @@ jobs:
                   if [ -n "$PR_SHA" ] && [ "$testp" != "N/A" ]; then testlink="[$testdisp](https://github.com/$REPO/blob/$PR_SHA/$testp)"; fi
                   if [ -n "$PR_SHA" ] && [ "$implp" != "N/A" ]; then impllink="[$impldisp](https://github.com/$REPO/blob/$PR_SHA/$implp)"; fi
                   if [ -n "$PR_SHA" ] && [ "$formp" != "N/A" ]; then formlink="[$formdisp](https://github.com/$REPO/blob/$PR_SHA/$formp)"; fi
-<<<<<<< HEAD
                   id=$(printf "%s\n" "$row" | jq -r '.id')
-=======
-                  id=$(printf "%s\n" "$row" | jq -r '.id')
->>>>>>> origin/main
                   printf "%s\n" "- $scenario (id: $id) test: $testlink impl: $impllink formal: $formlink"
                   idx=$((idx+1))
                 done < <(jq -c '.rows[] | select(.test!="N/A" and .impl!="N/A" and .formal!="N/A")' "$TRACE_JSON" 2>/dev/null)

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -35,6 +35,7 @@ const file = args.file || process.env.APALACHE_FILE || path.join('spec','tla','D
 const absFile = path.resolve(repoRoot, file);
 const outDir = path.join(repoRoot, 'hermetic-reports', 'formal');
 const outFile = path.join(outDir, 'apalache-summary.json');
+const outLog = path.join(outDir, 'apalache-output.txt');
 fs.mkdirSync(outDir, { recursive: true });
 
 const haveApalacheMc = has('apalache-mc');
@@ -74,6 +75,9 @@ function extractErrors(out){
   return picked;
 }
 
+// Persist raw output for artifact consumers
+try { fs.writeFileSync(outLog, output, 'utf-8'); } catch {}
+
 const summary = {
   tool: 'apalache',
   file: path.relative(repoRoot, absFile),
@@ -90,7 +94,8 @@ const summary = {
     : null,
   timestamp: new Date().toISOString(),
   errors: ran ? extractErrors(output) : [],
-  output: output.slice(0, 4000)
+  output: output.slice(0, 4000),
+  outputFile: path.relative(repoRoot, outLog)
 };
 
 fs.writeFileSync(outFile, JSON.stringify(summary, null, 2));


### PR DESCRIPTION
- verify-apalache: raw出力を hermetic-reports/formal/apalache-output.txt に保存\n- formal-verify: apalache-output.txt をartifactに含める\n- verify.yml: 競合残骸を解消（YAML構文/CIテストの安定化）\n\n検証\n- ローカル: types/build/test:fast 全てOK\n