### PR TITLE
chore+test: Formal CAUTION (ES 'Advertencia:' / JA '警告') + CB th=5 (4succ→fail) + TB alt-20

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -56,6 +56,7 @@ export const CAUTION_PATTERNS = [
   /attention[:\s]/i,           // EN/FR-like "attention:"
   /achtung[:\s]/i,             // DE "Achtung:"
   /precaución[:\s]/i,          // ES "Precaución:"
+  /advertencia[:\s]/i,         // ES "Advertencia:"
   /aviso[:\s]/i,               // ES "Aviso:"
   /warning[:\s]/i,             // EN "Warning:"
   /note[:\s]/i,                // EN "Note:"
@@ -68,6 +69,7 @@ export const CAUTION_PATTERNS = [
   /heads?\s*up[:\s]/i,         // EN "Heads up:"
   /psa[:\s]/i,                 // EN "PSA:"
   /注意[:：]/,                    // JA "注意:" / 全角コロン対応
+  /警告[:：]?/ ,                  // JA "警告:"（コロン有無）
   /備考[:：]/,                    // JA "備考:" / 全角コロン対応
   /留意点/ ,                    // JA "留意点"
   /重要[:：]/ ,                  // JA "重要:" / 全角コロン対応

--- a/tests/formal/heuristics.caution.more-boundaries.18.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.18.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (ES Advertencia:)', () => {
+  it('matches ES Advertencia:', () => {
+    const samples = [
+      'Advertencia: revise los supuestos',
+      'advertencia: exploración parcial'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.19.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.19.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA 警告:)', () => {
+  it('matches JA 警告: variant', () => {
+    const samples = [
+      '警告: 結果は参考です',
+      '警告：前提条件を確認してください'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/resilience/circuit-breaker.rapid-four-success-then-fail.opens.th5.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-four-success-then-fail.opens.th5.short.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid four successes then fail -> OPEN (th=5, short)', () => {
+  it(
+    formatGWT('rapid transitions', 'four successes then fail before threshold(5)', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const th = 5;
+      const cb = new CircuitBreaker('rapid-4s-then-f-th5', { failureThreshold: 1, successThreshold: th, timeout, monitoringWindow: 100 });
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-20.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-20.fast.pbt.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt-pattern-20 (fast)', () => {
+  it(
+    formatGWT('tiny interval varied waits', 'apply waits [i/6, 2i, 1, i]', 'tokens within [0,max]'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2, max: 6 }),
+          fc.integer({ min: 1, max: 3 }),
+          async (maxTokens, per) => {
+            const interval = 12;
+            const rl = new TokenBucketRateLimiter({ maxTokens, tokensPerInterval: per, interval });
+            for (let i = 0; i < maxTokens; i++) await rl.consume(1).catch(() => void 0);
+            const waits = [Math.max(1, Math.floor(interval/6)), 2*interval, 1, interval];
+            for (const w of waits) {
+              await new Promise((r) => setTimeout(r, w));
+              await rl.consume(1).catch(() => void 0);
+              const t = rl.getTokenCount();
+              expect(t).toBeGreaterThanOrEqual(0);
+              expect(t).toBeLessThanOrEqual(maxTokens);
+            }
+          }
+        ),
+        { numRuns: 10 }
+      );
+    }
+  );
+});
+


### PR DESCRIPTION
- Formal heuristics: CAUTION 境界に 'Advertencia:'（ES）/'警告:'（JA）を追加（回帰18/19）。\n- Resilience: CB rapid 4成功→失敗（th=5, short）/ TB tiny-interval alt-20 を追加。\n- 非ブロッキング・高速テスト（numRuns控えめ）。