### PR TITLE
chore(formal/docs/tests): apalache timeout/CB OPEN境界/Runbook追記

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -39,6 +39,7 @@
 Timeout（任意）
 - 長時間実行を避けるため、TLA/SMT ランナーは `--timeout <ms>` をサポート（GNU `timeout` を利用可能な環境で有効）
 - 例: `pnpm run verify:tla -- --engine=apalache --timeout 60000`
+- なお、GNU `timeout` 使用時にタイムアウトが発生すると、summary の `status: "timeout"` となります（非ブロッキング運用）
 
 Aggregate JSON の軽量検証（非ブロッキング）
 - 集約ワークフローでは `artifacts/formal/formal-aggregate.json` を出力し、最小スキーマを警告レベルで検証します。

--- a/tests/resilience/circuit-breaker.stays-open.until-timeout.test.ts
+++ b/tests/resilience/circuit-breaker.stays-open.until-timeout.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState, CircuitBreakerOpenError } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker stays OPEN until timeout elapses', () => {
+  it('rejects during OPEN window and transitions to HALF_OPEN after timeout', async () => {
+    const timeout = 40;
+    const cb = new CircuitBreaker('open-stays', {
+      failureThreshold: 1,
+      successThreshold: 1,
+      timeout,
+      monitoringWindow: 100,
+    });
+    await expect(cb.execute(async () => { throw new Error('f'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+    // Immediately try again: must reject
+    await expect(cb.execute(async () => 1)).rejects.toBeInstanceOf(CircuitBreakerOpenError);
+    // After timeout: allow trial (HALF_OPEN)
+    await new Promise(r => setTimeout(r, timeout + 5));
+    await expect(cb.execute(async () => 1)).resolves.toBe(1);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+  });
+});
+


### PR DESCRIPTION
- verify-apalache: GNU timeout 利用時にtimeout発生を検知し status="timeout" を設定\n- docs: formal-runbook に timeout ステータスの記載を追記\n- tests: CBがtimeoutまでOPENを維持→半開→CLOSED へ遷移する境界テスト\n