### PR TITLE
chore(ci): adapters 形状警告に Docs 参照を追記（a11y/perf/lh 共通）

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -70,9 +70,9 @@ jobs:
           if jq -e '(.violations.critical|type=="number") and (.violations.serious|type=="number")' "$FILE" >/dev/null 2>&1; then
             printf "%s\n" "a11y JSON shape ok";
           else
-            printf "%s\n" "::warning::a11y JSON shape unexpected (violations.critical/serious numeric check failed)";
+            printf "%s\n" "::warning::a11y JSON shape unexpected (violations.critical/serious numeric check failed) — see docs/quality/adapter-thresholds.md";
           fi
-          if jq -e '.components_tested|type=="array"' "$FILE" >/dev/null 2>&1; then :; else printf "%s\n" "::warning::a11y components_tested not array (optional)"; fi
+          if jq -e '.components_tested|type=="array"' "$FILE" >/dev/null 2>&1; then :; else printf "%s\n" "::warning::a11y components_tested not array (optional) — see docs/quality/adapter-thresholds.md"; fi
       - name: Enforce a11y thresholds (critical/serious==0)
         if: steps.a11y.outputs.present == 'true' && contains(github.event.pull_request.labels.*.name, 'enforce-a11y')
         run: |
@@ -157,7 +157,7 @@ jobs:
           if jq -e '.score? // .performance? // .metrics?.score? // empty' reports/perf-results.json >/dev/null 2>&1; then
             printf "%s\n" "perf JSON shape ok";
           else
-            printf "%s\n" "::warning::perf JSON shape unexpected (score/performance/metrics.score not found)";
+            printf "%s\n" "::warning::perf JSON shape unexpected (score/performance/metrics.score not found) — see docs/quality/adapter-thresholds.md";
           fi
 
   summarize-lh:
@@ -248,7 +248,7 @@ jobs:
           if jq -e '.categories?.performance?.score? // .performance? // .score? // empty' "$FILE" >/dev/null 2>&1; then
             printf "%s\n" "lighthouse JSON shape ok";
           else
-            printf "%s\n" "::warning::lighthouse JSON shape unexpected (categories.performance.score/performance/score not found)";
+            printf "%s\n" "::warning::lighthouse JSON shape unexpected (categories.performance.score/performance/score not found) — see docs/quality/adapter-thresholds.md";
           fi
       - name: Upload adapter artifacts (a11y)
         if: contains(github.event.pull_request.labels.*.name, 'run-adapters') && steps.a11y.outputs.present == 'true'


### PR DESCRIPTION
- 形状検証の警告 (::warning::) に docs/quality/adapter-thresholds.md への参照を追記
- a11y/perf/lh の3種共通で案内を統一
