### PR TITLE
test(property): PBT for makeEmail normalization (supersedes #673)

### DIFF
--- a/tests/property/email.normalize.pbt.test.ts
+++ b/tests/property/email.normalize.pbt.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { makeEmail } from '../../src/lib/email';
+
+describe('PBT: makeEmail normalization', () => {
+  it('trims and lowercases valid simple emails', async () => {
+    const localChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._%+-';
+    const arbLocal = fc.stringOf(fc.constantFrom(...localChars.split('')), { minLength: 1, maxLength: 10 });
+    await fc.assert(fc.asyncProperty(
+      arbLocal,
+      async (local) => {
+        const raw = `  ${local}@Example.COM  `;
+        const res = makeEmail(raw) as unknown as string;
+        expect(res).toBe(`${local.toLowerCase()}@example.com`);
+      }
+    ), { numRuns: 50 });
+  });
+
+  it('rejects obvious invalid emails (no @)', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.string({ minLength: 1, maxLength: 12 }).filter(s => !s.includes('@')),
+      async (s) => {
+        let ok = true;
+        try { makeEmail(s); } catch { ok = false; }
+        expect(ok).toBe(false);
+      }
+    ), { numRuns: 30 });
+  });
+});


### PR DESCRIPTION
- Valid emails get trimmed + lowercased\n- Obvious invalids (no @) are rejected\n\nThis PR supersedes #673 (rebasing conflicts).