### PR TITLE
chore(formal): normalize aggregate markdown (blank lines)

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -121,7 +121,17 @@ jobs:
           lines.push("_Reproduce locally: pnpm run verify:tla -- --engine=apalache_ (see docs/quality/formal-runbook.md)");
           lines.push("_Tools check: pnpm run tools:formal:check_");
           lines.push(`_Clamp: line=${clampInfo.lineClamp}, errors=${clampInfo.errorsLimit}_`);
-          const md = lines.join("\n");
+          // Normalize markdown: collapse excessive empty lines
+          function normalizeMd(arr){
+            const out=[]; let prevEmpty=false;
+            for (const l of arr){
+              const isEmpty = String(l).trim().length===0;
+              if (isEmpty && prevEmpty) continue;
+              out.push(l); prevEmpty = isEmpty;
+            }
+            return out.join("\n");
+          }
+          const md = normalizeMd(lines);
           fs.writeFileSync(outMd, md);
           // JSON aggregate for tooling
           const json = {


### PR DESCRIPTION
- Collapse consecutive blank lines in formal aggregate comment\n- Cosmetic; reduces noisy diffs and rendering variance