### PR TITLE
chore(ci): adaptersコメント体裁をcoverage準拠に統一（a11y）

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -39,16 +39,19 @@ jobs:
         with:
           script: |
             const header = '<!-- AE-ADAPTER-A11Y -->\n';
-            const body = [
-              header,
-              '### Accessibility',
-              '',
-              `Violations: critical=${{ steps.a11y.outputs.critical }}, serious=${{ steps.a11y.outputs.serious }}, moderate=${{ steps.a11y.outputs.moderate }}, minor=${{ steps.a11y.outputs.minor }}`,
-              `Passes: ${{ steps.a11y.outputs.passes }}, Components tested: ${{ steps.a11y.outputs.components }}`,
-              '',
-              `${{ contains(github.event.pull_request.labels.*.name, 'enforce-a11y') && 'Policy: enforced (label: enforce-a11y); Threshold: critical=0, serious=0' || 'Policy: report-only; Threshold: critical=0, serious=0' }}`,
-              'Docs: docs/quality/adapter-thresholds.md'
-            ].join('\n');
+            const enforced = ${{ contains(github.event.pull_request.labels.*.name, 'enforce-a11y') && 'true' || 'false' }};
+            const lines = [];
+            lines.push(header);
+            lines.push('### Accessibility');
+            lines.push('');
+            lines.push(`Violations: critical=${{ steps.a11y.outputs.critical }}, serious=${{ steps.a11y.outputs.serious }}, moderate=${{ steps.a11y.outputs.moderate }}, minor=${{ steps.a11y.outputs.minor }}`);
+            lines.push(`Passes: ${{ steps.a11y.outputs.passes }}, Components tested: ${{ steps.a11y.outputs.components }}`);
+            lines.push('');
+            lines.push('Threshold (effective): critical=0, serious=0');
+            lines.push(`Policy: ${enforced==='true' ? 'enforced (label: enforce-a11y)' : 'report-only'}`);
+            lines.push('');
+            lines.push('Docs: docs/quality/adapter-thresholds.md');
+            const body = lines.join('\n');
             const { owner, repo, number } = context.issue;
             const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
             const mine = comments.data.find(c => c.body && c.body.startsWith(header));


### PR DESCRIPTION
- a11yコメントにThreshold/Policyを明示\n- coverageとの体裁統一（由来はperf/lhと同等に表示）\n\nラベル: run-adapters, ci-non-blocking\n