### PR TITLE
chore(formal): heuristics boundaries EN/ES/DE/FR追加 + 回帰テスト

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -41,6 +41,11 @@ export const NEGATIVE_PATTERNS = [
   ,/invariant\s+(?:violated|verlet[zt]t)/i        // EN/DE invariant violated
   ,/propri[ée]t[ée]\s+viol[ée]e/i                // FR property violated
   ,/propiedad\s+violada/i                         // ES property violated
+  ,/counter-?example\s+(?:produced|generated)/i   // EN counterexample produced
+  ,/propert(?:y|ies)\s+(?:do(?:es)?\s+not|doesn't)\s+hold/i // EN property does not hold
+  ,/la\s+propiedad\s+no\s+se\s+cumple/i         // ES property does not hold
+  ,/die\s+eigenschaft\s+gilt\s+nicht/i          // DE property does not hold
+  ,/la\s+propri[ée]t[ée]\s+ne\s+tient\s+pas/i  // FR property does not hold
 ];
 
 export function computeOkFromOutput(out){

--- a/tests/formal/heuristics.negation.boundaries.2.test.ts
+++ b/tests/formal/heuristics.negation.boundaries.2.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { computeOkFromOutput } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: additional negation/caution boundaries', () => {
+  it('detects clear negatives across EN/ES/DE/FR', () => {
+    const samples = [
+      'Counterexample produced at step 12',
+      'The property does not hold for this execution',
+      'La propiedad no se cumple en este estado',
+      'Die Eigenschaft gilt nicht unter diesen Bedingungen',
+      'La propriété ne tient pas pour ce cas',
+    ];
+    for (const s of samples) {
+      expect(computeOkFromOutput(s)).toBe(false);
+    }
+  });
+
+  it('keeps null for non‑decisive messages', () => {
+    const neutral = [
+      'Analysis started...',
+      'Parsing input files',
+      'Checking invariants (this may take a while)',
+    ];
+    for (const s of neutral) {
+      expect(computeOkFromOutput(s)).toBeNull();
+    }
+  });
+
+  it('does not regress positives', () => {
+    const positives = [
+      'No counterexample found in 100 steps',
+      'Verification successful: all invariants hold',
+      'Keine Fehler gefunden',
+      'Aucune violation détectée',
+    ];
+    for (const s of positives) {
+      expect(computeOkFromOutput(s)).toBe(true);
+    }
+  });
+});
+


### PR DESCRIPTION
- NEGATIVEヒューリスティクスを多言語で2〜3件追加（保守的）
- 回帰テストを追加（positive/null/negativeの維持）
- 非破壊（実行経路/公開APIは不変）

Verify Lite で緑確認後、自動マージします。
