### PR TITLE
docs(templates): add Jest/Vitest adapters examples

### DIFF
--- a/docs/templates/adapters/jest/README.md
+++ b/docs/templates/adapters/jest/README.md
@@ -1,0 +1,23 @@
+# Jest Adapter Templates (Examples)
+
+This page shows minimal examples to aggregate Jest test results into JSON suitable for PR summaries.
+
+- Upload raw JUnit XML as artifacts (optional) and aggregate from JSON in CI.
+- Keep JSON in `artifacts/adapters/jest/summary.json` for summary scripts.
+
+Minimal CI snippet:
+```yaml
+- name: Aggregate Jest artifacts
+  run: node scripts/adapters/aggregate-artifacts.mjs || true
+  if: always()
+```
+
+Minimal JSON shape (`artifacts/adapters/jest/summary.json`):
+```json
+{
+  "adapter": "jest",
+  "summary": "passed=120 failed=0",
+  "status": "ok",
+  "traceId": null
+}
+```

--- a/docs/templates/adapters/vitest/README.md
+++ b/docs/templates/adapters/vitest/README.md
@@ -1,0 +1,23 @@
+# Vitest Adapter Templates (Examples)
+
+Vitest can emit JSON summary which can be aggregated in PR comments.
+
+- Write a minimal JSON summary to `artifacts/adapters/vitest/summary.json`.
+- Upload the directory as artifact in CI, and aggregate via `scripts/adapters/aggregate-artifacts.mjs`.
+
+Minimal CI snippet:
+```yaml
+- name: Aggregate Vitest artifacts
+  run: node scripts/adapters/aggregate-artifacts.mjs || true
+  if: always()
+```
+
+Minimal JSON shape (`artifacts/adapters/vitest/summary.json`):
+```json
+{
+  "adapter": "vitest",
+  "summary": "passed=200 failed=0",
+  "status": "ok",
+  "traceId": null
+}
+```


### PR DESCRIPTION
Adds adapter templates examples for Jest/Vitest (artifacts, minimal JSON shape, CI snippet).\n\nRefs: #413 (#408)