### PR TITLE
test(resilience/ddd): TB short-variation-3 + CB rapid 3s-then-f + TokenOptimizer priority boundary + replay alt19

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -23,6 +23,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt16 byType): `scripts/testing/fixtures/replay-failure.bytype.alt16.sample.json`（byType 風、短系列で onhand_min と allocated の各1件）
 - Failure (alt17 byType): `scripts/testing/fixtures/replay-failure.bytype.alt17.sample.json`（byType 風、onhand_min の複数違反が短系列で発生）
 - Failure (alt18 byType): `scripts/testing/fixtures/replay-failure.bytype.alt18.sample.json`（byType 風、allocated_le_onhand の複数違反）
+- Failure (alt19 byType): `scripts/testing/fixtures/replay-failure.bytype.alt19.sample.json`（byType 風、onhand_min と allocated_le_onhand の混在）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/testing/fixtures/replay-failure.bytype.alt19.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt19.sample.json
@@ -1,0 +1,12 @@
+{
+  "violatedInvariants": {
+    "onhand_min": { "count": 1, "indices": [0] },
+    "allocated_le_onhand": { "count": 1, "indices": [2] }
+  },
+  "events": [
+    {"type": "violation:onhand_min", "onHand": -1, "allocated": 0},
+    {"type": "ok", "onHand": 1, "allocated": 0},
+    {"type": "violation:allocated_le_onhand", "onHand": 0, "allocated": 2}
+  ]
+}
+

--- a/tests/property/token-optimizer.priority.boundary.large.pbt.test.ts
+++ b/tests/property/token-optimizer.priority.boundary.large.pbt.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer priority boundary (large)', () => {
+  it(
+    formatGWT('large with mixed sections', 'compressSteeringDocuments', 'headers follow preservePriority among present'),
+    async () => {
+      const uniqueKeysArb = fc
+        .array(fc.constantFrom('product', 'design', 'architecture', 'standards'), { minLength: 2, maxLength: 4 })
+        .map((a) => Array.from(new Set(a)));
+
+      await fc.assert(
+        fc.asyncProperty(uniqueKeysArb, async (keys) => {
+          const docs: Record<string, string> = {};
+          for (const k of keys) docs[k] = `# ${k}\n` + ('lorem '.repeat(120));
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments(docs, { preservePriority: ['product', 'design', 'architecture', 'standards'], maxTokens: 9000, enableCaching: false });
+          const body = res.compressed;
+          const idx = ['PRODUCT','DESIGN','ARCHITECTURE','STANDARDS'].map(h=> body.indexOf('## '+h)).filter(i=>i>=0);
+          for (let i=1;i<idx.length;i++) expect(idx[i-1]).toBeLessThan(idx[i]);
+          expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+        }),
+        { numRuns: 5 }
+      );
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.rapid-three-success-then-fail.opens.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-three-success-then-fail.opens.short.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid three successes then fail -> OPEN (short)', () => {
+  it(
+    formatGWT('rapid transitions', 'three successes then fail before threshold(4)', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const th = 4;
+      const cb = new CircuitBreaker('rapid-3s-then-f', { failureThreshold: 1, successThreshold: th, timeout, monitoringWindow: 80 });
+      // open
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      // half-open
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      // fail before threshold -> OPEN again
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.short-variation-3.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.short-variation-3.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval short variation 3 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'short waits [i/4, i, 1, 2i]', 'tokens within [0..max]'),
+    async () => {
+      const i = 8;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 3 });
+      for (let k = 0; k < 3; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [Math.max(1, Math.floor(i/4)), i, 1, 2*i];
+      for (const w of waits) {
+        await new Promise(r => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(3);
+      }
+    }
+  );
+});
+


### PR DESCRIPTION
Advancing #493 with small test batch.\n\n- TokenBucket: tiny-interval short-variation-3 (fast PBT)\n- CircuitBreaker: rapid three successes then fail -> OPEN (short)\n- TokenOptimizer: priority boundary (large PBT)\n- Replay: alt19 fixture + docs entry\n\nLocal: build OK, test:fast passes.\nCI: /verify-lite; optional jobs non-blocking.\n\nRefs: #493 #597 #413 #406