### PR TITLE
chore+test: CAUTION (ES 'Cuidado:' / JA '注意点') + CB th=5 (5succ→fail) + TB alt-23 + TokenOptimizer truncate alt2

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -57,6 +57,7 @@ export const CAUTION_PATTERNS = [
   /achtung[:\s]/i,             // DE "Achtung:"
   /precaución[:\s]/i,          // ES "Precaución:"
   /atención[:\s]/i,            // ES "Atención:"
+  /cuidado[:\s]/i,             // ES "Cuidado:"
   /advertencia[:\s]/i,         // ES "Advertencia:"
   /aviso[:\s]/i,               // ES "Aviso:"
   /warning[:\s]/i,             // EN "Warning:"
@@ -78,6 +79,7 @@ export const CAUTION_PATTERNS = [
   /警告[:：]?/ ,                  // JA "警告:"（コロン有無）
   /備考[:：]/,                    // JA "備考:" / 全角コロン対応
   /留意点/ ,                    // JA "留意点"
+  /注意点/ ,                    // JA "注意点"
   /重要[:：]/ ,                  // JA "重要:" / 全角コロン対応
   /注記[:：]?/ ,                 // JA "注記:"（コロン有無）
   /補足[:：]?/ ,                 // JA "補足:"（コロン有無）

--- a/tests/formal/heuristics.caution.more-boundaries.24.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.24.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (ES Cuidado:)', () => {
+  it('matches ES Cuidado:', () => {
+    const samples = [
+      'Cuidado: verifique los supuestos',
+      'cuidado: ejecución parcial'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.25.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.25.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA 注意点)', () => {
+  it('matches JA 注意点', () => {
+    const samples = [
+      '注意点: 事前条件を見直してください',
+      'この検査には注意点があります'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/property/token-optimizer.truncate.sentinel.alt2.test.ts
+++ b/tests/property/token-optimizer.truncate.sentinel.alt2.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('TokenOptimizer truncate sentinel (alt2)', () => {
+  it(
+    formatGWT('many large sections', 'compress with very small maxTokens', 'appends [...truncated] sentinel and no absent sections introduced'),
+    async () => {
+      const docs: Record<string,string> = {
+        product: '# product\n' + 'alpha '.repeat(200),
+        architecture: '# architecture\n' + 'beta '.repeat(200),
+        standards: '# standards\n' + 'gamma '.repeat(200)
+      };
+      const opt = new TokenOptimizer();
+      const { compressed, stats } = await opt.compressSteeringDocuments(docs, { maxTokens: 200, enableCaching: false });
+      expect(stats.compressed).toBeLessThanOrEqual(200);
+      expect(compressed.includes('[...truncated]')).toBe(true);
+      expect(compressed.includes('## DESIGN')).toBe(false);
+    }
+  );
+});
+

--- a/tests/resilience/circuit-breaker.rapid-five-success-then-fail.opens.th5.short.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-five-success-then-fail.opens.th5.short.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker rapid five successes then fail -> OPEN (th=5, short)', () => {
+  it(
+    formatGWT('rapid transitions', 'five successes then fail at threshold(5)', 'closes then reopens to OPEN on failure'),
+    async () => {
+      const timeout = 20;
+      const th = 5;
+      const cb = new CircuitBreaker('rapid-5s-then-f-th5', { failureThreshold: 1, successThreshold: th, timeout, monitoringWindow: 100 });
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      await new Promise((r) => setTimeout(r, timeout + 2));
+      // Five successes to close
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      expect(cb.getState()).toBe(CircuitState.CLOSED);
+      // Failure after closed should open again (given failureThreshold=1)
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-23.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-23.fast.pbt.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt-pattern-23 (fast)', () => {
+  it(
+    formatGWT('tiny interval varied waits', 'apply waits [2i, i, i/4, 1]', 'tokens within [0,max]'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2, max: 6 }),
+          fc.integer({ min: 1, max: 3 }),
+          async (maxTokens, per) => {
+            const interval = 12;
+            const rl = new TokenBucketRateLimiter({ maxTokens, tokensPerInterval: per, interval });
+            for (let i = 0; i < maxTokens; i++) await rl.consume(1).catch(() => void 0);
+            const waits = [2*interval, interval, Math.max(1, Math.floor(interval/4)), 1];
+            for (const w of waits) {
+              await new Promise((r) => setTimeout(r, w));
+              await rl.consume(1).catch(() => void 0);
+              const t = rl.getTokenCount();
+              expect(t).toBeGreaterThanOrEqual(0);
+              expect(t).toBeLessThanOrEqual(maxTokens);
+            }
+          }
+        ),
+        { numRuns: 10 }
+      );
+    }
+  );
+});
+


### PR DESCRIPTION
- Formal heuristics: CAUTION 境界に 'Cuidado:'（ES）/'注意点'（JA）を追加（回帰24/25）。\n- Resilience: CB rapid 5成功→失敗（th=5, short）/ TB tiny-interval alt-23 を追加。\n- Property: TokenOptimizer truncate alt2（小maxTokensでsentinel付加・欠損セクション非導入）。\n- 非ブロッキング・高速テスト。