### PR TITLE
chore(ci): coverage-check Docsリンク統一

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -67,7 +67,7 @@ jobs:
           if [ -f coverage/coverage-summary.json ]; then \
             PCT=$(node -e "console.log((require('./coverage/coverage-summary.json').total.lines.pct)||0)"); \
             printf "Coverage: %s%% (threshold: %s%%)\n" "$PCT" "$THRESHOLD"; \
-            awk 'BEGIN{ if ('"${PCT}"' + 0 < '"${THRESHOLD}"' + 0) exit 1 }' || { printf "%s\n" "::error::Coverage ${PCT}% below threshold ${THRESHOLD}% (see docs/quality/coverage-policy.md and docs/quality/coverage-required.md; tips: /coverage <pct>, /enforce-coverage)"; exit 1; }; \
+            awk 'BEGIN{ if ('"${PCT}"' + 0 < '"${THRESHOLD}"' + 0) exit 1 }' || { printf "%s\n" "::error::Coverage ${PCT}% below threshold ${THRESHOLD}% (see docs/quality/coverage-required.md; tips: /coverage <pct>, /enforce-coverage)"; exit 1; }; \
           else \
             printf "%s\n" "No coverage-summary.json found; skipping check"; \
           fi
@@ -105,6 +105,7 @@ jobs:
             lines.push(`- default: ${isFinite(defTh) ? defTh : 80}%`);
             lines.push(`Policy: ${policy}`);
             lines.push(`Policy source: ${rationale}`);
+            lines.push('Docs: docs/quality/coverage-required.md');
             const body = header + lines.join('\n');
             const { owner, repo, number } = context.issue;
             const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });


### PR DESCRIPTION
- ::error:: とPRコメントのDocsリンクを coverage-required.md に統一\n- 導線を一本化してRequired運用ガイドに誘導\n