### PR TITLE
docs(replay): add alt24 byType example

### DIFF
--- a/docs/examples/replay-mapping.md
+++ b/docs/examples/replay-mapping.md
@@ -28,6 +28,7 @@ This note shows a minimal way to prepare inputs and inspect outputs when using t
 - Failure (alt21 byType): `scripts/testing/fixtures/replay-failure.bytype.alt21.sample.json`（byType 風、allocated と onhand_min の混在・複数違反）
 - Failure (alt22 byType): `scripts/testing/fixtures/replay-failure.bytype.alt22.sample.json`（byType 風、allocated/onhand_min の混在・別順序）
 - Failure (alt23 byType): `scripts/testing/fixtures/replay-failure.bytype.alt23.sample.json`（byType 風、onhand_min と allocated の混在・別順序）
+- Failure (alt24 byType): `scripts/testing/fixtures/replay-failure.bytype.alt24.sample.json`（byType 風、onhand_min の複数違反・短系列）
 - Failure (sample3): `scripts/testing/fixtures/replay-failure.sample3.json`（典型的な allocated_le_onhand / onhand_min の違反例）
 
 Quick run

--- a/scripts/testing/fixtures/replay-failure.bytype.alt24.sample.json
+++ b/scripts/testing/fixtures/replay-failure.bytype.alt24.sample.json
@@ -1,0 +1,12 @@
+{
+  "violatedInvariants": {
+    "onhand_min": { "count": 2, "indices": [0, 3] }
+  },
+  "events": [
+    {"type": "violation:onhand_min", "onHand": -1, "allocated": 0},
+    {"type": "ok", "onHand": 0, "allocated": 0},
+    {"type": "ok", "onHand": 1, "allocated": 0},
+    {"type": "violation:onhand_min", "onHand": -2, "allocated": 0}
+  ]
+}
+


### PR DESCRIPTION
Adds scripts/testing/fixtures/replay-failure.bytype.alt24.sample.json and docs link.\n\nRefs: #413