### PR TITLE
chore(formal/ci): tools行/フック突合せ/BDD lint拡張/Resilience quick/temporal集約

### DIFF
--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -235,6 +235,10 @@ jobs:
                 await addLabels(['run-adapters']);
                 return reply('Label `run-adapters` added. Adapter thresholds (report-only) will run.');
               }
+              case '/run-resilience': {
+                await addLabels(['run-resilience']);
+                return reply('Label `run-resilience` added. Resilience quick tests will run (non-blocking).');
+              }
               case '/enforce-perf': {
                 await addLabels(['enforce-perf']);
                 return reply('Label `enforce-perf` added. Performance threshold enforcement may apply.');

--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -207,6 +207,9 @@ jobs:
               presentCount,
               ranOk: {
                 apalache: apalache ? { ran: !!apalache.ran, ok: (typeof apalache.ok === 'boolean' ? apalache.ok : null) } : null
+              },
+              temporal: {
+                alloy: alloyS && alloyS.temporal ? alloyS.temporal : null
               }
             }
           };

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -64,6 +64,11 @@ jobs:
         continue-on-error: true
         run: |
           if npm run -s | grep -q "artifacts:aggregate"; then pnpm -s run artifacts:aggregate; fi
+      - name: Resilience quick (label-gated, non-blocking)
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-resilience') }}
+        continue-on-error: true
+        run: |
+          pnpm -s vitest run tests/resilience --reporter=verbose --run --coverage=false || true
       - name: Render PR summary (digest)
         env:
           SUMMARY_MODE: digest

--- a/docs/templates/adapters/ltl-suggestions.sample.json
+++ b/docs/templates/adapters/ltl-suggestions.sample.json
@@ -1,0 +1,25 @@
+{
+  "count": 2,
+  "items": [
+    {
+      "file": "specs/bdd/features/inventory_reservation.feature",
+      "title": "Successful reservation",
+      "given": ["inventory has 10 units"],
+      "when": ["I reserve 3 units for order \"ORD-1\""],
+      "then": ["the remaining stock should be 7"],
+      "suggestions": [
+        { "ltl": "G( (I reserve 3 units for order \"ORD-1\") -> F(the remaining stock should be 7) )" }
+      ]
+    },
+    {
+      "file": "specs/bdd/features/inventory_reservation.feature",
+      "title": "Prevent negative stock",
+      "when": ["I reserve 11 units for order \"ORD-2\""],
+      "then": ["the operation should be rejected with code \"INSUFFICIENT_STOCK\""],
+      "suggestions": [
+        { "ltl": "G( (I reserve 11 units for order \"ORD-2\") -> F(the operation should be rejected with code \"INSUFFICIENT_STOCK\") )" }
+      ]
+    }
+  ]
+}
+

--- a/scripts/formal/conformance-driver.mjs
+++ b/scripts/formal/conformance-driver.mjs
@@ -19,6 +19,7 @@ const violated = Array.isArray(trace.violatedInvariants) ? trace.violatedInvaria
 const ok = violated.length === 0;
 // Compare runtime hooks with replay summary if both present (best-effort)
 let hooksInfo = null;
+let hooksCompare = null;
 try {
   if (hooks) {
     const events = Array.isArray(hooks) ? hooks : (Array.isArray(hooks.events) ? hooks.events : []);
@@ -33,6 +34,18 @@ try {
       traceId: hooksTraceId,
       matchesReplayTraceId: !!(hooksTraceId && replayTraceId && hooksTraceId === replayTraceId)
     };
+    // Best-effort set comparison if trace.events exists
+    const traceEvents = Array.isArray(trace?.events) ? trace.events : (Array.isArray(trace?.details?.events) ? trace.details.events : null);
+    if (Array.isArray(traceEvents)) {
+      const traceNames = Array.from(new Set(traceEvents.map(e => e && e.event).filter(Boolean)));
+      const hs = new Set(eventNames.filter(Boolean));
+      const ts = new Set(traceNames);
+      const onlyHooks = Array.from(hs).filter(x => !ts.has(x));
+      const onlyTrace = Array.from(ts).filter(x => !hs.has(x));
+      const inter = Array.from(hs).filter(x => ts.has(x));
+      const matchRate = (hs.size + ts.size) > 0 ? +(inter.length / Math.max(hs.size, ts.size)).toFixed(3) : 0;
+      hooksCompare = { onlyHooks, onlyTrace, intersect: inter, matchRate };
+    }
   }
 } catch {}
 const summary = {
@@ -46,7 +59,8 @@ const summary = {
   violatedInvariants: violated,
   spec: spec.result || 'n/a',
   timestamp: new Date().toISOString(),
-  runtimeHooks: hooksInfo
+  runtimeHooks: hooksInfo,
+  runtimeHooksCompare: hooksCompare
 };
 
 writeJson(out, summary);

--- a/scripts/formal/print-context.mjs
+++ b/scripts/formal/print-context.mjs
@@ -1,13 +1,25 @@
 #!/usr/bin/env node
-// Print formal run context (branch/commit/time). Non-blocking.
+// Print formal run context (branch/commit/time + tools presence/defaults). Non-blocking.
 import { execSync } from 'node:child_process';
 
 function tryCmd(cmd){ try { return execSync(cmd, {encoding:'utf8'}).trim(); } catch { return ''; } }
+function has(cmd){ try { execSync(`bash -lc 'command -v ${cmd}'`, {stdio:'ignore'}); return true; } catch { return false; } }
 
 const branch = tryCmd("bash -lc 'git rev-parse --abbrev-ref HEAD'") || process.env.GITHUB_REF_NAME || 'unknown';
 const commit = tryCmd("bash -lc 'git rev-parse --short HEAD'") || (process.env.GITHUB_SHA ? process.env.GITHUB_SHA.slice(0,7) : 'unknown');
 const when = new Date().toISOString();
 
-console.log(`Formal run context: branch=${branch} commit=${commit} time=${when}`);
-process.exit(0);
+// Tool presence
+const hasApalache = has('apalache-mc');
+const hasZ3 = has('z3');
+const hasCvc5 = has('cvc5');
+const hasTlc = !!(process.env.TLA_TOOLS_JAR || '').trim();
 
+// Defaults used by verify-lite flow
+const defaultTla = 'tlc';
+const defaultSmt = 'cvc5';
+
+console.log(`Formal run context: branch=${branch} commit=${commit} time=${when}`);
+console.log(`Tools: tlc=${hasTlc?'yes':'no'} apalache=${hasApalache?'yes':'no'} z3=${hasZ3?'yes':'no'} cvc5=${hasCvc5?'yes':'no'}`);
+console.log(`Defaults: tla=${defaultTla} smt=${defaultSmt}`);
+process.exit(0);


### PR DESCRIPTION
- print-context: Tools/Defaults 行を追加\n- conformance-driver: hooks と replay のイベント名突合せ（差集合/一致率）を追加（best-effort）\n- BDD lint: 環境変数 BDD_LINT_STRICT/BDD_ROOTS を追加\n- agent-commands: /run-resilience でラベル付与\n- verify-lite: run-resilience ラベルでレジリエンスのfastテストを非ブロッキング実行\n- formal-aggregate.json: info.temporal.alloy を追加（Alloy temporal presence）\n- adapters: ltl-suggestions のサンプル JSON 追加