### PR TITLE
chore(ci/tests): a11y Derived行追加・heuristics/Resilience PBT拡充

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -48,6 +48,7 @@ jobs:
             lines.push(`Passes: ${{ steps.a11y.outputs.passes }}, Components tested: ${{ steps.a11y.outputs.components }}`);
             lines.push('');
             lines.push('Threshold (effective): critical=0, serious=0');
+            lines.push('Derived: fixed thresholds (critical=0, serious=0)');
             lines.push(`Policy: ${enforced==='true' ? 'enforced (label: enforce-a11y)' : 'report-only'}`);
             lines.push(`Policy source: ${enforced==='true' ? 'enforced via label: enforce-a11y' : 'report-only'}`);
             lines.push('');
@@ -65,11 +66,13 @@ jobs:
         if: steps.a11y.outputs.present == 'true'
         run: |
           FILE="reports/a11y-results.json"
-          if jq -e '.violations?.critical? // empty' "$FILE" >/dev/null 2>&1; then
+          # check that violations.critical/serious are numbers and components_tested is array (if present)
+          if jq -e '(.violations.critical|type=="number") and (.violations.serious|type=="number")' "$FILE" >/dev/null 2>&1; then
             printf "%s\n" "a11y JSON shape ok";
           else
-            printf "%s\n" "::warning::a11y JSON shape unexpected (.violations.critical not found)";
+            printf "%s\n" "::warning::a11y JSON shape unexpected (violations.critical/serious numeric check failed)";
           fi
+          if jq -e '.components_tested|type=="array"' "$FILE" >/dev/null 2>&1; then :; else printf "%s\n" "::warning::a11y components_tested not array (optional)"; fi
       - name: Enforce a11y thresholds (critical/serious==0)
         if: steps.a11y.outputs.present == 'true' && contains(github.event.pull_request.labels.*.name, 'enforce-a11y')
         run: |

--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -16,6 +16,9 @@ export const POSITIVE_PATTERNS = [
   ,/keine\s+fehler\s+gefunden/i          // DE: no errors found
   ,/aucune?\s+(?:violation|erreur)s?\s+d[ée]tect[ée]?/i // FR: no violation/error detected
   ,/no\s+se\s+detectaron\s+(?:errores|violaciones|contraejemplos?)/i // ES: no errors/violations/counterexamples detected
+  ,/all\s+invariants?\s+(?:satisfied|hold)/i
+  ,/no\s+property\s+violations?\b/i
+  ,/no\s+counterexample\s+found\s+in\s+\d+\s+steps?/i
 ];
 
 export const NEGATIVE_PATTERNS = [
@@ -35,6 +38,9 @@ export const NEGATIVE_PATTERNS = [
   /échec\s+(?:détecté|trouvé)/i,                  // FR failure detected/found
   /violación\s+(?:detectada|encontrada)/i,        // ES violation detected/found
   /fehlers?\s+gefunden/i                          // DE error(s) found
+  ,/invariant\s+(?:violated|verlet[zt]t)/i        // EN/DE invariant violated
+  ,/propri[ée]t[ée]\s+viol[ée]e/i                // FR property violated
+  ,/propiedad\s+violada/i                         // ES property violated
 ];
 
 export function computeOkFromOutput(out){

--- a/tests/formal/heuristics.pos.neg.extras.test.ts
+++ b/tests/formal/heuristics.pos.neg.extras.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { computeOkFromOutput } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: extra positive/negative patterns', () => {
+  it('accepts additional positive messages', () => {
+    const pos = [
+      'All invariants satisfied',
+      'No property violations',
+      'No counterexample found in 12 steps'
+    ];
+    for (const s of pos) expect(computeOkFromOutput(s)).toBe(true);
+  });
+  it('detects additional negative messages', () => {
+    const neg = [
+      'Invariant violated at state 3',
+      'Propriété violée',
+      'Propiedad violada'
+    ];
+    for (const s of neg) expect(computeOkFromOutput(s)).toBe(false);
+  });
+});
+

--- a/tests/resilience/token-bucket.oversub.alternating.pbt.test.ts
+++ b/tests/resilience/token-bucket.oversub.alternating.pbt.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: TokenBucket oversubscribe alternating with waits', () => {
+  it('tokens remain within [0,max] under alternating consume/wait cycles', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ tokens: fc.integer({ min: 1, max: 10 }), interval: fc.integer({ min: 10, max: 40 }), max: fc.integer({ min: 5, max: 50 }) }),
+      async ({ tokens, interval, max }) => {
+        const rl = new TokenBucketRateLimiter({ tokensPerInterval: tokens, interval, maxTokens: max });
+        for (let i=0;i<5;i++){
+          try { await rl.consume(max + 1); } catch {}
+          await new Promise(r => setTimeout(r, Math.floor(interval * (0.5 + (i%2?1:0)))));
+          const c = rl.getTokenCount();
+          expect(c).toBeGreaterThanOrEqual(0);
+          expect(c).toBeLessThanOrEqual(max);
+        }
+      }
+    ), { numRuns: 10 });
+  });
+});
+


### PR DESCRIPTION
- a11yコメントに Derived 行を追加（固定しきい値の明示）\n- heuristics: 追加の陽性/陰性パターン回帰（EN/FR/ES/DE）\n- resilience: TokenBucket oversubscribe の交互パターン境界\n