### PR TITLE
docs(templates): add adapters CI examples index

### DIFF
--- a/docs/templates/adapters/ci-examples.md
+++ b/docs/templates/adapters/ci-examples.md
@@ -1,0 +1,11 @@
+# Adapter CI Examples
+
+This note consolidates adapter-related CI snippets and where to place artifacts.
+
+- Upload  for adapters to be summarized in PR comments.
+- Keep XML/JUnit raw files as artifacts, but aggregate from JSON.
+- See: docs/templates/ci/testing-ddd-scripts.snippet.yml
+
+Minimal snippet:
+
+


### PR DESCRIPTION
Adds docs/templates/adapters/ci-examples.md to consolidate adapter-related CI snippets.\n- Where to upload artifacts\n- Minimal aggregate step example\n\nRefs: #413 (#408)