### PR TITLE
chore(formal): add caution boundary 'warning:' + test

### DIFF
--- a/tests/formal/heuristics.caution.more-boundaries.6.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.6.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (warning:)', () => {
+  it('matches EN warning:', () => {
+    const samples = [
+      'Warning: check assumptions',
+      'warning: possible incomplete run'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+


### PR DESCRIPTION
Adds 'warning:' to caution boundaries and regression test.\n\nRefs: #491