### PR TITLE
chore(formal): refine Apalache ok heuristics

### DIFF
--- a/.ae/enhanced-state.db
+++ b/.ae/enhanced-state.db
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0.0",
-    "timestamp": "2025-09-16T10:43:42.495Z",
+    "timestamp": "2025-09-16T11:43:44.358Z",
     "options": {
       "databasePath": ".ae/enhanced-state.db",
       "enableCompression": true,
@@ -14,9 +14,9 @@
   },
   "entries": [
     {
-      "id": "735577ca-ee40-4efb-a1e5-9d7ae9fa945a",
+      "id": "3f6b6560-0fa3-49b8-aa80-34704a33f175",
       "logicalKey": "integration-ready",
-      "timestamp": "2025-09-16T10:43:42.495Z",
+      "timestamp": "2025-09-16T11:43:44.358Z",
       "version": 1,
       "checksum": "0094478148422a83dc50a368102314e8ddf937293f6679096c4b66f5d989afcb",
       "data": {
@@ -28,8 +28,8 @@
       "ttl": 604800,
       "metadata": {
         "size": 28,
-        "created": "2025-09-16T10:43:42.495Z",
-        "accessed": "2025-09-16T10:43:42.495Z",
+        "created": "2025-09-16T11:43:44.358Z",
+        "accessed": "2025-09-16T11:43:44.358Z",
         "source": "unknown"
       }
     }
@@ -37,7 +37,7 @@
   "indices": {
     "keyIndex": {
       "integration-ready": [
-        "integration-ready_2025-09-16T10:43:42.495Z"
+        "integration-ready_2025-09-16T11:43:44.358Z"
       ]
     },
     "versionIndex": {

--- a/.ae/phase-state.json
+++ b/.ae/phase-state.json
@@ -1,8 +1,8 @@
 {
-  "projectId": "7f613987-3c32-4fa6-8bb4-66eb1233db43",
+  "projectId": "34788c9c-7c99-433f-8117-3ef8db8514d7",
   "projectName": "phase1-integration",
-  "createdAt": "2025-09-16T10:43:42.492Z",
-  "updatedAt": "2025-09-16T10:43:43.104Z",
+  "createdAt": "2025-09-16T11:43:44.355Z",
+  "updatedAt": "2025-09-16T11:43:44.816Z",
   "currentPhase": "intent",
   "phaseStatus": {
     "intent": {
@@ -41,102 +41,90 @@
     "integration-test": {
       "ready": true
     },
-    "test-agent_task_started_1758019422879": {
+    "test-agent_task_started_1758023024797": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.879Z",
+      "timestamp": "2025-09-16T11:43:44.797Z",
       "taskId": "test-task-1",
       "type": "code-generation"
     },
-    "test-agent_task_completed_1758019422881": {
+    "test-agent_task_completed_1758023024798": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.881Z",
+      "timestamp": "2025-09-16T11:43:44.798Z",
       "taskId": "test-task-1",
       "success": true,
-      "executionTime": 2
+      "executionTime": 1
     },
-    "test-agent_task_started_1758019422886": {
+    "test-agent_task_started_1758023024805": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.886Z",
+      "timestamp": "2025-09-16T11:43:44.805Z",
       "taskId": "tdd-task",
       "type": "test-generation"
     },
-    "test-agent_task_completed_1758019422887": {
+    "test-agent_task_completed_1758023024805": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.887Z",
+      "timestamp": "2025-09-16T11:43:44.805Z",
       "taskId": "tdd-task",
       "success": true,
-      "executionTime": 1
+      "executionTime": 0
     },
-    "test-agent_task_started_1758019422890": {
+    "test-agent_task_started_1758023024809": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.890Z",
+      "timestamp": "2025-09-16T11:43:44.809Z",
       "taskId": "validation-test",
       "type": "validation"
     },
-    "test-agent_task_completed_1758019422891": {
+    "test-agent_task_completed_1758023024810": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.891Z",
+      "timestamp": "2025-09-16T11:43:44.810Z",
       "taskId": "validation-test",
       "success": true,
       "executionTime": 1
     },
-    "test-agent_task_started_1758019422893": {
+    "test-agent_task_started_1758023024811": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.893Z",
+      "timestamp": "2025-09-16T11:43:44.811Z",
       "taskId": "coverage-test",
       "type": "quality-assurance"
     },
-    "test-agent_task_completed_1758019422894": {
+    "test-agent_task_completed_1758023024812": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.894Z",
+      "timestamp": "2025-09-16T11:43:44.812Z",
       "taskId": "coverage-test",
       "success": true,
       "executionTime": 1
     },
-    "test-agent_task_started_1758019422896": {
+    "test-agent_task_started_1758023024815": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.896Z",
+      "timestamp": "2025-09-16T11:43:44.815Z",
       "taskId": "phase-transition",
       "type": "phase-validation"
     },
-    "test-agent_task_completed_1758019422897": {
+    "test-agent_task_completed_1758023024815": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T10:43:42.897Z",
+      "timestamp": "2025-09-16T11:43:44.815Z",
       "taskId": "phase-transition",
       "success": true,
-      "executionTime": 1
-    },
-    "intent_activity_1758019423097": {
-      "activity": "output_validation",
-      "timestamp": "2025-09-16T10:43:43.097Z",
-      "success": true,
-      "outputType": "generic",
-      "artifactCount": 2,
-      "qualityScore": 85,
-      "validationMessage": "Default validation passed (no custom validation implemented)"
+      "executionTime": 0
     }
   }
-}}
-}
-}
 }

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -101,6 +101,16 @@ function extractErrorSnippet(out, before=2, after=2){
 // Persist raw output for artifact consumers
 try { fs.writeFileSync(outLog, output, 'utf-8'); } catch {}
 
+function computeOkFromOutput(out){
+  if (!out) return null;
+  const s = out.toLowerCase();
+  // Positive indicators
+  if (/(no\s+(?:errors?|counterexamples?)\b|verification\s+successful|\bok\b)/i.test(out)) return true;
+  // Negative indicators
+  if (/(error|violation|counterexample|fail)/i.test(out)) return false;
+  return null;
+}
+
 const summary = {
   tool: 'apalache',
   file: path.relative(repoRoot, absFile),
@@ -108,7 +118,7 @@ const summary = {
   ran,
   status,
   version: version || null,
-  ok: ran ? !/error|violat|counterexample|fail/i.test(output) : null,
+  ok: ran ? (computeOkFromOutput(output)) : null,
   hints: ran ? ( /success|ok|no\s+(?:errors|counterexamples?)/i.test(output) ? 'success-indicators-found' : null ) : null,
   timeMs: timeMs || null,
   toolPath: toolPath || null,

--- a/tests/golden/snapshots/codegen-snapshot.json
+++ b/tests/golden/snapshots/codegen-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-16T10:43:42.298Z",
+  "timestamp": "2025-09-16T11:43:44.204Z",
   "version": "1.0.0",
   "files": {
     "examples/inventory/apps/web/components/ProductForm.tsx": {


### PR DESCRIPTION
- verify-apalache:  判定を success/ok/no errors の陽性インジケータ優先に、エラー語の陰性判定を補助（不確定時は null）\n- 非ブロッキングのまま（summaryに反映）\n- ローカル: types/build/test:fast 全てOK\n