### PR TITLE
test(property): TokenOptimizer cache eviction boundary + truncate boundary PBT

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -84,7 +84,8 @@ jobs:
             conformance: !!confSum
           };
           // Quick one-line present/ran summary（MD表示とJSONのpresentを完全同期）
-          const presentKeys = Object.entries(present).filter(([k,v])=>v).map(([k])=>k);
+          const order = ['tla','alloy','smt','apalache','conformance'];
+          const presentKeys = order.filter(k => present[k]);
           const presentCount = presentKeys.length;
           const apLine = apalacheSum && apalache ? `ran=${apalache.ran? 'yes':'no'} ok=${apalache.ok==null? 'n/a': (apalache.ok? 'yes':'no')}` : 'n/a';
           lines.push(`Present: ${presentCount}/5${presentCount? ` (${presentKeys.join(', ')})` : ''}`);

--- a/tests/property/token-optimizer.cache.eviction.boundary.test.ts
+++ b/tests/property/token-optimizer.cache.eviction.boundary.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+
+describe('TokenOptimizer: cache eviction boundary', () => {
+  it('cache size never exceeds maxSize under repeated compressions', async () => {
+    const opt = new TokenOptimizer();
+    // Generate more than internal CACHE_SIZE (=100)
+    const N = 120;
+    for (let i = 0; i < N; i++) {
+      const docs = { product: `p-${i}`, architecture: `a-${i}`, standards: `s-${i}` } as any;
+      await opt.compressSteeringDocuments(docs, { maxTokens: 200, compressionLevel: 'low', enableCaching: true });
+    }
+    const stats = opt.getCacheStats();
+    expect(stats.size).toBeLessThanOrEqual(stats.maxSize);
+  });
+});
+

--- a/tests/property/token-optimizer.truncate.boundary.large.pbt.test.ts
+++ b/tests/property/token-optimizer.truncate.boundary.large.pbt.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer';
+import fc from 'fast-check';
+
+describe('PBT: TokenOptimizer truncate boundary (large)', () => {
+  it('compressed estimateTokens should be <= maxTokens when max is small', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          product: fc.string({ minLength: 200, maxLength: 1200 }),
+          architecture: fc.string({ minLength: 200, maxLength: 1200 }),
+          standards: fc.string({ minLength: 200, maxLength: 1200 })
+        }),
+        async (docs) => {
+          const opt = new TokenOptimizer();
+          const maxTokens = 150; // intentionally small to trigger truncation
+          const { compressed } = await opt.compressSteeringDocuments(docs as any, { maxTokens, compressionLevel: 'medium' });
+          const est = opt.estimateTokens(compressed);
+          expect(est).toBeLessThanOrEqual(maxTokens);
+        }
+      ),
+      { numRuns: 6 }
+    );
+  });
+});
+


### PR DESCRIPTION
- Cache eviction boundary: size ≤ maxSize under repeated compressions
- Truncate boundary PBT: compressed estimateTokens ≤ maxTokens when small

Validation
- Local: pnpm types:check && pnpm build && pnpm test:fast — green

CI
- Please trigger /verify-lite; optional labels: run-qa:property, ci-non-blocking
