### PR TITLE
chore(formal): Apalache summary+aggregate minor improvements

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -24,6 +24,14 @@ jobs:
           const fs=require("fs"), path=require("path");
           function rj(p){ try { return JSON.parse(fs.readFileSync(p,"utf-8")); } catch { return undefined; } }
           function find(dir, name){ try { const p = path.join(dir, name); return fs.existsSync(p) ? p : undefined; } catch { return undefined; } }
+          function escMd(s){
+            if (!s) return '';
+            // Basic Markdown escaping to avoid breaking PR rendering
+            return String(s)
+              .replace(/`/g, "`\u200b")
+              .replace(/</g, "&lt;")
+              .replace(/>/g, "&gt;");
+          }
           const base = "artifacts_dl";
           const outDir = "artifacts/formal"; fs.mkdirSync(outDir,{recursive:true});
           const outMd = path.join(outDir, "formal-aggregate.md");
@@ -71,14 +79,22 @@ jobs:
             if (ok === false && Array.isArray(apalache.errors) && apalache.errors.length > 0) {
               lines.push('');
               lines.push('<details><summary>Apalache errors (top)</summary>');
-              for (const e of apalache.errors.slice(0,5)) lines.push(`- ${e}`);
+              lines.push('');
+              lines.push('```text');
+              for (const e of apalache.errors.slice(0,5)) lines.push(escMd(e));
+              lines.push('```');
+              lines.push('');
               lines.push('</details>');
             }
             if (ok === false && apalache.errorSnippet && Array.isArray(apalache.errorSnippet.lines)) {
-              const first = apalache.errorSnippet.lines.find(l=>l && l.trim().length>0) || '';
-              if (first) {
+              const ctxLines = apalache.errorSnippet.lines.map(escMd);
+              if (ctxLines.length) {
                 lines.push('');
-                lines.push(`- First error context: ${first}`);
+                lines.push('- First error context:');
+                lines.push('');
+                lines.push('```text');
+                for (const l of ctxLines) lines.push(l);
+                lines.push('```');
               }
             }
           } else {

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -91,6 +91,8 @@ function extractErrorSnippet(out, before=2, after=2){
         index: i,
         start,
         end,
+        before,
+        after,
         lines: lines.slice(start, end).map(s=>s.trim())
       };
     }
@@ -129,7 +131,8 @@ const summary = {
   errors: ran ? extractErrors(output) : [],
   errorCount: ran ? countErrors(output) : 0,
   errorSnippet: ran ? extractErrorSnippet(output) : null,
-  output: output.slice(0, 4000),
+  // capped raw output preview (full log saved to outputFile)
+  output: output ? String(output).slice(0, 4000) : '',
   outputFile: path.relative(repoRoot, outLog)
 };
 


### PR DESCRIPTION
目的
- Apalache 要約スキーマの軽微整備（errorSnippet に before/after を追加）
- formal-aggregate のPRコメント表示を微調整（エラー/スニペットをコードブロック化・Markdownエスケープ）

変更点
- scripts/formal/verify-apalache.mjs
  - errorSnippet: {index,start,end,before,after,lines[]} として出力
  - output は preview のみ（最大4KB）に明示し、全文は apalache-output.txt へ
- .github/workflows/formal-aggregate.yml
  - Apalache のエラー上位を ```text のコードブロックで表示
  - First error context も ```text で安全に表示（簡易エスケープ）

動作/運用
- 非ブロッキングのまま（run-formal ラベルで opt-in）
- 既存の validator（validate-apalache-summary.mjs）は許容範囲内（新キー追加のみ）
- 集約表示を確認するには、以下のいずれかで artifacts を生成してください:
  - ラベル: /run-formal → formal-verify.yml が走り、aggregator が upsert コメント
  - Dispatch: /formal-verify-dispatch（必要なら inputs.target=apalache ）

影響範囲
- CI 表示のみ。コード本体への影響なし。
- actionlint 互換: echo は使用せず、printf/Node を使用済み。

マージ方針
- 小粒PR。CI は非ブロッキング。緑確認後に通常マージでOK。
