### PR TITLE
docs(adapters): non-blocking + label-gated enforcement (decision)

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -20,6 +20,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt12 byType): `scripts/testing/fixtures/replay-failure.bytype.alt12.sample.json`（byType 風、allocated_le_onhand と onhand_min の交互違反）
 <<<<<<< HEAD
 - Failure (alt13 byType): `scripts/testing/fixtures/replay-failure.bytype.alt13.sample.json`（byType 風、onhand_min=1/2 混在＋allocated境界の複合）
+- Failure (alt14 byType): `scripts/testing/fixtures/replay-failure.bytype.alt14.sample.json`（byType 風、連続OK→複合違反→OK の混在）
 =======
 >>>>>>> c7fa9b9 (Merge: ddd batch 37 (rebased) (admin))
 =======

--- a/docs/quality/adapter-thresholds.md
+++ b/docs/quality/adapter-thresholds.md
@@ -1,15 +1,15 @@
 # Adapter Thresholds — Lighthouse/Perf/A11y (Label-Gated)
 
-Purpose
-- Define adapter thresholds and label-gated enforcement without slowing down PRs by default.
+Purpose（決定）
+- Adapter thresholds は「PRは非ブロッキング、必要時ラベルで強制」の方針とする（段階導入）。
 
 Proposal
-- Keep adapter checks non-blocking on PRs; use labels to opt-in enforcement and/or stricter thresholds.
+- PRは非ブロッキング（report-only）。必要に応じてラベルで強制・しきい値上書きを行う。
 - Example labels (to be wired incrementally):
   - `enforce-a11y`, `enforce-perf`, `enforce-lh` — turn results into gates
   - `a11y:<score>`, `perf:<score>` — override thresholds ad hoc
 
-Repository variables (recommended)
+Repository variables（推奨/決定）
 - `PERF_DEFAULT_THRESHOLD`（未設定時は既定 75）
 - `LH_DEFAULT_THRESHOLD`（未設定時は既定 80）
 未設定の場合でもレポートは非ブロッキングで動作します（強制時はラベル/値の解決順：ラベル > 変数 > 既定）。
@@ -31,10 +31,10 @@ Lighthouse (proposal → minimal wiring)
 - PRコメント: Threshold (effective) / Derived（label > repo var > default）/ Policy / Policy source / Docs
 - Slash Commands: `/enforce-lh`, `/lh <pct|clear>`
 
-Phasing
-- Phase 1: Reporting only (post PR comments/artifacts)
-- Phase 2: Label-gated enforcement
-- Phase 3: Consider main defaults after observation
+Phasing（段階導入）
+- Phase 1: Reporting only（PRコメント/アーティファクト）
+- Phase 2: Label-gated enforcement（`enforce-*` ラベルでブロック化）
+- Phase 3: main 既定（観測後に検討）
 
 Notes
 - See `quality-gates-centralized.yml` for central jobs and consider adding thresholds as follow-up.

--- a/docs/quality/coverage-required.md
+++ b/docs/quality/coverage-required.md
@@ -3,13 +3,13 @@
 目的
 - PRでは非ブロッキングでカバレッジを可視化し、mainに対しては必要に応じてしきい値を強制する。
 
-手順（推奨）
+手順（推奨／決定）
 - リポジトリ変数の設定（Settings → Variables → Repository variables）
-  - `COVERAGE_ENFORCE_MAIN=1`（main への push を強制対象に）
+- `COVERAGE_ENFORCE_MAIN=1`（main への push を強制対象に）— 本リポジトリではこの方針を採用する（段階導入）
   - `COVERAGE_DEFAULT_THRESHOLD`（例: 80）
 - ブランチ保護（Settings → Branches → Branch protection rules）
   - `Require status checks to pass before merging` を有効化
-  - ステータスチェックに `coverage-check` を追加（必要に応じて `coverage-check (push)` / `(pull_request)` を選択）
+- ステータスチェックに `coverage-check` を追加（必要に応じて `coverage-check (push)` / `(pull_request)` を選択）— Required 化を有効にする
   - （任意）`Require branches to be up to date before merging` を一時的に無効化して段階導入を容易に（運用安定後に有効化を検討）
   - 例: `coverage-check` と `verify-lite` を必須チェックとして追加（段階導入時は `ci-non-blocking` を活用）
   - スクリーンショット（任意）: ブランチ保護設定UIのキャプチャを内部ナレッジに保存（このリポジトリに画像をコミットする必要はありません）。

--- a/scripts/testing/fixtures/replay-failure.bytype.alt14.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt14.sample.json
@@ -1,0 +1,16 @@
+{
+  "events": [
+    { "type": "allocate", "onHand": 5, "allocated": 2 },
+    { "type": "allocate", "onHand": 4, "allocated": 3 },
+    { "type": "allocate", "onHand": -1, "allocated": 0 },
+    { "type": "allocate", "onHand": 1, "allocated": 2 },
+    { "type": "allocate", "onHand": 3, "allocated": 1 }
+  ],
+  "violatedInvariants": {
+    "byType": {
+      "onhand_min": { "count": 1, "indices": [2] },
+      "allocated_le_onhand": { "count": 1, "indices": [3] }
+    }
+  }
+}
+

--- a/tests/property/token-optimizer.random-large.mixed-order.pbt.test.ts
+++ b/tests/property/token-optimizer.random-large.mixed-order.pbt.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer random large docs (mixed order)', () => {
+  it(
+    formatGWT('random large mixed docs', 'compressSteeringDocuments', 'priority order among present & tokens reduce or equal'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(fc.array(fc.constantFrom('product','design','architecture','standards'), {minLength:2, maxLength:4}).map(a=>Array.from(new Set(a))), async (keys) => {
+          const docs: Record<string,string> = {};
+          for (const k of keys) docs[k] = (k+': '+('lorem '.repeat(50))).repeat(3);
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments(docs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 5000, enableCaching: false });
+          const body = res.compressed;
+          const idx = ['PRODUCT','DESIGN','ARCHITECTURE','STANDARDS'].map(h=> body.indexOf('## '+h)).filter(i=>i>=0);
+          for (let i=1;i<idx.length;i++) expect(idx[i-1]).toBeLessThan(idx[i]);
+          expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+        }),
+        { numRuns: 6 }
+      );
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-success-fail-success.opens.th4.alt4.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-success-fail-success.opens.th4.alt4.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: HALF_OPEN success→fail→success -> stays not CLOSED (th=4, alt4)', () => {
+  it(
+    formatGWT('HALF_OPEN with th=4', 'one success then fail then success', 'state is not CLOSED (requires 4 successes)'),
+    async () => {
+      const timeout = 26;
+      const cb = new CircuitBreaker('halfopen-s-f-s-th4-alt4', {
+        failureThreshold: 1,
+        successThreshold: 4,
+        timeout,
+        monitoringWindow: 100,
+      });
+
+      await expect(cb.execute(async () => { throw new Error('e1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => { throw new Error('e2'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 2)).resolves.toBe(2);
+      expect(cb.getState()).not.toBe(CircuitState.CLOSED);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-13.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-13.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt pattern 13 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'apply waits [i*7, i*3, i, 1]', 'tokens within [0..max]'),
+    async () => {
+      const i = 4;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 4 });
+      for (let k = 0; k < 4; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [i * 7, i * 3, i, 1];
+      for (const w of waits) {
+        await new Promise((r) => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(rl.maxTokens ?? 4);
+      }
+    }
+  );
+});
+


### PR DESCRIPTION
#596 対応: Adapters（a11y/perf/lh）の方針を docs に明記。\n- PRは非ブロッキング（report-only）\n- ラベル（enforce-*, perf:<pct>, lh:<pct>）で強制/上書き\n- 既定値は repo vars（PERF_DEFAULT_THRESHOLD/LH_DEFAULT_THRESHOLD）に寄せ、Derived/Policy 表示をパリティ化済み