### PR TITLE
chore: BDD so-that guard/AE‑IR actor?/Resilience 3-success fast

### DIFF
--- a/packages/spec-compiler/src/types.ts
+++ b/packages/spec-compiler/src/types.ts
@@ -55,7 +55,7 @@ export interface AEIR {
   usecases?: Array<{
     name: string;
     description?: string;
-    actor: string;
+    actor?: string;
     preconditions?: string[];
     postconditions?: string[];
     steps: Array<{

--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -57,7 +57,7 @@ function lintContent(content, file){
       violations.push({ file, line: i+1, message: 'Double negative detected (prefer direct, positive phrasing)', text: l });
     }
     // Intensifiers (STRICT): very/so/really/extremely (warn for overuse)
-    if (STRICT && /(\bvery\b|\bso\b\s+\b\w+|\breally\b|\bextremely\b)/i.test(l)){
+    if (STRICT && /(\bvery\b|\breally\b|\bextremely\b|\bso\b\s+(?!that)\b\w+)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Intensifier detected (prefer precise, measurable criteria over very/so/really)', text: l });
     }
     // Repeated intensifiers (STRICT): really very / very very / so so

--- a/tests/resilience/circuit-breaker.halfopen-three-success-threshold.fast.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-three-success-threshold.fast.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker HALF_OPEN three-success threshold (fast)', () => {
+  it('requires 3 successes to close when successThreshold=3', async () => {
+    const cb = new CircuitBreaker('cb-ho-3s', {
+      failureThreshold: 1,
+      successThreshold: 3,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Force OPEN
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+
+    await cb.execute(async () => 'ok1');
+    await cb.execute(async () => 'ok2');
+    // Not yet CLOSED (threshold not met); a failure now should reopen
+    let reopened = false;
+    try { await cb.execute(async () => { throw new Error('fail'); }); } catch { reopened = true; }
+    expect(reopened).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- BDD lint STRICT: 'so that' を強調語判定から除外（誤検知回避）\n- AE‑IR types: usecases.actor を optional 化（最小）\n- Resilience fast: successThreshold=3 の境界ケースを追加（非ブロッキング）