### PR TITLE
chore(formal): heuristics 境界追補 + Resilience 境界PBT + Runbook補足

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -44,6 +44,8 @@ Timeout（任意）
 Aggregate JSON の軽量検証（非ブロッキング）
 - 集約ワークフローでは `artifacts/formal/formal-aggregate.json` を出力し、最小スキーマを警告レベルで検証します。
 - ローカル確認: `node scripts/formal/validate-aggregate-json.mjs`（存在時に検証、欠損/不正は `::warning::` 出力）
+- 1行サマリを表示する簡易CLI（ローカル）:
+  - `node -e "const p='artifacts/formal/formal-aggregate.json';const j=require('fs').existsSync(p)?require('./'+p):null;if(!j){console.log('no aggregate');process.exit(0)}const pr=j.info?.present||{};const keys=Object.entries(pr).filter(([,v])=>v).map(([k])=>k);console.log('Present:', keys.length+'/5', keys.length?('('+keys.join(', ')+')'):'');"`
 
 ログ例（label: run-formal 実行時）
 ```

--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -46,6 +46,8 @@ export const NEGATIVE_PATTERNS = [
   ,/la\s+propiedad\s+no\s+se\s+cumple/i         // ES property does not hold
   ,/die\s+eigenschaft\s+gilt\s+nicht/i          // DE property does not hold
   ,/la\s+propri[ée]t[ée]\s+ne\s+tient\s+pas/i  // FR property does not hold
+  ,/assertion\s+failed/i                          // EN assertion failed
+  ,/unsatisfied\s+(?:invariant|property|spec)/i   // EN unsatisfied invariant/property/spec
 ];
 
 export function computeOkFromOutput(out){

--- a/tests/formal/heuristics.negation.boundaries.3.test.ts
+++ b/tests/formal/heuristics.negation.boundaries.3.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { computeOkFromOutput } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: additional boundaries (assertion/unsatisfied)', () => {
+  it('detects explicit assertion failure / unsatisfied messages as negative', () => {
+    const samples = [
+      'Assertion failed at line 42',
+      'Invariant unsatisfied in state S3',
+      'Property unsatisfied for input a=1',
+      'Spec unsatisfied under constraints',
+    ];
+    for (const s of samples) {
+      expect(computeOkFromOutput(s)).toBe(false);
+    }
+  });
+
+  it('retains null for non-decisive info lines', () => {
+    const neutral = [
+      'Reading model...',
+      'Preparing solver context',
+      'Note: using default options',
+    ];
+    for (const s of neutral) {
+      expect(computeOkFromOutput(s)).toBeNull();
+    }
+  });
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-failure-returns-open.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-failure-returns-open.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState, CircuitBreakerOpenError } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker half-open failure returns to OPEN', () => {
+  it('on half-open, a failure immediately forces OPEN and rejects subsequent calls until timeout', async () => {
+    const timeout = 40;
+    const cb = new CircuitBreaker('half-open-fail', {
+      failureThreshold: 1,
+      successThreshold: 1,
+      timeout,
+      monitoringWindow: 100,
+    });
+
+    // First call fails → OPEN
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+
+    // Wait to become HALF_OPEN
+    await new Promise(r => setTimeout(r, timeout + 5));
+    // Next call fails in HALF_OPEN → immediately OPEN again
+    await expect(cb.execute(async () => { throw new Error('fail-half'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+
+    // During OPEN window, user calls are rejected
+    await expect(cb.execute(async () => 1)).rejects.toBeInstanceOf(CircuitBreakerOpenError);
+  });
+});
+

--- a/tests/resilience/token-bucket.longrun.alternating.pbt.test.ts
+++ b/tests/resilience/token-bucket.longrun.alternating.pbt.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: TokenBucket long-run alternating pattern', () => {
+  it('sequence across 4..7 steps stays within [0,max] with varied waits (fast)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          tokens: fc.integer({ min: 1, max: 10 }),
+          interval: fc.integer({ min: 10, max: 50 }),
+          max: fc.integer({ min: 6, max: 60 }),
+          steps: fc.integer({ min: 4, max: 7 }),
+        }),
+        async ({ tokens, interval, max, steps }) => {
+          const rl = new TokenBucketRateLimiter({ tokensPerInterval: tokens, interval, maxTokens: max });
+          // Start partially drained
+          await rl.consume(Math.min(max, Math.ceil(max * 0.6)));
+          for (let i = 0; i < steps; i++) {
+            const req = (i % 3 === 0) ? max + tokens : (i % 3 === 1) ? Math.max(1, Math.ceil(max / 2)) : Math.max(1, Math.ceil(max / 4));
+            await rl.consume(req).catch(() => void 0);
+            let c = rl.getTokenCount();
+            expect(c).toBeGreaterThanOrEqual(0);
+            expect(c).toBeLessThanOrEqual(max);
+            const wait = (i % 3 === 0) ? Math.floor(interval / 3) : (i % 3 === 1) ? Math.floor((2 * interval) / 3) : interval;
+            await new Promise((r) => setTimeout(r, wait));
+            c = rl.getTokenCount();
+            expect(c).toBeGreaterThanOrEqual(0);
+            expect(c).toBeLessThanOrEqual(max);
+          }
+        }
+      ),
+      { numRuns: 12 }
+    );
+  });
+});


### PR DESCRIPTION
- heuristics: assertion failed / unsatisfied invariant|property|spec をNEGATIVEへ追補（保守的）
- tests(resilience): TokenBucket 長期交互（高速化パラメタ）/ CB half-open失敗→OPEN 回帰
- docs(runbook): aggregate JSON 一行サマリ表示CLIの例を追記

Verify Lite / run-formal / run-qa で緑確認後、マージします。
