### PR TITLE
test(resilience/property/docs): ddd batch 37 (TB alt-9, CB th3 reopen-after-closed, no-duplicate headers, replay alt12)

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -12,13 +12,10 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt5 byType): `scripts/testing/fixtures/replay-failure.bytype.alt5.sample.json`（byType 風、最小構成の割当過多）
 - Failure (alt6 byType): `scripts/testing/fixtures/replay-failure.bytype.alt6.sample.json`（byType 風、さらに最小の2イベントケース）
 - Failure (alt7 byType): `scripts/testing/fixtures/replay-failure.bytype.alt7.sample.json`（byType 風、単一タイプの複数違反をまとめた例）
- - Failure (alt8 byType): `scripts/testing/fixtures/replay-failure.bytype.alt8.sample.json`（byType 風、onhand_min のみの連続違反）
-<<<<<<< HEAD
+- Failure (alt8 byType): `scripts/testing/fixtures/replay-failure.bytype.alt8.sample.json`（byType 風、onhand_min のみの連続違反）
 - Failure (alt9 byType): `scripts/testing/fixtures/replay-failure.bytype.alt9.sample.json`（byType 風、onhand_min と allocated_le_onhand の混在）
 - Failure (alt10 byType): `scripts/testing/fixtures/replay-failure.bytype.alt10.sample.json`（byType 風、allocated_le_onhand の連続違反＋one ok）
-=======
- - Failure (alt9 byType): `scripts/testing/fixtures/replay-failure.bytype.alt9.sample.json`（byType 風、onhand_min と allocated_le_onhand の混在）
->>>>>>> 7bb5625 (Merge: ddd batch 32 (rebased) (admin))
+- Failure (alt11 byType): `scripts/testing/fixtures/replay-failure.bytype.alt11.sample.json`（byType 風、onhand_min=2 の閾値超過の組合せ）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -16,6 +16,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt9 byType): `scripts/testing/fixtures/replay-failure.bytype.alt9.sample.json`（byType 風、onhand_min と allocated_le_onhand の混在）
 - Failure (alt10 byType): `scripts/testing/fixtures/replay-failure.bytype.alt10.sample.json`（byType 風、allocated_le_onhand の連続違反＋one ok）
 - Failure (alt11 byType): `scripts/testing/fixtures/replay-failure.bytype.alt11.sample.json`（byType 風、onhand_min=2 の閾値超過の組合せ）
+- Failure (alt12 byType): `scripts/testing/fixtures/replay-failure.bytype.alt12.sample.json`（byType 風、allocated_le_onhand と onhand_min の交互違反）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/testing/fixtures/replay-failure.bytype.alt11.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt11.sample.json
@@ -1,0 +1,13 @@
+{
+  "events": [
+    { "type": "allocate", "onHand": 1, "allocated": 0 },
+    { "type": "allocate", "onHand": 2, "allocated": 1 },
+    { "type": "allocate", "onHand": 1, "allocated": 1 }
+  ],
+  "violatedInvariants": {
+    "byType": {
+      "onhand_min": { "count": 2, "indices": [0, 2], "min": 2 }
+    }
+  }
+}
+

--- a/scripts/testing/fixtures/replay-failure.bytype.alt12.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt12.sample.json
@@ -1,0 +1,15 @@
+{
+  "events": [
+    { "type": "allocate", "onHand": -1, "allocated": 0 },
+    { "type": "allocate", "onHand": 2, "allocated": 3 },
+    { "type": "allocate", "onHand": -2, "allocated": 1 },
+    { "type": "allocate", "onHand": 1, "allocated": 2 }
+  ],
+  "violatedInvariants": {
+    "byType": {
+      "onhand_min": { "count": 2, "indices": [0, 2] },
+      "allocated_le_onhand": { "count": 2, "indices": [1, 3] }
+    }
+  }
+}
+

--- a/tests/property/token-optimizer.large-mixed.sections.order.randomized.pbt.test.ts
+++ b/tests/property/token-optimizer.large-mixed.sections.order.randomized.pbt.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer sections order stable under random docs', () => {
+  it(
+    formatGWT('randomized section order', 'compressSteeringDocuments', 'headers follow preservePriority among present'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.array(fc.constantFrom('product','design','architecture','standards'), {minLength:2, maxLength:4}).map(arr=>Array.from(new Set(arr))), async (keys) => {
+          const docs: Record<string,string> = {};
+          for (const k of keys) docs[k] = `${k} content`.repeat(2);
+          // randomize insertion order
+          const shuffled = [...keys].sort(()=>Math.random()-0.5);
+          const randomizedDocs: Record<string,string> = {};
+          for (const k of shuffled) randomizedDocs[k] = docs[k];
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments(randomizedDocs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 1000, enableCaching: false });
+          const body = res.compressed;
+          const indices = ['PRODUCT','DESIGN','ARCHITECTURE','STANDARDS'].map(h=> body.indexOf(`## ${h}`)).filter(i=>i>=0);
+          for (let i=1;i<indices.length;i++) expect(indices[i-1]).toBeLessThan(indices[i]);
+        }),
+        { numRuns: 8 }
+      );
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.preservePriority.no-duplicate.headers.test.ts
+++ b/tests/property/token-optimizer.preservePriority.no-duplicate.headers.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('TokenOptimizer: no duplicate headers in output', () => {
+  it(
+    formatGWT('subset with repeats in input docs', 'compressSteeringDocuments', 'each included section header appears once'),
+    async () => {
+      const docs = {
+        product: 'P one',
+        architecture: 'A first',
+        standards: 'S alpha\nS beta'
+      } as Record<string,string>;
+      const opt = new TokenOptimizer();
+      const { compressed } = await opt.compressSteeringDocuments(docs, {
+        preservePriority: ['product','design','architecture','standards'],
+        maxTokens: 400,
+        enableCaching: false,
+      });
+      const occurs = (header: string) => (compressed.match(new RegExp(header,'g')) || []).length;
+      if (compressed.trim().length > 0) {
+        expect(occurs('## PRODUCT')).toBeLessThanOrEqual(1);
+        if (compressed.includes('## ARCHITECTURE')) expect(occurs('## ARCHITECTURE')).toBe(1);
+        if (compressed.includes('## STANDARDS')) expect(occurs('## STANDARDS')).toBe(1);
+      }
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.closed-after-halfopen-then-fail.reopens.th3.test.ts
+++ b/tests/resilience/circuit-breaker.closed-after-halfopen-then-fail.reopens.th3.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CLOSED after HALF_OPEN then immediate fail -> OPEN (th=3)', () => {
+  it(
+    formatGWT('HALF_OPEN reaches CLOSED', 'then next failure re-opens (th=3)', 'OPEN state observed'),
+    async () => {
+      const timeout = 24;
+      const cb = new CircuitBreaker('closed-then-fail-reopen-th3', {
+        failureThreshold: 1,
+        successThreshold: 3,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      // Trip to OPEN
+      await expect(cb.execute(async () => { throw new Error('e1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+
+      // Move to HALF_OPEN and reach CLOSED
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 2)).resolves.toBe(2);
+      await expect(cb.execute(async () => 3)).resolves.toBe(3);
+      expect(cb.getState()).toBe(CircuitState.CLOSED);
+
+      // Immediate failure should re-open
+      await expect(cb.execute(async () => { throw new Error('e2'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-closes-after-three.th3.alt.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-closes-after-three.th3.alt.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker HALF_OPEN closes after 3 successes (th=3, alt)', () => {
+  it(
+    formatGWT('HALF_OPEN', 'three consecutive successes (th=3)', 'transitions to CLOSED'),
+    async () => {
+      const timeout = 24;
+      const cb = new CircuitBreaker('halfopen-close-after-3-alt', {
+        failureThreshold: 1,
+        successThreshold: 3,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      // Trip to OPEN first
+      await expect(cb.execute(async () => { throw new Error('e1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+
+      // Transition to HALF_OPEN then 3 successes -> CLOSED
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 2)).resolves.toBe(2);
+      await expect(cb.execute(async () => 3)).resolves.toBe(3);
+      expect(cb.getState()).toBe(CircuitState.CLOSED);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-8.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-8.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 8 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [1, i*2, i*6, i]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [1, i * 2, i * 6, i];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-9.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-9.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 9 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [i*3, i, i*7, 1]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [i * 3, i, i * 7, 1];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+


### PR DESCRIPTION
小粒の高速PBT/ユニット/ドキュメント追加（Verify Lite 対応）— 第37弾

- Resilience / TokenBucket（高速PBT）
  - tiny-interval alt-pattern-9: waits [i*3, i, i*7, 1] で tokens ∈ [0..max]
- Resilience / CircuitBreaker（ユニット）
  - HALF_OPEN(th=3) → CLOSED 後の直後失敗で OPEN に戻る
- DDD/Testing / TokenOptimizer（ユニット）
  - preservePriority: 見出しの重複が出ない（各セクション1回だけ）
- Docs（replay）
  - alt12（byType: allocated_le_onhand と onhand_min の交互違反）を追加し mapping ノートに追記

運用
- run-qa（QA light）/ qa-batch:property を付与。
- ci-non-blocking で重いジョブは非ブロッキング。
- 本PRは #493（Roadmap）に紐付く #597（Resilience）/#413（Testing/DDD）/#491（Formal可視化補助）の一環です。

ローカル
- pnpm build OK / pnpm run test:fast 緑（202 files, 941 tests: 940 passed / 1 skipped）

