### PR TITLE
chore(formal): enforce Apalache (label: enforce-formal) + expectedErrors test

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -163,3 +163,22 @@ jobs:
           path: |
             hermetic-reports/formal/apalache-summary.json
             hermetic-reports/formal/apalache-output.txt
+      - name: Enforce Apalache (label: enforce-formal)
+        if: contains(github.event.pull_request.labels.*.name, 'enforce-formal')
+        run: |
+          FILE="hermetic-reports/formal/apalache-summary.json"
+          if [ ! -f "$FILE" ]; then
+            printf "%s\n" "::error::apalache-summary.json not found"
+            exit 1
+          fi
+          ok=$(jq -r '.ok // ""' "$FILE" 2>/dev/null || printf "\n")
+          ran=$(jq -r '.ran // false' "$FILE" 2>/dev/null || printf "false\n")
+          if [ "$ran" != "true" ]; then
+            printf "%s\n" "::error::Apalache did not run; cannot enforce"
+            exit 1
+          fi
+          if [ "$ok" != "true" ]; then
+            ec=$(jq -r '.errorCount // 0' "$FILE" 2>/dev/null || printf "0\n")
+            printf "%s\n" "::error::Apalache not ok (errors=$ec)"
+            exit 1
+          fi

--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -163,7 +163,7 @@ jobs:
           path: |
             hermetic-reports/formal/apalache-summary.json
             hermetic-reports/formal/apalache-output.txt
-      - name: Enforce Apalache (label: enforce-formal)
+      - name: "Enforce Apalache (label: enforce-formal)"
         if: contains(github.event.pull_request.labels.*.name, 'enforce-formal')
         run: |
           FILE="hermetic-reports/formal/apalache-summary.json"

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -135,6 +135,7 @@ This document defines CI policies to keep PR experience fast and stable while ma
 - `run-formal` ラベル時のみ、Formal Verify（stub）と成果物の集約（Alloy/TLA/SMT/Apalache の要約）を実行（非ブロッキング）
 - 集約結果は PR コメントにアップサート（重複を避けるためヘッダー識別）
 - 必須化・閾値強化は段階導入（別Issueで合意のうえ切替）
+- `enforce-formal` ラベル時は Apalache 実行結果（summary.ok）が `true` であることをチェック（非true で失敗）
 
 ### 運用メモ
 - 緊急時は `ci-non-blocking` ラベルで PR をブロックしない運用に切替可能

--- a/tests/resilience/circuit-breaker.expected-errors.test.ts
+++ b/tests/resilience/circuit-breaker.expected-errors.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+
+class ExpectedErr extends Error {}
+class UnexpectedErr extends Error {}
+
+describe('Resilience: CircuitBreaker expectedErrors behavior', () => {
+  it('counts only expectedErrors towards opening the circuit', async () => {
+    const cb = new CircuitBreaker('expected', {
+      failureThreshold: 1,
+      successThreshold: 1,
+      timeout: 10,
+      monitoringWindow: 100,
+      expectedErrors: [ExpectedErr],
+    });
+    // Unexpected error should not open the circuit
+    await expect(cb.execute(async () => { throw new UnexpectedErr('u'); })).rejects.toBeInstanceOf(UnexpectedErr);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+    // Expected error should open the circuit
+    await expect(cb.execute(async () => { throw new ExpectedErr('e'); })).rejects.toBeInstanceOf(ExpectedErr);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+  });
+});
+


### PR DESCRIPTION
- formal-verify.yml:  ラベル時に apalache-summary.json の ok をチェック、NGなら失敗\n- docs/ci-policy.md: formal の enforcement 説明を追記\n- tests/resilience: expectedErrors で OPEN になるのは指定エラーのみ、という最小テストを追加\n\n検証\n- ローカル: types/build/test:fast 全てOK（YAML 検証含む）\n