### PR TITLE
chore: Conformance events/PRサマリ/BDD二重否定/Resilience fast

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -239,7 +239,9 @@ jobs:
                     : null))),
                 onlyHooksCount: (conf && conf.hookStats && typeof conf.hookStats.onlyHooksCount === 'number') ? conf.hookStats.onlyHooksCount : null,
                 onlyTraceCount: (conf && conf.hookStats && typeof conf.hookStats.onlyTraceCount === 'number') ? conf.hookStats.onlyTraceCount : null,
-                intersectCount: (conf && conf.hookStats && typeof conf.hookStats.intersectCount === 'number') ? conf.hookStats.intersectCount : null
+                intersectCount: (conf && conf.hookStats && typeof conf.hookStats.intersectCount === 'number') ? conf.hookStats.intersectCount : null,
+                hookEvents: (conf && conf.hookStats && typeof conf.hookStats.events === 'number') ? conf.hookStats.events : null,
+                traceEvents: (conf && conf.hookStats && typeof conf.hookStats.replayEvents === 'number') ? conf.hookStats.replayEvents : null
               }
             }
           };

--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -48,6 +48,10 @@ function lintContent(content, file){
     if (STRICT && /(\bmaybe\b|\bapproximately\b|\baround\b|\broughly\b|\babout\b)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Ambiguous wording detected (prefer precise, testable phrasing)', text: l });
     }
+    // Double negatives (STRICT): simple patterns
+    if (STRICT && /(\bnot\b\s+.*\bnot\b|can't\s+not|cannot\s+not|don't\s+not|never\s+not)/i.test(l)){
+      violations.push({ file, line: i+1, message: 'Double negative detected (prefer direct, positive phrasing)', text: l });
+    }
   }
   return violations;
 }

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -88,11 +88,14 @@ try {
     : (typeof conf?.runtimeHooksCompare?.matchRate === 'number' ? conf.runtimeHooksCompare.matchRate : null);
   const onlyH = (typeof formalAgg?.info?.conformance?.onlyHooksCount === 'number') ? formalAgg.info.conformance.onlyHooksCount : null;
   const onlyT = (typeof formalAgg?.info?.conformance?.onlyTraceCount === 'number') ? formalAgg.info.conformance.onlyTraceCount : null;
+  const hEv = (typeof formalAgg?.info?.conformance?.hookEvents === 'number') ? formalAgg.info.conformance.hookEvents : null;
+  const tEv = (typeof formalAgg?.info?.conformance?.traceEvents === 'number') ? formalAgg.info.conformance.traceEvents : null;
   const delta = (onlyH!==null || onlyT!==null) ? ` Δ(hooks=${onlyH ?? 'n/a'}/trace=${onlyT ?? 'n/a'})` : '';
+  const evs = (hEv!==null || tEv!==null) ? ` ev(h=${hEv ?? 'n/a'}/t=${tEv ?? 'n/a'})` : '';
   if (vr !== null || mr !== null) {
     conformanceLine = t(
-      `Conformance: rate=${vr ?? 'n/a'}${mr!==null? ` hooksMatch=${mr}`:''}${delta}`,
-      `適合性: 率=${vr ?? 'n/a'}${mr!==null? ` hooks一致=${mr}`:''}${delta}`
+      `Conformance: rate=${vr ?? 'n/a'}${mr!==null? ` hooksMatch=${mr}`:''}${delta}${evs}`,
+      `適合性: 率=${vr ?? 'n/a'}${mr!==null? ` hooks一致=${mr}`:''}${delta}${evs}`
     );
   }
 } catch {}

--- a/tests/resilience/circuit-breaker.halfopen-single-success-then-single-fail.fast.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-single-success-then-single-fail.fast.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker HALF_OPEN single success then single failure (fast)', () => {
+  it('reopens after one success followed by failure before reaching successThreshold', async () => {
+    const cb = new CircuitBreaker('cb-halfopen-1s-1f', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Force OPEN
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+
+    // One success in HALF_OPEN
+    await cb.execute(async () => 'ok');
+    // Then a failure should reopen (not enough successes to close)
+    let reopened = false;
+    try { await cb.execute(async () => { throw new Error('fail'); }); } catch { reopened = true; }
+    expect(reopened).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- formal-aggregate: info.conformance に hookEvents/traceEvents を集約\n- PR summary: Conformance 短行に ev(h/t) を追加\n- BDD lint STRICT: 二重否定の検出を追加\n- Resilience: HALF_OPEN 1成功→1失敗のfastケースを追加（非ブロッキング）