### PR TITLE
chore: Alloy temporal表示/Tools digest/Conformance matchRate/Resilience fast

### DIFF
--- a/scripts/formal/conformance-driver.mjs
+++ b/scripts/formal/conformance-driver.mjs
@@ -60,7 +60,8 @@ const summary = {
   spec: spec.result || 'n/a',
   timestamp: new Date().toISOString(),
   runtimeHooks: hooksInfo,
-  runtimeHooksCompare: hooksCompare
+  runtimeHooksCompare: hooksCompare,
+  hookReplayMatchRate: hooksCompare?.matchRate ?? null
 };
 
 writeJson(out, summary);

--- a/scripts/formal/tools-check.mjs
+++ b/scripts/formal/tools-check.mjs
@@ -38,6 +38,18 @@ for (const r of report) {
   console.log(`- ${status} ${r.tool}${extra}`);
 }
 
+// One-line digest (non-blocking)
+try {
+  const map = Object.fromEntries(report.map(r => [r.tool, r.present]));
+  const tlc = !!(process.env.TLA_TOOLS_JAR || '').trim();
+  const line = [
+    `tlc=${tlc?'yes':'no'}`,
+    `apalache=${map['apalache-mc']?'yes':'no'}`,
+    `z3=${map['z3']?'yes':'no'}`,
+    `cvc5=${map['cvc5']?'yes':'no'}`
+  ].join(' ');
+  console.log(`Tools: ${line}`);
+} catch {}
+
 // Non-blocking: always exit 0
 process.exit(0);
-

--- a/tests/resilience/circuit-breaker.halfopen-threshold.plus1.fast.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-threshold.plus1.fast.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker HALF_OPEN success threshold +1 (fast)', () => {
+  it('re-opens when failure occurs after threshold-1 successes', async () => {
+    const cb = new CircuitBreaker('test-cb', {
+      failureThreshold: 1,
+      successThreshold: 3,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Force OPEN
+    await expect(cb.execute(async () => { throw new Error('fail'); })).rejects.toBeTruthy();
+
+    // Wait then transition to HALF_OPEN
+    await new Promise(r => setTimeout(r, 6));
+
+    // Two successes (< threshold)
+    await cb.execute(async () => 'ok');
+    await cb.execute(async () => 'ok');
+
+    // Then a failure triggers OPEN again (threshold+1 boundary guard)
+    await expect(cb.execute(async () => { throw new Error('fail2'); })).rejects.toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
- PR summary: artifacts/formal/formal-aggregate.json から Alloy temporal 行を表示\n- tools-check: 最後に一行ダイジェスト出力\n- conformance-driver: hookReplayMatchRate を top-level で出力\n- Resilience: CircuitBreaker half-open successThreshold +1 fast テストを追加