### PR TITLE
test(resilience/ddd): TB short-permutation + CB rapid reopen + TokenOptimizer order + replay alt16

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -20,6 +20,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt13 byType): `scripts/testing/fixtures/replay-failure.bytype.alt13.sample.json`（byType 風、onhand_min=1/2 混在＋allocated境界の複合）
 - Failure (alt14 byType): `scripts/testing/fixtures/replay-failure.bytype.alt14.sample.json`（byType 風、連続OK→複合違反→OK の混在）
 - Failure (alt15 byType): `scripts/testing/fixtures/replay-failure.bytype.alt15.sample.json`（byType 風、最小長の交互違反: onhand_min→allocated→onhand_min）
+- Failure (alt16 byType): `scripts/testing/fixtures/replay-failure.bytype.alt16.sample.json`（byType 風、短系列で onhand_min と allocated の各1件）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/testing/fixtures/replay-failure.bytype.alt16.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt16.sample.json
@@ -1,0 +1,19 @@
+{
+  "violatedInvariants": {
+    "onhand_min": {
+      "count": 1,
+      "indices": [2]
+    },
+    "allocated_le_onhand": {
+      "count": 1,
+      "indices": [3]
+    }
+  },
+  "events": [
+    {"type": "ok", "onHand": 1, "allocated": 0},
+    {"type": "ok", "onHand": 2, "allocated": 1},
+    {"type": "violation:onhand_min", "onHand": 0, "allocated": 0},
+    {"type": "violation:allocated_le_onhand", "onHand": 0, "allocated": 1}
+  ]
+}
+

--- a/tests/property/token-optimizer.present-only.order.idempotent.pbt.test.ts
+++ b/tests/property/token-optimizer.present-only.order.idempotent.pbt.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer present-only sections keep order (idempotent)', () => {
+  it(
+    formatGWT('present-only order', 'compressSteeringDocuments', 'preservePriority order among present is stable'),
+    async () => {
+      const uniqueKeysArb = fc
+        .array(fc.constantFrom('product', 'design', 'architecture', 'standards'), { minLength: 2, maxLength: 4 })
+        .map((a) => Array.from(new Set(a)));
+      await fc.assert(
+        fc.asyncProperty(uniqueKeysArb, async (keys) => {
+          const docs: Record<string, string> = {};
+          for (const k of keys) docs[k] = `# ${k}\n` + ('lorem '.repeat(40));
+          const opt = new TokenOptimizer();
+          const res1 = await opt.compressSteeringDocuments(docs, { preservePriority: ['product', 'design', 'architecture', 'standards'], maxTokens: 5000, enableCaching: false });
+          const res2 = await opt.compressSteeringDocuments(docs, { preservePriority: ['product', 'design', 'architecture', 'standards'], maxTokens: 5000, enableCaching: false });
+          const body1 = res1.compressed;
+          const body2 = res2.compressed;
+          expect(body1).toBe(body2);
+        }),
+        { numRuns: 6 }
+      );
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.rapid-halfopen-reopen.sequence.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-halfopen-reopen.sequence.short.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid HALF_OPEN→OPEN sequence (short)', () => {
+  it(
+    formatGWT('rapid transitions', 'OPEN→HALF_OPEN→OPEN with quick failure', 'never CLOSED until threshold met'),
+    async () => {
+      const timeout = 20;
+      const cb = new CircuitBreaker('rapid', { failureThreshold: 1, successThreshold: 3, timeout, monitoringWindow: 80 });
+      // Open
+      await expect(cb.execute(async () => { throw new Error('x'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      // Half-open window
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      expect(cb.getState()).toBe(CircuitState.HALF_OPEN);
+      // quick failure → back to OPEN
+      await expect(cb.execute(async () => { throw new Error('y'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.short-permutation.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.short-permutation.fast.pbt.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import fc from 'fast-check';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval short permutation (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'short waits permutation [1, i/3, i, i/2]', 'tokens within [0..max]'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2, max: 5 }),
+          fc.integer({ min: 1, max: 3 }),
+          async (maxTokens, per) => {
+            const i = 6;
+            const rl = new TokenBucketRateLimiter({ tokensPerInterval: per, interval: i, maxTokens });
+            // drain
+            for (let k = 0; k < maxTokens; k++) await rl.consume(1).catch(() => void 0);
+            const waits = [1, Math.max(1, Math.floor(i / 3)), i, Math.max(1, Math.floor(i / 2))];
+            for (const w of waits) {
+              await new Promise((r) => setTimeout(r, w));
+              await rl.consume(1).catch(() => void 0);
+              const t = rl.getTokenCount();
+              expect(t).toBeGreaterThanOrEqual(0);
+              expect(t).toBeLessThanOrEqual(maxTokens);
+            }
+          }
+        ),
+        { numRuns: 8 }
+      );
+    }
+  );
+});
+


### PR DESCRIPTION
Batch advancing #493 (#597, #413, #406).\n\n- TokenBucket: tiny-interval short-permutation waits (fast PBT)\n- CircuitBreaker: rapid HALF_OPEN→OPEN sequence (short)\n- TokenOptimizer: present-only order idempotent (PBT)\n- Replay: alt16 fixture + docs entry\n\nLocal: build OK, test:fast green.\nCI: use /verify-lite; optional jobs non-blocking.\n\nRefs: #493 #597 #413 #406