### PR TITLE
test: heuristics 多言語陽性回帰・Email 正規化冪等性PBT

### DIFF
--- a/tests/formal/heuristics.multilingual.additional.test.ts
+++ b/tests/formal/heuristics.multilingual.additional.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { computeOkFromOutput } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: additional multilingual positives', () => {
+  it('accepts common positive phrases across FR/ES/DE', () => {
+    const samples = [
+      'Aucune violation détectée', // FR
+      'No se detectaron errores', // ES variant
+      'Keine Fehler gefunden' // DE
+    ];
+    for (const s of samples) expect(computeOkFromOutput(s)).toBe(true);
+  });
+});
+

--- a/tests/property/email.normalize.idempotent.pbt.test.ts
+++ b/tests/property/email.normalize.idempotent.pbt.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { makeEmail } from '../../src/lib/email';
+
+describe('PBT: Email normalization is idempotent and case/space-insensitive', () => {
+  it('makeEmail trims and lowercases; repeated make produces same value', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.tuple(fc.string(), fc.string(), fc.string()).filter(([l, d, t]) => {
+        // crude generator for emails local@domain.tld
+        return /[a-zA-Z0-9._%+-]{1,32}/.test(l) && /[a-zA-Z0-9.-]{1,32}/.test(d) && /[a-zA-Z]{2,7}/.test(t);
+      }),
+      async ([local, domain, tld]) => {
+        const raw = `  ${local}@${domain}.${tld}  `;
+        const e1 = makeEmail(raw) as unknown as string;
+        const e2 = makeEmail(e1) as unknown as string;
+        expect(e1).toBe(e2);
+        expect(e1).toBe(e1.trim().toLowerCase());
+      }
+    ), { numRuns: 25 });
+  });
+});
+


### PR DESCRIPTION
- heuristics: FR/ES/DE 陽性句の回帰\n- property: Email 正規化の冪等性（trim/lowercase, 再makeで不変）\n