### PR TITLE
chore+test: CAUTION (NL) + TB alt-25 + GWT (BenchmarkRunner)

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -74,6 +74,8 @@ export const CAUTION_PATTERNS = [
   /nota[:\s]/i,                // ES "Nota:"
   /attenzione[:\s]/i,          // IT "Attenzione:"
   /aten[cç]ão[:\s]/i,          // PT "Atenção:"
+  /let\s*op[:\s]/i,            // NL "Let op:"
+  /opgelet[:\s]/i,             // NL "Opgelet:"
   /heads?\s*up[:\s]/i,         // EN "Heads up:"
   /psa[:\s]/i,                 // EN "PSA:"
   /注意[:：]/,                    // JA "注意:" / 全角コロン対応

--- a/tests/benchmark/req2run/BenchmarkRunner.test.ts
+++ b/tests/benchmark/req2run/BenchmarkRunner.test.ts
@@ -148,13 +148,13 @@ describe('BenchmarkRunner', () => {
   });
 
   describe('runBenchmarks', () => {
-    it('should handle empty problem list', async () => {
+    it(formatGWT('empty list', 'runBenchmarks', 'returns empty results'), async () => {
       const results = await runner.runBenchmarks([]);
       
       expect(results).toEqual([]);
     });
 
-    it('should run multiple problems sequentially when parallel is false', async () => {
+    it(formatGWT('sequential run', 'runBenchmarks (parallel=false)', 'runs problems in sequence'), async () => {
       const problemIds = ['problem-1', 'problem-2', 'problem-3'];
       const startTime = Date.now();
       

--- a/tests/formal/heuristics.caution.more-boundaries.28.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.28.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (NL Let op:)', () => {
+  it('matches NL Let op:', () => {
+    const samples = [
+      'Let op: controleer de aannames',
+      'let op: gedeeltelijke verkenning'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.29.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.29.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (NL Opgelet:)', () => {
+  it('matches NL Opgelet:', () => {
+    const samples = [
+      'Opgelet: controleer de assumpties',
+      'opgelet: onvolledige uitvoering'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/resilience/token-bucket.tiny-interval.alt-pattern-25.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.tiny-interval.alt-pattern-25.fast.pbt.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('PBT: TokenBucket tiny-interval alt-pattern-25 (fast)', () => {
+  it(
+    formatGWT('tiny interval varied waits', 'apply waits [i/5, i/2, i, 2i, 1]', 'tokens within [0,max]'),
+    async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.integer({ min: 2, max: 6 }),
+          fc.integer({ min: 1, max: 3 }),
+          async (maxTokens, per) => {
+            const interval = 10;
+            const rl = new TokenBucketRateLimiter({ maxTokens, tokensPerInterval: per, interval });
+            for (let i = 0; i < maxTokens; i++) await rl.consume(1).catch(() => void 0);
+            const waits = [Math.max(1, Math.floor(interval/5)), Math.max(1, Math.floor(interval/2)), interval, 2*interval, 1];
+            for (const w of waits) {
+              await new Promise((r) => setTimeout(r, w));
+              await rl.consume(1).catch(() => void 0);
+              const t = rl.getTokenCount();
+              expect(t).toBeGreaterThanOrEqual(0);
+              expect(t).toBeLessThanOrEqual(maxTokens);
+            }
+          }
+        ),
+        { numRuns: 10 }
+      );
+    }
+  );
+});
+


### PR DESCRIPTION
- Formal heuristics: CAUTION 境界に 'Let op:'／'Opgelet:'（NL）を追加（回帰28/29）。\n- Resilience: TB tiny-interval alt-25 を追加。\n- Tests: BenchmarkRunner の empty/sequential を GWT タイトル統一。\n- 非ブロッキング・高速テスト。