### PR TITLE
chore(ci/resilience/docs): coverage rationale + more PBTs + docs tweaks

### DIFF
--- a/.ae/enhanced-state.db
+++ b/.ae/enhanced-state.db
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0.0",
-    "timestamp": "2025-09-16T13:45:39.197Z",
+    "timestamp": "2025-09-16T14:19:37.195Z",
     "options": {
       "databasePath": ".ae/enhanced-state.db",
       "enableCompression": true,
@@ -14,9 +14,9 @@
   },
   "entries": [
     {
-      "id": "554e0a86-6771-4d40-a0f0-02e2332fe32e",
+      "id": "afb82032-431b-4c1e-a321-80901b2029fe",
       "logicalKey": "integration-ready",
-      "timestamp": "2025-09-16T13:45:39.197Z",
+      "timestamp": "2025-09-16T14:19:37.195Z",
       "version": 1,
       "checksum": "0094478148422a83dc50a368102314e8ddf937293f6679096c4b66f5d989afcb",
       "data": {
@@ -28,8 +28,8 @@
       "ttl": 604800,
       "metadata": {
         "size": 28,
-        "created": "2025-09-16T13:45:39.197Z",
-        "accessed": "2025-09-16T13:45:39.197Z",
+        "created": "2025-09-16T14:19:37.195Z",
+        "accessed": "2025-09-16T14:19:37.195Z",
         "source": "unknown"
       }
     }
@@ -37,7 +37,7 @@
   "indices": {
     "keyIndex": {
       "integration-ready": [
-        "integration-ready_2025-09-16T13:45:39.197Z"
+        "integration-ready_2025-09-16T14:19:37.195Z"
       ]
     },
     "versionIndex": {

--- a/.ae/phase-state.json
+++ b/.ae/phase-state.json
@@ -1,0 +1,142 @@
+{
+  "projectId": "8422e758-3860-4059-88a7-660f61f32e57",
+  "projectName": "phase1-integration",
+  "createdAt": "2025-09-16T14:19:37.192Z",
+  "updatedAt": "2025-09-16T14:19:37.804Z",
+  "currentPhase": "intent",
+  "phaseStatus": {
+    "intent": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "formal": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "test": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "code": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "verify": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "operate": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    }
+  },
+  "approvalsRequired": true,
+  "metadata": {
+    "integration-test": {
+      "ready": true
+    },
+    "test-agent_task_started_1758032377600": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.601Z",
+      "taskId": "test-task-1",
+      "type": "code-generation"
+    },
+    "test-agent_task_completed_1758032377602": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.602Z",
+      "taskId": "test-task-1",
+      "success": true,
+      "executionTime": 2
+    },
+    "test-agent_task_started_1758032377604": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.604Z",
+      "taskId": "tdd-task",
+      "type": "test-generation"
+    },
+    "test-agent_task_completed_1758032377605": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.605Z",
+      "taskId": "tdd-task",
+      "success": true,
+      "executionTime": 1
+    },
+    "test-agent_task_started_1758032377609": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.609Z",
+      "taskId": "validation-test",
+      "type": "validation"
+    },
+    "test-agent_task_completed_1758032377609": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.609Z",
+      "taskId": "validation-test",
+      "success": true,
+      "executionTime": 0
+    },
+    "test-agent_task_started_1758032377611": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.611Z",
+      "taskId": "coverage-test",
+      "type": "quality-assurance"
+    },
+    "test-agent_task_completed_1758032377611": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.611Z",
+      "taskId": "coverage-test",
+      "success": true,
+      "executionTime": 0
+    },
+    "test-agent_task_started_1758032377613": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.613Z",
+      "taskId": "phase-transition",
+      "type": "phase-validation"
+    },
+    "test-agent_task_completed_1758032377614": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-16T14:19:37.614Z",
+      "taskId": "phase-transition",
+      "success": true,
+      "executionTime": 1
+    },
+    "intent_activity_1758032377798": {
+      "activity": "output_validation",
+      "timestamp": "2025-09-16T14:19:37.798Z",
+      "success": true,
+      "outputType": "generic",
+      "artifactCount": 2,
+      "qualityScore": 85,
+      "validationMessage": "Default validation passed (no custom validation implemented)"
+    }
+  }
+}}
+}
+}
+}

--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -46,7 +46,7 @@ jobs:
               `Violations: critical=${{ steps.a11y.outputs.critical }}, serious=${{ steps.a11y.outputs.serious }}, moderate=${{ steps.a11y.outputs.moderate }}, minor=${{ steps.a11y.outputs.minor }}`,
               `Passes: ${{ steps.a11y.outputs.passes }}, Components tested: ${{ steps.a11y.outputs.components }}`,
               '',
-              `${{ contains(github.event.pull_request.labels.*.name, 'enforce-a11y') && 'Policy: enforced (label: enforce-a11y)' || 'Policy: report-only' }}`,
+              `${{ contains(github.event.pull_request.labels.*.name, 'enforce-a11y') && 'Policy: enforced (label: enforce-a11y); Threshold: critical=0, serious=0' || 'Policy: report-only; Threshold: critical=0, serious=0' }}`,
               'Docs: docs/quality/adapter-thresholds.md'
             ].join('\n');
             const { owner, repo, number } = context.issue;

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -88,13 +88,20 @@ jobs:
             const covLabel = labels.find(n => typeof n === 'string' && n.startsWith('coverage:')) || null;
             const defTh = Number(process.env.COVERAGE_DEFAULT_THRESHOLD || 80);
             const effTh = `${{ needs.gate.outputs.threshold }}`;
-            const policy = ${{ needs.gate.outputs.strict == 'true' }} ? 'enforced' : 'report-only';
+            const strict = `${{ needs.gate.outputs.strict }}` === 'true';
+            const policy = strict ? 'enforced' : 'report-only';
+            let rationale = 'report-only';
+            if (strict) {
+              if (labels.includes('enforce-coverage')) rationale = 'enforced via label: enforce-coverage';
+              else rationale = 'enforced via main + repo vars (COVERAGE_ENFORCE_MAIN)';
+            }
             const lines = [];
             lines.push(`Coverage (lines): ${pct}%`);
             lines.push(`Threshold (effective): ${effTh}%`);
             if (covLabel) lines.push(`- via label: ${covLabel}`);
             lines.push(`- default: ${isFinite(defTh) ? defTh : 80}%`);
             lines.push(`Policy: ${policy}`);
+            lines.push(`Policy source: ${rationale}`);
             const body = header + lines.join('\n');
             const { owner, repo, number } = context.issue;
             const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });

--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -106,7 +106,8 @@ jobs:
           lines.push(confSum ? `- Conformance summary file: ${path.basename(confSum)}` : "- Conformance summary: n/a");
           lines.push("");
           lines.push("_Non-blocking. Add/remove label run-formal to control._");
-          lines.push("_Reproduce locally: pnpm run verify:tla -- --engine=apalache_ (or see docs/quality/formal-runbook.md)");
+          lines.push("_Reproduce locally: pnpm run verify:tla -- --engine=apalache_ (see docs/quality/formal-runbook.md)");
+          lines.push("_Tools check: pnpm run tools:formal:check_");
           const md = lines.join("\n");
           fs.writeFileSync(outMd, md);
           console.log(md);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - CI 安定化・段階導入（Verify Lite 必須、その他はラベル駆動）
 - 小さく安全な PR を多数（revert しやすい粒度）
 - actionlint 準拠（echo→printf、GITHUB_OUTPUT/GITHUB_ENV は printf で追記）
+ - Coverage/ Formal の表示はPRコメントに要約を投稿（coverageは閾値の由来/ポリシー、formalは再現ヒントとtoolsチェックを提示）
 
 ## ブランチ/PR運用
 - ブランチ名: `chore/ci-<topic>-<short>`（例: `chore/ci-actionlint-printf-2`）

--- a/docs/adapters/adapter-template.md
+++ b/docs/adapters/adapter-template.md
@@ -1,0 +1,13 @@
+# Adapter Template — Minimal Outline
+
+This document provides a minimal outline for implementing an adapter with thresholds.
+
+Sections
+- Purpose and scope
+- Input/output format
+- Thresholds (defaults and label overrides)
+- CI wiring (report-only vs enforce)
+- Reproduce locally (commands)
+
+See also: `docs/quality/adapter-thresholds.md`.
+

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -99,6 +99,7 @@ This document defines CI policies to keep PR experience fast and stable while ma
 ### 必須チェック（PR ブロッキング）
 - Verify Lite（types:check / lint / build）
 - 必要に応じて validate-artifacts-ajv / coverage-check を必須化可能
+ - カバレッジ運用とRequired化の詳細は `docs/quality/coverage-policy.md` を参照（しきい値の由来、ラベル/変数、main運用）
 
 ### ラベル運用（Opt-in）
 - `ci-non-blocking`: 一部ジョブ（traceability, model-check, contracts, security 等）を continue-on-error で実行し PR をブロックしない

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -30,6 +30,12 @@
   - 集計: `hermetic-reports/formal/summary.json` に要約を出力
   - 表示: 実行後にコンソールへ簡易サマリを表示
 
+### Reproduce Locally / ローカル再現
+- Tools check: `pnpm run tools:formal:check`（利用可能ツールの一覧）
+- Apalache（ある場合）: `pnpm run verify:tla -- --engine=apalache`
+- TLC（`TLA_TOOLS_JAR` がある場合）: `TLA_TOOLS_JAR=/path/to/tla2tools.jar pnpm run verify:tla -- --engine=tlc`
+- SMT（z3/cvc5 がある場合）: `pnpm run verify:smt -- --solver=z3 --file spec/smt/sample.smt2`
+
 ログ例（label: run-formal 実行時）
 ```
 --- Formal Summary ---

--- a/docs/testing/replay-runner.md
+++ b/docs/testing/replay-runner.md
@@ -29,3 +29,9 @@ REPLAY_STRICT=0 \
 node scripts/testing/replay-runner.mjs
 ```
 
+Sample Fixture
+You can also try the minimal sample fixture included in this repo:
+
+```
+REPLAY_INPUT=scripts/testing/fixtures/replay-sample.json pnpm tsx scripts/testing/replay-runner.mjs
+```

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -115,10 +115,12 @@ function computeOkFromOutput(out){
   // Positive indicators (prefer these if present)
   const positives = [
     /\bno\s+(?:errors?|counterexamples?)\b/i,
+    /no\s+counterexamples?\s+found/i,
     /verification\s+successful/i,
     /\bok\b/i,
     /invariant[^\n]*holds/i,
-    /no\s+violations?/i
+    /no\s+violations?/i,
+    /all\s+propert(?:y|ies)\s+hold/i
   ];
   if (positives.some(re => re.test(out))) return true;
   // Negative indicators

--- a/scripts/formal/verify-smt.mjs
+++ b/scripts/formal/verify-smt.mjs
@@ -23,6 +23,7 @@ function sh(cmd) { try { return execSync(cmd, { encoding: 'utf8' }); } catch (e)
 const args = parseArgs(process.argv);
 if (args.help) {
   console.log(`Usage: node scripts/formal/verify-smt.mjs [--solver=z3|cvc5] [--file path/to/input.smt2]`);
+  console.log('See docs/quality/formal-tools-setup.md for solver setup.');
   process.exit(0);
 }
 

--- a/scripts/testing/fixtures/replay-sample.json
+++ b/scripts/testing/fixtures/replay-sample.json
@@ -1,0 +1,10 @@
+{
+  "replay": {
+    "version": 1,
+    "events": [
+      { "type": "item_allocated", "qty": 1 },
+      { "type": "item_shipped", "qty": 1 }
+    ]
+  }
+}
+

--- a/tests/golden/snapshots/codegen-snapshot.json
+++ b/tests/golden/snapshots/codegen-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-16T13:45:39.024Z",
+  "timestamp": "2025-09-16T14:19:37.031Z",
   "version": "1.0.0",
   "files": {
     "examples/inventory/apps/web/components/ProductForm.tsx": {

--- a/tests/resilience/backoff.nearmax.equal-full.bounds.pbt.test.ts
+++ b/tests/resilience/backoff.nearmax.equal-full.bounds.pbt.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { BackoffStrategy } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: Backoff near maxDelay bounds (equal/full)', () => {
+  it('equal/full jitter stay within [low, base(attempt)] near max', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ base: fc.integer({ min: 2, max: 200 }), mult: fc.integer({ min: 2, max: 5 }), pow: fc.integer({ min: 3, max: 8 }) }),
+      async ({ base, mult, pow }) => {
+        const maxDelayMs = base * Math.pow(mult, pow);
+        const expected = (attempt: number) => Math.min(base * Math.pow(mult, attempt), maxDelayMs);
+        const eq = new BackoffStrategy({ baseDelayMs: base, maxDelayMs, multiplier: mult, jitterType: 'equal' as const });
+        const fu = new BackoffStrategy({ baseDelayMs: base, maxDelayMs, multiplier: mult, jitterType: 'full' as const });
+        const attempt = pow; // boundary at or near max
+        const dEq = (eq as any)['calculateDelay'](attempt);
+        const dFu = (fu as any)['calculateDelay'](attempt);
+        const baseDelay = expected(attempt);
+        expect(dEq).toBeGreaterThanOrEqual(baseDelay / 2);
+        expect(dEq).toBeLessThanOrEqual(baseDelay);
+        expect(dFu).toBeGreaterThanOrEqual(0);
+        expect(dFu).toBeLessThanOrEqual(baseDelay);
+      }
+    ), { numRuns: 30 });
+  });
+});
+

--- a/tests/resilience/circuit-breaker.expected-errors.multi.test.ts
+++ b/tests/resilience/circuit-breaker.expected-errors.multi.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+
+class ExpectedA extends Error {}
+class ExpectedB extends Error {}
+class UnexpectedC extends Error {}
+
+describe('Resilience: CircuitBreaker expectedErrors with multiple types', () => {
+  it('counts only expected error classes towards opening', async () => {
+    const cb = new CircuitBreaker('multi-expected', {
+      failureThreshold: 2,
+      successThreshold: 1,
+      timeout: 10,
+      monitoringWindow: 100,
+      expectedErrors: [ExpectedA, ExpectedB],
+    });
+    // Unexpected should not count
+    await expect(cb.execute(async () => { throw new UnexpectedC('u'); })).rejects.toBeInstanceOf(UnexpectedC);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+    // Two expected errors open
+    await expect(cb.execute(async () => { throw new ExpectedA('a'); })).rejects.toBeInstanceOf(ExpectedA);
+    await expect(cb.execute(async () => { throw new ExpectedB('b'); })).rejects.toBeInstanceOf(ExpectedB);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+  });
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-threshold.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-threshold.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker HALF_OPEN success threshold boundary', () => {
+  it('closes when successCount reaches successThreshold exactly', async () => {
+    const cb = new CircuitBreaker('boundary', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      timeout: 10,
+      monitoringWindow: 100,
+    });
+    // Open
+    await expect(cb.execute(async () => { throw new Error('fail'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+    // Wait to half-open
+    await new Promise(r=>setTimeout(r, 12));
+    // Two successes should close
+    await cb.execute(async () => 1);
+    expect(cb.getState()).toBe(CircuitState.HALF_OPEN);
+    await cb.execute(async () => 2);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+  });
+});
+

--- a/tests/resilience/token-bucket.oversub.replenish.pbt.test.ts
+++ b/tests/resilience/token-bucket.oversub.replenish.pbt.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: TokenBucket oversubscribe with replenish', () => {
+  it('after waiting ~interval, tokens replenish (>0) and <= max', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ tokens: fc.integer({ min: 1, max: 10 }), interval: fc.integer({ min: 10, max: 60 }), max: fc.integer({ min: 5, max: 50 }) }),
+      async ({ tokens, interval, max }) => {
+        const rl = new TokenBucketRateLimiter({ tokensPerInterval: tokens, interval, maxTokens: max });
+        await rl.consume(max); // drain
+        const before = rl.getTokenCount();
+        expect(before).toBeGreaterThanOrEqual(0);
+        await new Promise(r => setTimeout(r, interval));
+        const after = rl.getTokenCount();
+        expect(after).toBeGreaterThan(0);
+        expect(after).toBeLessThanOrEqual(max);
+      }
+    ), { numRuns: 20 });
+  });
+});
+

--- a/tests/utils/gwt-format.test.ts
+++ b/tests/utils/gwt-format.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { formatGWT } from './gwt-format';
+
+describe('Utils: GWT formatter', () => {
+  it('formats Given/When/Then into a single line', () => {
+    const s = formatGWT('state initialized', 'action executed', 'result observed');
+    expect(s).toBe('Given state initialized | When action executed | Then result observed');
+  });
+});
+

--- a/tests/utils/gwt-format.ts
+++ b/tests/utils/gwt-format.ts
@@ -1,0 +1,4 @@
+export function formatGWT(given: string, when: string, then: string): string {
+  return [`Given ${given}`, `When ${when}`, `Then ${then}`].join(' | ');
+}
+


### PR DESCRIPTION
まとめて小粒：\n- coverage-check: PRコメントに policy source（label or main+vars）を追記\n- adapters: a11y の閾値をPRコメントに明示（critical=0, serious=0）\n- resilience: 追加PBT（backoff near max: equal/full、tokenbucket replenish、CB half-open閾値/expectedErrors multi）\n- docs: replay-runner にサンプルfixture・formal-runbookにローカル再現セクション、adapterテンプレ追加\n- docs/ci-policy: coverage-policy 参照を追加\n\nいずれも非ブロッキング。テストは test:fast 緑。