### PR TITLE
test(resilience/property): ddd batch 34 (TB alt-6, CB closed-stays-closed, TokenOptimizer deterministic)

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -13,6 +13,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt6 byType): `scripts/testing/fixtures/replay-failure.bytype.alt6.sample.json`（byType 風、さらに最小の2イベントケース）
 - Failure (alt7 byType): `scripts/testing/fixtures/replay-failure.bytype.alt7.sample.json`（byType 風、単一タイプの複数違反をまとめた例）
  - Failure (alt8 byType): `scripts/testing/fixtures/replay-failure.bytype.alt8.sample.json`（byType 風、onhand_min のみの連続違反）
+ - Failure (alt9 byType): `scripts/testing/fixtures/replay-failure.bytype.alt9.sample.json`（byType 風、onhand_min と allocated_le_onhand の混在）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/testing/fixtures/replay-failure.bytype.alt9.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt9.sample.json
@@ -1,0 +1,14 @@
+{
+  "events": [
+    { "type": "allocate", "onHand": -1, "allocated": 0 },
+    { "type": "allocate", "onHand": 2, "allocated": 3 },
+    { "type": "deallocate", "onHand": -2, "allocated": 1 }
+  ],
+  "violatedInvariants": {
+    "byType": {
+      "onhand_min": { "count": 2, "indices": [0, 2] },
+      "allocated_le_onhand": { "count": 1, "indices": [1] }
+    }
+  }
+}
+

--- a/tests/property/token-optimizer.estimateTokens.punctuation.monotonicity.test.ts
+++ b/tests/property/token-optimizer.estimateTokens.punctuation.monotonicity.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { estimateTokens } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('TokenOptimizer: estimateTokens punctuation monotonicity', () => {
+  it(
+    formatGWT('base text', 'append punctuation/whitespace variants', 'token estimate does not decrease'),
+    () => {
+      const base = 'This is a sample text';
+      const variants = [
+        base + '.',
+        base + '...',
+        base + ' . ',
+        base + ' — end',
+      ];
+      const baseEst = estimateTokens(base);
+      for (const v of variants) {
+        expect(estimateTokens(v)).toBeGreaterThanOrEqual(baseEst);
+      }
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.estimateTokens.whitespace.monotonicity.test.ts
+++ b/tests/property/token-optimizer.estimateTokens.whitespace.monotonicity.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { estimateTokens } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('TokenOptimizer: estimateTokens whitespace monotonicity', () => {
+  it(
+    formatGWT('base text', 'append newlines/spaces', 'token estimate does not decrease'),
+    () => {
+      const base = 'A short sample';
+      const variants = [
+        base + '\n',
+        base + '  ',
+        base + '\n\n  ',
+        base + '\n  more',
+      ];
+      const baseEst = estimateTokens(base);
+      for (const v of variants) {
+        expect(estimateTokens(v)).toBeGreaterThanOrEqual(baseEst);
+      }
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.nocache.deterministic.output.pbt.test.ts
+++ b/tests/property/token-optimizer.nocache.deterministic.output.pbt.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer deterministic output without cache', () => {
+  it(
+    formatGWT('same docs/options twice', 'compressSteeringDocuments (enableCaching=false)', 'outputs are identical'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.string({ minLength: 5, maxLength: 80 }), async (s) => {
+          const docs = { product: `P ${s}`, design: `D ${s.slice(0, 10)}` } as Record<string, string>;
+          const opt = new TokenOptimizer();
+          const opts = { maxTokens: 500, enableCaching: false } as const;
+          const a = await opt.compressSteeringDocuments(docs, opts);
+          const b = await opt.compressSteeringDocuments(docs, opts);
+          expect(a.compressed).toBe(b.compressed);
+          expect(a.stats.compressed).toBe(b.stats.compressed);
+        }),
+        { numRuns: 8 }
+      );
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.preservePriority.standards-only.first.test.ts
+++ b/tests/property/token-optimizer.preservePriority.standards-only.first.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('TokenOptimizer: preservePriority standards-only becomes first', () => {
+  it(
+    formatGWT('only standards present', 'compressSteeringDocuments', 'STANDARDS becomes first section'),
+    async () => {
+      const docs = { standards: 'S std' } as Record<string, string>;
+      const opt = new TokenOptimizer();
+      const res = await opt.compressSteeringDocuments(docs, {
+        preservePriority: ['product', 'design', 'architecture', 'standards'],
+        maxTokens: 120,
+        enableCaching: false,
+      });
+      if (res.compressed.trim().length > 0) {
+        expect(res.compressed.trim().startsWith('## STANDARDS')).toBe(true);
+      }
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.closed-stays-closed.on-successes.test.ts
+++ b/tests/resilience/circuit-breaker.closed-stays-closed.on-successes.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker CLOSED stays CLOSED on successes', () => {
+  it(
+    formatGWT('CLOSED state', 'several successful executions', 'state remains CLOSED'),
+    async () => {
+      const timeout = 20;
+      const cb = new CircuitBreaker('closed-stays-closed', {
+        failureThreshold: 1,
+        successThreshold: 2,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      for (let k = 0; k < 3; k++) {
+        await expect(cb.execute(async () => k)).resolves.toBe(k);
+        expect(cb.getState()).toBe(CircuitState.CLOSED);
+      }
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-fail-first.opens-again.th3.alt.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-fail-first.opens-again.th3.alt.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker fail first in HALF_OPEN -> OPEN (th=3, alt)', () => {
+  it(
+    formatGWT('OPEN after initial fail', 'fail immediately in HALF_OPEN (th=3)', 'returns to OPEN'),
+    async () => {
+      const timeout = 26;
+      const cb = new CircuitBreaker('halfopen-fail-first-th3-alt', {
+        failureThreshold: 1,
+        successThreshold: 3,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      await expect(cb.execute(async () => { throw new Error('e1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => { throw new Error('e2'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-failure-success-failure.opens-again.th3.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-failure-success-failure.opens-again.th3.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker fail→success→fail in HALF_OPEN -> OPEN (th=3)', () => {
+  it(
+    formatGWT('OPEN after initial fail', 'then success once, then fail in HALF_OPEN (th=3)', 'returns to OPEN'),
+    async () => {
+      const timeout = 26;
+      const cb = new CircuitBreaker('halfopen-fsf-th3', {
+        failureThreshold: 1,
+        successThreshold: 3,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      // trip to OPEN
+      await expect(cb.execute(async () => { throw new Error('e1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+
+      // HALF_OPEN -> success once
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+
+      // then fail -> back to OPEN
+      await expect(cb.execute(async () => { throw new Error('e2'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-4.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-4.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 4 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [i*2, i*7, 1, i]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [i * 2, i * 7, 1, i];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-5.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-5.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 5 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [i*3, 1, i*2, 1]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [i * 3, 1, i * 2, 1];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-6.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-6.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 6 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [i*5, i*2, 1, i*3]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [i * 5, i * 2, 1, i * 3];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+


### PR DESCRIPTION
小粒の高速PBT/ユニット追加（Verify Lite 対応）— 第34弾

- Resilience / TokenBucket（高速PBT）
  - tiny-interval alt-pattern-6: waits [i*5, i*2, 1, i*3] で tokens ∈ [0..max]
- Resilience / CircuitBreaker（短ユニット）
  - CLOSED stays CLOSED on successes: 連続成功時は CLOSED 維持
- DDD/Testing / TokenOptimizer（PBT）
  - deterministic output (no-cache): 同一入力/オプションで出力が安定

運用
- run-qa（QA light）/ qa-batch:property を付与。
- ci-non-blocking で重いジョブは非ブロッキング。
- 本PRは #493（Roadmap）に紐付く #597（Resilience）/#413（Testing/DDD）の一環です。

ローカル
- pnpm build OK / pnpm run test:fast 緑（196 files, 935 tests: 934 passed / 1 skipped）

