### PR TITLE
test(resilience): HALF_OPEN maxCalls guard fast

### DIFF
--- a/tests/resilience/circuit-breaker.halfopen-maxcalls-guard.fast.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-maxcalls-guard.fast.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker HALF_OPEN maxCalls guard (fast)', () => {
+  it('limits number of attempts in HALF_OPEN (maxCalls=1)', async () => {
+    const cb = new CircuitBreaker('cb-ho-max1', {
+      failureThreshold: 1,
+      successThreshold: 2,
+      halfOpenMaxCalls: 1,
+      resetTimeoutMs: 5,
+    } as any);
+
+    // Force OPEN
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+
+    // Move to HALF_OPEN
+    await new Promise(r => setTimeout(r, 6));
+
+    // First attempt allowed (may succeed or fail)
+    try { await cb.execute(async () => 'ok'); } catch {}
+
+    // Second immediate attempt should be guarded when still HALF_OPEN and maxCalls=1
+    let guarded = false;
+    try { await cb.execute(async () => 'ok2'); } catch { guarded = true; }
+    expect(guarded).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- HALF_OPEN で halfOpenMaxCalls=1 の場合、2回目の即時試行がガードされることを高速に検証（非ブロッキング）