### PR TITLE
chore(formal): heuristics CAUTION boundaries (+EN 'Note:' / JA '備考:')

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -58,11 +58,13 @@ export const CAUTION_PATTERNS = [
   /precaución[:\s]/i,          // ES "Precaución:"
   /aviso[:\s]/i,               // ES "Aviso:"
   /warning[:\s]/i,             // EN "Warning:"
+  /note[:\s]/i,                // EN "Note:"
   /notice[:\s]/i,              // EN "Notice:"
   /nota[:\s]/i,                // ES "Nota:"
   /heads?\s*up[:\s]/i,         // EN "Heads up:"
   /psa[:\s]/i,                 // EN "PSA:"
   /注意[:：]/,                    // JA "注意:" / 全角コロン対応
+  /備考[:：]/,                    // JA "備考:" / 全角コロン対応
   /注意喚起/ ,                  // JA "注意喚起"
   /注意事項/ ,                  // JA "注意事項"
   /注意/                        // JA "注意"

--- a/tests/formal/heuristics.caution.more-boundaries.10.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.10.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA 備考:)', () => {
+  it('matches JA 備考: variant', () => {
+    const samples = [
+      '備考: 仕様の補足を確認してください',
+      '備考：この結果は参考値です'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.9.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.9.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (EN Note:)', () => {
+  it('matches EN Note:', () => {
+    const samples = [
+      'Note: review assumptions',
+      'note: check incomplete traces'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+


### PR DESCRIPTION
- CAUTION_PATTERNS に EN 'Note:' と JA '備考:' を追加。\n- 回帰テスト 2 件を追加。\n- ok/fail 判定には非影響（caution 判定のみ）。