### PR TITLE
test(optimizer): compression levels monotonicity + code fence >=1 preserved

### DIFF
--- a/tests/utils/token-optimizer.codefence.atleastone.test.ts
+++ b/tests/utils/token-optimizer.codefence.atleastone.test.ts
@@ -1,0 +1,14 @@
+import { describe, test, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer.js';
+
+describe('TokenOptimizer — code fences preserved (>=1)', () => {
+  test('if input has >=1 code fence then output has >=1', async () => {
+    const optimizer = new TokenOptimizer();
+    const docs = {
+      code: '```ts\nconst x=1;\n```\n' + 'Some prose. '.repeat(50)
+    } as Record<string, string>;
+    const res = await optimizer.compressSteeringDocuments(docs, { compressionLevel: 'high', maxTokens: 1200 });
+    expect((res.compressed.match(/```/g) || []).length).toBeGreaterThanOrEqual(1);
+  });
+});
+

--- a/tests/utils/token-optimizer.compression.levels.monotonic.test.ts
+++ b/tests/utils/token-optimizer.compression.levels.monotonic.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer.js';
+
+describe('TokenOptimizer — compression levels monotonicity', () => {
+  test('high <= medium <= low in compressed tokens', async () => {
+    const optimizer = new TokenOptimizer();
+    const docs = {
+      product: 'Important: keep. '.repeat(300),
+      standards: '- rule A\n- rule B\n'.repeat(150),
+      architecture: '# Section\nDetails. '.repeat(200)
+    } as Record<string, string>;
+
+    const low = await optimizer.compressSteeringDocuments(docs, { compressionLevel: 'low', maxTokens: 4000 });
+    const med = await optimizer.compressSteeringDocuments(docs, { compressionLevel: 'medium', maxTokens: 4000 });
+    const high = await optimizer.compressSteeringDocuments(docs, { compressionLevel: 'high', maxTokens: 4000 });
+
+    expect(med.stats.compressed).toBeLessThanOrEqual(low.stats.compressed);
+    expect(high.stats.compressed).toBeLessThanOrEqual(med.stats.compressed);
+  });
+});
+


### PR DESCRIPTION
Two additional TokenOptimizer tests. /verify-lite