### PR TITLE
test(resilience): rapid two successes then fail -> OPEN (th=4, short)

### DIFF
--- a/tests/resilience/circuit-breaker.rapid-two-success-then-fail.opens.th4.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-two-success-then-fail.opens.th4.short.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid two successes then fail -> OPEN (th=4, short)', () => {
+  it(
+    formatGWT('rapid transitions', 'two successes then fail before threshold(4)', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const th = 4;
+      const cb = new CircuitBreaker('rapid-2s-then-f-th4', { failureThreshold: 1, successThreshold: th, timeout, monitoringWindow: 100 });
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+


### PR DESCRIPTION
Adds final rapid CB short sequence for th=4 (two successes then fail -> OPEN).\n\nRefs: #597