### PR TITLE
chore(formal-aggregate): deterministic Present order (tla,alloy,smt,apalache,conformance)

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -84,7 +84,8 @@ jobs:
             conformance: !!confSum
           };
           // Quick one-line present/ran summary（MD表示とJSONのpresentを完全同期）
-          const presentKeys = Object.entries(present).filter(([k,v])=>v).map(([k])=>k);
+          const order = ['tla','alloy','smt','apalache','conformance'];
+          const presentKeys = order.filter(k => present[k]);
           const presentCount = presentKeys.length;
           const apLine = apalacheSum && apalache ? `ran=${apalache.ran? 'yes':'no'} ok=${apalache.ok==null? 'n/a': (apalache.ok? 'yes':'no')}` : 'n/a';
           lines.push(`Present: ${presentCount}/5${presentCount? ` (${presentKeys.join(', ')})` : ''}`);


### PR DESCRIPTION
- Aggregate MD Present 行の順序を固定化（tla, alloy, smt, apalache, conformance）
- JSON(info.present) と整合（MDは同じ present を参照）

Validation
- Local: pnpm types:check && pnpm build && pnpm test:fast — green

CI
- Please trigger /verify-lite; optional labels: run-formal, ci-non-blocking
