### PR TITLE
chore(formal): heuristics — add 'warning:' to CAUTION patterns

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -57,6 +57,7 @@ export const CAUTION_PATTERNS = [
   /achtung[:\s]/i,             // DE "Achtung:"
   /precaución[:\s]/i,          // ES "Precaución:"
   /aviso[:\s]/i,               // ES "Aviso:"
+  /warning[:\s]/i,             // EN "Warning:"
   /notice[:\s]/i,              // EN "Notice:"
   /heads?\s*up[:\s]/i,         // EN "Heads up:"
   /psa[:\s]/i,                 // EN "PSA:"


### PR DESCRIPTION
- 既存の回帰テスト（tests/formal/heuristics.caution.more-boundaries.6.test.ts）に整合するよう、CAUTION_PATTERNS に 'warning:' を追加しました。
- 挙動変更は警告扱いの境界判定のみで、ok/fail 判定には影響しません（computeOkFromOutput は pos/neg のみ参照）。

CI 運用:
- /verify-lite 実行推奨
- ラベル: run-formal 併用で aggregate 側の表示確認が容易です。ci-non-blocking も付与可。
