### PR TITLE
test(resilience): TokenBucket PBT (bounds + wait semantics)

### DIFF
--- a/.ae/enhanced-state.db
+++ b/.ae/enhanced-state.db
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0.0",
-    "timestamp": "2025-09-16T12:19:05.671Z",
+    "timestamp": "2025-09-16T12:24:52.509Z",
     "options": {
       "databasePath": ".ae/enhanced-state.db",
       "enableCompression": true,
@@ -14,9 +14,9 @@
   },
   "entries": [
     {
-      "id": "172da597-0766-44e9-8ceb-3b0da8bf6e83",
+      "id": "762c8c82-2df3-4d37-abd1-fd9b3e38d53f",
       "logicalKey": "integration-ready",
-      "timestamp": "2025-09-16T12:19:05.671Z",
+      "timestamp": "2025-09-16T12:24:52.509Z",
       "version": 1,
       "checksum": "0094478148422a83dc50a368102314e8ddf937293f6679096c4b66f5d989afcb",
       "data": {
@@ -28,8 +28,8 @@
       "ttl": 604800,
       "metadata": {
         "size": 28,
-        "created": "2025-09-16T12:19:05.671Z",
-        "accessed": "2025-09-16T12:19:05.671Z",
+        "created": "2025-09-16T12:24:52.509Z",
+        "accessed": "2025-09-16T12:24:52.509Z",
         "source": "unknown"
       }
     }
@@ -37,7 +37,7 @@
   "indices": {
     "keyIndex": {
       "integration-ready": [
-        "integration-ready_2025-09-16T12:19:05.671Z"
+        "integration-ready_2025-09-16T12:24:52.509Z"
       ]
     },
     "versionIndex": {

--- a/.ae/phase-state.json
+++ b/.ae/phase-state.json
@@ -1,0 +1,130 @@
+{
+  "projectId": "4df4a45e-eff0-4fe0-8897-73c71fb0da07",
+  "projectName": "phase1-integration",
+  "createdAt": "2025-09-16T12:24:52.507Z",
+  "updatedAt": "2025-09-16T12:24:52.915Z",
+  "currentPhase": "intent",
+  "phaseStatus": {
+    "intent": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "formal": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "test": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "code": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "verify": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "operate": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    }
+  },
+  "approvalsRequired": true,
+  "metadata": {
+    "integration-test": {
+      "ready": true
+    },
+    "test-agent_task_started_1758025492900": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.900Z",
+      "taskId": "test-task-1",
+      "type": "code-generation"
+    },
+    "test-agent_task_completed_1758025492901": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.901Z",
+      "taskId": "test-task-1",
+      "success": true,
+      "executionTime": 2
+    },
+    "test-agent_task_started_1758025492905": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.905Z",
+      "taskId": "tdd-task",
+      "type": "test-generation"
+    },
+    "test-agent_task_completed_1758025492905": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.905Z",
+      "taskId": "tdd-task",
+      "success": true,
+      "executionTime": 0
+    },
+    "test-agent_task_started_1758025492909": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.909Z",
+      "taskId": "validation-test",
+      "type": "validation"
+    },
+    "test-agent_task_completed_1758025492910": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.910Z",
+      "taskId": "validation-test",
+      "success": true,
+      "executionTime": 1
+    },
+    "test-agent_task_started_1758025492911": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.911Z",
+      "taskId": "coverage-test",
+      "type": "quality-assurance"
+    },
+    "test-agent_task_completed_1758025492912": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.912Z",
+      "taskId": "coverage-test",
+      "success": true,
+      "executionTime": 1
+    },
+    "test-agent_task_started_1758025492914": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.914Z",
+      "taskId": "phase-transition",
+      "type": "phase-validation"
+    },
+    "test-agent_task_completed_1758025492915": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T12:24:52.915Z",
+      "taskId": "phase-transition",
+      "success": true,
+      "executionTime": 1
+    }
+  }
+}

--- a/tests/golden/snapshots/codegen-snapshot.json
+++ b/tests/golden/snapshots/codegen-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-16T12:19:05.431Z",
+  "timestamp": "2025-09-16T12:24:52.369Z",
   "version": "1.0.0",
   "files": {
     "examples/inventory/apps/web/components/ProductForm.tsx": {


### PR DESCRIPTION
TokenBucketRateLimiter のPBTを追加:\n- 非負/上限クランプの境界確認\n- waitForTokens が（内部で消費する）実装に沿う形で完了性のみ検証\n\nローカル test:fast 緑。小粒/非ブロッキング。