### PR TITLE
test+pbt: optimizer large3, resilience CB alt2; formal heuristics boundary

### DIFF
--- a/scripts/formal/heuristics.mjs
+++ b/scripts/formal/heuristics.mjs
@@ -49,6 +49,7 @@ export const NEGATIVE_PATTERNS = [
   ,/assertion\s+failed/i                          // EN assertion failed
   ,/unsatisfied\s+(?:invariant|property|spec)/i   // EN unsatisfied invariant/property/spec
   ,/(?:invariant|property|spec)\s+unsatisfied/i   // EN <kind> unsatisfied
+  ,/dead\s*end/i                                  // EN dead end encountered
 ];
 
 export const CAUTION_PATTERNS = [

--- a/tests/resilience/circuit-breaker.rapid-two-success-then-fail.opens.th4.short.alt2.test.ts
+++ b/tests/resilience/circuit-breaker.rapid-two-success-then-fail.opens.th4.short.alt2.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker, CircuitState } from '../../src/resilience/backoff-strategies';
+
+describe('CircuitBreaker rapid (th=4) — two successes then a failure opens (alt2)', () => {
+  it('remains CLOSED on two successes, then OPENs on failure', async () => {
+    const cb = new CircuitBreaker({
+      failureThreshold: 2,
+      successThreshold: 4,
+      recoveryTimeout: 10,
+      monitoringPeriod: 50,
+    });
+    await cb.execute(async () => true);
+    expect(cb.getStats().state).toBe(CircuitState.CLOSED);
+    await cb.execute(async () => true);
+    expect(cb.getStats().state).toBe(CircuitState.CLOSED);
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+    expect(cb.getStats().state).toBe(CircuitState.OPEN);
+  });
+});
+

--- a/tests/utils/token-optimizer.large-mixed-variant3.pbt.test.ts
+++ b/tests/utils/token-optimizer.large-mixed-variant3.pbt.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect } from 'vitest';
+import { TokenOptimizer } from '../../src/utils/token-optimizer.js';
+
+// Large mixed variant: headers + bullets + code fences + prose
+describe('TokenOptimizer — large mixed variant 3 (PBT-lite)', () => {
+  test('preserves code fences and reduces tokens non-negatively', async () => {
+    const optimizer = new TokenOptimizer();
+    const headers = Array.from({ length: 30 }, (_, i) => `# H${i}\nSub ${i}`).join('\n');
+    const bullets = Array.from({ length: 60 }, (_, i) => `- item ${i}`).join('\n');
+    const code = Array.from({ length: 10 }, (_, i) => `\n\n\`\`\`ts\nfunction v${i}(){ return ${i}; }\n\`\`\``).join('\n');
+    const prose = 'Important: keep signals. '.repeat(600);
+    const docs = { product: headers + '\n' + prose, standards: bullets, architecture: code } as Record<string, string>;
+    const res = await optimizer.compressSteeringDocuments(docs, { maxTokens: 3500, compressionLevel: 'high' });
+    // Code fences should survive
+    expect((res.compressed.match(/```/g) || []).length).toBeGreaterThanOrEqual(1);
+    // Reduction percentage is >= 0
+    expect(res.stats.reductionPercentage).toBeGreaterThanOrEqual(0);
+  });
+});
+


### PR DESCRIPTION
- TokenOptimizer: large mixed variant 3 (code fences preserved, non-negative reduction)\n- Resilience: CB(th=4) two success then fail → OPEN (short alt2)\n- Formal: add 'dead end' negative boundary in heuristics\n\n/verify-lite