### PR TITLE
chore: Conformance差集合件数/PRサマリ/BDD曖昧語STRICT

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -236,7 +236,10 @@ jobs:
                   ? conf.hookReplayMatchRate
                   : (conf.runtimeHooksCompare && typeof conf.runtimeHooksCompare.matchRate === 'number'
                     ? conf.runtimeHooksCompare.matchRate
-                    : null)))
+                    : null))),
+                onlyHooksCount: (conf && conf.hookStats && typeof conf.hookStats.onlyHooksCount === 'number') ? conf.hookStats.onlyHooksCount : null,
+                onlyTraceCount: (conf && conf.hookStats && typeof conf.hookStats.onlyTraceCount === 'number') ? conf.hookStats.onlyTraceCount : null,
+                intersectCount: (conf && conf.hookStats && typeof conf.hookStats.intersectCount === 'number') ? conf.hookStats.intersectCount : null
               }
             }
           };

--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -44,6 +44,10 @@ function lintContent(content, file){
         violations.push({ file, line: i+1, message: 'Given should avoid UI-specific terms (focus on domain state)', text: l });
       }
     }
+    // Ambiguous words (STRICT): "maybe/approximately/around/roughly/about"
+    if (STRICT && /(\bmaybe\b|\bapproximately\b|\baround\b|\broughly\b|\babout\b)/i.test(l)){
+      violations.push({ file, line: i+1, message: 'Ambiguous wording detected (prefer precise, testable phrasing)', text: l });
+    }
   }
   return violations;
 }

--- a/scripts/formal/conformance-driver.mjs
+++ b/scripts/formal/conformance-driver.mjs
@@ -20,6 +20,7 @@ const ok = violated.length === 0;
 // Compare runtime hooks with replay summary if both present (best-effort)
 let hooksInfo = null;
 let hooksCompare = null;
+let hookStats = null;
 try {
   if (hooks) {
     const events = Array.isArray(hooks) ? hooks : (Array.isArray(hooks.events) ? hooks.events : []);
@@ -45,6 +46,14 @@ try {
       const inter = Array.from(hs).filter(x => ts.has(x));
       const matchRate = (hs.size + ts.size) > 0 ? +(inter.length / Math.max(hs.size, ts.size)).toFixed(3) : 0;
       hooksCompare = { onlyHooks, onlyTrace, intersect: inter, matchRate };
+      hookStats = {
+        events: Array.isArray(events) ? events.length : 0,
+        replayEvents: Array.isArray(traceEvents) ? traceEvents.length : 0,
+        onlyHooksCount: onlyHooks.length,
+        onlyTraceCount: onlyTrace.length,
+        intersectCount: inter.length,
+        matchRate
+      };
     }
   }
 } catch {}
@@ -61,7 +70,8 @@ const summary = {
   timestamp: new Date().toISOString(),
   runtimeHooks: hooksInfo,
   runtimeHooksCompare: hooksCompare,
-  hookReplayMatchRate: hooksCompare?.matchRate ?? null
+  hookReplayMatchRate: hooksCompare?.matchRate ?? null,
+  hookStats
 };
 
 writeJson(out, summary);

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -86,10 +86,13 @@ try {
   const mr = (typeof formalAgg?.info?.conformance?.hookReplayMatchRate === 'number')
     ? formalAgg.info.conformance.hookReplayMatchRate
     : (typeof conf?.runtimeHooksCompare?.matchRate === 'number' ? conf.runtimeHooksCompare.matchRate : null);
+  const onlyH = (typeof formalAgg?.info?.conformance?.onlyHooksCount === 'number') ? formalAgg.info.conformance.onlyHooksCount : null;
+  const onlyT = (typeof formalAgg?.info?.conformance?.onlyTraceCount === 'number') ? formalAgg.info.conformance.onlyTraceCount : null;
+  const delta = (onlyH!==null || onlyT!==null) ? ` Δ(hooks=${onlyH ?? 'n/a'}/trace=${onlyT ?? 'n/a'})` : '';
   if (vr !== null || mr !== null) {
     conformanceLine = t(
-      `Conformance: rate=${vr ?? 'n/a'}${mr!==null? ` hooksMatch=${mr}`:''}`,
-      `適合性: 率=${vr ?? 'n/a'}${mr!==null? ` hooks一致=${mr}`:''}`
+      `Conformance: rate=${vr ?? 'n/a'}${mr!==null? ` hooksMatch=${mr}`:''}${delta}`,
+      `適合性: 率=${vr ?? 'n/a'}${mr!==null? ` hooks一致=${mr}`:''}${delta}`
     );
   }
 } catch {}


### PR DESCRIPTION
- conformance-driver: hookStats を追加（events/replayEvents/onlyHooksCount/onlyTraceCount/intersectCount/matchRate）\n- formal-aggregate: info.conformance に onlyHooksCount/onlyTraceCount/intersectCount を集約\n- PR summary: Conformance 短行に Δ(hooks/trace) を追記\n- BDD lint STRICT: 曖昧語（maybe/approximately/around/roughly/about）検出を追加