### PR TITLE
chore(ci/formal): add Apalache presence guard to formal-verify

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -152,6 +152,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Check Apalache presence (non-blocking)
+        run: |
+          node scripts/formal/check-apalache.mjs || true
       - name: Run verify:apalache (summary, non-blocking)
         run: |
           node scripts/formal/verify-apalache.mjs --file "${{ inputs.tlaFile || 'spec/tla/DomainSpec.tla' }}" || true


### PR DESCRIPTION
Adds a non-blocking presence/version guard step (scripts/formal/check-apalache.mjs) to verify:apalache job.\n\nRefs: #594