### PR TITLE
chore: Summary clean/BDD 'should be'/TokenBucket cap fast

### DIFF
--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -69,6 +69,10 @@ function lintContent(content, file){
     if (STRICT && /(really\s+very|very\s+very|\bso\b\s+\bso\b)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Repeated intensifier detected (avoid "really very"/"very very"/"so so")', text: l });
     }
+    // "should be" pattern (STRICT): prefer declarative outcomes
+    if (STRICT && /\bshould\s+be\b/i.test(l)){
+      violations.push({ file, line: i+1, message: 'Prefer declarative outcomes over "should be" phrasing', text: l });
+    }
     // Passive voice (STRICT): "is/are/was/were <verb>ed by"（false positive を避けるため by を必須に）
     if (STRICT && /(\bis\b|\bare\b|\bwas\b|\bwere\b)\s+\w+ed\s+by\b/i.test(l)){
       violations.push({ file, line: i+1, message: 'Passive voice detected (prefer active voice in steps)', text: l });

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -115,21 +115,7 @@ try {
   }
 } catch {}
 
-// Conformance short line (violationRate / hooks matchRate)
-try {
-  const conf = formalHerm?.conformance || {};
-  const vr = (typeof conf.violationRate === 'number') ? conf.violationRate : null;
-  const mr = (typeof formalHerm?.hookReplayMatchRate === 'number')
-    ? formalHerm.hookReplayMatchRate
-    : (typeof conf?.runtimeHooksCompare?.matchRate === 'number' ? conf.runtimeHooksCompare.matchRate : null);
-  if (vr !== null || mr !== null) {
-    const line = t(
-      `Conformance: rate=${vr ?? 'n/a'}${mr!==null? ` hooksMatch=${mr}`:''}`,
-      `適合性: 率=${vr ?? 'n/a'}${mr!==null? ` hooks一致=${mr}`:''}`
-    );
-    if (mode === 'digest') md += ` | ${line}`; else md += `\n- ${line}`;
-  }
-} catch {}
+// (Removed duplicate conformance fallback line; unified above using aggregate JSON)
 fs.mkdirSync('artifacts/summary',{recursive:true});
 fs.writeFileSync('artifacts/summary/PR_SUMMARY.md', md);
 console.log(md);

--- a/tests/resilience/token-bucket.capacity-cap.after-many-intervals.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.capacity-cap.after-many-intervals.fast.pbt.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('TokenBucket capacity cap after many intervals (fast)', () => {
+  it('never exceeds maxTokens even after many refills', async () => {
+    const maxTokens = 5;
+    const rl = new TokenBucketRateLimiter({ tokensPerInterval: 3, interval: 5, maxTokens });
+    // drain
+    rl.tryRemoveTokens(maxTokens);
+    // wait multiple intervals
+    for (let i = 0; i < 4; i++) await new Promise(r => setTimeout(r, 6));
+    // now attempt to remove more than capacity
+    const allowed = rl.tryRemoveTokens(maxTokens + 1);
+    expect(allowed).toBe(false);
+    // exactly capacity should be allowed
+    const allowedExact = rl.tryRemoveTokens(maxTokens);
+    expect(allowedExact).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- PR summary: Conformance短行の重複fallbackを削除し aggregate由来に統一\n- BDD lint STRICT: 'should be' を警告（宣言的な期待に寄せる）\n- Resilience fast: TokenBucket が多回補充後も maxTokens を超えないテストを追加（非ブロッキング）