### PR TITLE
chore: print-context versions/aggregate conformance info/resilience fast

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -230,6 +230,13 @@ jobs:
               },
               temporal: {
                 alloy: alloyS && alloyS.temporal ? alloyS.temporal : null
+              },
+              conformance: {
+                hookReplayMatchRate: (conf && (typeof conf.hookReplayMatchRate === 'number'
+                  ? conf.hookReplayMatchRate
+                  : (conf.runtimeHooksCompare && typeof conf.runtimeHooksCompare.matchRate === 'number'
+                    ? conf.runtimeHooksCompare.matchRate
+                    : null)))
               }
             }
           };

--- a/scripts/formal/print-context.mjs
+++ b/scripts/formal/print-context.mjs
@@ -4,6 +4,18 @@ import { execSync } from 'node:child_process';
 
 function tryCmd(cmd){ try { return execSync(cmd, {encoding:'utf8'}).trim(); } catch { return ''; } }
 function has(cmd){ try { execSync(`bash -lc 'command -v ${cmd}'`, {stdio:'ignore'}); return true; } catch { return false; } }
+function ver(cmd, args=['--version']){ try { return execSync(`bash -lc '${cmd} ${args.join(' ')}'`, {encoding:'utf8'}).trim(); } catch { return ''; } }
+function short(tool, raw){
+  if (!raw) return '';
+  const line = String(raw).split('\n')[0];
+  try {
+    if (tool==='z3') { const m=/Z3 version\s+([\w\.-]+)/i.exec(line); return m?m[1]:line; }
+    if (tool==='cvc5') { const m=/cvc5\s+([\w\.-]+)/i.exec(line); return m?m[1]:line; }
+    if (tool==='apalache') { const m=/version\s+([\w\.-]+)/i.exec(line); return m?m[1]:line; }
+    if (tool==='java') { const m=/version\s+"([\w\.-]+)"/i.exec(line); return m?m[1]:line; }
+    return line;
+  } catch { return line; }
+}
 
 const branch = tryCmd("bash -lc 'git rev-parse --abbrev-ref HEAD'") || process.env.GITHUB_REF_NAME || 'unknown';
 const commit = tryCmd("bash -lc 'git rev-parse --short HEAD'") || (process.env.GITHUB_SHA ? process.env.GITHUB_SHA.slice(0,7) : 'unknown');
@@ -14,12 +26,16 @@ const hasApalache = has('apalache-mc');
 const hasZ3 = has('z3');
 const hasCvc5 = has('cvc5');
 const hasTlc = !!(process.env.TLA_TOOLS_JAR || '').trim();
+const vZ3 = hasZ3 ? short('z3', ver('z3', ['--version'])) : '';
+const vCvc5 = hasCvc5 ? short('cvc5', ver('cvc5', ['--version'])) : '';
+const vAp = hasApalache ? short('apalache', ver('apalache-mc', ['version'])) : '';
+const vJava = has('java') ? short('java', ver('java', ['-version'])) : '';
 
 // Defaults used by verify-lite flow
 const defaultTla = 'tlc';
 const defaultSmt = 'cvc5';
 
 console.log(`Formal run context: branch=${branch} commit=${commit} time=${when}`);
-console.log(`Tools: tlc=${hasTlc?'yes':'no'} apalache=${hasApalache?'yes':'no'} z3=${hasZ3?'yes':'no'} cvc5=${hasCvc5?'yes':'no'}`);
+console.log(`Tools: tlc=${hasTlc?'yes':'no'} apalache=${hasApalache?('yes('+vAp+')'):'no'} z3=${hasZ3?('yes('+vZ3+')'):'no'} cvc5=${hasCvc5?('yes('+vCvc5+')'):'no'} java=${vJava||'n/a'}`);
 console.log(`Defaults: tla=${defaultTla} smt=${defaultSmt}`);
 process.exit(0);

--- a/tests/resilience/circuit-breaker.recovery-then-fail-sequence.fast.test.ts
+++ b/tests/resilience/circuit-breaker.recovery-then-fail-sequence.fast.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker recovery then quick failures (fast)', () => {
+  it('closes after enough successes then reopens on two quick failures', async () => {
+    const cb = new CircuitBreaker('cb-recov-fail', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // OPEN
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+    // Recover to CLOSED with 2 successes
+    await cb.execute(async () => 'ok');
+    await cb.execute(async () => 'ok');
+    // Now two quick failures should push it back toward OPEN depending on impl
+    let thrown1 = false, thrown2 = false;
+    try { await cb.execute(async () => { throw new Error('f1'); }); } catch { thrown1 = true; }
+    try { await cb.execute(async () => { throw new Error('f2'); }); } catch { thrown2 = true; }
+    expect(thrown1 && thrown2).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- print-context: z3/cvc5/apalache/java の短縮版を表示（Tools: ...）\n- formal-aggregate: info.conformance.hookReplayMatchRate を集約JSONに追加\n- resilience: 快速シナリオのfastテストを1本追加