### PR TITLE
docs/tests: Adapters/Coverage Glossary・replay alt2・TB/TokenOptimizer GWT適用

### DIFF
--- a/.ae/enhanced-state.db
+++ b/.ae/enhanced-state.db
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0.0",
-    "timestamp": "2025-09-17T03:21:37.457Z",
+    "timestamp": "2025-09-17T03:24:10.112Z",
     "options": {
       "databasePath": ".ae/enhanced-state.db",
       "enableCompression": true,
@@ -14,9 +14,9 @@
   },
   "entries": [
     {
-      "id": "0e6fdcaa-b1b3-4361-b39c-b9ddf46fccea",
+      "id": "4d77ab9f-2341-4154-9c98-02c4ecaae4e2",
       "logicalKey": "integration-ready",
-      "timestamp": "2025-09-17T03:21:37.457Z",
+      "timestamp": "2025-09-17T03:24:10.112Z",
       "version": 1,
       "checksum": "0094478148422a83dc50a368102314e8ddf937293f6679096c4b66f5d989afcb",
       "data": {
@@ -28,8 +28,8 @@
       "ttl": 604800,
       "metadata": {
         "size": 28,
-        "created": "2025-09-17T03:21:37.457Z",
-        "accessed": "2025-09-17T03:21:37.457Z",
+        "created": "2025-09-17T03:24:10.112Z",
+        "accessed": "2025-09-17T03:24:10.112Z",
         "source": "unknown"
       }
     }
@@ -37,7 +37,7 @@
   "indices": {
     "keyIndex": {
       "integration-ready": [
-        "integration-ready_2025-09-17T03:21:37.457Z"
+        "integration-ready_2025-09-17T03:24:10.112Z"
       ]
     },
     "versionIndex": {

--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -6,6 +6,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure sample (output-like): `scripts/testing/fixtures/replay-failure.sample.json`
 - Missing traceId sample: `scripts/testing/fixtures/replay-missing-traceid.sample.json`（traceId 欠損ケースの挙動を確認）
 - Failure (alt shape): `scripts/testing/fixtures/replay-failure.alt.sample.json`（violatedInvariants を byType 風に集約した例）
+- Failure (alt2 shape): `scripts/testing/fixtures/replay-failure.bytype.alt2.sample.json`（byType 風の別例）
 
 Quick run
 ```

--- a/docs/quality/adapter-thresholds.md
+++ b/docs/quality/adapter-thresholds.md
@@ -60,6 +60,11 @@ Enforcement notes
 - しきい値の導出順は「ラベル（perf:<pct>/lh:<pct>）> リポジトリ変数（PERF_DEFAULT_THRESHOLD/LH_DEFAULT_THRESHOLD）> 既定（perf=75, lh=80）」です。
 - 変数未設定でも動作しますが、しきい値の既定を統一するためリポジトリ変数を設定する運用を推奨します。
 
+Glossary（表示用語の統一）
+- Derived: `label > repo var > default`（しきい値の導出順）
+- Policy: `enforced | report-only`
+- Policy source: `enforced via label: enforce-<name>` or `report-only`
+
 ### Minimal JSON examples
 
 Accessibility (reports/a11y-results.json)

--- a/docs/quality/coverage-required.md
+++ b/docs/quality/coverage-required.md
@@ -11,6 +11,7 @@
   - `Require status checks to pass before merging` を有効化
   - ステータスチェックに `coverage-check` を追加（必要に応じて `coverage-check (push)` / `(pull_request)` を選択）
   - （任意）`Require branches to be up to date before merging` を一時的に無効化して段階導入を容易に（運用安定後に有効化を検討）
+  - 例: `coverage-check` と `verify-lite` を必須チェックとして追加（段階導入時は `ci-non-blocking` を活用）
 - 運用
   - PRではコメントに `Coverage (lines):` と `Threshold (effective):` を表示（`/coverage <pct>` で上書き可能）
   - main への push 時は `COVERAGE_ENFORCE_MAIN=1` で強制。違反時は失敗。

--- a/scripts/testing/fixtures/replay-failure.bytype.alt2.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt2.sample.json
@@ -1,0 +1,12 @@
+{
+  "events": [
+    { "type": "allocate", "onHand": 2, "allocated": 4 },
+    { "type": "receive", "onHand": 1 }
+  ],
+  "violatedInvariants": {
+    "allocated_le_onhand": 1,
+    "onhand_min": 0
+  },
+  "note": "Alternative byType-like shape (alt2)"
+}
+

--- a/tests/golden/snapshots/codegen-snapshot.json
+++ b/tests/golden/snapshots/codegen-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-17T03:21:37.204Z",
+  "timestamp": "2025-09-17T03:24:09.830Z",
   "version": "1.0.0",
   "files": {
     "examples/inventory/apps/web/components/ProductForm.tsx": {

--- a/tests/property/token-optimizer.truncate.sentinel.absence.test.ts
+++ b/tests/property/token-optimizer.truncate.sentinel.absence.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('TokenOptimizer: no sentinel when not truncated', () => {
+  it(formatGWT('small docs', 'compress with large maxTokens', 'no [...truncated] sentinel appears'), async () => {
+    const opt = new TokenOptimizer();
+    const docs = {
+      product: 'must: goals.',
+      architecture: 'should: structure.',
+      standards: 'key: style.'
+    } as Record<string,string>;
+    const { compressed, stats } = await opt.compressSteeringDocuments(docs, { maxTokens: 5000 });
+    expect(stats.compressed).toBeLessThanOrEqual(5000);
+    expect(compressed.includes('[...truncated]')).toBe(false);
+  });
+});
+

--- a/tests/resilience/token-bucket.alternating-oversubscribe.pbt.test.ts
+++ b/tests/resilience/token-bucket.alternating-oversubscribe.pbt.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import { formatGWT } from '../utils/gwt-format';
 import fc from 'fast-check';
 import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
 
 describe('PBT: TokenBucket alternating oversubscribe with waits', () => {
-  it('alternating oversubscribe/await patterns never go negative or exceed max', async () => {
+  it(formatGWT('partial drain', 'alternate oversubscribe + waits', 'tokens remain within [0,max]'), async () => {
     await fc.assert(
       fc.asyncProperty(
         fc.record({


### PR DESCRIPTION
- Adapters/Coverage: Glossary 追記（Derived/Policy/Policy source）\n- replay: alt2(byType風) 例を追加\n- tests: TB alternate oversubscribe をGWT見出し化、TokenOptimizer truncate非truncated時のsentinel不在回帰