### PR TITLE
chore: PRサマリ順序統一 + AE‑IR optional最小

### DIFF
--- a/packages/spec-compiler/src/types.ts
+++ b/packages/spec-compiler/src/types.ts
@@ -17,7 +17,7 @@ export interface AEIR {
   };
 
   /** Business glossary and terminology */
-  glossary: Array<{
+  glossary?: Array<{
     term: string;
     definition: string;
     aliases?: string[];
@@ -52,7 +52,7 @@ export interface AEIR {
   }>;
 
   /** Use cases and business processes */
-  usecases: Array<{
+  usecases?: Array<{
     name: string;
     description?: string;
     actor: string;


### PR DESCRIPTION
- PR summary: Formal/Conformance/BDD/LTL/GWT の順に整形（digest/detailed）\n- AE‑IR types: glossary/usecases を optional 化（最小、既存参照箇所は Array.isArray ガードで安全）