### PR TITLE
chore(ci): adaptersコメント順序統一 + 小テスト群追加（formal/resilience/property）

### DIFF
--- a/.ae/enhanced-state.db
+++ b/.ae/enhanced-state.db
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0.0",
-    "timestamp": "2025-09-16T19:58:59.679Z",
+    "timestamp": "2025-09-17T02:25:17.854Z",
     "options": {
       "databasePath": ".ae/enhanced-state.db",
       "enableCompression": true,
@@ -14,9 +14,9 @@
   },
   "entries": [
     {
-      "id": "594e491f-ae52-4592-bd10-f71a8acd1a80",
+      "id": "f23992c9-86d5-4790-91c3-3549ddf97073",
       "logicalKey": "integration-ready",
-      "timestamp": "2025-09-16T19:58:59.679Z",
+      "timestamp": "2025-09-17T02:25:17.854Z",
       "version": 1,
       "checksum": "0094478148422a83dc50a368102314e8ddf937293f6679096c4b66f5d989afcb",
       "data": {
@@ -28,8 +28,8 @@
       "ttl": 604800,
       "metadata": {
         "size": 28,
-        "created": "2025-09-16T19:58:59.679Z",
-        "accessed": "2025-09-16T19:58:59.679Z",
+        "created": "2025-09-17T02:25:17.854Z",
+        "accessed": "2025-09-17T02:25:17.854Z",
         "source": "unknown"
       }
     }
@@ -37,7 +37,7 @@
   "indices": {
     "keyIndex": {
       "integration-ready": [
-        "integration-ready_2025-09-16T19:58:59.679Z"
+        "integration-ready_2025-09-17T02:25:17.854Z"
       ]
     },
     "versionIndex": {

--- a/.ae/phase-state.json
+++ b/.ae/phase-state.json
@@ -1,8 +1,8 @@
 {
-  "projectId": "d7be788c-83cb-47c8-8389-784136065966",
+  "projectId": "6aec9cca-59e3-4345-940e-858add7f9126",
   "projectName": "phase1-integration",
-  "createdAt": "2025-09-16T19:58:59.678Z",
-  "updatedAt": "2025-09-16T19:59:00.063Z",
+  "createdAt": "2025-09-17T02:25:17.851Z",
+  "updatedAt": "2025-09-17T02:25:18.509Z",
   "currentPhase": "intent",
   "phaseStatus": {
     "intent": {
@@ -41,90 +41,101 @@
     "integration-test": {
       "ready": true
     },
-    "test-agent_task_started_1758052740045": {
+    "test-agent_task_started_1758075918330": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.045Z",
+      "timestamp": "2025-09-17T02:25:18.330Z",
       "taskId": "test-task-1",
       "type": "code-generation"
     },
-    "test-agent_task_completed_1758052740047": {
+    "test-agent_task_completed_1758075918332": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.047Z",
+      "timestamp": "2025-09-17T02:25:18.332Z",
       "taskId": "test-task-1",
       "success": true,
       "executionTime": 2
     },
-    "test-agent_task_started_1758052740053": {
+    "test-agent_task_started_1758075918335": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.053Z",
+      "timestamp": "2025-09-17T02:25:18.335Z",
       "taskId": "tdd-task",
       "type": "test-generation"
     },
-    "test-agent_task_completed_1758052740054": {
+    "test-agent_task_completed_1758075918337": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.054Z",
+      "timestamp": "2025-09-17T02:25:18.337Z",
       "taskId": "tdd-task",
       "success": true,
-      "executionTime": 1
+      "executionTime": 2
     },
-    "test-agent_task_started_1758052740057": {
+    "test-agent_task_started_1758075918344": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.057Z",
+      "timestamp": "2025-09-17T02:25:18.344Z",
       "taskId": "validation-test",
       "type": "validation"
     },
-    "test-agent_task_completed_1758052740058": {
+    "test-agent_task_completed_1758075918345": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.058Z",
+      "timestamp": "2025-09-17T02:25:18.345Z",
       "taskId": "validation-test",
       "success": true,
       "executionTime": 1
     },
-    "test-agent_task_started_1758052740059": {
+    "test-agent_task_started_1758075918350": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.059Z",
+      "timestamp": "2025-09-17T02:25:18.350Z",
       "taskId": "coverage-test",
       "type": "quality-assurance"
     },
-    "test-agent_task_completed_1758052740060": {
+    "test-agent_task_completed_1758075918351": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.060Z",
+      "timestamp": "2025-09-17T02:25:18.351Z",
       "taskId": "coverage-test",
       "success": true,
       "executionTime": 1
     },
-    "test-agent_task_started_1758052740062": {
+    "test-agent_task_started_1758075918354": {
       "activity": "task_started",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.062Z",
+      "timestamp": "2025-09-17T02:25:18.354Z",
       "taskId": "phase-transition",
       "type": "phase-validation"
     },
-    "test-agent_task_completed_1758052740063": {
+    "test-agent_task_completed_1758075918355": {
       "activity": "task_completed",
       "agentId": "test-agent",
       "agentType": "code-generation",
-      "timestamp": "2025-09-16T19:59:00.063Z",
+      "timestamp": "2025-09-17T02:25:18.355Z",
       "taskId": "phase-transition",
       "success": true,
       "executionTime": 1
+    },
+    "intent_activity_1758075918501": {
+      "activity": "output_validation",
+      "timestamp": "2025-09-17T02:25:18.501Z",
+      "success": true,
+      "outputType": "generic",
+      "artifactCount": 2,
+      "qualityScore": 85,
+      "validationMessage": "Default validation passed (no custom validation implemented)"
     }
   }
+}  }
+}
 }

--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -48,6 +48,7 @@ export const NEGATIVE_PATTERNS = [
   ,/la\s+propri[ée]t[ée]\s+ne\s+tient\s+pas/i  // FR property does not hold
   ,/assertion\s+failed/i                          // EN assertion failed
   ,/unsatisfied\s+(?:invariant|property|spec)/i   // EN unsatisfied invariant/property/spec
+  ,/(?:invariant|property|spec)\s+unsatisfied/i   // EN <kind> unsatisfied
 ];
 
 export function computeOkFromOutput(out){

--- a/tests/formal/aggregate-utils.present-count.test.ts
+++ b/tests/formal/aggregate-utils.present-count.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { computeAggregateInfo } from '../../scripts/formal/aggregate-utils.mjs';
+
+describe('Formal aggregate utils: presentCount reflects available summaries', () => {
+  it('counts present summaries among tla/alloy/smt/apalache/conformance', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agg-'));
+    const mk = (p: string) => { fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, '{}'); };
+    mk(path.join(tmp, 'formal-reports-tla/tla-summary.json'));
+    mk(path.join(tmp, 'formal-reports-alloy/alloy-summary.json'));
+    // omit smt
+    mk(path.join(tmp, 'formal-reports-apalache/apalache-summary.json'));
+    // omit conformance
+    const info = computeAggregateInfo(tmp);
+    expect(info.present).toEqual({ tla: true, alloy: true, smt: false, apalache: true, conformance: false });
+    expect(info.presentCount).toBe(3);
+  });
+});
+

--- a/tests/golden/snapshots/codegen-snapshot.json
+++ b/tests/golden/snapshots/codegen-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-16T19:58:59.505Z",
+  "timestamp": "2025-09-17T02:25:17.637Z",
   "version": "1.0.0",
   "files": {
     "examples/inventory/apps/web/components/ProductForm.tsx": {
@@ -233,16 +233,16 @@
       "typeScriptErrors": 0,
       "eslintErrors": 1
     },
-    "examples/inventory/src/ui/components/generated/apps/web/app/product/page.tsx": {
-      "hash": "570f9a23015e98085e65242be1d1f856f0ded10a633d5d3a7180996a956607be",
-      "lineCount": 116,
+    "examples/inventory/src/ui/components/generated/apps/web/app/order/page.tsx": {
+      "hash": "ee96a7eca90231078b552c6b12f83532fd659c9fb262382d5bb33f9ba3c2c00b",
+      "lineCount": 118,
       "ariaAttributeCount": 0,
       "typeScriptErrors": 1,
       "eslintErrors": 0
     },
-    "examples/inventory/src/ui/components/generated/apps/web/app/order/page.tsx": {
-      "hash": "ee96a7eca90231078b552c6b12f83532fd659c9fb262382d5bb33f9ba3c2c00b",
-      "lineCount": 118,
+    "examples/inventory/src/ui/components/generated/apps/web/app/product/page.tsx": {
+      "hash": "570f9a23015e98085e65242be1d1f856f0ded10a633d5d3a7180996a956607be",
+      "lineCount": 116,
       "ariaAttributeCount": 0,
       "typeScriptErrors": 1,
       "eslintErrors": 0
@@ -252,20 +252,6 @@
       "lineCount": 108,
       "ariaAttributeCount": 0,
       "typeScriptErrors": 0,
-      "eslintErrors": 0
-    },
-    "examples/inventory/src/ui/components/generated/apps/web/app/product/new/page.tsx": {
-      "hash": "42abe506569d1322dbf03be5451f58a622fb1df27fbca9b4dabef5ba97bd973d",
-      "lineCount": 82,
-      "ariaAttributeCount": 0,
-      "typeScriptErrors": 1,
-      "eslintErrors": 0
-    },
-    "examples/inventory/src/ui/components/generated/apps/web/app/product/[id]/page.tsx": {
-      "hash": "0d5a036c54b86701b607d3995d5e130944a31cc3c7a9872d612b556e5ff2212e",
-      "lineCount": 293,
-      "ariaAttributeCount": 0,
-      "typeScriptErrors": 1,
       "eslintErrors": 0
     },
     "examples/inventory/src/ui/components/generated/apps/web/app/order/new/page.tsx": {
@@ -278,6 +264,20 @@
     "examples/inventory/src/ui/components/generated/apps/web/app/order/[id]/page.tsx": {
       "hash": "2bdfd1c9d8c5afeef0ece789c25c0ba6f7e570660d2ae6ce293a221c48078925",
       "lineCount": 305,
+      "ariaAttributeCount": 0,
+      "typeScriptErrors": 1,
+      "eslintErrors": 0
+    },
+    "examples/inventory/src/ui/components/generated/apps/web/app/product/new/page.tsx": {
+      "hash": "42abe506569d1322dbf03be5451f58a622fb1df27fbca9b4dabef5ba97bd973d",
+      "lineCount": 82,
+      "ariaAttributeCount": 0,
+      "typeScriptErrors": 1,
+      "eslintErrors": 0
+    },
+    "examples/inventory/src/ui/components/generated/apps/web/app/product/[id]/page.tsx": {
+      "hash": "0d5a036c54b86701b607d3995d5e130944a31cc3c7a9872d612b556e5ff2212e",
+      "lineCount": 293,
       "ariaAttributeCount": 0,
       "typeScriptErrors": 1,
       "eslintErrors": 0

--- a/tests/property/error-utils.tomessage.idempotent.pbt.test.ts
+++ b/tests/property/error-utils.tomessage.idempotent.pbt.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { toMessage } from '../../src/utils/error-utils';
+
+describe('PBT: error-utils toMessage idempotency', () => {
+  it('toMessage(toMessage(x)) === toMessage(x) for arbitrary strings', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string(), async (s) => {
+        const m1 = toMessage(s as unknown as Error);
+        const m2 = toMessage(m1 as unknown as Error);
+        expect(m2).toBe(m1);
+      }),
+      { numRuns: 50 }
+    );
+  });
+});
+

--- a/tests/property/error-utils.tostack.nullsafe.pbt.test.ts
+++ b/tests/property/error-utils.tostack.nullsafe.pbt.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { toStack } from '../../src/utils/error-utils';
+
+describe('PBT: error-utils toStack null-safety', () => {
+  it('toStack returns undefined for non-Error values', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.anything(), async (v) => {
+        if (v instanceof Error) return; // skip actual Error
+        const st = toStack(v);
+        expect(st).toBeUndefined();
+      }),
+      { numRuns: 50 }
+    );
+  });
+});
+

--- a/tests/property/token-optimizer.max-tokens.boundary.pbt.test.ts
+++ b/tests/property/token-optimizer.max-tokens.boundary.pbt.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+
+describe('PBT: TokenOptimizer optimizeContext respects maxTokens', () => {
+  const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ';
+  it('optimizeContext never exceeds maxTokens (estimation)', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          repeats: fc.integer({ min: 1, max: 40 }),
+          maxTokens: fc.integer({ min: 50, max: 500 }),
+          kws: fc.array(fc.string({ minLength: 1, maxLength: 6 }), { minLength: 0, maxLength: 4 })
+        }),
+        async ({ repeats, maxTokens, kws }) => {
+          const opt = new TokenOptimizer();
+          const ctx = lorem.repeat(repeats);
+          const { optimized, stats } = await opt.optimizeContext(ctx, maxTokens, kws);
+          // estimation invariant: optimized tokens <= maxTokens
+          expect(stats.compressed).toBeLessThanOrEqual(maxTokens);
+          // sanity: output is string
+          expect(typeof optimized).toBe('string');
+        }
+      ),
+      { numRuns: 30 }
+    );
+  });
+});
+

--- a/tests/resilience/backoff.decorrelated.min-gte-base.pbt.test.ts
+++ b/tests/resilience/backoff.decorrelated.min-gte-base.pbt.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { BackoffStrategy } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: Decorrelated jitter min delay >= base', () => {
+  it('for attempts 1..10, delay >= base and <= min(max, 3*prevDet)', async () => {
+    await fc.assert(fc.asyncProperty(
+      fc.record({ base: fc.integer({ min: 1, max: 200 }), mult: fc.integer({ min: 2, max: 5 }) }),
+      async ({ base, mult }) => {
+        const maxDelayMs = base * Math.pow(mult, 10);
+        const s = new BackoffStrategy({ baseDelayMs: base, maxDelayMs, multiplier: mult, jitterType: 'decorrelated' as const });
+        for (let attempt=1; attempt<=10; attempt++){
+          const d = (s as any)['calculateDelay'](attempt);
+          const prevDet = Math.min(base * Math.pow(mult, Math.max(0, attempt-1)), maxDelayMs);
+          expect(d).toBeGreaterThanOrEqual(base);
+          expect(d).toBeLessThanOrEqual(Math.min(prevDet*3, maxDelayMs));
+        }
+      }
+    ), { numRuns: 10 });
+  });
+});
+

--- a/tests/resilience/circuit-breaker.consecutive-fails.maintains-open.test.ts
+++ b/tests/resilience/circuit-breaker.consecutive-fails.maintains-open.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState, CircuitBreakerOpenError } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker consecutive failures keep OPEN until timeout', () => {
+  it('multiple calls during OPEN reject, state remains OPEN until half-open window', async () => {
+    const timeout = 40;
+    const cb = new CircuitBreaker('open-consecutive', {
+      failureThreshold: 1,
+      successThreshold: 1,
+      timeout,
+      monitoringWindow: 100,
+    });
+    await expect(cb.execute(async () => { throw new Error('f'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+    for (let i=0; i<3; i++) {
+      await expect(cb.execute(async () => 1)).rejects.toBeInstanceOf(CircuitBreakerOpenError);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+    await new Promise(r => setTimeout(r, timeout + 5));
+    await expect(cb.execute(async () => 1)).resolves.toBe(1);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+  });
+});
+


### PR DESCRIPTION
- adapters(a11y): コメントの順序/語彙を既存方針に合わせ最終統一（Derived/Policy/Docs）
- property: error-utils toMessage/toStack 境界、TokenOptimizer maxTokens 境界PBT
- resilience: 既存の追加境界テスト群を同ブランチで反映（非破壊）

Verify Lite / QA Light 併用、緑になり次第マージします。
