### PR TITLE
test(resilience): TokenBucket refill up to maxTokens (PBT)

### DIFF
--- a/.ae/enhanced-state.db
+++ b/.ae/enhanced-state.db
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0.0",
-    "timestamp": "2025-09-16T12:28:58.683Z",
+    "timestamp": "2025-09-16T12:33:14.232Z",
     "options": {
       "databasePath": ".ae/enhanced-state.db",
       "enableCompression": true,
@@ -14,9 +14,9 @@
   },
   "entries": [
     {
-      "id": "b16e1e8c-eb21-4d18-b48e-2eece41c700d",
+      "id": "076c9740-f3f3-4506-8128-ce1683678f1c",
       "logicalKey": "integration-ready",
-      "timestamp": "2025-09-16T12:28:58.683Z",
+      "timestamp": "2025-09-16T12:33:14.232Z",
       "version": 1,
       "checksum": "0094478148422a83dc50a368102314e8ddf937293f6679096c4b66f5d989afcb",
       "data": {
@@ -28,8 +28,8 @@
       "ttl": 604800,
       "metadata": {
         "size": 28,
-        "created": "2025-09-16T12:28:58.683Z",
-        "accessed": "2025-09-16T12:28:58.683Z",
+        "created": "2025-09-16T12:33:14.232Z",
+        "accessed": "2025-09-16T12:33:14.232Z",
         "source": "unknown"
       }
     }
@@ -37,7 +37,7 @@
   "indices": {
     "keyIndex": {
       "integration-ready": [
-        "integration-ready_2025-09-16T12:28:58.683Z"
+        "integration-ready_2025-09-16T12:33:14.232Z"
       ]
     },
     "versionIndex": {

--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -24,6 +24,8 @@ jobs:
           const fs=require("fs"), path=require("path");
           function rj(p){ try { return JSON.parse(fs.readFileSync(p,"utf-8")); } catch { return undefined; } }
           function find(dir, name){ try { const p = path.join(dir, name); return fs.existsSync(p) ? p : undefined; } catch { return undefined; } }
+          const LINE_CLAMP = parseInt(process.env.FORMAL_AGG_LINE_CLAMP || '200', 10);
+          const ERRORS_LIMIT = parseInt(process.env.FORMAL_AGG_ERRORS_LIMIT || '5', 10);
           function escMd(s){
             if (!s) return '';
             // Basic Markdown escaping to avoid breaking PR rendering
@@ -32,7 +34,7 @@ jobs:
               .replace(/</g, "&lt;")
               .replace(/>/g, "&gt;");
           }
-          function clamp(s, n=200){ s = String(s||''); return s.length>n ? (s.slice(0,n)+"…") : s; }
+          function clamp(s, n=LINE_CLAMP){ s = String(s||''); return s.length>n ? (s.slice(0,n)+"…") : s; }
           const base = "artifacts_dl";
           const outDir = "artifacts/formal"; fs.mkdirSync(outDir,{recursive:true});
           const outMd = path.join(outDir, "formal-aggregate.md");
@@ -82,7 +84,7 @@ jobs:
               lines.push('<details><summary>Apalache errors (top)</summary>');
               lines.push('');
               lines.push('```text');
-              for (const e of apalache.errors.slice(0,5)) lines.push(escMd(clamp(e)));
+              for (const e of apalache.errors.slice(0,ERRORS_LIMIT)) lines.push(escMd(clamp(e)));
               lines.push('```');
               lines.push('');
               lines.push('</details>');

--- a/tests/golden/snapshots/codegen-snapshot.json
+++ b/tests/golden/snapshots/codegen-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-16T12:28:58.559Z",
+  "timestamp": "2025-09-16T12:33:14.041Z",
   "version": "1.0.0",
   "files": {
     "examples/inventory/apps/web/components/ProductForm.tsx": {
@@ -135,16 +135,16 @@
       "typeScriptErrors": 1,
       "eslintErrors": 0
     },
-    "examples/inventory/apps/web/app/customer/new/page.tsx": {
-      "hash": "ddaf62479aa61e9eaa97d021c29c05d438bf740c1964a91f75eada1da6ed6263",
-      "lineCount": 75,
+    "examples/inventory/apps/web/app/customer/[id]/page.tsx": {
+      "hash": "2a001e47fd626011516478ac7f1f6930ee748e6e68a37c02a3c3c68c98e4c5e4",
+      "lineCount": 214,
       "ariaAttributeCount": 0,
       "typeScriptErrors": 0,
       "eslintErrors": 0
     },
-    "examples/inventory/apps/web/app/customer/[id]/page.tsx": {
-      "hash": "2a001e47fd626011516478ac7f1f6930ee748e6e68a37c02a3c3c68c98e4c5e4",
-      "lineCount": 214,
+    "examples/inventory/apps/web/app/customer/new/page.tsx": {
+      "hash": "ddaf62479aa61e9eaa97d021c29c05d438bf740c1964a91f75eada1da6ed6263",
+      "lineCount": 75,
       "ariaAttributeCount": 0,
       "typeScriptErrors": 0,
       "eslintErrors": 0

--- a/tests/resilience/token-bucket.refill.pbt.test.ts
+++ b/tests/resilience/token-bucket.refill.pbt.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: TokenBucketRateLimiter refill behavior', () => {
+  it('refills up to maxTokens after several intervals', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ tokens: fc.integer({ min: 1, max: 10 }), interval: fc.integer({ min: 5, max: 50 }), max: fc.integer({ min: 5, max: 50 }), steps: fc.integer({ min: 1, max: 5 }) }),
+      async ({ tokens, interval, max, steps }) => {
+        const rl = new TokenBucketRateLimiter({ tokensPerInterval: tokens, interval, maxTokens: max });
+        // drain completely
+        await rl.consume(max);
+        // wait N intervals
+        await new Promise(r=>setTimeout(r, interval * steps));
+        const count = rl.getTokenCount();
+        expect(count).toBeGreaterThanOrEqual(0);
+        expect(count).toBeLessThanOrEqual(max);
+      }
+    ), { numRuns: 20 });
+  });
+});


### PR DESCRIPTION
TokenBucketRateLimiter のリフィル動作をPBTで検証:\n- 全消費→N intervals 後に 0〜maxTokens に収まること（上限クランプ維持）\n- numRuns=20（CI耐性）