### PR TITLE
chore: BDD lint追加/CI LTL閾値/Resilience fast

### DIFF
--- a/docs/templates/adapters/CI.ltl-threshold.snippet.yml
+++ b/docs/templates/adapters/CI.ltl-threshold.snippet.yml
@@ -1,0 +1,24 @@
+name: ltl-suggestions-threshold
+on:
+  pull_request:
+jobs:
+  ltl-threshold:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: pnpm install --frozen-lockfile || pnpm install
+      - name: Generate BDD → LTL suggestions (report-only)
+        run: pnpm -s run bdd:suggest || true
+      - name: Check LTL suggestions threshold (warn-only by default)
+        env:
+          LTL_WARN_MAX: ${{ vars.LTL_WARN_MAX }}
+          LTL_ERROR_MAX: ${{ vars.LTL_ERROR_MAX }}
+        run: |
+          cnt=$(jq -r '.count // 0' artifacts/properties/ltl-suggestions.json 2>/dev/null || echo 0)
+          printf "LTL suggestions: %s\n" "$cnt"
+          warn=${LTL_WARN_MAX:-0}
+          err=${LTL_ERROR_MAX:-999999}
+          if [ "$cnt" -gt "$warn" ]; then printf "::warning::LTL suggestions > warn threshold (%s>%s)\n" "$cnt" "$warn"; fi
+          if [ "$cnt" -gt "$err" ]; then printf "::error::LTL suggestions > error threshold (%s>%s)\n" "$cnt" "$err"; exit 1; fi

--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -26,10 +26,17 @@ function lintContent(content, file){
       if (STRICT && /\bshould\b/i.test(l)) {
         violations.push({ file, line: i+1, message: 'When should not contain modal verbs like "should" (use declarative command)', text: l });
       }
+      if (STRICT && /\bclick|button|ui|page|css|selector\b/i.test(l)){
+        violations.push({ file, line: i+1, message: 'When should avoid UI-specific terms (use domain command)', text: l });
+      }
     }
     if (STRICT && /^Then\b/i.test(l)){
       if (/\bdatabase|sql|table|insert|update\b/i.test(l)){
         violations.push({ file, line: i+1, message: 'Then should not mention persistence concerns directly (behavioral outcome expected)', text: l });
+      }
+      const andCount = (l.match(/\bAnd\b/gi) || []).length;
+      if (andCount >= 2) {
+        violations.push({ file, line: i+1, message: 'Then has too many conjunctions (prefer small, focused expectations)', text: l });
       }
     }
     if (STRICT && /^Given\b/i.test(l)){

--- a/tests/resilience/circuit-breaker.halfopen-reopen.quick.fast.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-reopen.quick.fast.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker half-open quick reopen (fast)', () => {
+  it('reopens on failure after initial success in HALF_OPEN', async () => {
+    const cb = new CircuitBreaker('cb-quick-reopen', {
+      failureThreshold: 1,
+      successThreshold: 3,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // To OPEN
+    await expect(cb.execute(async () => { throw new Error('fail'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+    // First success in HALF_OPEN
+    await expect(cb.execute(async () => 'ok')).resolves.toBe('ok');
+    // Then a failure should reopen
+    let reopened = false;
+    try {
+      await cb.execute(async () => { throw new Error('boom'); });
+    } catch {
+      reopened = true;
+    }
+    expect(reopened).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- BDD lint: STRICT時に When のUI語/ Then の And 過多を検出\n- Docs: CI.ltl-threshold.snippet.yml を追加（warn/error 閾値で運用）\n- Resilience: half-open quick reopen の fast テストを追加