### PR TITLE
test(resilience): long-run decorrelated/CB counts/wait patterns

### DIFF
--- a/tests/resilience/backoff.decorrelated.longrun.sequence.pbt.test.ts
+++ b/tests/resilience/backoff.decorrelated.longrun.sequence.pbt.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { BackoffStrategy } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: Backoff decorrelated jitter long-run sequence bounds', () => {
+  it('attempts 1..N keep base <= d_i <= min(maxDelay, 3*prevDet)', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ base: fc.integer({ min: 1, max: 400 }), mult: fc.integer({ min: 2, max: 4 }), steps: fc.integer({ min: 3, max: 12 }) }),
+      async ({ base, mult, steps }) => {
+        const maxDelayMs = base * Math.pow(mult, 8);
+        const s = new BackoffStrategy({ baseDelayMs: base, maxDelayMs, multiplier: mult, jitterType: 'decorrelated' as const });
+        for (let attempt=1; attempt<=steps; attempt++) {
+          const d = (s as any)['calculateDelay'](attempt);
+          const minDelay = base;
+          const prevDet = Math.min(base * Math.pow(mult, Math.max(0, attempt - 1)), maxDelayMs);
+          const maxDelay = Math.min(prevDet * 3, maxDelayMs);
+          expect(d).toBeGreaterThanOrEqual(minDelay);
+          expect(d).toBeLessThanOrEqual(maxDelay);
+        }
+      }
+    ), { numRuns: 30 });
+  });
+});
+

--- a/tests/resilience/circuit-breaker.events.counts.test.ts
+++ b/tests/resilience/circuit-breaker.events.counts.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/resilience/backoff-strategies';
+
+describe('CircuitBreaker: state change counts', () => {
+  it('produces expected number of state changes for OPEN→HALF_OPEN→CLOSED', async () => {
+    vi.useFakeTimers();
+    const changes: CircuitState[] = [];
+    const cb = new CircuitBreaker({ failureThreshold: 2, recoveryTimeout: 100, monitoringPeriod: 10000, onStateChange: s => changes.push(s) });
+    const fail = vi.fn().mockRejectedValue(new Error('fail'));
+    for (let i=0;i<2;i++) { try { await cb.execute(fail); } catch {} }
+    vi.advanceTimersByTime(120);
+    const ok = vi.fn().mockResolvedValue('ok');
+    await cb.execute(ok);
+    const seq = changes.map(c=>c);
+    expect(seq.length).toBeGreaterThanOrEqual(2);
+    expect(seq).toContain(CircuitState.OPEN);
+    expect(seq).toContain(CircuitState.CLOSED);
+    for (let i=1;i<seq.length;i++) expect(seq[i]).not.toBe(seq[i-1]);
+    vi.useRealTimers();
+  });
+});
+

--- a/tests/resilience/token-bucket.wait.patterns.pbt.test.ts
+++ b/tests/resilience/token-bucket.wait.patterns.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: TokenBucket varied wait patterns', () => {
+  it('after varied waits, tokens remain within [0,max]', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ tokens: fc.integer({ min: 1, max: 10 }), interval: fc.integer({ min: 10, max: 80 }), max: fc.integer({ min: 5, max: 50 }) }),
+      async ({ tokens, interval, max }) => {
+        const rl = new TokenBucketRateLimiter({ tokensPerInterval: tokens, interval, maxTokens: max });
+        await rl.consume(Math.min(max, Math.ceil(max/2)));
+        const waits = [Math.floor(interval/4), Math.floor(interval/2), interval+5, interval*2+5];
+        for (const w of waits) {
+          await new Promise(r => setTimeout(r, w));
+          const c = rl.getTokenCount();
+          expect(c).toBeGreaterThanOrEqual(0);
+          expect(c).toBeLessThanOrEqual(max);
+        }
+      }
+    ), { numRuns: 20 });
+  });
+});
+


### PR DESCRIPTION
- Decorrelated long-run sequence bounds\n- CircuitBreaker state-change counts\n- TokenBucket varied waits within [0,max]