### PR TITLE
test(resilience): Decorrelated/TB/CBのPBT境界追加

### DIFF
--- a/tests/resilience/backoff.decorrelated.attempt-middle.bounds.pbt.test.ts
+++ b/tests/resilience/backoff.decorrelated.attempt-middle.bounds.pbt.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { BackoffStrategy } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: Backoff decorrelated jitter middle attempts', () => {
+  it('attempt in 2..6 has bounded delay [base, min(max, 3*prevDet)]', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ base: fc.integer({ min: 1, max: 200 }), mult: fc.integer({ min: 2, max: 5 }), attempt: fc.integer({ min: 2, max: 6 }) }),
+      async ({ base, mult, attempt }) => {
+        const maxDelayMs = base * Math.pow(mult, 8); // ample headroom
+        const s = new BackoffStrategy({ baseDelayMs: base, maxDelayMs, multiplier: mult, jitterType: 'decorrelated' as const });
+        const d = (s as any)['calculateDelay'](attempt);
+        const minDelay = base;
+        const prevDet = Math.min(base * Math.pow(mult, Math.max(0, attempt - 1)), maxDelayMs);
+        const maxDelay = Math.min(prevDet * 3, maxDelayMs);
+        expect(d).toBeGreaterThanOrEqual(minDelay);
+        expect(d).toBeLessThanOrEqual(maxDelay);
+      }
+    ), { numRuns: 20 });
+  });
+});
+

--- a/tests/resilience/circuit-breaker.success-threshold-3.boundary.test.ts
+++ b/tests/resilience/circuit-breaker.success-threshold-3.boundary.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker successThreshold=3 boundary', () => {
+  it('requires 3 consecutive successes in HALF_OPEN to close', async () => {
+    const cb = new CircuitBreaker('succ3', {
+      failureThreshold: 1,
+      successThreshold: 3,
+      timeout: 10,
+      monitoringWindow: 100,
+    });
+    // Open
+    await expect(cb.execute(async () => { throw new Error('fail'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+    // Go HALF_OPEN
+    await new Promise(r => setTimeout(r, 12));
+    // 1st success -> remain HALF_OPEN
+    await cb.execute(async () => 1);
+    expect(cb.getState()).toBe(CircuitState.HALF_OPEN);
+    // 2nd success -> remain HALF_OPEN
+    await cb.execute(async () => 1);
+    expect(cb.getState()).toBe(CircuitState.HALF_OPEN);
+    // 3rd success -> CLOSED
+    await cb.execute(async () => 1);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+  });
+});
+

--- a/tests/resilience/token-bucket.oversub.waits.combo.pbt.test.ts
+++ b/tests/resilience/token-bucket.oversub.waits.combo.pbt.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: TokenBucket oversubscribe with varied waits', () => {
+  it('tokens remain within [0,max] across oversubscribe and waits', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ tokens: fc.integer({ min: 1, max: 10 }), interval: fc.integer({ min: 10, max: 40 }), max: fc.integer({ min: 5, max: 50 }) }),
+      async ({ tokens, interval, max }) => {
+        const rl = new TokenBucketRateLimiter({ tokensPerInterval: tokens, interval, maxTokens: max });
+        // Oversubscribe sequence
+        const ask = Math.min(max + 2, max * 2);
+        try { await rl.consume(ask); } catch {}
+        // Wait patterns: /3, /2, 1×, 2×, 3×
+        const waits = [Math.floor(interval/3), Math.floor(interval/2), interval, interval*2];
+        for (const w of waits) {
+          await new Promise(r => setTimeout(r, w));
+          const c = rl.getTokenCount();
+          expect(c).toBeGreaterThanOrEqual(0);
+          expect(c).toBeLessThanOrEqual(max);
+        }
+      }
+    ), { numRuns: 10 });
+  });
+});


### PR DESCRIPTION
- Decorrelated: 中間域 attempts (2..6) の上下界\n- TokenBucket: oversubscribe + varied waits の境界（短時間/少ラン）\n- CircuitBreaker: successThreshold=3 でのCLOSED遷移境界\n