### PR TITLE
chore: Tools digest versions/BDD passive/AE‑IR invariants?/Resilience fast

### DIFF
--- a/packages/spec-compiler/src/types.ts
+++ b/packages/spec-compiler/src/types.ts
@@ -43,7 +43,7 @@ export interface AEIR {
   }>;
 
   /** Business invariants and rules */
-  invariants: Array<{
+  invariants?: Array<{
     id: string;
     description: string;
     expression: string;

--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -56,6 +56,10 @@ function lintContent(content, file){
     if (STRICT && /(\bnot\b\s+.*\bnot\b|can't\s+not|cannot\s+not|don't\s+not|never\s+not)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Double negative detected (prefer direct, positive phrasing)', text: l });
     }
+    // Passive voice (STRICT): "is/are/was/were <verb>ed (by)" (heuristic)
+    if (STRICT && /(\bis\b|\bare\b|\bwas\b|\bwere\b)\s+\w+ed(\b|\s+by\b)/i.test(l)){
+      violations.push({ file, line: i+1, message: 'Passive voice detected (prefer active voice in steps)', text: l });
+    }
   }
   return violations;
 }

--- a/scripts/formal/tools-check.mjs
+++ b/scripts/formal/tools-check.mjs
@@ -65,13 +65,18 @@ for (const r of report) {
 // One-line digest (non-blocking)
 try {
   const map = Object.fromEntries(report.map(r => [r.tool, r.present]));
+  const vers = Object.fromEntries(report.map(r => [r.tool, r.version || 'n/a']));
   const tlc = !!(process.env.TLA_TOOLS_JAR || '').trim();
+  const ap = map['apalache-mc'] ? `yes(${vers['apalache-mc']||'n/a'})` : 'no';
+  const z3 = map['z3'] ? `yes(${vers['z3']||'n/a'})` : 'no';
+  const c5 = map['cvc5'] ? `yes(${vers['cvc5']||'n/a'})` : 'no';
+  const jv = vers['java'] || 'n/a';
   const line = [
     `tlc=${tlc?'yes':'no'}`,
-    `apalache=${map['apalache-mc']?'yes':'no'}`,
-    `z3=${map['z3']?'yes':'no'}`,
-    `cvc5=${map['cvc5']?'yes':'no'}`,
-    `java=${report.find(r=>r.tool==='java')?.version||'n/a'}`
+    `apalache=${ap}`,
+    `z3=${z3}`,
+    `cvc5=${c5}`,
+    `java=${jv}`
   ].join(' ');
   console.log(`Tools: ${line}`);
 } catch {}


### PR DESCRIPTION
- tools-check: digest行に apalache/z3/cvc5 の短縮版を併記\n- BDD lint STRICT: 受動態（is/are/was/were + <verb>ed by?）の検出を追加\n- AE‑IR types: invariants を optional 化（最小）\n- Resilience fast: OPEN→HALF_OPEN→CLOSED→OPEN への最短経路の一端を検証するテストを追加