### PR TITLE
chore: BDD強調語STRICT/Resilience closed→open fast

### DIFF
--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -56,6 +56,10 @@ function lintContent(content, file){
     if (STRICT && /(\bnot\b\s+.*\bnot\b|can't\s+not|cannot\s+not|don't\s+not|never\s+not)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Double negative detected (prefer direct, positive phrasing)', text: l });
     }
+    // Intensifiers (STRICT): very/so/really/extremely (warn for overuse)
+    if (STRICT && /(\bvery\b|\bso\b\s+\b\w+|\breally\b|\bextremely\b)/i.test(l)){
+      violations.push({ file, line: i+1, message: 'Intensifier detected (prefer precise, measurable criteria over very/so/really)', text: l });
+    }
     // Passive voice (STRICT): "is/are/was/were <verb>ed (by)" (heuristic)
     if (STRICT && /(\bis\b|\bare\b|\bwas\b|\bwere\b)\s+\w+ed(\b|\s+by\b)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Passive voice detected (prefer active voice in steps)', text: l });

--- a/tests/resilience/circuit-breaker.closed-then-open-again.fast.test.ts
+++ b/tests/resilience/circuit-breaker.closed-then-open-again.fast.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker CLOSED then reopen on failure (fast)', () => {
+  it('closes after successes then reopens on next failure (th=1)', async () => {
+    const cb = new CircuitBreaker('cb-close-then-open', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Force OPEN then recover to CLOSED
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+    await cb.execute(async () => 'ok');
+    await cb.execute(async () => 'ok'); // should be CLOSED now
+
+    // Failure should cause OPEN with failureThreshold=1
+    let reopened = false;
+    try { await cb.execute(async () => { throw new Error('fail'); }); } catch { reopened = true; }
+    expect(reopened).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- BDD lint STRICT: very/so/really/extremely の強調語を検出（精密な基準を推奨）\n- Resilience fast: CLOSED後の再OPEN（failureThreshold=1）を検証するテストを追加（非ブロッキング）