### PR TITLE
docs(formal): aggregate JSON の jq 例を追記（presentCount/by-type）

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -46,6 +46,9 @@ Aggregate JSON の軽量検証（非ブロッキング）
 - ローカル確認: `node scripts/formal/validate-aggregate-json.mjs`（存在時に検証、欠損/不正は `::warning::` 出力）
 - 1行サマリを表示する簡易CLI（ローカル）:
   - `node -e "const p='artifacts/formal/formal-aggregate.json';const j=require('fs').existsSync(p)?require('./'+p):null;if(!j){console.log('no aggregate');process.exit(0)}const pr=j.info?.present||{};const keys=Object.entries(pr).filter(([,v])=>v).map(([k])=>k);console.log('Present:', keys.length+'/5', keys.length?('('+keys.join(', ')+')'):'');"`
+  - jq 例（presentCount/by-type）:
+    - `jq '.info.presentCount' artifacts/formal/formal-aggregate.json`
+    - `jq -r '.info.present | to_entries | map("\(.key)=\(.value|tostring)") | join(", ")' artifacts/formal/formal-aggregate.json`
 
 ログ例（label: run-formal 実行時）
 ```


### PR DESCRIPTION
- formal-aggregate.json の presentCount/by-type を jq で確認する例を追記