### PR TITLE
docs(ci/agents): Derived/Policy整形ガイド・AEコメント運用の例

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,3 +91,9 @@
 - 同一ヘッダのコメントはアップサート（一意に更新）
 - 1行サマリ→詳細→メタ情報（Clamp/Generated/Derived/Policy）の順で可読性を確保
 5) 小PR連投時の推奨ラベル: `ci-non-blocking`（非ブロッキング運用）, `run-formal`（Formalをopt-in）
+
+#### 例（良い/BAD）
+- 良い: Coverage コメントは `Threshold (effective)` → `Derived` → `Policy/Policy source` の順で表示（docsリンク付き）
+- 良い: Formal Aggregate コメントは `Present` → `Summary` → `By-type present` → `Apalache ran/ok` → `メタ（Tools/Reproduce/Policy/Clamp/Generated）`
+- BAD: 同一ヘッダのコメントを重複投稿する（アップサートせずノイズが増える）
+- BAD: 由来（Derived）/Policy の表記がCoverage/Adaptersで不一致になる

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -32,6 +32,13 @@ This document defines CI policies to keep PR experience fast and stable while ma
 - `coverage:<pct>`: override coverage threshold for coverage-check (default 80). e.g., `coverage:75`
  - `qa-batch:commands` / `qa-batch:cli` / `qa-batch:property` / `qa-batch:agents`: run additional CI Fast batches for the specific categories (opt-in)
 
+### Comment formatting (Coverage/Adapters)
+- Coverage / Adapters comments show:
+  - Threshold (effective)
+  - Derived: label > repo var > default（a11yは固定: critical=0, serious=0）
+  - Policy / Policy source（enforced via label, or report-only）
+  - Links to docs
+
 ### Slash Commands (Instant Dispatch / Labels)
 - コメントで以下を投稿すると、対象ワークフローの即時起動やラベル付与ができます（main取り込み後有効）。
   - Dispatch（workflow_dispatch 直起動）


### PR DESCRIPTION
- CIポリシー: Coverage/Adapters コメントのDerived/Policy整形方針を明記\n- AGENTS.md: AE-ヘッダのアップサート運用、良い/悪い例を追記\n