### PR TITLE
test(optimizer): large smoke + preservePriority order

### DIFF
--- a/tests/resilience/circuit-breaker.rapid-five-success-then-fail.opens-again.th5.short.alt2.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-five-success-then-fail.opens-again.th5.short.alt2.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/resilience/backoff-strategies';
+
+describe('CircuitBreaker rapid (th=5) — five successes then a failure opens (short alt2)', () => {
+  it('stays CLOSED on successes then OPENs on a failure', async () => {
+    const cb = new CircuitBreaker({
+      failureThreshold: 3,
+      successThreshold: 5,
+      recoveryTimeout: 10,
+      monitoringPeriod: 50,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await cb.execute(async () => true);
+      expect(cb.getStats().state).toBe(CircuitState.CLOSED);
+    }
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    expect(cb.getStats().state).toBe(CircuitState.OPEN);
+  });
+});
+

--- a/tests/utils/token-optimizer.large-smoke.test.ts
+++ b/tests/utils/token-optimizer.large-smoke.test.ts
@@ -1,0 +1,23 @@
+import { describe, test, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer.js';
+
+describe('TokenOptimizer — huge input smoke (code fences preserved)', () => {
+  test('preserves code fences and reduces tokens monotonically', async () => {
+    const optimizer = new TokenOptimizer();
+    const bigCode = Array.from({ length: 20 }, (_, i) => (
+      '```ts\n' +
+      `function f${i}(){ return ${i}; }\n` +
+      '```\n'
+    )).join('\n');
+    const prose = 'Important: keep key points. '.repeat(200);
+    const docs = { code: bigCode + prose };
+    const low = await optimizer.compressSteeringDocuments(docs, { compressionLevel: 'low', maxTokens: 4000 });
+    const high = await optimizer.compressSteeringDocuments(docs, { compressionLevel: 'high', maxTokens: 4000 });
+
+    expect(low.compressed).toContain('```');
+    expect(high.compressed).toContain('```');
+    // High compression should not exceed low compression token count (allow tiny tolerance)
+    expect(high.stats.compressed).toBeLessThanOrEqual(low.stats.compressed + 10);
+  });
+});
+

--- a/tests/utils/token-optimizer.priority.missing.order.test.ts
+++ b/tests/utils/token-optimizer.priority.missing.order.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer.js';
+
+describe('TokenOptimizer — preservePriority with missing/extra sections', () => {
+  test('orders present sections by preservePriority even if some are missing', async () => {
+    const optimizer = new TokenOptimizer();
+    const docs = {
+      medium: 'Medium priority text',
+      extra: 'Extra section not listed',
+      high: 'High priority first',
+    } as Record<string, string>;
+
+    const res = await optimizer.compressSteeringDocuments(docs, {
+      maxTokens: 500,
+      preservePriority: ['high', 'medium', 'low']
+    });
+
+    const idxHigh = res.compressed.indexOf('## HIGH');
+    const idxMedium = res.compressed.indexOf('## MEDIUM');
+    expect(idxHigh).toBeGreaterThan(-1);
+    expect(idxMedium).toBeGreaterThan(-1);
+    expect(idxHigh).toBeLessThan(idxMedium);
+    // Extra section should appear after known priorities
+    const idxExtra = res.compressed.indexOf('## EXTRA');
+    expect(idxExtra).toBeGreaterThan(idxMedium);
+  });
+});
+


### PR DESCRIPTION
- Large smoke: code fences preserved; high<=low tokens (tolerance)\n- Ordering: preservePriority respected with missing/extra sections\n\n/verify-lite to run.