### PR TITLE
chore(formal): add caution patterns + regression test

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -51,6 +51,13 @@ export const NEGATIVE_PATTERNS = [
   ,/(?:invariant|property|spec)\s+unsatisfied/i   // EN <kind> unsatisfied
 ];
 
+export const CAUTION_PATTERNS = [
+  /caution/i,
+  /attention[:\s]/i,           // EN/FR-like "attention:"
+  /achtung[:\s]/i,             // DE "Achtung:"
+  /precaución[:\s]/i           // ES "Precaución:"
+];
+
 export function computeOkFromOutput(out){
   if (!out) return null;
   if (POSITIVE_PATTERNS.some(re => re.test(out))) return true;

--- a/tests/formal/heuristics.caution.more-boundaries.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: additional caution boundaries', () => {
+  it('matches multilingual caution/attention phrases conservatively', () => {
+    const samples = [
+      'Attention: review incomplete traces',
+      'Achtung: Ergebnis könnte unvollständig sein',
+      'Precaución: verifique los invariantes',
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+


### PR DESCRIPTION
Add multilingual caution boundary phrases to heuristics and include a small regression test.\n\n- heuristics: add attention/achtung/precaución to CAUTION_PATTERNS\n- tests: tests/formal/heuristics.caution.more-boundaries.test.ts\n\nLocal: build OK, test:fast passes.\nCI: /verify-lite\n\nRefs: #493 #491 #594