### PR TITLE
chore: BDD passive(by)/AE‑IR step.type?/Resilience fast補強

### DIFF
--- a/packages/spec-compiler/src/types.ts
+++ b/packages/spec-compiler/src/types.ts
@@ -61,7 +61,7 @@ export interface AEIR {
     steps: Array<{
       step: number;
       description: string;
-      type: 'action' | 'validation' | 'computation';
+      type?: 'action' | 'validation' | 'computation';
     }>;
   }>;
 

--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -64,8 +64,8 @@ function lintContent(content, file){
     if (STRICT && /(really\s+very|very\s+very|\bso\b\s+\bso\b)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Repeated intensifier detected (avoid "really very"/"very very"/"so so")', text: l });
     }
-    // Passive voice (STRICT): "is/are/was/were <verb>ed (by)" (heuristic)
-    if (STRICT && /(\bis\b|\bare\b|\bwas\b|\bwere\b)\s+\w+ed(\b|\s+by\b)/i.test(l)){
+    // Passive voice (STRICT): "is/are/was/were <verb>ed by"（false positive を避けるため by を必須に）
+    if (STRICT && /(\bis\b|\bare\b|\bwas\b|\bwere\b)\s+\w+ed\s+by\b/i.test(l)){
       violations.push({ file, line: i+1, message: 'Passive voice detected (prefer active voice in steps)', text: l });
     }
   }

--- a/tests/resilience/circuit-breaker.closed-after-many-success-then-fail.fast.test.ts
+++ b/tests/resilience/circuit-breaker.closed-after-many-success-then-fail.fast.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker CLOSED after many successes then single failure (fast)', () => {
+  it('reopens on failure after being CLOSED with prior successes (th=1)', async () => {
+    const cb = new CircuitBreaker('cb-closed-many-then-fail', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Move to CLOSED via OPEN -> HALF_OPEN -> successes
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+    await cb.execute(async () => 'ok1');
+    await cb.execute(async () => 'ok2');
+    await cb.execute(async () => 'ok3');
+
+    // Now a single failure should reopen (threshold=1)
+    let reopened = false;
+    try { await cb.execute(async () => { throw new Error('fail'); }); } catch { reopened = true; }
+    expect(reopened).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- BDD lint STRICT: 受動態検出を '...ed by' 必須にして誤検知を低減\n- AE‑IR types: usecases.steps.type を optional 化（最小）\n- Resilience fast: CLOSED後多成功→単発失敗の再OPENケースを追加（非ブロッキング）