### PR TITLE
chore(formal): apalache verify key phrases (unsat/dead end)

### DIFF
--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -97,7 +97,7 @@ const SNIPPET_AFTER = Number(process.env.APALACHE_SNIPPET_AFTER || '2');
 
 function extractErrors(out){
   const lines = (out || '').split(/\r?\n/);
-  const key = /error|violat|counterexample|fail|unsatisfied|deadlock/i;
+  const key = /error|violat|counterexample|fail|unsatisfied|unsat\b|dead\s*lock|dead\s*end/i;
   const picked = [];
   for (const l of lines) { if (key.test(l)) picked.push(l.trim()); if (picked.length>=ERRORS_LIMIT) break; }
   // Trim very long lines for readability in aggregate comments
@@ -105,13 +105,13 @@ function extractErrors(out){
 }
 function countErrors(out){
   const lines = (out || '').split(/\r?\n/);
-  const key = /error|violat|counterexample|fail|unsatisfied|deadlock/i;
+  const key = /error|violat|counterexample|fail|unsatisfied|unsat\b|dead\s*lock|dead\s*end/i;
   let n = 0; for (const l of lines) if (key.test(l)) n++;
   return n;
 }
 function extractErrorSnippet(out, before=SNIPPET_BEFORE, after=SNIPPET_AFTER){
   const lines = (out || '').split(/\r?\n/);
-  const key = /error|violat|counterexample|fail/i;
+  const key = /error|violat|counterexample|fail|unsatisfied|unsat\b|dead\s*lock|dead\s*end/i;
   for (let i=0;i<lines.length;i++){
     if (key.test(lines[i])){
       const start = Math.max(0, i-before);


### PR DESCRIPTION
- verify-apalache.mjs: extend error/snippet key phrases to include `unsat`, `dead end` (in addition to existing error/violation/counterexample/fail/unsatisfied/deadlock)
- Non-blocking path; improves robustness of summary extraction

Validation
- Local: pnpm types:check && pnpm build && pnpm test:fast — green

CI
- Please trigger /verify-lite; optional labels: run-formal, ci-non-blocking
