### PR TITLE
test+chore(formal,resilience,ddd): heuristics CAUTION +2（EN FYI:/JA 参考までに）；TB alt-19；CB th5 2succ→fail；GWT +2

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -66,6 +66,7 @@ export const CAUTION_PATTERNS = [
   /caveat[:\s]/i,              // EN "Caveat:"
   /disclaimer[:\s]/i,          // EN "Disclaimer:"
   /please\s+note[:\s]/i,       // EN "Please note:"
+  /fyi[:\s]/i,                 // EN "FYI:"
   /\bN\.?B\.?[:\s]/i,          // EN "NB:" / "N.B.:"
   /hinweis[:\s]/i,             // DE "Hinweis:"
   /warnung[:\s]/i,             // DE "Warnung:"
@@ -93,6 +94,8 @@ export const CAUTION_PATTERNS = [
   /補足[:：]?/ ,                 // JA "補足:"（コロン有無）
   /注意喚起/ ,                  // JA "注意喚起"
   /注意事項/ ,                  // JA "注意事項"
+  /参考までに/ ,                // JA "参考までに"
+  /ご参考/ ,                    // JA "ご参考"
   /注意/                        // JA "注意"
   ,/ご承知おきください/         // JA 丁寧な注意喚起
 ];

--- a/tests/api/security-headers.test.ts
+++ b/tests/api/security-headers.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { formatGWT } from '../utils/gwt-format';
 import { createServer } from '../../src/api/server.js';
 import { FastifyInstance } from 'fastify';
 
@@ -19,7 +20,9 @@ describe('Security Headers Middleware', () => {
     await app.close();
   });
 
-  it('should add Content-Security-Policy header', async () => {
+  it(
+    formatGWT('GET /health', 'adds Content-Security-Policy header', 'CSP is present and default-src self'),
+    async () => {
     const response = await app.inject({
       method: 'GET',
       url: '/health'
@@ -28,16 +31,20 @@ describe('Security Headers Middleware', () => {
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-security-policy']).toBeDefined();
     expect(response.headers['content-security-policy']).toContain("default-src 'self'");
-  });
+  }
+  );
 
-  it('should add X-Frame-Options header', async () => {
+  it(
+    formatGWT('GET /health', 'adds X-Frame-Options header', 'DENY is set'),
+    async () => {
     const response = await app.inject({
       method: 'GET',
       url: '/health'
     });
 
     expect(response.headers['x-frame-options']).toBe('DENY');
-  });
+  }
+  );
 
   it('should add X-Content-Type-Options header', async () => {
     const response = await app.inject({

--- a/tests/formal/heuristics.caution.more-boundaries.36.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.36.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (EN FYI:)', () => {
+  it('matches EN FYI:', () => {
+    const samples = [
+      'FYI: partial check only',
+      'fyi: run with higher bounds for completeness'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/formal/heuristics.caution.more-boundaries.37.test.ts
+++ b/tests/formal/heuristics.caution.more-boundaries.37.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { CAUTION_PATTERNS } from '../../scripts/formal/heuristics.mjs';
+
+describe('Formal heuristics: caution boundaries (JA 参考までに/ご参考)', () => {
+  it('matches JA 参考までに / ご参考', () => {
+    const samples = [
+      '参考までに: 結果は参考情報です',
+      'ご参考: 制限時間内の探索のみを実施'
+    ];
+    for (const s of samples) {
+      expect(CAUTION_PATTERNS.some((re) => re.test(s))).toBe(true);
+    }
+  });
+});
+

--- a/tests/resilience/circuit-breaker.halfopen-two-success-then-failure.opens-again.th5.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-two-success-then-failure.opens-again.th5.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/utils/circuit-breaker';
+import { formatGWT } from '../utils/gwt-format';
+
+describe('Resilience: CircuitBreaker HALF_OPEN two success then failure -> OPEN (th=5)', () => {
+  it(
+    formatGWT('HALF_OPEN partial successes', 'two successes then failure at threshold=5', 'returns to OPEN'),
+    async () => {
+      const timeout = 20;
+      const cb = new CircuitBreaker('halfopen-2succ-then-fail-th5', { failureThreshold: 1, successThreshold: 5, timeout, monitoringWindow: 100 });
+      // open first
+      await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+      await new Promise(r => setTimeout(r, timeout + 2));
+      // partial successes
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      await expect(cb.execute(async () => 1)).resolves.toBe(1);
+      // then failure should re-open (since threshold not met)
+      await expect(cb.execute(async () => { throw new Error('again'); })).rejects.toBeInstanceOf(Error);
+      expect(cb.getState()).toBe(CircuitState.OPEN);
+    }
+  );
+});
+

--- a/tests/self-improvement/tdd-setup.test.ts
+++ b/tests/self-improvement/tdd-setup.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { formatGWT } from '../utils/gwt-format';
 import { SelfImprovementTDDSetup, createSelfImprovementTDDSetup } from '../../src/self-improvement/tdd-setup.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -62,19 +63,25 @@ describe('SelfImprovementTDDSetup', () => {
   });
 
   describe('initialization', () => {
-    it('should create TDD setup with default configuration', () => {
+    it(
+      formatGWT('TDD setup', 'create with default configuration', 'instance is created'),
+      () => {
       const defaultSetup = new SelfImprovementTDDSetup();
       expect(defaultSetup).toBeInstanceOf(SelfImprovementTDDSetup);
-    });
+    }
+    );
 
-    it('should create TDD setup with custom configuration', () => {
+    it(
+      formatGWT('TDD setup', 'create with custom configuration', 'instance is created'),
+      () => {
       const config = {
         projectRoot: '/custom/path',
         targetCoverage: 90
       };
       const customSetup = new SelfImprovementTDDSetup(config);
       expect(customSetup).toBeInstanceOf(SelfImprovementTDDSetup);
-    });
+    }
+    );
 
     it('should be created via factory function', () => {
       const factorySetup = createSelfImprovementTDDSetup();


### PR DESCRIPTION
- Formal heuristics: add EN "FYI:", JA 「参考までに/ご参考」＋回帰
- Resilience: TokenBucket tiny-interval alt-pattern-19 fast PBT
- Resilience: HALF_OPEN two success then failure -> OPEN（successThreshold=5）
- GWT: security-headers/tdd-setup の2ケースを GWT タイトルへ

Validation
- Local: pnpm types:check && pnpm build && pnpm test:fast — green

CI
- Please trigger /verify-lite; optional labels: run-qa, run-formal, ci-non-blocking
