### PR TITLE
chore(formal+resilience): Apalache errorSnippet + first-error context; CB reset-counts test

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -74,6 +74,13 @@ jobs:
               for (const e of apalache.errors.slice(0,5)) lines.push(`- ${e}`);
               lines.push('</details>');
             }
+            if (ok === false && apalache.errorSnippet && Array.isArray(apalache.errorSnippet.lines)) {
+              const first = apalache.errorSnippet.lines.find(l=>l && l.trim().length>0) || '';
+              if (first) {
+                lines.push('');
+                lines.push(`- First error context: ${first}`);
+              }
+            }
           } else {
             lines.push("- Apalache summary: n/a");
           }

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -80,6 +80,23 @@ function countErrors(out){
   let n = 0; for (const l of lines) if (key.test(l)) n++;
   return n;
 }
+function extractErrorSnippet(out, before=2, after=2){
+  const lines = (out || '').split(/\r?\n/);
+  const key = /error|violat|counterexample|fail/i;
+  for (let i=0;i<lines.length;i++){
+    if (key.test(lines[i])){
+      const start = Math.max(0, i-before);
+      const end = Math.min(lines.length, i+after+1);
+      return {
+        index: i,
+        start,
+        end,
+        lines: lines.slice(start, end).map(s=>s.trim())
+      };
+    }
+  }
+  return null;
+}
 
 // Persist raw output for artifact consumers
 try { fs.writeFileSync(outLog, output, 'utf-8'); } catch {}
@@ -101,6 +118,7 @@ const summary = {
   timestamp: new Date().toISOString(),
   errors: ran ? extractErrors(output) : [],
   errorCount: ran ? countErrors(output) : 0,
+  errorSnippet: ran ? extractErrorSnippet(output) : null,
   output: output.slice(0, 4000),
   outputFile: path.relative(repoRoot, outLog)
 };

--- a/tests/resilience/circuit-breaker.reset-counts.test.ts
+++ b/tests/resilience/circuit-breaker.reset-counts.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker resets failure count on success', () => {
+  it('resets failureCount after a successful call in CLOSED state', async () => {
+    const cb = new CircuitBreaker('reset', {
+      failureThreshold: 2,
+      successThreshold: 1,
+      timeout: 50,
+      monitoringWindow: 100,
+    });
+    // One failure
+    await expect(cb.execute(async () => { throw new Error('x'); })).rejects.toBeInstanceOf(Error);
+    let stats = cb.getStats();
+    expect(stats.failureCount).toBeGreaterThanOrEqual(1);
+    // One success should reset failureCount in CLOSED
+    await cb.execute(async () => 1);
+    stats = cb.getStats();
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+    expect(stats.failureCount).toBe(0);
+  });
+});
+


### PR DESCRIPTION
- verify-apalache.mjs: errorSnippet（前後2行の文脈）をsummaryに追加\n- formal-aggregate.yml: NG時に first error context を1行表示\n- tests/resilience: 成功時に failureCount をリセットする最小テストを追加\n\n検証\n- ローカル: types/build/test:fast 全てOK\n- Formal は run-formal ラベルで非ブロッキング\n