### PR TITLE
chore: Conformance日本語短行統一/AE‑IR invariants.entities?

### DIFF
--- a/packages/spec-compiler/src/types.ts
+++ b/packages/spec-compiler/src/types.ts
@@ -47,7 +47,7 @@ export interface AEIR {
     id: string;
     description: string;
     expression: string;
-    entities: string[];
+    entities?: string[];
     severity: 'error' | 'warning';
   }>;
 

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -94,7 +94,7 @@ try {
   const evs = (hEv!==null || tEv!==null) ? ` ev(h=${hEv ?? 'n/a'}/t=${tEv ?? 'n/a'})` : '';
   if (vr !== null || mr !== null) {
     const en = `Conf: rate=${vr ?? 'n/a'}${mr!==null? ` match=${mr}`:''}${delta}${evs}`;
-    const ja = `適合: 率=${vr ?? 'n/a'}${mr!==null? ` 一致=${mr}`:''}${delta}${evs}`;
+    const ja = `適合: 率=${vr ?? 'n/a'}${mr!==null? ` 一致率=${mr}`:''}${delta}${evs}`;
     conformanceLine = t(en, ja);
   }
 } catch {}


### PR DESCRIPTION
- PR summary: Conformance の日本語短行で "一致率" を使用（簡潔さ維持）\n- AE‑IR types: invariants.entities を optional 化（最小）