### PR TITLE
chore(formal): include Apalache in formal summary.json

### DIFF
--- a/scripts/formal/aggregate-formal.mjs
+++ b/scripts/formal/aggregate-formal.mjs
@@ -14,6 +14,7 @@ const conformance = readJsonSafe(path.join(confDir, 'summary.json'));
 const smt = readJsonSafe(path.join(formalDir, 'smt-summary.json'));
 const alloy = readJsonSafe(path.join(formalDir, 'alloy-summary.json'));
 const tla = readJsonSafe(path.join(formalDir, 'tla-summary.json'));
+const apalache = readJsonSafe(path.join(formalDir, 'apalache-summary.json'));
 
 const summary = {
   timestamp: new Date().toISOString(),
@@ -21,12 +22,14 @@ const summary = {
     conformance: !!conformance,
     smt: !!smt,
     alloy: !!alloy,
-    tla: !!tla
+    tla: !!tla,
+    apalache: !!apalache
   },
   conformance: conformance || null,
   smt: smt || null,
   alloy: alloy || null,
-  tla: tla || null
+  tla: tla || null,
+  apalache: apalache || null
 };
 
 const outFile = path.join(formalDir, 'summary.json');


### PR DESCRIPTION
aggregate-formal.mjs を更新し、formal summary.json に Apalache を追加:\n- present.apalache を出力\n- apalache セクション（apalache-summary.json のJSONをそのまま格納）\n\n影響範囲はアーティファクト内のsummary.jsonのみ。非ブロッキング。