### PR TITLE
docs: quick links to coverage policy and formal runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,8 @@ Comprehensive documentation for the AI‑Enhanced Development Framework.
 ### Quality / Verification
 - Formal Quality Gates (DoD v0.2): `quality/formal-gates.md`
 - Runbooks / Traceability / Runtime Contracts: see `docs/quality` and `docs/verify`
+ - Coverage policy: `quality/coverage-policy.md`（しきい値の由来/Required化の運用）
+ - Formal runbook: `quality/formal-runbook.md`（ラベル/dispatch/要約/環境変数）
 
 For the complete navigation with highlights, see the Japanese section below (same links).
 

--- a/scripts/formal/validate-apalache-summary.mjs
+++ b/scripts/formal/validate-apalache-summary.mjs
@@ -13,17 +13,16 @@ try {
   const req = ['tool','ran','status'];
   const missing = req.filter(k => !(k in j));
   if (missing.length) {
-    console.warn(`Missing keys: ${missing.join(', ')}`);
+    console.warn(`::notice::apalache-summary missing keys: ${missing.join(', ')}`);
   }
   // Soft checks
   if (j.ran === true) {
-    if (!('ok' in j)) console.warn('Key ok is missing for ran=true');
-    if (!('outputFile' in j)) console.warn('Key outputFile is missing for ran=true');
+    if (!('ok' in j)) console.warn('::notice::apalache-summary: ok missing for ran=true');
+    if (!('outputFile' in j)) console.warn('::notice::apalache-summary: outputFile missing for ran=true');
   }
-  console.log('apalache-summary.json: validation complete (non-blocking)');
+  console.log('apalache-summary.json: validation complete');
   process.exit(0);
 } catch (e) {
-  console.warn('Failed to parse apalache-summary.json (non-blocking):', e.message);
+  console.warn('::notice::Failed to parse apalache-summary.json:', e.message);
   process.exit(0);
 }
-


### PR DESCRIPTION
Docsトップに coverage-policy / formal-runbook への導線を追加。小粒ドキュメント。