### PR TITLE
docs(formal): aggregate JSON 検証の記載追加

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -40,6 +40,10 @@ Timeout（任意）
 - 長時間実行を避けるため、TLA/SMT ランナーは `--timeout <ms>` をサポート（GNU `timeout` を利用可能な環境で有効）
 - 例: `pnpm run verify:tla -- --engine=apalache --timeout 60000`
 
+Aggregate JSON の軽量検証（非ブロッキング）
+- 集約ワークフローでは `artifacts/formal/formal-aggregate.json` を出力し、最小スキーマを警告レベルで検証します。
+- ローカル確認: `node scripts/formal/validate-aggregate-json.mjs`（存在時に検証、欠損/不正は `::warning::` 出力）
+
 ログ例（label: run-formal 実行時）
 ```
 --- Formal Summary ---
@@ -276,3 +280,4 @@ jobs:
 verify-formal:
 	pnpm run verify:formal
 ```
+- `artifacts/formal/formal-aggregate.json`: PR向け集約（byType/present/ranOk 等の最小情報を含む）


### PR DESCRIPTION
- aggregate JSON (artifacts/formal/formal-aggregate.json) の最小スキーマ警告の記載\n- ローカルでの検証手順: scripts/formal/validate-aggregate-json.mjs\n- verify-apalache の timeout 記載は既に反映済み（補足整備）\n