### PR TITLE
chore(ci): verify-lite強化 + formal(BDD/LTL/hooks) [digest]

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -36,3 +36,34 @@ jobs:
         run: pnpm lint || true
       - name: Build
         run: pnpm run build
+      - name: BDD lint (non-blocking)
+        continue-on-error: true
+        run: |
+          if [ -f scripts/bdd/lint.mjs ]; then node scripts/bdd/lint.mjs; else printf "No BDD linter\n"; fi
+      - name: BDD → LTL suggestions (report-only)
+        run: |
+          if npm run -s | grep -q "bdd:suggest"; then pnpm -s run bdd:suggest; else printf "No BDD suggest script\n"; fi
+      - name: Formal tools check (non-blocking)
+        continue-on-error: true
+        run: |
+          if [ -f scripts/formal/tools-check.mjs ]; then node scripts/formal/tools-check.mjs; fi
+      - name: Run formal (label gated: run-formal)
+        if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-formal') }}
+        run: |
+          node scripts/formal/verify-conformance.mjs || true
+          node scripts/formal/verify-alloy.mjs || true
+          node scripts/formal/verify-tla.mjs --engine=tlc || true
+          node scripts/formal/verify-smt.mjs --solver=cvc5 || true
+          node scripts/formal/aggregate-formal.mjs || true
+          node scripts/formal/print-summary.mjs || true
+      - name: Aggregate adapters/formal/properties (non-blocking)
+        continue-on-error: true
+        run: |
+          if npm run -s | grep -q "artifacts:aggregate"; then pnpm -s run artifacts:aggregate; fi
+      - name: Render PR summary (digest)
+        env:
+          SUMMARY_MODE: digest
+          SUMMARY_LANG: ${{ (github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'lang:ja')) && 'ja' || 'en' }}
+        run: |
+          if [ -f scripts/summary/render-pr-summary.mjs ]; then node scripts/summary/render-pr-summary.mjs; fi
+          [ -f artifacts/summary/PR_SUMMARY.md ] && cat artifacts/summary/PR_SUMMARY.md >> "$GITHUB_STEP_SUMMARY" || true

--- a/artifacts/bdd/scenarios.json
+++ b/artifacts/bdd/scenarios.json
@@ -1,0 +1,4 @@
+{
+  "title": "Reserve inventory without going negative or double-booking",
+  "criteriaCount": 3
+}

--- a/artifacts/properties/ltl-suggestions.json
+++ b/artifacts/properties/ltl-suggestions.json
@@ -1,0 +1,61 @@
+{
+  "count": 3,
+  "items": [
+    {
+      "file": "specs/bdd/features/inventory_reservation.feature",
+      "title": "Successful reservation",
+      "given": [],
+      "when": [
+        "I reserve 3 units for order \"ORD-1\""
+      ],
+      "then": [
+        "the remaining stock should be 7"
+      ],
+      "suggestions": [
+        {
+          "when": "I reserve 3 units for order \"ORD-1\"",
+          "then": "the remaining stock should be 7",
+          "ltl": "G( (I reserve 3 units for order \"ORD-1\") -> F(the remaining stock should be 7) )"
+        }
+      ]
+    },
+    {
+      "file": "specs/bdd/features/inventory_reservation.feature",
+      "title": "Prevent negative stock",
+      "given": [],
+      "when": [
+        "I reserve 11 units for order \"ORD-2\""
+      ],
+      "then": [
+        "the operation should be rejected with code \"INSUFFICIENT_STOCK\""
+      ],
+      "suggestions": [
+        {
+          "when": "I reserve 11 units for order \"ORD-2\"",
+          "then": "the operation should be rejected with code \"INSUFFICIENT_STOCK\"",
+          "ltl": "G( (I reserve 11 units for order \"ORD-2\") -> F(the operation should be rejected with code \"INSUFFICIENT_STOCK\") )"
+        }
+      ]
+    },
+    {
+      "file": "specs/bdd/features/inventory_reservation.feature",
+      "title": "Idempotent by order id",
+      "given": [
+        "order \"ORD-3\" already reserved 2 units"
+      ],
+      "when": [
+        "I reserve 2 units again for order \"ORD-3\""
+      ],
+      "then": [
+        "the remaining stock should be 8"
+      ],
+      "suggestions": [
+        {
+          "when": "I reserve 2 units again for order \"ORD-3\"",
+          "then": "the remaining stock should be 8",
+          "ltl": "G( (I reserve 2 units again for order \"ORD-3\") -> F(the remaining stock should be 8) )"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -30,6 +30,19 @@
   - 集計: `hermetic-reports/formal/summary.json` に要約を出力
   - 表示: 実行後にコンソールへ簡易サマリを表示
 
+### Runtime Hooks（PObserve 型）取り込み（Phase 2.2）
+- ランタイムフック JSON を（任意で）`hermetic-reports/runtime/hooks.json` に保存し、ドライバーが再生サマリと突き合わせます。
+- 環境変数:
+  - `RUNTIME_HOOKS` または `CONFORMANCE_RUNTIME_HOOKS` — フック JSON のパス
+  - `CONFORMANCE_TRACE` — リプレイサマリ（既定: `artifacts/domain/replay.summary.json`）
+- conformance-summary には `runtimeHooks: {present, path, count, uniqueEvents[], traceId, matchesReplayTraceId}` が追加されます。
+
+### BDD → LTL プロパティ候補（レポートのみ）
+- `pnpm run bdd:suggest` で `specs/bdd/**/*.feature`（フォールバック: `features/`）から GWT を抽出し、LTL 候補を出力します。
+  - 出力: 
+    - `artifacts/bdd/scenarios.json` — PRサマリ用の {title, criteriaCount}
+    - `artifacts/properties/ltl-suggestions.json` — {count, items[]}（集約/参考用）
+
 ### Reproduce Locally / ローカル再現（要点）
 - Tools check: `pnpm run tools:formal:check`（利用可能ツールの一覧）
 - Apalache（ある場合）: `pnpm run verify:tla -- --engine=apalache`

--- a/docs/templates/adapters/ci-examples.md
+++ b/docs/templates/adapters/ci-examples.md
@@ -8,4 +8,27 @@ This note consolidates adapter-related CI snippets and where to place artifacts.
 
 Minimal snippet:
 
+```yaml
+name: adapters-quick
+on: [pull_request]
+jobs:
+  adapters:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: pnpm install --frozen-lockfile || pnpm install
+      - name: Run BDD lint (non-blocking)
+        run: node scripts/bdd/lint.mjs || true
+      - name: BDD → LTL suggestions (report-only)
+        run: pnpm -s run bdd:suggest || true
+      - name: Aggregate adapter artifacts
+        run: pnpm -s run artifacts:aggregate || true
+      - name: Render PR summary (digest)
+        env:
+          SUMMARY_MODE: digest
+          SUMMARY_LANG: ${{ contains(github.event.pull_request.labels.*.name, 'lang:ja') && 'ja' || 'en' }}
+        run: node scripts/summary/render-pr-summary.mjs || true
+```
 

--- a/hermetic-reports/formal/alloy-summary.json
+++ b/hermetic-reports/formal/alloy-summary.json
@@ -1,0 +1,12 @@
+{
+  "file": "spec/alloy/Domain.als",
+  "ran": false,
+  "status": "tool_not_available",
+  "timestamp": "2025-09-17T19:57:44.834Z",
+  "output": "Alloy CLI not found. Set ALLOY_JAR=/path/to/alloy.jar or install Alloy CLI. See docs/quality/formal-tools-setup.md",
+  "temporal": {
+    "present": false,
+    "operators": [],
+    "pastOperators": []
+  }
+}

--- a/hermetic-reports/formal/smt-summary.json
+++ b/hermetic-reports/formal/smt-summary.json
@@ -1,0 +1,8 @@
+{
+  "solver": "cvc5",
+  "file": "nonexistent.smt2",
+  "ran": false,
+  "status": "file_not_found",
+  "timestamp": "2025-09-17T19:57:44.879Z",
+  "output": "SMT-LIB file not found: nonexistent.smt2"
+}

--- a/package.json
+++ b/package.json
@@ -299,6 +299,8 @@
     ,
     "bdd:lint": "node scripts/bdd/lint.mjs"
     ,
+    "bdd:suggest": "node scripts/bdd/ltl-suggest.mjs"
+    ,
     "test:replay": "node scripts/testing/replay-runner.mjs",
     "test:replay:focus": "node scripts/testing/replay-runner.mjs --focus=$TRACE_ID",
     "test:replay:strict": "REPLAY_ONHAND_MIN=0 REPLAY_DISABLE= node scripts/testing/replay-runner.mjs",

--- a/scripts/bdd/ltl-suggest.mjs
+++ b/scripts/bdd/ltl-suggest.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+// BDD -> LTL property suggestions (report-only)
+import fs from 'node:fs';
+import path from 'node:path';
+
+function globFeatures(root='features'){
+  try {
+    const entries = fs.readdirSync(root, { withFileTypes: true });
+    const files = [];
+    for (const e of entries){
+      const p = path.join(root, e.name);
+      if (e.isDirectory()) files.push(...globFeatures(p));
+      else if (e.isFile() && p.endsWith('.feature')) files.push(p);
+    }
+    return files;
+  } catch {
+    return [];
+  }
+}
+
+function read(p){ try { return fs.readFileSync(p,'utf8'); } catch { return ''; } }
+function writeJson(p,obj){ fs.mkdirSync(path.dirname(p),{recursive:true}); fs.writeFileSync(p, JSON.stringify(obj,null,2)); }
+
+function parseScenarioLines(content){
+  const lines = content.split(/\r?\n/).map(l=>l.trim());
+  const scenarios = [];
+  let current = null;
+  let featureTitle = '';
+  for (const l of lines){
+    if (l.toLowerCase().startsWith('feature:')) {
+      featureTitle = l.slice(8).trim();
+      continue;
+    }
+    if (/^scenario:/i.test(l)){
+      if (current) scenarios.push(current);
+      current = { title: l.replace(/^[Ss]cenario:\s*/, ''), given: [], when: [], then: [] };
+      continue;
+    }
+    if (!current) continue;
+    if (/^given\b/i.test(l)) current.given.push(l.replace(/^given\s*/i,''));
+    else if (/^when\b/i.test(l)) current.when.push(l.replace(/^when\s*/i,''));
+    else if (/^then\b/i.test(l)) current.then.push(l.replace(/^then\s*/i,''));
+    else if (/^and\b/i.test(l)) {
+      // Attach AND to the last non-empty section (then > when > given)
+      const text = l.replace(/^and\s*/i,'');
+      if (current.then.length) current.then.push(text);
+      else if (current.when.length) current.when.push(text);
+      else if (current.given.length) current.given.push(text);
+    }
+  }
+  if (current) scenarios.push(current);
+  return { featureTitle, scenarios };
+}
+
+function suggestLTL(s){
+  // Very coarse templates from GWT:
+  // For each When -> Then, propose: G( when -> F then )
+  const props = [];
+  for (const w of (s.when.length ? s.when : ['condition'])){
+    for (const t of (s.then.length ? s.then : ['expected'])){
+      const ltl = `G( (${w}) -> F(${t}) )`;
+      props.push({ when: w, then: t, ltl });
+    }
+  }
+  return props;
+}
+
+const featureFiles = globFeatures('specs/bdd');
+const fallbackFiles = featureFiles.length ? [] : globFeatures('features');
+const files = featureFiles.length ? featureFiles : fallbackFiles;
+
+let allScenarios = [];
+let title = '';
+for (const f of files){
+  const { featureTitle, scenarios } = parseScenarioLines(read(f));
+  if (!title && featureTitle) title = featureTitle;
+  for (const s of scenarios){
+    const suggestions = suggestLTL(s);
+    allScenarios.push({ file: f, title: s.title, given: s.given, when: s.when, then: s.then, suggestions });
+  }
+}
+
+// Write BDD scenarios summary for PR summary aggregation (criteriaCount/title best-effort)
+const bddOut = { title: title || (files[0] ? path.basename(files[0]) : 'Feature'), criteriaCount: allScenarios.length };
+writeJson('artifacts/bdd/scenarios.json', bddOut);
+
+// Write suggestions in a dedicated file
+writeJson('artifacts/properties/ltl-suggestions.json', { count: allScenarios.reduce((acc, s)=> acc + (s.suggestions?.length||0), 0), items: allScenarios });
+
+console.log(`BDD→LTL suggestions: scenarios=${allScenarios.length}, files=${files.length}`);
+process.exit(0);
+

--- a/scripts/formal/conformance-driver.mjs
+++ b/scripts/formal/conformance-driver.mjs
@@ -7,14 +7,35 @@ function writeJson(p,obj){ fs.mkdirSync(path.dirname(p),{recursive:true}); fs.wr
 
 const tracePath = process.env.CONFORMANCE_TRACE || 'artifacts/domain/replay.summary.json';
 const specSummary = process.env.CONFORMANCE_SPEC || 'hermetic-reports/formal/tla-summary.json';
+const runtimeHooksPath = process.env.RUNTIME_HOOKS || process.env.CONFORMANCE_RUNTIME_HOOKS || 'hermetic-reports/runtime/hooks.json';
 const out = process.env.CONFORMANCE_OUTPUT || 'hermetic-reports/formal/conformance-summary.json';
 
 const trace = readJson(tracePath) || {};
 const spec = readJson(specSummary) || {};
+const hooks = readJson(runtimeHooksPath) || undefined;
 
 const t0 = Date.now();
 const violated = Array.isArray(trace.violatedInvariants) ? trace.violatedInvariants : [];
 const ok = violated.length === 0;
+// Compare runtime hooks with replay summary if both present (best-effort)
+let hooksInfo = null;
+try {
+  if (hooks) {
+    const events = Array.isArray(hooks) ? hooks : (Array.isArray(hooks.events) ? hooks.events : []);
+    const hooksTraceId = hooks.traceId || (events[0]?.traceId) || null;
+    const replayTraceId = trace.traceId || null;
+    const eventNames = Array.isArray(events) ? Array.from(new Set(events.map(e => e && e.event))) : [];
+    hooksInfo = {
+      present: true,
+      path: runtimeHooksPath,
+      count: Array.isArray(events) ? events.length : 0,
+      uniqueEvents: eventNames.filter(Boolean),
+      traceId: hooksTraceId,
+      matchesReplayTraceId: !!(hooksTraceId && replayTraceId && hooksTraceId === replayTraceId)
+    };
+  }
+} catch {}
+
 const summary = {
   tool: 'conformance-driver',
   ran: true,
@@ -25,7 +46,8 @@ const summary = {
   events: Number(trace.totalEvents || 0),
   violatedInvariants: violated,
   spec: spec.result || 'n/a',
-  timestamp: new Date().toISOString()
+  timestamp: new Date().toISOString(),
+  runtimeHooks: hooksInfo
 };
 
 writeJson(out, summary);


### PR DESCRIPTION
このPRは、非ブロッキング/ラベルゲートで Verify Lite からの形式系レポートと BDD 補助を強化します。

変更点（小PR方針）
- Alloy6: LTL/過去演算子の presence を alloy-summary.json に追加（report-only）
- Conformance（PObserve）: runtime hooks JSON 取り込みと replay.summary 突き合わせ（report-only）
- BDD→LTL 候補: `scripts/bdd/ltl-suggest.mjs` を追加し artifacts に出力（report-only）
- verify-lite: bdd:lint / bdd:suggest / tools-check（非ブロッキング） + run-formal（`run-formal` ラベルが付いたPRのみ）を実行し、PRサマリに反映
- docs: formal-runbook に hooks/BDD→LTL を追記、adapter CI 例にスニペット追加

CI/ラベル運用
- 常時: BDD lint/suggest + 軽集約 + PRサマリ（digest）
- `run-formal` 付与時: conformance/alloy/tla(tlc)/smt(cvc5) をレポートのみ実行→formal aggregate→サマリ表示（非ブロッキング）

想定される影響
- 既存スキーマと衝突しないよう、LTL候補は `artifacts/properties/ltl-suggestions.json` に分離
- 既存の properties/summary.json は未変更

レビュー観点
- YAML は actionlint/printf 原則準拠（追従済）
- verify-lite の追加ステップは continue-on-error で非ブロッキング
- PRサマリは scripts/summary/render-pr-summary.mjs 既存ロジックに適合

ラベルの推奨
- `ci-non-blocking`, `run-formal`, `pr-summary:digest`, `lang:ja`

Refs: #481, #483, #484, #488
