### PR TITLE
chore: remove stray merge markers in scripts/verify/* and fix Inventory.tla Init

### DIFF
--- a/scripts/verify/execute-contracts.ts
+++ b/scripts/verify/execute-contracts.ts
@@ -82,7 +82,6 @@ async function main() {
                     if (req.includes(k) && (sample[k] === '' || sample[k] === null || sample[k] === undefined)) {
                       sample[k] = sample[k] === '' ? 'REQUIRED' : sample[k];
                     }
->>>>>>> e2a347e (verify: add OpenAPI sample, contracts skeleton, TLC Spec fix, traceability links (refs #381))
                   }
                 }
                 if (schema.default !== undefined) return schema.default;
@@ -125,7 +124,6 @@ async function main() {
               if (!derived) {
                 if (names.length > 0) input = synth((schemas as any)[names[0]]);
                 else if (pathKeys.length > 0) input = { path: pathKeys[0] };
->>>>>>> e2a347e (verify: add OpenAPI sample, contracts skeleton, TLC Spec fix, traceability links (refs #381))
               if (names.length > 0) {
                 input = synth((schemas as any)[names[0]]);
               } else {

--- a/specs/formal/tla+/Inventory.tla
+++ b/specs/formal/tla+/Inventory.tla
@@ -8,8 +8,6 @@ VARIABLES stock, reserved
 \* Scenario: idempotent-by-order-id @inventory @idempotency
 
 Init == /\ stock = MaxStock /\ reserved = [o \in Orders |-> 0]
->>>>>>> e2a347e (verify: add OpenAPI sample, contracts skeleton, TLC Spec fix, traceability links (refs #381))
-Init == /\ stock = MaxStock /\ reserved = [o \in {} |-> 0]
 
 Reserve(o, q) ==
   /\ o \in Orders


### PR DESCRIPTION
- 残存していたマージマーカー（>>>>>>）を削除し、TLA Spec の Init 重複を整理しました。\n- いずれも動作非影響（scripts はCIのオプションステップ、specは雛形）。\n- /verify-lite を起動し、以降のPRでの競合再発を抑止します。