### PR TITLE
test(resilience/property): ddd batch 30 (TB alt-3, CB open-rejects-until-timeout, TokenOptimizer large-code & fallback)

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -12,6 +12,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt5 byType): `scripts/testing/fixtures/replay-failure.bytype.alt5.sample.json`（byType 風、最小構成の割当過多）
 - Failure (alt6 byType): `scripts/testing/fixtures/replay-failure.bytype.alt6.sample.json`（byType 風、さらに最小の2イベントケース）
 - Failure (alt7 byType): `scripts/testing/fixtures/replay-failure.bytype.alt7.sample.json`（byType 風、単一タイプの複数違反をまとめた例）
+ - Failure (alt8 byType): `scripts/testing/fixtures/replay-failure.bytype.alt8.sample.json`（byType 風、onhand_min のみの連続違反）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/testing/fixtures/replay-failure.bytype.alt8.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt8.sample.json
@@ -1,0 +1,16 @@
+{
+  "events": [
+    { "type": "allocate", "onHand": -1, "allocated": 0 },
+    { "type": "allocate", "onHand": -2, "allocated": 0 },
+    { "type": "deallocate", "onHand": -3, "allocated": 0 }
+  ],
+  "violatedInvariants": {
+    "byType": {
+      "onhand_min": {
+        "count": 3,
+        "indices": [0, 1, 2]
+      }
+    }
+  }
+}
+

--- a/tests/property/token-optimizer.codeblocks.large-preserve.pbt.test.ts
+++ b/tests/property/token-optimizer.codeblocks.large-preserve.pbt.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer large codeblocks preserved', () => {
+  it(
+    formatGWT('large code fences', 'compressSteeringDocuments', 'compressed <= original and fences remain'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.string({ minLength: 5, maxLength: 60 }), async (s) => {
+          const code = '```ts\n' + Array.from({ length: 20 }, (_, i) => `const v${i} = '${s}';`).join('\n') + '\n```';
+          const content = ['# Title', s.repeat(3), code, s.repeat(2), code].join('\n');
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments({ product: content }, { maxTokens: 8000 });
+          expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+          const fences = (res.compressed.match(/```/g) || []).length;
+          expect(fences % 2).toBe(0);
+        }),
+        { numRuns: 6 }
+      );
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.codefence.balanced.pbt.test.ts
+++ b/tests/property/token-optimizer.codefence.balanced.pbt.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer code fences remain balanced', () => {
+  it(
+    formatGWT('docs with a code fence', 'compressSteeringDocuments', 'number of ``` is even (balanced)'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.string({ minLength: 1, maxLength: 80 }), async (s) => {
+          const code = '```ts\nconst v = 1;\n```';
+          const content = ['# Title', s, code, s].join('\n');
+          const opt = new TokenOptimizer();
+          const { compressed } = await opt.compressSteeringDocuments({ product: content }, { maxTokens: 4000 });
+          const fenceCount = (compressed.match(/```/g) || []).length;
+          expect(fenceCount % 2).toBe(0);
+        }),
+        { numRuns: 8 }
+      );
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.preservePriority.empty-top.fallback.pbt.test.ts
+++ b/tests/property/token-optimizer.preservePriority.empty-top.fallback.pbt.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer preservePriority empty top falls back', () => {
+  it(
+    formatGWT('product empty, design present', 'compressSteeringDocuments', 'DESIGN becomes first section'),
+    async () => {
+      const docs = {
+        product: '',
+        design: 'D design',
+        architecture: 'A arch'
+      } as Record<string, string>;
+      const opt = new TokenOptimizer();
+      const res = await opt.compressSteeringDocuments(docs, {
+        preservePriority: ['product', 'design', 'architecture', 'standards'],
+        maxTokens: 200,
+        enableCaching: false,
+      });
+      if (res.compressed.trim().length > 0) {
+        expect(res.compressed.trim().startsWith('## DESIGN')).toBe(true);
+      }
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.preservePriority.missing-first-but-second-present.pbt.test.ts
+++ b/tests/property/token-optimizer.preservePriority.missing-first-but-second-present.pbt.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer preservePriority missing first but second present', () => {
+  it(
+    formatGWT('docs missing product but design present', 'compressSteeringDocuments', 'DESIGN becomes first section'),
+    async () => {
+      const docs = {
+        design: 'D design',
+        architecture: 'A arch',
+        standards: 'S std'
+      } as Record<string, string>;
+      const opt = new TokenOptimizer();
+      const res = await opt.compressSteeringDocuments(docs, {
+        preservePriority: ['product', 'design', 'architecture', 'standards'],
+        maxTokens: 200,
+        enableCaching: false,
+      });
+      if (res.compressed.trim().length > 0) {
+        expect(res.compressed.trim().startsWith('## DESIGN')).toBe(true);
+      }
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-fail-first.opens-again.th4.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-fail-first.opens-again.th4.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker fail first in HALF_OPEN -> OPEN (th=4)', () => {
+  it(
+    formatGWT('OPEN after initial fail', 'fail immediately in HALF_OPEN (th=4)', 'returns to OPEN'),
+    async () => {
+      const timeout = 26;
+      const cb = new CircuitBreaker('halfopen-fail-first-th4', {
+        failureThreshold: 1,
+        successThreshold: 4,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      // trip to OPEN
+      await expect(cb.execute(async () => { throw new Error('e1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+
+      // move to HALF_OPEN then fail again => should re-open
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => { throw new Error('e2'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.open-rejects-until-timeout.short.test.ts
+++ b/tests/resilience/circuit-breaker.open-rejects-until-timeout.short.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker OPEN rejects until timeout (short)', () => {
+  it(
+    formatGWT('OPEN state', 'multiple execute attempts before timeout', 'all reject and state remains OPEN'),
+    async () => {
+      const timeout = 24;
+      const cb = new CircuitBreaker('open-rejects-until-timeout', {
+        failureThreshold: 1,
+        successThreshold: 2,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      // trip to OPEN
+      await expect(cb.execute(async () => { throw new Error('e1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+
+      // attempts before timeout should reject and remain OPEN
+      for (let k = 0; k < 3; k++) {
+        await expect(cb.execute(async () => 1)).rejects.toBeInstanceOf(Error);
+        expect(cb.getState()).toBe(CircuitState.OPEN);
+      }
+
+      // after timeout → HALF_OPEN
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      expect(cb.getState()).toBe(CircuitState.HALF_OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-2.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-2.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 2 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [i*1, 1, i*6, 1, i*2]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [i * 1, 1, i * 6, 1, i * 2];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-3.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-3.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 3 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [1, i*4, i, i*5]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [1, i * 4, i, i * 5];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+


### PR DESCRIPTION
小粒の高速PBT/ユニット追加（Verify Lite 対応）— 第30弾

- Resilience / TokenBucket（高速PBT）
  - tiny-interval alt-pattern-3: waits [1, i*4, i, i*5] で tokens ∈ [0..max]
- Resilience / CircuitBreaker（短ユニット）
  - OPEN rejects until timeout: タイムアウト前は全て reject & OPEN 維持、タイムアウト後に HALF_OPEN
- DDD/Testing / TokenOptimizer（PBT）
  - large codeblocks preserved: 大きなコードフェンスでも compressed <= original & フェンス健全
  - preservePriority empty-top fallback: product 空なら DESIGN が先頭（fallback）

運用
- run-qa（QA light）/ qa-batch:property を付与。
- ci-non-blocking で重いジョブは非ブロッキング。
- 本PRは #493（Roadmap）に紐付く #597（Resilience）/#413（Testing/DDD）の一環です。

ローカル
- pnpm build OK / pnpm run test:fast 緑（190 files, 929 tests: 928 passed / 1 skipped）

