### PR TITLE
chore/formal heuristics boundaries 7

### DIFF
--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -48,6 +48,11 @@ Timeout（任意）
 - 例: `pnpm run verify:tla -- --engine=apalache --timeout 60000`
 - なお、GNU `timeout` 使用時にタイムアウトが発生すると、summary の `status: "timeout"` となります（非ブロッキング運用）
 
+### Troubleshooting（よくある確認ポイント）
+- PATH: `apalache` または `apalache-mc` が見つからない場合は `node scripts/formal/check-apalache.mjs` で存在/バージョンを確認
+- Timeout: 長時間のログが出続ける場合は `--timeout` を設定し、aggregate コメントの `status: "timeout"` を目安に切り上げ
+- Logs: 生ログは `hermetic-reports/formal/apalache-output.txt` に保存（aggregate コメントは長行をトリム/折返し）
+
 Aggregate JSON の軽量検証（非ブロッキング）
 - 集約ワークフローでは `artifacts/formal/formal-aggregate.json` を出力し、最小スキーマを警告レベルで検証します。
 - ローカル確認: `node scripts/formal/validate-aggregate-json.mjs`（存在時に検証、欠損/不正は `::warning::` 出力）

--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -59,8 +59,10 @@ export const CAUTION_PATTERNS = [
   /aviso[:\s]/i,               // ES "Aviso:"
   /warning[:\s]/i,             // EN "Warning:"
   /notice[:\s]/i,              // EN "Notice:"
+  /nota[:\s]/i,                // ES "Nota:"
   /heads?\s*up[:\s]/i,         // EN "Heads up:"
   /psa[:\s]/i,                 // EN "PSA:"
+  /注意[:：]/,                    // JA "注意:" / 全角コロン対応
   /注意喚起/ ,                  // JA "注意喚起"
   /注意事項/ ,                  // JA "注意事項"
   /注意/                        // JA "注意"

--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -57,6 +57,7 @@ export const CAUTION_PATTERNS = [
   /achtung[:\s]/i,             // DE "Achtung:"
   /precaución[:\s]/i,          // ES "Precaución:"
   /aviso[:\s]/i,               // ES "Aviso:"
+  /warning[:\s]/i,             // EN "Warning:"
   /notice[:\s]/i,              // EN "Notice:"
   /heads?\s*up[:\s]/i,         // EN "Heads up:"
   /psa[:\s]/i,                 // EN "PSA:"

--- a/tests/benchmark/req2run/basic.test.ts
+++ b/tests/benchmark/req2run/basic.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { formatGWT } from '../../tests/utils/gwt-format';
+import { formatGWT } from '../../utils/gwt-format';
 
 describe('Req2Run Benchmark Integration', () => {
   it(formatGWT('benchmark setup', 'initialize basic structure', 'is in place'), () => {

--- a/tests/formal/heuristics.caution.more-boundaries.7.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.7.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA 注意:)', () => {
+  it('matches JA 注意: variant', () => {
+    const samples = [
+      '注意: 入力を確認してください',
+      '注意：仕様の前提を見直してください'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.8.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.8.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (ES Nota:)', () => {
+  it('matches ES Nota:', () => {
+    const samples = [
+      'Nota: revise los invariantes',
+      'nota: verifique los supuestos'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+


### PR DESCRIPTION
- **chore(formal): heuristics — add 'warning:' to CAUTION patterns (regression in tests/formal/heuristics.caution.more-boundaries.6)**
- **docs(formal): add Troubleshooting notes (PATH/timeout/logs) to runbook**
- **test(benchmark): fix GWT helper import path in req2run/basic.test.ts**
- **chore(formal): heuristics CAUTION patterns — add JA '注意:' and ES 'Nota:' (with regressions)**
