### PR TITLE
test(resilience/property/docs): ddd batch 36 (rebased)

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -12,13 +12,10 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt5 byType): `scripts/testing/fixtures/replay-failure.bytype.alt5.sample.json`（byType 風、最小構成の割当過多）
 - Failure (alt6 byType): `scripts/testing/fixtures/replay-failure.bytype.alt6.sample.json`（byType 風、さらに最小の2イベントケース）
 - Failure (alt7 byType): `scripts/testing/fixtures/replay-failure.bytype.alt7.sample.json`（byType 風、単一タイプの複数違反をまとめた例）
- - Failure (alt8 byType): `scripts/testing/fixtures/replay-failure.bytype.alt8.sample.json`（byType 風、onhand_min のみの連続違反）
-<<<<<<< HEAD
+- Failure (alt8 byType): `scripts/testing/fixtures/replay-failure.bytype.alt8.sample.json`（byType 風、onhand_min のみの連続違反）
 - Failure (alt9 byType): `scripts/testing/fixtures/replay-failure.bytype.alt9.sample.json`（byType 風、onhand_min と allocated_le_onhand の混在）
 - Failure (alt10 byType): `scripts/testing/fixtures/replay-failure.bytype.alt10.sample.json`（byType 風、allocated_le_onhand の連続違反＋one ok）
-=======
- - Failure (alt9 byType): `scripts/testing/fixtures/replay-failure.bytype.alt9.sample.json`（byType 風、onhand_min と allocated_le_onhand の混在）
->>>>>>> 7bb5625 (Merge: ddd batch 32 (rebased) (admin))
+- Failure (alt11 byType): `scripts/testing/fixtures/replay-failure.bytype.alt11.sample.json`（byType 風、onhand_min=2 の閾値超過の組合せ）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/testing/fixtures/replay-failure.bytype.alt11.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt11.sample.json
@@ -1,0 +1,13 @@
+{
+  "events": [
+    { "type": "allocate", "onHand": 1, "allocated": 0 },
+    { "type": "allocate", "onHand": 2, "allocated": 1 },
+    { "type": "allocate", "onHand": 1, "allocated": 1 }
+  ],
+  "violatedInvariants": {
+    "byType": {
+      "onhand_min": { "count": 2, "indices": [0, 2], "min": 2 }
+    }
+  }
+}
+

--- a/tests/property/token-optimizer.large-mixed.sections.order.randomized.pbt.test.ts
+++ b/tests/property/token-optimizer.large-mixed.sections.order.randomized.pbt.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer sections order stable under random docs', () => {
+  it(
+    formatGWT('randomized section order', 'compressSteeringDocuments', 'headers follow preservePriority among present'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.array(fc.constantFrom('product','design','architecture','standards'), {minLength:2, maxLength:4}).map(arr=>Array.from(new Set(arr))), async (keys) => {
+          const docs: Record<string,string> = {};
+          for (const k of keys) docs[k] = `${k} content`.repeat(2);
+          // randomize insertion order
+          const shuffled = [...keys].sort(()=>Math.random()-0.5);
+          const randomizedDocs: Record<string,string> = {};
+          for (const k of shuffled) randomizedDocs[k] = docs[k];
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments(randomizedDocs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 1000, enableCaching: false });
+          const body = res.compressed;
+          const indices = ['PRODUCT','DESIGN','ARCHITECTURE','STANDARDS'].map(h=> body.indexOf(`## ${h}`)).filter(i=>i>=0);
+          for (let i=1;i<indices.length;i++) expect(indices[i-1]).toBeLessThan(indices[i]);
+        }),
+        { numRuns: 8 }
+      );
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-closes-after-three.th3.alt.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-closes-after-three.th3.alt.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker HALF_OPEN closes after 3 successes (th=3, alt)', () => {
+  it(
+    formatGWT('HALF_OPEN', 'three consecutive successes (th=3)', 'transitions to CLOSED'),
+    async () => {
+      const timeout = 24;
+      const cb = new CircuitBreaker('halfopen-close-after-3-alt', {
+        failureThreshold: 1,
+        successThreshold: 3,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      // Trip to OPEN first
+      await expect(cb.execute(async () => { throw new Error('e1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+
+      // Transition to HALF_OPEN then 3 successes -> CLOSED
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 2)).resolves.toBe(2);
+      await expect(cb.execute(async () => 3)).resolves.toBe(3);
+      expect(cb.getState()).toBe(CircuitState.CLOSED);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-8.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-8.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 8 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [1, i*2, i*6, i]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [1, i * 2, i * 6, i];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+


### PR DESCRIPTION
Rebased clean on main. Replacement for #773. Same contents (TB alt-8; CB th3 close-after-3 alt; TokenOptimizer sections order randomized; replay alt11).