### PR TITLE
chore: PRサマリ順序/BDD 'and then'/Resilience close fast

### DIFF
--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -38,6 +38,11 @@ function lintContent(content, file){
       if (andCount >= 2) {
         violations.push({ file, line: i+1, message: 'Then has too many conjunctions (prefer small, focused expectations)', text: l });
       }
+      // "and then" repeated (STRICT)
+      const andThenCount = (l.match(/\band\s+then\b/gi) || []).length;
+      if (andThenCount >= 2) {
+        violations.push({ file, line: i+1, message: 'Avoid repeated "and then"; prefer separate steps', text: l });
+      }
     }
     if (STRICT && /^Given\b/i.test(l)){
       if (/\bclick|button|ui|page|css|selector\b/i.test(l)){

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -103,7 +103,7 @@ let md;
 if (mode === 'digest') {
   md = `${coverageLine} | ${alertsLine} | ${t('Formal','フォーマル')}: ${formal}${alloyTemporalLine? ` | ${alloyTemporalLine}`:''}${conformanceLine? ` | ${conformanceLine}`:''} | ${bddLine} | ${ltlLine} | ${gwtLine} | ${adapterCountsLine} | ${adaptersLine} | ${replayLine} | ${t('Trace','トレース')}: ${Array.from(traceIds).join(', ')}`;
 } else {
-  md = `## ${t('Quality Summary','品質サマリ')}\n- ${coverageLine}\n- ${alertsLine}\n- ${t('Formal','フォーマル')}: ${formal}\n${alloyTemporalLine? `- ${alloyTemporalLine}\n`:''}${conformanceLine? `- ${conformanceLine}\n`:''}- ${bddLine}\n- ${ltlLine}\n- ${gwtLine}\n- ${adapterCountsLine}\n- ${t('Adapters','アダプタ')}:\n${adaptersList}\n- ${replayLine}\n- ${t('Trace IDs','トレースID')}: ${Array.from(traceIds).join(', ')}`;
+  md = `## ${t('Quality Summary','品質サマリ')}\n- ${coverageLine}\n- ${alertsLine}\n- ${t('Formal','フォーマル')}: ${formal}\n${alloyTemporalLine? `- ${alloyTemporalLine}\n`:''}${conformanceLine? `- ${conformanceLine}\n`:''}- ${adapterCountsLine}\n- ${t('Adapters','アダプタ')}:\n${adaptersList}\n- ${bddLine}\n- ${ltlLine}\n- ${gwtLine}\n- ${replayLine}\n- ${t('Trace IDs','トレースID')}: ${Array.from(traceIds).join(', ')}`;
 }
 // Fallback: if formal is n/a, print presentCount from aggregate JSON
 try {

--- a/tests/resilience/circuit-breaker.halfopen-fail-then-successes-close.fast.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-fail-then-successes-close.fast.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker HALF_OPEN failure then enough successes (fast)', () => {
+  it('fails once in HALF_OPEN then closes after reaching threshold', async () => {
+    const cb = new CircuitBreaker('cb-ho-f-then-close', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      halfOpenMaxCalls: 10,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Force OPEN
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+
+    // First call in HALF_OPEN fails
+    let failed = false;
+    try { await cb.execute(async () => { throw new Error('f1'); }); } catch { failed = true; }
+    expect(failed).toBe(true);
+
+    // Wait and then provide enough successes to close
+    await new Promise(r => setTimeout(r, 6));
+    await cb.execute(async () => 'ok1');
+    await cb.execute(async () => 'ok2');
+    // Should be CLOSED: next call succeeds
+    await expect(cb.execute(async () => 'ok3')).resolves.toBe('ok3');
+  });
+});
+


### PR DESCRIPTION
- PR summary (detailed): Formal→temporal→Conf→Adapters→BDD/LTL/GWT→Replay の順に整形\n- BDD lint STRICT: 'and then' の反復を検出（warn）\n- Resilience fast: HALF_OPEN 失敗後、成功でCLOSEDへ遷移するケースを追加（非ブロッキング）