### PR TITLE
test(formal): aggregate-utils 欠損/不正JSON安全性テスト

### DIFF
--- a/scripts/formal/aggregate-utils.mjs
+++ b/scripts/formal/aggregate-utils.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function readJsonSafe(p){
+  try { return JSON.parse(fs.readFileSync(p,'utf-8')); } catch { return undefined; }
+}
+
+function find(base, rel){
+  const p = path.join(base, rel);
+  return fs.existsSync(p) ? p : undefined;
+}
+
+export function computeAggregateInfo(baseDir){
+  const tlaSum = find(baseDir, 'formal-reports-tla/tla-summary.json');
+  const alloySum = find(baseDir, 'formal-reports-alloy/alloy-summary.json');
+  const smtSum = find(baseDir, 'formal-reports-smt/smt-summary.json');
+  const apalacheSum = find(baseDir, 'formal-reports-apalache/apalache-summary.json');
+  const confSum = find(baseDir, 'formal-reports-conformance/conformance-summary.json');
+
+  const apalache = apalacheSum ? readJsonSafe(apalacheSum) : undefined;
+
+  const present = {
+    tla: !!tlaSum,
+    alloy: !!alloySum,
+    smt: !!smtSum,
+    apalache: !!apalacheSum,
+    conformance: !!confSum,
+  };
+  const presentCount = Object.values(present).filter(Boolean).length;
+  const ranOk = {
+    apalache: apalache ? { ran: !!apalache.ran, ok: (typeof apalache.ok === 'boolean' ? apalache.ok : null) } : null
+  };
+  return { present, presentCount, ranOk };
+}
+

--- a/tests/formal/aggregate-utils.missing-artifacts.test.ts
+++ b/tests/formal/aggregate-utils.missing-artifacts.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { computeAggregateInfo } from '../../scripts/formal/aggregate-utils.mjs';
+
+describe('Formal aggregate utils: missing/invalid artifacts safety', () => {
+  it('returns present=false when summary files are absent', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agg-')); 
+    const info = computeAggregateInfo(tmp);
+    expect(info.present).toEqual({ tla: false, alloy: false, smt: false, apalache: false, conformance: false });
+    expect(info.presentCount).toBe(0);
+    expect(info.ranOk.apalache).toBeNull();
+  });
+  it('handles invalid JSON gracefully (present=true but ranOk null)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agg-'));
+    const p = path.join(tmp, 'formal-reports-apalache');
+    fs.mkdirSync(p, { recursive: true });
+    fs.writeFileSync(path.join(p, 'apalache-summary.json'), '{invalid json');
+    const info = computeAggregateInfo(tmp);
+    expect(info.present.apalache).toBe(true);
+    expect(info.ranOk.apalache).toBeNull();
+  });
+  it('extracts ran/ok from apalache summary if present', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agg-'));
+    const p = path.join(tmp, 'formal-reports-apalache');
+    fs.mkdirSync(p, { recursive: true });
+    fs.writeFileSync(path.join(p, 'apalache-summary.json'), JSON.stringify({ ran: false, ok: null }));
+    const info = computeAggregateInfo(tmp);
+    expect(info.present.apalache).toBe(true);
+    expect(info.ranOk.apalache).toEqual({ ran: false, ok: null });
+  });
+});
+


### PR DESCRIPTION
- aggregate の最小ユーティリティを抽出し、欠損/不正JSON時の安全性をテスト\n- ワークフローの挙動（presentは存在ベース、ranOkはJSON依存）と整合\n