### PR TITLE
ci(adapters): dedupe perf comment step (report-only)

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -90,36 +90,6 @@ jobs:
       - name: Comment PR with perf summary
         if: steps.perf.outputs.present == 'true'
         uses: actions/github-script@v7
-        with:
-          script: |
-            const header = '<!-- AE-ADAPTER-PERF -->\n';
-            const score = '${{ steps.perf.outputs.score }}' || 'n/a';
-            const enforced = ${{ contains(github.event.pull_request.labels.*.name, 'enforce-perf') && 'true' || 'false' }};
-            const labels = context.payload.pull_request.labels.map(l=>l.name);
-            const perfLbl = labels.find(n=>/^perf:\\d{1,3}$/.test(n));
-            const threshold = perfLbl ? Number(perfLbl.split(':')[1]) : (Number(process.env.PERF_DEFAULT_THRESHOLD||75));
-            const body = [
-              header,
-              '### Performance (report-only)',
-              '',
-              `Score: ${score}`,
-              `Policy: ${enforced==='true' ? 'enforced (label: enforce-perf)' : 'report-only'}; Threshold: ${threshold}%`,
-              '',
-              'Docs: docs/quality/adapter-thresholds.md'
-            ].join('\n');
-            const { owner, repo, number } = context.issue;
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
-            const mine = comments.data.find(c => c.body && c.body.startsWith(header));
-            if (mine) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
-            }
-        env:
-          PERF_DEFAULT_THRESHOLD: ${{ vars.PERF_DEFAULT_THRESHOLD }}
-      - name: Comment PR with perf summary
-        if: steps.perf.outputs.present == 'true'
-        uses: actions/github-script@v7
         env:
           PERF_DEFAULT_THRESHOLD: ${{ vars.PERF_DEFAULT_THRESHOLD }}
         with:


### PR DESCRIPTION
- Remove duplicate perf comment step; keep version with derivation lines (via label/default)\n- No behavior change otherwise; small CI hygiene