### PR TITLE
chore(formal): aggregate MD micro-polish + Apalache error extraction

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -199,7 +199,7 @@ jobs:
             }
           };
           // Append an explicit consistency line referencing JSON info.present
-          lines.push(`Consistency: present in MD/JSON = ok (${presentCount}/5)`);
+          lines.push(`Consistency: MD=JSON present (${presentCount}/5)`);
           lines.push('_Source: info.present (aggregate JSON)_');
           const md = normalizeMd(lines);
           fs.writeFileSync(outMd, md);

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -97,7 +97,7 @@ const SNIPPET_AFTER = Number(process.env.APALACHE_SNIPPET_AFTER || '2');
 
 function extractErrors(out){
   const lines = (out || '').split(/\r?\n/);
-  const key = /error|violat|counterexample|fail/i;
+  const key = /error|violat|counterexample|fail|unsatisfied/i;
   const picked = [];
   for (const l of lines) { if (key.test(l)) picked.push(l.trim()); if (picked.length>=ERRORS_LIMIT) break; }
   // Trim very long lines for readability in aggregate comments
@@ -105,7 +105,7 @@ function extractErrors(out){
 }
 function countErrors(out){
   const lines = (out || '').split(/\r?\n/);
-  const key = /error|violat|counterexample|fail/i;
+  const key = /error|violat|counterexample|fail|unsatisfied/i;
   let n = 0; for (const l of lines) if (key.test(l)) n++;
   return n;
 }


### PR DESCRIPTION
- Aggregateコメントの一行表記を微調整（Consistency行）。\n- Apalacheのエラー抽出に 'unsatisfied' を追加（負の指標に合致するログの拾い漏れを低減）。\n- 挙動非破壊、非ブロッキング。