### PR TITLE
test(resilience/ddd): TB short-variation-5 + CB rapid 3s-then-f (th5) + TokenOptimizer PBT×2 + replay alt21

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -25,6 +25,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt18 byType): `scripts/testing/fixtures/replay-failure.bytype.alt18.sample.json`（byType 風、allocated_le_onhand の複数違反）
 - Failure (alt19 byType): `scripts/testing/fixtures/replay-failure.bytype.alt19.sample.json`（byType 風、onhand_min と allocated_le_onhand の混在）
 - Failure (alt20 byType): `scripts/testing/fixtures/replay-failure.bytype.alt20.sample.json`（byType 風、allocated と onhand_min の混在・短系列）
+- Failure (alt21 byType): `scripts/testing/fixtures/replay-failure.bytype.alt21.sample.json`（byType 風、allocated と onhand_min の混在・複数違反）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/testing/fixtures/replay-failure.bytype.alt21.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt21.sample.json
@@ -1,0 +1,13 @@
+{
+  "violatedInvariants": {
+    "onhand_min": { "count": 2, "indices": [1, 3] },
+    "allocated_le_onhand": { "count": 1, "indices": [0] }
+  },
+  "events": [
+    {"type": "violation:allocated_le_onhand", "onHand": 0, "allocated": 1},
+    {"type": "violation:onhand_min", "onHand": -1, "allocated": 0},
+    {"type": "ok", "onHand": 1, "allocated": 0},
+    {"type": "violation:onhand_min", "onHand": -2, "allocated": 0}
+  ]
+}
+

--- a/tests/property/token-optimizer.mixed-headers-bullets.large.pbt.test.ts
+++ b/tests/property/token-optimizer.mixed-headers-bullets.large.pbt.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer mixed headers and bullets (large)', () => {
+  it(
+    formatGWT('mixed headers/bullets', 'compressSteeringDocuments', 'headers first; bullets dedup; tokens reduced'),
+    async () => {
+      const uniqueKeysArb = fc
+        .array(fc.constantFrom('product','design','architecture','standards'), { minLength: 2, maxLength: 4 })
+        .map(a=>Array.from(new Set(a)));
+      await fc.assert(
+        fc.asyncProperty(uniqueKeysArb, async (keys) => {
+          const docs: Record<string, string> = {};
+          for (const k of keys) {
+            docs[k] = [
+              `# ${k}`,
+              '- x',
+              '- y',
+              '- x',
+              ('lorem '.repeat(120)),
+            ].join('\n');
+          }
+          const opt = new TokenOptimizer();
+          const res = await opt.compressSteeringDocuments(docs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 9000, enableCaching: false });
+          const body = res.compressed;
+          const idx = ['PRODUCT','DESIGN','ARCHITECTURE','STANDARDS'].map(h=> body.indexOf('## '+h)).filter(i=>i>=0);
+          for (let i=1;i<idx.length;i++) expect(idx[i-1]).toBeLessThan(idx[i]);
+          expect((body.match(/^-[ ](x|y)$/gmi) || []).length).toBeLessThanOrEqual(2*keys.length);
+          expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+        }),
+        { numRuns: 6 }
+      );
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.priority.random-subsets.large.pbt.test.ts
+++ b/tests/property/token-optimizer.priority.random-subsets.large.pbt.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer priority random subsets (large)', () => {
+  it(
+    formatGWT('random subsets', 'compressSteeringDocuments twice', 'idempotent ordering & tokens reduced'),
+    async () => {
+      const uniqueKeysArb = fc
+        .array(fc.constantFrom('product','design','architecture','standards'), { minLength: 1, maxLength: 4 })
+        .map(a=>Array.from(new Set(a)));
+      await fc.assert(
+        fc.asyncProperty(uniqueKeysArb, async (keys) => {
+          const docs: Record<string, string> = {};
+          for (const k of keys) docs[k] = `# ${k}\n` + ('ipsum '.repeat(80));
+          const opt = new TokenOptimizer();
+          const r1 = await opt.compressSteeringDocuments(docs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 8000, enableCaching: false });
+          const r2 = await opt.compressSteeringDocuments(docs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 8000, enableCaching: false });
+          expect(r1.compressed).toBe(r2.compressed);
+          expect(r1.stats.compressed).toBeLessThanOrEqual(r1.stats.original);
+        }),
+        { numRuns: 6 }
+      );
+    }
+  );
+});
+

--- a/tests/resilience/backoff.decorrelated.attempt0.boundary.pbt.test.ts
+++ b/tests/resilience/backoff.decorrelated.attempt0.boundary.pbt.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
+import { formatGWT } from '../utils/gwt-format';
 import fc from 'fast-check';
 import { BackoffStrategy } from '../../src/resilience/backoff-strategies';
 
 describe('PBT: Backoff decorrelated jitter attempt=0 boundary', () => {
-  it('attempt 0: base <= delay <= min(maxDelay, 3*base)', async () => {
+  it(formatGWT('decorrelated jitter', 'attempt=0', 'base <= delay <= min(maxDelay, 3*base)'), async () => {
     await fc.assert(fc.asyncProperty(
       fc.record({ base: fc.integer({ min: 1, max: 400 }), mult: fc.integer({ min: 2, max: 4 }) }),
       async ({ base, mult }) => {
@@ -19,4 +20,3 @@ describe('PBT: Backoff decorrelated jitter attempt=0 boundary', () => {
     ), { numRuns: 30 });
   });
 });
-

--- a/tests/resilience/circuit-breaker.rapid-three-success-then-fail.opens.th5.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-three-success-then-fail.opens.th5.short.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid three successes then fail -> OPEN (th=5, short)', () => {
+  it(
+    formatGWT('rapid transitions', 'three successes then fail before threshold(5)', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const th = 5;
+      const cb = new CircuitBreaker('rapid-3s-then-f-th5', { failureThreshold: 1, successThreshold: th, timeout, monitoringWindow: 100 });
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      for (let i = 0; i < 3; i++) {
+        await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      }
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.short-variation-5.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.short-variation-5.fast.pbt.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval short variation 5 (fast)', () => {
+  it(
+    formatGWT('tiny interval', 'short waits [i/2, 1, i/3, 2i]', 'tokens within [0..max]'),
+    async () => {
+      const i = 12;
+      const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: i, maxTokens: 3 });
+      for (let k = 0; k < 3; k++) await rl.consume(1).catch(() => void 0);
+      const waits = [Math.max(1, Math.floor(i/2)), 1, Math.max(1, Math.floor(i/3)), 2*i];
+      for (const w of waits) {
+        await new Promise(r => setTimeout(r, w));
+        await rl.consume(1).catch(() => void 0);
+        const t = rl.getTokenCount();
+        expect(t).toBeGreaterThanOrEqual(0);
+        expect(t).toBeLessThanOrEqual(3);
+      }
+    }
+  );
+});
+


### PR DESCRIPTION
Advancing #493 with another small batch.\n\n- TokenBucket: tiny-interval short-variation-5 (fast PBT)\n- CircuitBreaker: rapid 3 successes then fail -> OPEN (th=5, short)\n- TokenOptimizer: mixed headers+bullets (large), priority random subsets (large)\n- Replay: alt21 fixture + docs entry\n- GWT: decorrelated attempt0 title\n\nLocal: build OK, test:fast passes.\nCI: /verify-lite; optional jobs non-blocking.\n\nRefs: #493 #597 #413 #406