### PR TITLE
chore(formal/tests): apalache timeout対応・PBT拡充

### DIFF
--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -57,9 +57,14 @@ if (!fs.existsSync(absFile)){
   output = 'Apalache CLI not found. Install apalache or ensure apalache-mc is on PATH. See docs/quality/formal-tools-setup.md';
 } else {
   // Minimal "typecheck" like run; apalache-mc supports: apalache-mc check <Spec>
-  const cmd = `${apalacheCmd} check ${absFile.replace(/'/g, "'\\''")}`;
+  let baseCmd = `${apalacheCmd} check ${absFile.replace(/'/g, "'\\''")}`;
+  // Optional timeout wrapper (GNU timeout)
+  if (args.timeout && Number.isFinite(args.timeout) && args.timeout > 0 && has('timeout')) {
+    const secs = Math.max(1, Math.floor(Number(args.timeout)/1000));
+    baseCmd = `timeout ${secs}s ${baseCmd}`;
+  }
   const t0 = Date.now();
-  output = sh(`bash -lc '${cmd} 2>&1 || true'`);
+  output = sh(`bash -lc '${baseCmd} 2>&1 || true'`);
   timeMs = Date.now() - t0;
   status = 'ran';
   ran = true;

--- a/tests/property/token-optimizer.deduplication.pbt.test.ts
+++ b/tests/property/token-optimizer.deduplication.pbt.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+
+describe('PBT: TokenOptimizer.deduplicatePatterns (implicit via compressSteeringDocuments)', () => {
+  it('removes duplicate sentences ignoring case/spacing', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.array(fc.string({ minLength: 3, maxLength: 32 }), { minLength: 3, maxLength: 6 }),
+      async (sentences) => {
+        const base = sentences[0] || 'alpha';
+        const dupVariants = [base, base.toUpperCase(), ` ${base}  `];
+        const docs = { product: dupVariants.join('. ') + '.', standards: sentences.slice(1).join('. ') + '.' };
+        const opt = new TokenOptimizer();
+        const { compressed } = await opt.compressSteeringDocuments(docs, { compressionLevel: 'medium', enableCaching: false });
+        const count = (compressed.match(new RegExp(base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi')) || []).length;
+        expect(count).toBeGreaterThanOrEqual(1);
+      }
+    ), { numRuns: 10 });
+  });
+});
+

--- a/tests/resilience/circuit-breaker.failure-threshold-2.open.boundary.test.ts
+++ b/tests/resilience/circuit-breaker.failure-threshold-2.open.boundary.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker failureThreshold=2 boundary', () => {
+  it('opens after two consecutive failures', async () => {
+    const cb = new CircuitBreaker('fail2', {
+      failureThreshold: 2,
+      successThreshold: 1,
+      timeout: 10,
+      monitoringWindow: 100,
+    });
+    await expect(cb.execute(async () => { throw new Error('x1'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+    await expect(cb.execute(async () => { throw new Error('x2'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+  });
+});
+


### PR DESCRIPTION
- verify-apalache: --timeout 指定時にGNU timeoutでラップ（存在時）\n- property: TokenOptimizerの重複除去PBT\n- resilience: CircuitBreaker failureThreshold=2 のOPEN遷移境界\n