### PR TITLE
chore(formal): aggregate MD polish (By-type present)

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -137,9 +137,9 @@ jobs:
           }
           lines.push(confSum ? `- Conformance summary file: ${path.basename(confSum)}` : "- Conformance summary: n/a");
           // By-type/present summary（簡潔・Present行の補助、一行で整形）
-          const presentPairs = ['tla','alloy','smt','apalache','conformance']
-            .map(k => `${k}=${present[k]? '1':'0'}`).join(', ');
-          lines.push(`By-type presence: ${presentPairs}`);
+          // Deterministic by-type present line (JSON→MDと順序を完全同期)
+          const presentList = ['tla','alloy','smt','apalache','conformance'].filter(k => present[k]);
+          lines.push(`By-type present: ${presentList.length}/5${presentList.length? ` (${presentList.join(', ')})` : ''}`);
           if (apalacheSum && apalache) {
             lines.push(`Ran/OK summary: apalache ran=${apalache.ran? 'yes':'no'} ok=${apalache.ok==null? 'n/a': (apalache.ok? 'yes':'no')}`);
           }

--- a/scripts/formal/aggregate-utils.mjs
+++ b/scripts/formal/aggregate-utils.mjs
@@ -33,3 +33,23 @@ export function computeAggregateInfo(baseDir){
   return { present, presentCount, ranOk };
 }
 
+// Deterministic表示用のキー順（tla→alloy→smt→apalache→conformance）
+export const ORDERED_PRESENT_KEYS = ['tla', 'alloy', 'smt', 'apalache', 'conformance'];
+
+// present（{k: boolean}）から、true のものを ORDERED_PRESENT_KEYS 順に並べて返す
+export function orderedPresentPairs(present){
+  if (!present) return [];
+  return ORDERED_PRESENT_KEYS
+    .filter((k) => present[k])
+    .map((k) => [k, true]);
+}
+
+// MD向けの一行表現を組み立て（空なら空文字）。呼び出し側で前置語を付ける想定でも可
+export function formatByTypePresentLine(info){
+  const p = info?.present || {};
+  const pairs = orderedPresentPairs(p);
+  const count = pairs.length;
+  if (count === 0) return 'By-type present: 0/5';
+  const names = pairs.map(([k]) => k).join(', ');
+  return `By-type present: ${count}/5 (${names})`;
+}

--- a/tests/formal/aggregate-utils.present-order.test.ts
+++ b/tests/formal/aggregate-utils.present-order.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { ORDERED_PRESENT_KEYS, orderedPresentPairs, formatByTypePresentLine } from '../../scripts/formal/aggregate-utils.mjs';
+
+describe('Formal aggregate utils: ordered present pairs and MD line', () => {
+  it('returns keys in deterministic order', () => {
+    expect(ORDERED_PRESENT_KEYS).toEqual(['tla','alloy','smt','apalache','conformance']);
+    const present = { smt: true, conformance: true, tla: true, alloy: false, apalache: true };
+    const pairs = orderedPresentPairs(present);
+    expect(pairs.map(([k]) => k)).toEqual(['tla','smt','apalache','conformance']);
+  });
+
+  it('formats MD line with count and names (non-empty)', () => {
+    const info = { present: { tla: true, alloy: true, smt: false, apalache: true, conformance: false } };
+    const line = formatByTypePresentLine(info);
+    expect(line).toBe('By-type present: 3/5 (tla, alloy, apalache)');
+  });
+
+  it('formats MD line for empty case', () => {
+    const line = formatByTypePresentLine({ present: { tla: false, alloy: false, smt: false, apalache: false, conformance: false } });
+    expect(line).toBe('By-type present: 0/5');
+  });
+});
+


### PR DESCRIPTION
- Formal Aggregate MD: By-type present as 'N/5 (tla, alloy, smt, apalache, conformance)'\n- Keep JSON→MD single source\n- Add aggregate-utils (ordered present + MD line) with regression tests\n\nLabels: run-formal, ci-non-blocking