### PR TITLE
chore(formal+resilience): Apalache errorCount + CB transition test

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -60,7 +60,8 @@ jobs:
             const timeMs = apalache.timeMs || null;
             const toolPath = apalache.toolPath || '';
             const run = apalache.run || '';
-            lines.push(`- Apalache: ran=${ran? 'yes':'no'} ok=${ok==null? 'n/a': (ok? 'yes':'no')} status=${status||'n/a'} (v=${v}${timeMs?`, ${Math.round(timeMs/1000)}s`:''})`);
+            const ec = (typeof apalache.errorCount === 'number') ? apalache.errorCount : null;
+            lines.push(`- Apalache: ran=${ran? 'yes':'no'} ok=${ok==null? 'n/a': (ok? 'yes':'no')} status=${status||'n/a'}${ec!=null?`, errors=${ec}`:''} (v=${v}${timeMs?`, ${Math.round(timeMs/1000)}s`:''})`);
             if (toolPath || run) {
               lines.push(`  - ${toolPath?`tool: ${toolPath}`:''}${toolPath&&run?' | ':''}${run?`run: ${run}`:''}`);
             }

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -74,6 +74,12 @@ function extractErrors(out){
   for (const l of lines) { if (key.test(l)) picked.push(l.trim()); if (picked.length>=5) break; }
   return picked;
 }
+function countErrors(out){
+  const lines = (out || '').split(/\r?\n/);
+  const key = /error|violat|counterexample|fail/i;
+  let n = 0; for (const l of lines) if (key.test(l)) n++;
+  return n;
+}
 
 // Persist raw output for artifact consumers
 try { fs.writeFileSync(outLog, output, 'utf-8'); } catch {}
@@ -94,6 +100,7 @@ const summary = {
     : null,
   timestamp: new Date().toISOString(),
   errors: ran ? extractErrors(output) : [],
+  errorCount: ran ? countErrors(output) : 0,
   output: output.slice(0, 4000),
   outputFile: path.relative(repoRoot, outLog)
 };

--- a/tests/resilience/circuit-breaker.transitions.test.ts
+++ b/tests/resilience/circuit-breaker.transitions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker transitions', () => {
+  it('OPEN -> HALF_OPEN after timeout', async () => {
+    const cb = new CircuitBreaker('transitions', {
+      failureThreshold: 1,
+      successThreshold: 1,
+      timeout: 15, // ms
+      monitoringWindow: 100,
+    });
+    // Force to OPEN by causing one failure
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+    // Wait beyond timeout to trigger HALF_OPEN schedule
+    await new Promise((r) => setTimeout(r, 25));
+    // Executing should be allowed in HALF_OPEN (not immediately rejecting)
+    // and a success closes the breaker
+    const result = await cb.execute(async () => 42);
+    expect(result).toBe(42);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+  });
+});
+


### PR DESCRIPTION
- verify-apalache: errorCount を summary に追加\n- formal-aggregate: errors=N を表示\n- tests/resilience: CircuitBreaker の OPEN→HALF_OPEN→CLOSED 遷移の最小テストを追加\n\n検証\n- ローカル: types/build/test:fast 全てOK\n- Formal は run-formal ラベルで非ブロッキング\n