### PR TITLE
chore: Conf短行/Tools(java)/AE‑IR api?/BDD etc./Resilience fast

### DIFF
--- a/packages/spec-compiler/src/types.ts
+++ b/packages/spec-compiler/src/types.ts
@@ -85,7 +85,7 @@ export interface AEIR {
   }>;
 
   /** API specifications */
-  api: Array<{
+  api?: Array<{
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     path: string;
     summary?: string;

--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -48,6 +48,10 @@ function lintContent(content, file){
     if (STRICT && /(\bmaybe\b|\bapproximately\b|\baround\b|\broughly\b|\babout\b)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Ambiguous wording detected (prefer precise, testable phrasing)', text: l });
     }
+    // Ambiguous tails (STRICT): etc./and so on/...
+    if (STRICT && /(\betc\.?\b|and\s+so\s+on|\.\.\.)/i.test(l)){
+      violations.push({ file, line: i+1, message: 'Avoid ambiguous tails like "etc."/"and so on"/"..."', text: l });
+    }
     // Double negatives (STRICT): simple patterns
     if (STRICT && /(\bnot\b\s+.*\bnot\b|can't\s+not|cannot\s+not|don't\s+not|never\s+not)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Double negative detected (prefer direct, positive phrasing)', text: l });

--- a/scripts/formal/tools-check.mjs
+++ b/scripts/formal/tools-check.mjs
@@ -70,7 +70,8 @@ try {
     `tlc=${tlc?'yes':'no'}`,
     `apalache=${map['apalache-mc']?'yes':'no'}`,
     `z3=${map['z3']?'yes':'no'}`,
-    `cvc5=${map['cvc5']?'yes':'no'}`
+    `cvc5=${map['cvc5']?'yes':'no'}`,
+    `java=${report.find(r=>r.tool==='java')?.version||'n/a'}`
   ].join(' ');
   console.log(`Tools: ${line}`);
 } catch {}

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -93,10 +93,9 @@ try {
   const delta = (onlyH!==null || onlyT!==null) ? ` Δ(hooks=${onlyH ?? 'n/a'}/trace=${onlyT ?? 'n/a'})` : '';
   const evs = (hEv!==null || tEv!==null) ? ` ev(h=${hEv ?? 'n/a'}/t=${tEv ?? 'n/a'})` : '';
   if (vr !== null || mr !== null) {
-    conformanceLine = t(
-      `Conformance: rate=${vr ?? 'n/a'}${mr!==null? ` hooksMatch=${mr}`:''}${delta}${evs}`,
-      `適合性: 率=${vr ?? 'n/a'}${mr!==null? ` hooks一致=${mr}`:''}${delta}${evs}`
-    );
+    const en = `Conf: rate=${vr ?? 'n/a'}${mr!==null? ` match=${mr}`:''}${delta}${evs}`;
+    const ja = `適合: 率=${vr ?? 'n/a'}${mr!==null? ` 一致=${mr}`:''}${delta}${evs}`;
+    conformanceLine = t(en, ja);
   }
 } catch {}
 

--- a/tests/resilience/circuit-breaker.open-to-halfopen-immediate-fail.fast.test.ts
+++ b/tests/resilience/circuit-breaker.open-to-halfopen-immediate-fail.fast.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker OPEN→HALF_OPEN immediate failure (fast)', () => {
+  it('stays/open-reopens on immediate failure after HALF_OPEN', async () => {
+    const cb = new CircuitBreaker('cb-open-ho-fail', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      halfOpenMaxCalls: 5,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Force OPEN
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    // Move to HALF_OPEN
+    await new Promise(r => setTimeout(r, 6));
+    // Immediate failure should re-open
+    let reopened = false;
+    try { await cb.execute(async () => { throw new Error('fail'); }); } catch { reopened = true; }
+    expect(reopened).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- PR summary: Conformance 短行を簡潔化（Conf: rate/match/Δ/ev）\n- tools-check: digest に java バージョンを追加\n- AE‑IR types: api を optional 化（最小）\n- BDD lint STRICT: etc./and so on/... の検出を追加\n- Resilience: OPEN→HALF_OPEN 直後失敗の fast テストを追加