### PR TITLE
test(formal,resilience,property): heuristics CAUTION +2（FR/JA）; CB th5 close→rapid fail; TokenOptimizer PBT +2

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -71,6 +71,7 @@ export const CAUTION_PATTERNS = [
   /vorsicht[:\s]/i,            // DE "Vorsicht:"
   /remarque[:\s]/i,            // FR "Remarque:"
   /avertissement[:\s]/i,       // FR "Avertissement:"
+  /veuillez\s+noter[:\s]/i,    // FR "Veuillez noter:"
   /nota[:\s]/i,                // ES "Nota:"
   /attenzione[:\s]/i,          // IT "Attenzione:"
   /aten[cç]ão[:\s]/i,          // PT "Atenção:"
@@ -91,6 +92,7 @@ export const CAUTION_PATTERNS = [
   /注意喚起/ ,                  // JA "注意喚起"
   /注意事項/ ,                  // JA "注意事項"
   /注意/                        // JA "注意"
+  ,/ご承知おきください/         // JA 丁寧な注意喚起
 ];
 
 export function computeOkFromOutput(out){

--- a/tests/formal/heuristics.caution.more-boundaries.32.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.32.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (FR Veuillez noter:)', () => {
+  it('matches FR Veuillez noter:', () => {
+    const samples = [
+      'Veuillez noter: ces résultats sont partiels',
+      'veuillez noter: vérifiez les hypothèses avant de conclure'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.33.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.33.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA ご承知おきください)', () => {
+  it('matches JA ご承知おきください', () => {
+    const samples = [
+      'ご承知おきください: これは注意喚起であり、失敗の確定ではありません',
+      'ご承知おきください。実行条件に制約があります'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/property/token-optimizer.optimize-context.monotonic.pbt.test.ts
+++ b/tests/property/token-optimizer.optimize-context.monotonic.pbt.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import fc from 'fast-check';
+
+describe('PBT: TokenOptimizer optimizeContext monotonicity (tokens)', () => {
+  it('optimized tokens should not decrease when maxTokens increases', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.string({ minLength: 200, maxLength: 1200 }),
+        fc.array(fc.string({ minLength: 3, maxLength: 10 }), { minLength: 0, maxLength: 5 }),
+        async (text, keywords) => {
+          const opt = new TokenOptimizer();
+          const small = await opt.optimizeContext(text, 200, keywords);
+          const large = await opt.optimizeContext(text, 400, keywords);
+          expect(large.stats.compressed).toBeGreaterThanOrEqual(small.stats.compressed);
+        }
+      ),
+      { numRuns: 10 }
+    );
+  });
+});
+

--- a/tests/property/token-optimizer.present-only.sections.large.alt4.pbt.test.ts
+++ b/tests/property/token-optimizer.present-only.sections.large.alt4.pbt.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import fc from 'fast-check';
+
+describe('PBT: TokenOptimizer present-only sections (large alt4)', () => {
+  it('output includes only present sections and priority order preserved', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          product: fc.option(fc.string({ minLength: 50, maxLength: 300 }), { nil: undefined }),
+          architecture: fc.option(fc.string({ minLength: 50, maxLength: 300 }), { nil: undefined }),
+          standards: fc.option(fc.string({ minLength: 50, maxLength: 300 }), { nil: undefined }),
+          misc: fc.option(fc.string({ minLength: 50, maxLength: 300 }), { nil: undefined })
+        }),
+        async (docs) => {
+          const opt = new TokenOptimizer();
+          const { compressed } = await opt.compressSteeringDocuments(docs as any, { maxTokens: 800, compressionLevel: 'medium' });
+          const present = Object.entries(docs).filter(([_, v]) => typeof v === 'string');
+          // ensure missing are not present
+          for (const [name, v] of Object.entries(docs)) {
+            if (!v) {
+              expect(compressed).not.toMatch(new RegExp(`^## ${name.toUpperCase()}`, 'm'));
+            }
+          }
+          // ensure priority order among present priority sections
+          const order = ['PRODUCT', 'ARCHITECTURE', 'STANDARDS'];
+          const presentPriority = order.filter(h => present.some(([n]) => n.toUpperCase() === h));
+          const idx = presentPriority.map(h => compressed.indexOf(`\n## ${h}\n`)).filter(i => i >= 0);
+          const sorted = [...idx].sort((a,b)=>a-b);
+          expect(idx).toEqual(sorted);
+        }
+      ),
+      { numRuns: 8 }
+    );
+  });
+});
+

--- a/tests/resilience/circuit-breaker.close-then-rapid-failure.opens-again.th5.test.ts
+++ b/tests/resilience/circuit-breaker.close-then-rapid-failure.opens-again.th5.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker close then rapid failure -> OPEN (th=5)', () => {
+  it(
+    formatGWT('OPEN after fail', 'five successes -> CLOSED then rapid failure', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const cb = new CircuitBreaker('close-then-rapid-fail-th5', { failureThreshold: 1, successThreshold: 5, timeout, monitoringWindow: 100 });
+      await expect(cb.execute(async () => { throw new Error('f1'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      await new Promise(r => setTimeout(r, timeout + 2));
+      for (let i = 0; i < 5; i++) {
+        await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      }
+      expect(cb.getState()).toBe(CircuitState.CLOSED);
+      // Rapid subsequent failure in CLOSED should re-open on threshold=1
+      await expect(cb.execute(async () => { throw new Error('f2'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+


### PR DESCRIPTION
- Formal heuristics: add FR "Veuillez noter:", JA "ご承知おきください"
- Resilience: th=5 close→rapid failure returns to OPEN (short)
- TokenOptimizer: optimizeContext monotonic tokens; present-only sections large alt4

Validation
- Local: pnpm types:check && pnpm build OK
- test:fast: 1 flaky failure in contracts (non-blocking by policy); others green

CI
- Please trigger Verify Lite via /verify-lite. Optionally add labels: run-qa, ci-non-blocking.
