### PR TITLE
test(resilience/ddd): TB short-variation-2 + CB rapid 2s-then-f + TokenOptimizer PBT×2 + replay alt17/alt18 + GWT titles + heuristics

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -21,6 +21,8 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt14 byType): `scripts/testing/fixtures/replay-failure.bytype.alt14.sample.json`（byType 風、連続OK→複合違反→OK の混在）
 - Failure (alt15 byType): `scripts/testing/fixtures/replay-failure.bytype.alt15.sample.json`（byType 風、最小長の交互違反: onhand_min→allocated→onhand_min）
 - Failure (alt16 byType): `scripts/testing/fixtures/replay-failure.bytype.alt16.sample.json`（byType 風、短系列で onhand_min と allocated の各1件）
+- Failure (alt17 byType): `scripts/testing/fixtures/replay-failure.bytype.alt17.sample.json`（byType 風、onhand_min の複数違反が短系列で発生）
+- Failure (alt18 byType): `scripts/testing/fixtures/replay-failure.bytype.alt18.sample.json`（byType 風、allocated_le_onhand の複数違反）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -55,7 +55,9 @@ export const CAUTION_PATTERNS = [
   /caution/i,
   /attention[:\s]/i,           // EN/FR-like "attention:"
   /achtung[:\s]/i,             // DE "Achtung:"
-  /precaución[:\s]/i           // ES "Precaución:"
+  /precaución[:\s]/i,          // ES "Precaución:"
+  /aviso[:\s]/i,               // ES "Aviso:"
+  /注意/                        // JA "注意"
 ];
 
 export function computeOkFromOutput(out){

--- a/scripts/testing/fixtures/replay-failure.bytype.alt17.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt17.sample.json
@@ -1,0 +1,13 @@
+{
+  "violatedInvariants": {
+    "onhand_min": { "count": 2, "indices": [1, 4] }
+  },
+  "events": [
+    {"type": "ok", "onHand": 2, "allocated": 0},
+    {"type": "violation:onhand_min", "onHand": -1, "allocated": 0},
+    {"type": "ok", "onHand": 0, "allocated": 0},
+    {"type": "ok", "onHand": 1, "allocated": 0},
+    {"type": "violation:onhand_min", "onHand": -2, "allocated": 0}
+  ]
+}
+

--- a/scripts/testing/fixtures/replay-failure.bytype.alt18.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt18.sample.json
@@ -1,0 +1,12 @@
+{
+  "violatedInvariants": {
+    "allocated_le_onhand": { "count": 2, "indices": [0, 3] }
+  },
+  "events": [
+    {"type": "violation:allocated_le_onhand", "onHand": 0, "allocated": 1},
+    {"type": "ok", "onHand": 1, "allocated": 0},
+    {"type": "ok", "onHand": 2, "allocated": 1},
+    {"type": "violation:allocated_le_onhand", "onHand": 1, "allocated": 3}
+  ]
+}
+

--- a/tests/formal/heuristics.caution.more-boundaries.2.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.2.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA/ES extra)', () => {
+  it('matches JA/ES attention-like phrases', () => {
+    const samples = [
+      '注意: この結果は要確認',
+      'Aviso: revise los resultados',
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/property/token-optimizer.bullets.reorder.dedup.large.pbt.test.ts
+++ b/tests/property/token-optimizer.bullets.reorder.dedup.large.pbt.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer bulleted lists reorder & dedup (large)', () => {
+  it(
+    formatGWT('large with bullets', 'compressSteeringDocuments', 'bullets dedup; headers first; tokens reduced'),
+    async () => {
+      const uniqueKeysArb = fc
+        .array(fc.constantFrom('product', 'design', 'architecture', 'standards'), { minLength: 2, maxLength: 4 })
+        .map((a) => Array.from(new Set(a)));
+
+      await fc.assert(
+        fc.asyncProperty(uniqueKeysArb, async (keys) => {
+          const docs: Record<string, string> = {};
+          for (const k of keys) {
+            docs[k] = [
+              `# ${k}`,
+              '- A',
+              '- B',
+              '- A',
+              '- C',
+              ('lorem '.repeat(150))
+            ].join('\n');
+          }
+
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments(docs, {
+            preservePriority: ['product', 'design', 'architecture', 'standards'],
+            maxTokens: 9000,
+            enableCaching: false,
+          });
+          const body = res.compressed;
+          // bullets likely deduped to <=3 unique
+          expect((body.match(/^-[ ](A|B|C)$/gmi) || []).length).toBeLessThanOrEqual(3 * keys.length);
+          expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+        }),
+        { numRuns: 5 }
+      );
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.codefence.many.large.pbt.test.ts
+++ b/tests/property/token-optimizer.codefence.many.large.pbt.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer many code fences in large inputs', () => {
+  it(
+    formatGWT('large docs with many code fences', 'compressSteeringDocuments', 'preserve at least one fence; tokens reduced or equal'),
+    async () => {
+      const uniqueKeysArb = fc
+        .array(fc.constantFrom('product', 'design', 'architecture', 'standards'), { minLength: 2, maxLength: 4 })
+        .map((a) => Array.from(new Set(a)));
+
+      await fc.assert(
+        fc.asyncProperty(uniqueKeysArb, async (keys) => {
+          const docs: Record<string, string> = {};
+          for (const k of keys) {
+            docs[k] = [
+              `# ${k}`,
+              '```
+code A
+```
+',
+              '```
+code B
+```
+',
+              '```
+code C
+```
+',
+              ('lorem '.repeat(100)),
+            ].join('\n');
+          }
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments(docs, { preservePriority: ['product', 'design', 'architecture', 'standards'], maxTokens: 8000, enableCaching: false });
+          const body = res.compressed;
+          // At least one code fence should remain
+          expect((body.match(/```/g) || []).length).toBeGreaterThanOrEqual(1);
+          expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+        }),
+        { numRuns: 5 }
+      );
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.duplicate-headers.large.pbt.test.ts
+++ b/tests/property/token-optimizer.duplicate-headers.large.pbt.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer duplicate headers on large inputs', () => {
+  it(
+    formatGWT('large docs with duplicate headers', 'compressSteeringDocuments', 'dedup headers; tokens reduced or equal'),
+    async () => {
+      const uniqueKeysArb = fc
+        .array(fc.constantFrom('product', 'design', 'architecture', 'standards'), { minLength: 2, maxLength: 4 })
+        .map((a) => Array.from(new Set(a)));
+
+      await fc.assert(
+        fc.asyncProperty(uniqueKeysArb, async (keys) => {
+          const docs: Record<string, string> = {};
+          for (const k of keys) {
+            docs[k] = [
+              `# ${k}`,
+              `# ${k}`,
+              `# ${k}`,
+              ('lorem '.repeat(120)),
+            ].join('\n');
+          }
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments(docs, { preservePriority: ['product', 'design', 'architecture', 'standards'], maxTokens: 8000, enableCaching: false });
+          const body = res.compressed;
+          // Expect at most two repeated lines of the same header text in compressed output
+          expect((body.match(/^#\s+(product|design|architecture|standards)$/gmi) || []).length).toBeLessThanOrEqual(2 * keys.length);
+          expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+        }),
+        { numRuns: 5 }
+      );
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.empty-sections.zero-output.pbt.test.ts
+++ b/tests/property/token-optimizer.empty-sections.zero-output.pbt.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer empty sections produce zero or minimal output', () => {
+  it(
+    formatGWT('empty docs', 'compressSteeringDocuments', 'outputs minimal content (<= input tokens)'),
+    async () => {
+      const opt = new TokenOptimizer();
+      const docs: Record<string, string> = { product: '', design: '', architecture: '', standards: '' };
+      const res = await opt.compressSteeringDocuments(docs, { preservePriority: ['product', 'design', 'architecture', 'standards'], maxTokens: 1000, enableCaching: false });
+      expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+      // Body should be small; at least not larger than a few headers
+      expect(res.compressed.length).toBeLessThanOrEqual(200);
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.failure-threshold-2.open.boundary.test.ts
+++ b/tests/resilience/circuit-breaker.failure-threshold-2.open.boundary.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
 
 describe('Resilience: CircuitBreaker failureThreshold=2 boundary', () => {
-  it('opens after two consecutive failures', async () => {
+  it(
+    // GWT-style title for consistency
+    'Given failureThreshold=2 | When two consecutive failures | Then circuit opens (rejects until timeout)',
+    async () => {
     const cb = new CircuitBreaker('fail2', {
       failureThreshold: 2,
       successThreshold: 1,
@@ -13,6 +16,6 @@ describe('Resilience: CircuitBreaker failureThreshold=2 boundary', () => {
     expect(cb.getState()).toBe(CircuitState.CLOSED);
     await expect(cb.execute(async () => { throw new Error('x2'); })).rejects.toBeInstanceOf(Error);
     expect(cb.getState()).toBe(CircuitState.OPEN);
-  });
+  }
+  );
 });
-

--- a/tests/resilience/circuit-breaker.rapid-success-then-fail.opens.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-success-then-fail.opens.short.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid success then fail -> OPEN (short)', () => {
+  it(
+    formatGWT('rapid transitions', 'one success then failure before threshold', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const th = 3;
+      const cb = new CircuitBreaker('rapid-s-then-f', { failureThreshold: 1, successThreshold: th, timeout, monitoringWindow: 80 });
+      // open
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      // half-open
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      // one failure before hitting threshold -> OPEN again
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.rapid-two-success-then-fail.opens.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-two-success-then-fail.opens.short.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid two successes then fail -> OPEN (short)', () => {
+  it(
+    formatGWT('rapid transitions', 'two successes then failure before threshold', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const th = 4;
+      const cb = new CircuitBreaker('rapid-2s-then-f', { failureThreshold: 1, successThreshold: th, timeout, monitoringWindow: 80 });
+      // open
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      // half-open
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      // fail before reaching threshold -> OPEN again
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.transitions.events.test.ts
+++ b/tests/resilience/circuit-breaker.transitions.events.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
 
 describe('Resilience: CircuitBreaker state transition events', () => {
-  it('emits state change events in expected order', async () => {
+  it(
+    // GWT-style title for consistency
+    'Given breaker hooks | When failures and recoveries occur | Then emits state change events in expected order',
+    async () => {
     const events: Array<{evt: string, state?: CircuitState}> = [];
     const cb = new CircuitBreaker('events', {
       failureThreshold: 1,
@@ -27,6 +30,6 @@ describe('Resilience: CircuitBreaker state transition events', () => {
     expect(names).toContain('circuitOpened');
     expect(names).toContain('circuitHalfOpen');
     expect(names).toContain('circuitClosed');
-  });
+  }
+  );
 });
-

--- a/tests/resilience/token-bucket.oversub.replenish.pbt.test.ts
+++ b/tests/resilience/token-bucket.oversub.replenish.pbt.test.ts
@@ -3,7 +3,10 @@ import fc from 'fast-check';
 import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
 
 describe('PBT: TokenBucket oversubscribe with replenish', () => {
-  it('after waiting ~interval, tokens replenish (>0) and <= max', async () => {
+  it(
+    // GWT-style title for consistency
+    'Given empty bucket | When waiting about one interval | Then tokens replenish (>0) and stay <= max',
+    async () => {
     await fc.assert(fc.asyncProperty(
       fc.record({ tokens: fc.integer({ min: 1, max: 10 }), interval: fc.integer({ min: 10, max: 60 }), max: fc.integer({ min: 5, max: 50 }) }),
       async ({ tokens, interval, max }) => {
@@ -19,5 +22,6 @@ describe('PBT: TokenBucket oversubscribe with replenish', () => {
         expect(after).toBeLessThanOrEqual(max);
       }
     ), { numRuns: 20 });
-  });
+  }
+  );
 });

--- a/tests/resilience/token-bucket.tiny-interval.short-variation-2.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.short-variation-2.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval short variation 2 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'short waits [i/5, 1, i/2, 2i]', 'tokens within [0..max]'),
+    async () => {
+      const i = 10;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 3 });
+      for (let k = 0; k < 3; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [Math.max(1, Math.floor(i/5)), 1, Math.max(1, Math.floor(i/2)), 2*i];
+      for (const w of waits) {
+        await new Promise(r => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(3);
+      }
+    }
+  );
+});
+


### PR DESCRIPTION
Advancing #493 with a small but comprehensive test batch.\n\n- TokenBucket: tiny-interval short-variation-2 (fast PBT)\n- CircuitBreaker: rapid two-success then fail -> OPEN (short)\n- TokenOptimizer: bullets reorder/dedup (large), empty sections zero output (PBT)\n- Replay: alt17/alt18 fixtures + docs entries\n- GWT titles: unify 3 existing tests\n- Formal: heuristics caution extra (JA/ES) + regression test\n\nLocal: build OK, test:fast green.\nCI: /verify-lite; optional jobs non-blocking.\n\nRefs: #493 #597 #413 #406 #491 #594