### PR TITLE
docs(adapters): compact JSON shape examples (jest/vitest)

### DIFF
--- a/docs/templates/adapters/jest/README.md
+++ b/docs/templates/adapters/jest/README.md
@@ -21,3 +21,13 @@ Minimal JSON shape (`artifacts/adapters/jest/summary.json`):
   "traceId": null
 }
 ```
+
+Alternative compact shape:
+```
+{
+  "tool": "jest",
+  "summary": { "passed": 12, "failed": 0, "skipped": 1 },
+  "files": [ { "path": "tests/foo.test.ts", "passed": 5, "failed": 0 } ]
+}
+```
+This artifact can be aggregated by `scripts/adapters/aggregate-artifacts.mjs` to generate a PR summary.

--- a/docs/templates/adapters/vitest/README.md
+++ b/docs/templates/adapters/vitest/README.md
@@ -21,3 +21,13 @@ Minimal JSON shape (`artifacts/adapters/vitest/summary.json`):
   "traceId": null
 }
 ```
+
+Alternative compact shape:
+```
+{
+  "tool": "vitest",
+  "summary": { "passed": 42, "failed": 0, "skipped": 0 },
+  "suites": [ { "name": "unit", "passed": 30, "failed": 0 } ]
+}
+```
+Aggregated by `scripts/adapters/aggregate-artifacts.mjs` into a single PR summary.

--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -58,11 +58,13 @@ export const CAUTION_PATTERNS = [
   /precaución[:\s]/i,          // ES "Precaución:"
   /aviso[:\s]/i,               // ES "Aviso:"
   /warning[:\s]/i,             // EN "Warning:"
+  /note[:\s]/i,                // EN "Note:"
   /notice[:\s]/i,              // EN "Notice:"
   /nota[:\s]/i,                // ES "Nota:"
   /heads?\s*up[:\s]/i,         // EN "Heads up:"
   /psa[:\s]/i,                 // EN "PSA:"
   /注意[:：]/,                    // JA "注意:" / 全角コロン対応
+  /備考[:：]/,                    // JA "備考:" / 全角コロン対応
   /注意喚起/ ,                  // JA "注意喚起"
   /注意事項/ ,                  // JA "注意事項"
   /注意/                        // JA "注意"

--- a/tests/formal/heuristics.caution.more-boundaries.10.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.10.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA 備考:)', () => {
+  it('matches JA 備考: variant', () => {
+    const samples = [
+      '備考: 仕様の補足を確認してください',
+      '備考：この結果は参考値です'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.9.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.9.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (EN Note:)', () => {
+  it('matches EN Note:', () => {
+    const samples = [
+      'Note: review assumptions',
+      'note: check incomplete traces'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/property/token-optimizer.mixed-headers-fences.large3.alt.pbt.test.ts
+++ b/tests/property/token-optimizer.mixed-headers-fences.large3.alt.pbt.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer mixed headers+fences large3 (alt)', () => {
+  it(
+    formatGWT('mixed alt', 'compressSteeringDocuments', 'one code fence kept; headers lead; tokens reduced'),
+    async () => {
+      const docs: Record<string,string> = {
+        product: ['# product','```','sample','```',('a '.repeat(120))].join('\n'),
+        architecture: ['# architecture',('b '.repeat(110))].join('\n'),
+        standards: ['# standards','- k','- k',('c '.repeat(90))].join('\n'),
+      };
+      const opt = new TokenOptimizer();
+      const res = await opt.compressSteeringDocuments(docs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 10000, enableCaching: false });
+      const body = res.compressed;
+      expect((body.match(/```/g) || []).length).toBeGreaterThanOrEqual(1);
+      const iProd = body.indexOf('## PRODUCT');
+      const iArch = body.indexOf('## ARCHITECTURE');
+      const iStd = body.indexOf('## STANDARDS');
+      expect(iProd).toBeGreaterThanOrEqual(0);
+      expect(iArch).toBeGreaterThan(iProd);
+      expect(iStd).toBeGreaterThan(iArch);
+      expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+    }
+  );
+});
+

--- a/tests/property/token-optimizer.priority.extreme.boundary.large4.pbt.test.ts
+++ b/tests/property/token-optimizer.priority.extreme.boundary.large4.pbt.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer priority extreme boundary 4 (large)', () => {
+  it(
+    formatGWT('missing middle priority', 'compressSteeringDocuments', 'order respects present sections only'),
+    async () => {
+      const opt = new TokenOptimizer();
+      const docs = {
+        product: '# product\n' + 'lorem '.repeat(100),
+        standards: '# standards\n' + 'ipsum '.repeat(80)
+      } as Record<string,string>;
+      const res = await opt.compressSteeringDocuments(docs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 7000, enableCaching: false });
+      const body = res.compressed;
+      const iProd = body.indexOf('## PRODUCT');
+      const iStd = body.indexOf('## STANDARDS');
+      expect(iProd).toBeGreaterThanOrEqual(0);
+      expect(iStd).toBeGreaterThan(iProd);
+      expect(res.stats.compressed).toBeLessThanOrEqual(res.stats.original);
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.rapid-one-success-then-fail.opens.th3.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-one-success-then-fail.opens.th3.short.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid one success then fail -> OPEN (th=3, short)', () => {
+  it(
+    formatGWT('rapid transitions', 'one success then failure before threshold(3)', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const th = 3;
+      const cb = new CircuitBreaker('rapid-1s-then-f-th3', { failureThreshold: 1, successThreshold: th, timeout, monitoringWindow: 100 });
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+


### PR DESCRIPTION
- jest/vitest のテンプレートREADMEに、コンパクトなJSON形状の例と集約スクリプトの注記を追記。\n- 既存のCI断片と整合。