### PR TITLE
test(resilience/ddd): failureThreshold=3・混在interval交互PBT・GWT適用・replay fixture

### DIFF
--- a/.ae/enhanced-state.db
+++ b/.ae/enhanced-state.db
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0.0",
-    "timestamp": "2025-09-17T02:39:17.952Z",
+    "timestamp": "2025-09-17T02:43:00.338Z",
     "options": {
       "databasePath": ".ae/enhanced-state.db",
       "enableCompression": true,
@@ -14,9 +14,9 @@
   },
   "entries": [
     {
-      "id": "fc7a4546-8b50-4871-a9d1-fd0f2b645910",
+      "id": "90069024-2430-4419-b04e-4a8fb1a64cc5",
       "logicalKey": "integration-ready",
-      "timestamp": "2025-09-17T02:39:17.952Z",
+      "timestamp": "2025-09-17T02:43:00.338Z",
       "version": 1,
       "checksum": "0094478148422a83dc50a368102314e8ddf937293f6679096c4b66f5d989afcb",
       "data": {
@@ -28,8 +28,8 @@
       "ttl": 604800,
       "metadata": {
         "size": 28,
-        "created": "2025-09-17T02:39:17.952Z",
-        "accessed": "2025-09-17T02:39:17.952Z",
+        "created": "2025-09-17T02:43:00.338Z",
+        "accessed": "2025-09-17T02:43:00.338Z",
         "source": "unknown"
       }
     }
@@ -37,7 +37,7 @@
   "indices": {
     "keyIndex": {
       "integration-ready": [
-        "integration-ready_2025-09-17T02:39:17.952Z"
+        "integration-ready_2025-09-17T02:43:00.338Z"
       ]
     },
     "versionIndex": {

--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -4,6 +4,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 
 - Input events (sample): `scripts/testing/fixtures/replay-sample.json`
 - Failure sample (output-like): `scripts/testing/fixtures/replay-failure.sample.json`
+- Missing traceId sample: `scripts/testing/fixtures/replay-missing-traceid.sample.json`（traceId 欠損ケースの挙動を確認）
 
 Quick run
 ```
@@ -17,4 +18,3 @@ Checks mapping (concept)
 - onhand_min: onHand must be >= REPLAY_ONHAND_MIN (default 0)
 
 A minimal failure example is provided at `scripts/testing/fixtures/replay-failure.sample.json` to illustrate `violatedInvariants` shape.
-

--- a/scripts/testing/fixtures/replay-missing-traceid.sample.json
+++ b/scripts/testing/fixtures/replay-missing-traceid.sample.json
@@ -1,0 +1,10 @@
+{
+  "events": [
+    { "type": "allocate", "amount": 5 },
+    { "type": "ship", "amount": 2 }
+  ],
+  "metadata": {
+    "note": "traceId intentionally missing to illustrate mapping robustness"
+  }
+}
+

--- a/tests/golden/snapshots/codegen-snapshot.json
+++ b/tests/golden/snapshots/codegen-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-17T02:39:17.702Z",
+  "timestamp": "2025-09-17T02:43:00.095Z",
   "version": "1.0.0",
   "files": {
     "examples/inventory/apps/web/components/ProductForm.tsx": {

--- a/tests/property/token-optimizer.truncate.sentinel.test.ts
+++ b/tests/property/token-optimizer.truncate.sentinel.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import { formatGWT } from '../utils/gwt-format';
 import { TokenOptimizer } from '../../src/utils/token-optimizer';
 
 describe('TokenOptimizer truncate sentinel', () => {
-  it('adds [...truncated] when section is truncated due to maxTokens', async () => {
+  it(formatGWT('many large sections', 'compress with small maxTokens', 'append [...truncated] sentinel'), async () => {
     const opt = new TokenOptimizer();
     // craft multiple large sections to exceed small maxTokens
     const docs: Record<string,string> = {
@@ -18,4 +19,3 @@ describe('TokenOptimizer truncate sentinel', () => {
     expect(compressed.includes('[...truncated]') || stats.compressed <= 300).toBe(true);
   });
 });
-

--- a/tests/resilience/circuit-breaker.composite.transitions.test.ts
+++ b/tests/resilience/circuit-breaker.composite.transitions.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import { formatGWT } from '../utils/gwt-format';
 import { CircuitBreaker, CircuitState, CircuitBreakerOpenError } from '../../src/utils/circuit-breaker';
 
 describe('Resilience: CircuitBreaker composite transitions', () => {
-  it('CLOSED → OPEN (fail) → HALF_OPEN (timeout) → CLOSED (successThreshold) → OPEN (fail in CLOSED after threshold)', async () => {
+  it(formatGWT('CLOSED→OPEN (fail)', 'HALF_OPEN→CLOSED (success)', 'CLOSED→OPEN (fail)'), async () => {
     const timeout = 40;
     const cb = new CircuitBreaker('composite', {
       failureThreshold: 1,
@@ -29,4 +30,3 @@ describe('Resilience: CircuitBreaker composite transitions', () => {
     await expect(cb.execute(async () => 1)).rejects.toBeInstanceOf(CircuitBreakerOpenError);
   });
 });
-

--- a/tests/resilience/circuit-breaker.failure-threshold-3.open.boundary.test.ts
+++ b/tests/resilience/circuit-breaker.failure-threshold-3.open.boundary.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState, CircuitBreakerOpenError } from '../../src/utils/circuit-breaker';
+
+describe('Resilience: CircuitBreaker failureThreshold=3 boundary', () => {
+  it('opens after three consecutive failures and rejects until half-open window', async () => {
+    const timeout = 40;
+    const cb = new CircuitBreaker('fail3', {
+      failureThreshold: 3,
+      successThreshold: 1,
+      timeout,
+      monitoringWindow: 100,
+    });
+    await expect(cb.execute(async () => { throw new Error('f1'); })).rejects.toBeInstanceOf(Error);
+    await expect(cb.execute(async () => { throw new Error('f2'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+    await expect(cb.execute(async () => { throw new Error('f3'); })).rejects.toBeInstanceOf(Error);
+    expect(cb.getState()).toBe(CircuitState.OPEN);
+    await expect(cb.execute(async () => 1)).rejects.toBeInstanceOf(CircuitBreakerOpenError);
+    await new Promise(r => setTimeout(r, timeout + 5));
+    await expect(cb.execute(async () => 1)).resolves.toBe(1);
+    expect(cb.getState()).toBe(CircuitState.CLOSED);
+  });
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-success-threshold-2.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-success-threshold-2.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import { formatGWT } from '../utils/gwt-format';
 import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
 
 describe('Resilience: CircuitBreaker HALF_OPEN successThreshold=2', () => {
-  it('requires two successes in HALF_OPEN to close', async () => {
+  it(formatGWT('OPEN after failure', 'two successes in HALF_OPEN', 'transition to CLOSED'), async () => {
     const timeout = 30;
     const cb = new CircuitBreaker('half-open-2', {
       failureThreshold: 1,
@@ -22,4 +23,3 @@ describe('Resilience: CircuitBreaker HALF_OPEN successThreshold=2', () => {
     expect(cb.getState()).toBe(CircuitState.CLOSED);
   });
 });
-

--- a/tests/resilience/token-bucket.mixed-intervals.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.mixed-intervals.fast.pbt.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('PBT: TokenBucket mixed intervals (fast)', () => {
+  it('alternating small/large waits keeps tokens within [0,max] for 5..7 steps', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({ tokens: fc.integer({ min: 1, max: 8 }), interval: fc.integer({ min: 12, max: 80 }), max: fc.integer({ min: 6, max: 50 }), steps: fc.integer({ min: 5, max: 7 }) }),
+        async ({ tokens, interval, max, steps }) => {
+          const rl = new TokenBucketRateLimiter({ tokensPerInterval: tokens, interval, maxTokens: max });
+          await rl.consume(Math.min(max, Math.ceil(max/2)));
+          for (let i=0;i<steps;i++){
+            const req = (i % 2 === 0) ? max + tokens : Math.max(1, Math.ceil(max/4));
+            await rl.consume(req).catch(()=>void 0);
+            let c = rl.getTokenCount();
+            expect(c).toBeGreaterThanOrEqual(0);
+            expect(c).toBeLessThanOrEqual(max);
+            const wait = (i % 3 === 0) ? Math.floor(interval/3) : (i % 3 === 1) ? (2*interval) : interval;
+            await new Promise(r=>setTimeout(r, wait));
+            c = rl.getTokenCount();
+            expect(c).toBeGreaterThanOrEqual(0);
+            expect(c).toBeLessThanOrEqual(max);
+          }
+        }
+      ),
+      { numRuns: 12 }
+    );
+  });
+});
+


### PR DESCRIPTION
- Resilience: CB failureThreshold=3 境界、TokenBucket 混在interval交互PBT（高速）
- GWT整形ヘルパの適用（3件: CB/TokenOptimizer）
- Docs/fixtures: replay-missing-traceid を追加し、replay-mapping.md を補足
