### PR TITLE
chore(ci): formal-aggregate JSON ranOk 追加（安全化/参照情報強化）

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -166,7 +166,16 @@ jobs:
             smt: smt || null,
             apalache: apalache || null,
             conformance: conf || null,
-            info: { lineClamp: LINE_CLAMP, errorsLimit: ERRORS_LIMIT, generatedAt: GENERATED_AT, present, presentCount }
+            info: { 
+              lineClamp: LINE_CLAMP, 
+              errorsLimit: ERRORS_LIMIT, 
+              generatedAt: GENERATED_AT, 
+              present, 
+              presentCount,
+              ranOk: {
+                apalache: apalache ? { ran: !!apalache.ran, ok: (typeof apalache.ok === 'boolean' ? apalache.ok : null) } : null
+              }
+            }
           };
           fs.writeFileSync(outJson, JSON.stringify(json,null,2));
           const aggPresent = fs.existsSync(outJson) ? 'yes' : 'no';


### PR DESCRIPTION
- JSON info.ranOk.apalache に ran/ok を追加（null安全）\n- 参照情報を強化し、MD/他ツールからの活用性を向上\n- 現行のMD表示は現状維持（present/summary/by-type present/Ran/OKは従来通り）\n