### PR TITLE
chore+test: CAUTION (ES 'Atención:' / JA 'ご注意') + TB alt-22 + TokenOptimizer present-only alt3

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -56,6 +56,7 @@ export const CAUTION_PATTERNS = [
   /attention[:\s]/i,           // EN/FR-like "attention:"
   /achtung[:\s]/i,             // DE "Achtung:"
   /precaución[:\s]/i,          // ES "Precaución:"
+  /atención[:\s]/i,            // ES "Atención:"
   /advertencia[:\s]/i,         // ES "Advertencia:"
   /aviso[:\s]/i,               // ES "Aviso:"
   /warning[:\s]/i,             // EN "Warning:"
@@ -66,12 +67,14 @@ export const CAUTION_PATTERNS = [
   /\bN\.?B\.?[:\s]/i,          // EN "NB:" / "N.B.:"
   /hinweis[:\s]/i,             // DE "Hinweis:"
   /warnung[:\s]/i,             // DE "Warnung:"
+  /vorsicht[:\s]/i,            // DE "Vorsicht:"
   /remarque[:\s]/i,            // FR "Remarque:"
   /avertissement[:\s]/i,       // FR "Avertissement:"
   /nota[:\s]/i,                // ES "Nota:"
   /heads?\s*up[:\s]/i,         // EN "Heads up:"
   /psa[:\s]/i,                 // EN "PSA:"
   /注意[:：]/,                    // JA "注意:" / 全角コロン対応
+  /ご注意/ ,                      // JA "ご注意"
   /警告[:：]?/ ,                  // JA "警告:"（コロン有無）
   /備考[:：]/,                    // JA "備考:" / 全角コロン対応
   /留意点/ ,                    // JA "留意点"

--- a/tests/formal/heuristics.caution.more-boundaries.22.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.22.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (ES Atención:)', () => {
+  it('matches ES Atención:', () => {
+    const samples = [
+      'Atención: verifique los invariantes',
+      'atención: ejecución parcial'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.23.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.23.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA ご注意)', () => {
+  it('matches JA ご注意', () => {
+    const samples = [
+      'ご注意: 仕様の注意点を確認してください',
+      'ご注意 この検査は参考値です'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/property/token-optimizer.present-only.sections.large.alt3.pbt.test.ts
+++ b/tests/property/token-optimizer.present-only.sections.large.alt3.pbt.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenOptimizer present-only sections (large alt3)', () => {
+  it(
+    formatGWT('docs with product only', 'compressSteeringDocuments', 'no absent sections introduced'),
+    async () => {
+      const docs: Record<string,string> = {
+        product: '# product\n' + 'alpha '.repeat(180)
+      };
+      const opt = new TokenOptimizer();
+      const { compressed, stats } = await opt.compressSteeringDocuments(docs, { preservePriority: ['product','design','architecture','standards'], maxTokens: 12000, enableCaching: false });
+      expect(stats.compressed).toBeLessThanOrEqual(stats.original);
+      expect(compressed.includes('## DESIGN')).toBe(false);
+      expect(compressed.includes('## ARCHITECTURE')).toBe(false);
+      expect(compressed.includes('## STANDARDS')).toBe(false);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-22.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-22.fast.pbt.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt-pattern-22 (fast)', () => {
+  it(
+    formatGWT('tiny interval varied waits', 'apply waits [i, i/4, 2i, i/2]', 'tokens within [0,max]'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2, max: 6 }),
+          fc.integer({ min: 1, max: 3 }),
+          async (maxTokens, per) => {
+            const interval = 8;
+            const rl = new TokenBucketRateLimiter({ maxTokens, tokensPerInterval: per, interval });
+            for (let i = 0; i < maxTokens; i++) await rl.consume(1).catch(() => void 0);
+            const waits = [interval, Math.max(1, Math.floor(interval/4)), 2*interval, Math.max(1, Math.floor(interval/2))];
+            for (const w of waits) {
+              await new Promise((r) => setTimeout(r, w));
+              await rl.consume(1).catch(() => void 0);
+              const t = rl.getTokenCount();
+              expect(t).toBeGreaterThanOrEqual(0);
+              expect(t).toBeLessThanOrEqual(maxTokens);
+            }
+          }
+        ),
+        { numRuns: 10 }
+      );
+    }
+  );
+});
+


### PR DESCRIPTION
- Formal heuristics: CAUTION 境界に 'Atención:'（ES）/'ご注意'（JA）を追加（回帰22/23）。\n- Resilience: TB tiny-interval alt-22 を追加。\n- Property: TokenOptimizer PBT（present-only alt3）。\n- 非ブロッキング・高速テスト。