### PR TITLE
chore: Tools version短縮 + Resilience reset fast

### DIFF
--- a/scripts/formal/tools-check.mjs
+++ b/scripts/formal/tools-check.mjs
@@ -8,12 +8,36 @@ function has(cmd) {
 function version(cmd, args = ['--version']) {
   try { return execSync(`bash -lc '${cmd} ${args.join(' ')}'`, { encoding: 'utf8' }).trim(); } catch { return 'n/a'; }
 }
+function shortVer(tool, raw) {
+  if (!raw || raw === 'n/a') return 'n/a';
+  try {
+    const line = String(raw).split('\n')[0];
+    // Heuristics per tool
+    if (tool === 'z3') {
+      // "Z3 version 4.12.4 - 64 bit"
+      const m = /Z3 version\s+([\w\.-]+)/i.exec(line); return m ? m[1] : line;
+    }
+    if (tool === 'cvc5') {
+      // "cvc5 1.0.8"
+      const m = /cvc5\s+([\w\.-]+)/i.exec(line); return m ? m[1] : line;
+    }
+    if (tool === 'apalache-mc') {
+      // "apalache-mc version x.y.z-..."
+      const m = /version\s+([\w\.-]+)/i.exec(line); return m ? m[1] : line;
+    }
+    if (tool === 'java') {
+      // "openjdk version \"21.0.2\" 2024-01-16"
+      const m = /version\s+"([\w\.-]+)"/i.exec(line); return m ? m[1] : line;
+    }
+    return line;
+  } catch { return raw; }
+}
 
 const report = [];
 
 // Java (for TLC)
 const hasJava = has('java');
-report.push({ tool: 'java', present: hasJava, version: hasJava ? version('java', ['-version']).split('\n')[0] : 'n/a' });
+report.push({ tool: 'java', present: hasJava, version: hasJava ? shortVer('java', version('java', ['-version'])) : 'n/a' });
 
 // TLC via TLA_TOOLS_JAR (best-effort)
 const tlaJar = process.env.TLA_TOOLS_JAR || '';
@@ -21,15 +45,15 @@ report.push({ tool: 'tla2tools.jar', present: !!tlaJar, path: tlaJar || 'unset (
 
 // Apalache
 const hasApalache = has('apalache-mc');
-report.push({ tool: 'apalache-mc', present: hasApalache, version: hasApalache ? version('apalache-mc', ['version']) : 'n/a' });
+report.push({ tool: 'apalache-mc', present: hasApalache, version: hasApalache ? shortVer('apalache-mc', version('apalache-mc', ['version'])) : 'n/a' });
 
 // Z3
 const hasZ3 = has('z3');
-report.push({ tool: 'z3', present: hasZ3, version: hasZ3 ? version('z3', ['--version']) : 'n/a' });
+report.push({ tool: 'z3', present: hasZ3, version: hasZ3 ? shortVer('z3', version('z3', ['--version'])) : 'n/a' });
 
 // cvc5
 const hasCvc5 = has('cvc5');
-report.push({ tool: 'cvc5', present: hasCvc5, version: hasCvc5 ? version('cvc5', ['--version']) : 'n/a' });
+report.push({ tool: 'cvc5', present: hasCvc5, version: hasCvc5 ? shortVer('cvc5', version('cvc5', ['--version'])) : 'n/a' });
 
 console.log('Formal tools status');
 for (const r of report) {

--- a/tests/resilience/circuit-breaker.reset-recovery.fast.test.ts
+++ b/tests/resilience/circuit-breaker.reset-recovery.fast.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker reset timeout minimal recovery (fast)', () => {
+  it('transitions OPEN -> HALF_OPEN -> CLOSED on successes after resetTimeout', async () => {
+    const cb = new CircuitBreaker('cb-reset', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Force OPEN
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    // Wait to allow HALF_OPEN
+    await new Promise(r => setTimeout(r, 6));
+    // Provide enough successes to close
+    await cb.execute(async () => 'ok');
+    await cb.execute(async () => 'ok');
+    // Should accept without throwing now
+    await expect(cb.execute(async () => 'ok')).resolves.toBe('ok');
+  });
+});
+


### PR DESCRIPTION
- tools-check: z3/cvc5/apalache/java の version を短縮整形（1行）\n- resilience: CircuitBreaker resetTimeout 最小復帰のfastテストを追加（非ブロッキング、run-resilience で実行）