### PR TITLE
chore(ci/docs): resilience fast限定 + BDD step lint + adapters doc

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -71,7 +71,15 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-resilience') }}
         continue-on-error: true
         run: |
-          pnpm -s vitest run tests/resilience --reporter=verbose --run --coverage=false || true
+          pnpm -s vitest run "tests/resilience/**/*.fast.*.test.ts" --reporter=verbose --run --coverage=false || true
+      - name: BDD step lint (non-blocking)
+        continue-on-error: true
+        run: |
+          if [ -f scripts/bdd/step-lint.mjs ]; then node scripts/bdd/step-lint.mjs || true; fi
+      - name: BDD step lint (strict; label-gated)
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-bdd-lint') }}
+        run: |
+          if [ -f scripts/bdd/step-lint.mjs ]; then node scripts/bdd/step-lint.mjs; fi
       - name: Render PR summary (digest)
         env:
           SUMMARY_MODE: digest

--- a/docs/templates/adapters/README.md
+++ b/docs/templates/adapters/README.md
@@ -24,3 +24,10 @@ JUnit/XML に関する注意
 - Prefer emitting normalized JSON summaries alongside JUnit XML.
 - Do not require core to parse XML; keep parsing in adapters/CI if needed.
 - Example: upload both `junit.xml` and `artifacts/<adapter>/summary.json`.
+
+## Related templates
+- CI.validate-artifacts.snippet.yml — 正規化 JSON/JUnit を AJV で検証する CI 例
+- ajv-failures.md — AJV 失敗例とトラブルシューティング
+- ajv-validation.md — AJV 検証ガイド
+- ci-examples.md — アダプター含む最小CIスニペット
+- ltl-suggestions.md — BDD→LTL 候補の warn-only 運用例と CI スニペット


### PR DESCRIPTION
- verify-lite: run-resilience で *.fast.* のみ実行（非ブロッキング）\n- verify-lite: BDD step lint を非ブロッキング/ラベル厳格で追加\n- docs: adapters/README に ltl-suggestions のリンク追記