### PR TITLE
test(pbt): heuristics/CB/TokenOptimizer 追加

### DIFF
--- a/tests/formal/heuristics.caution.null.test.ts
+++ b/tests/formal/heuristics.caution.null.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { computeOkFromOutput } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution/warning phrases remain inconclusive', () => {
+  it('returns null for cautionary notes without explicit failure/ok', () => {
+    const notes = [
+      'Analysis completed with warnings only',
+      'Some checks were skipped due to configuration',
+      'Avertissement: résultats partiels', // FR
+      'Advertencia: resultados parciales',  // ES
+      'Hinweis: Teilresultate'              // DE
+    ];
+    for (const s of notes) expect(computeOkFromOutput(s)).toBeNull();
+  });
+});
+

--- a/tests/property/token-optimizer.priority.order.pbt.test.ts
+++ b/tests/property/token-optimizer.priority.order.pbt.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+
+describe('PBT: TokenOptimizer preservePriority ordering', () => {
+  it('sections appear in preservePriority order when present', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({
+        product: fc.string({ minLength: 1, maxLength: 64 }),
+        architecture: fc.string({ minLength: 1, maxLength: 64 }),
+        standards: fc.string({ minLength: 1, maxLength: 64 }),
+      }),
+      async ({ product, architecture, standards }) => {
+        const opt = new TokenOptimizer();
+        const { compressed } = await opt.compressSteeringDocuments(
+          { product, standards, architecture },
+          { compressionLevel: 'low', enableCaching: false }
+        );
+        const idxProd = compressed.indexOf('## PRODUCT');
+        const idxArch = compressed.indexOf('## ARCHITECTURE');
+        const idxStd  = compressed.indexOf('## STANDARDS');
+        expect(idxProd).toBeGreaterThanOrEqual(0);
+        expect(idxArch).toBeGreaterThan(idxProd);
+        expect(idxStd).toBeGreaterThan(idxArch);
+      }
+    ), { numRuns: 10 });
+  });
+});
+

--- a/tests/resilience/circuit-breaker.open-rejects.until-halfopen.test.ts
+++ b/tests/resilience/circuit-breaker.open-rejects.until-halfopen.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState, CircuitBreakerOpenError } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker OPEN rejects until half-open window', () => {
+  it('OPEN state rejects immediately until timeout elapses', async () => {
+    const cb = new CircuitBreaker('open-rejects', {
+      failureThreshold: 1,
+      successThreshold: 1,
+      timeout: 50,
+      monitoringWindow: 100,
+    });
+    await expect(cb.execute(async () => { throw new Error('f'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+    // Should reject while still OPEN
+    await expect(cb.execute(async () => 1)).rejects.toBeInstanceOf(CircuitBreakerOpenError);
+    // Wait to enter HALF_OPEN
+    await new Promise(r => setTimeout(r, 55));
+    await expect(cb.execute(async () => 1)).resolves.toBe(1);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+  });
+});
+


### PR DESCRIPTION
- heuristics: 注意/警告系はnull判定の回帰\n- CB: OPEN中の即時拒否→半開→CLOSED の境界\n- TokenOptimizer: preservePriority順（product→architecture→standards）\n