### PR TITLE
chore: BDD double-negative whitelist + TokenBucket interleaved cap fast

### DIFF
--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -57,9 +57,13 @@ function lintContent(content, file){
     if (STRICT && /(\betc\.?\b|and\s+so\s+on|\.\.\.)/i.test(l)){
       violations.push({ file, line: i+1, message: 'Avoid ambiguous tails like "etc."/"and so on"/"..."', text: l });
     }
-    // Double negatives (STRICT): simple patterns
-    if (STRICT && /(\bnot\b\s+.*\bnot\b|can't\s+not|cannot\s+not|don't\s+not|never\s+not)/i.test(l)){
-      violations.push({ file, line: i+1, message: 'Double negative detected (prefer direct, positive phrasing)', text: l });
+    // Double negatives (STRICT): simple patterns（"not only ... but also" は除外）
+    if (STRICT) {
+      const dn = /(\bnot\b\s+.*\bnot\b|can't\s+not|cannot\s+not|don't\s+not|never\s+not)/i.test(l);
+      const whitelist = /\bnot\s+only\b[\s\S]*\bbut\s+(also\b)?/i.test(l);
+      if (dn && !whitelist) {
+        violations.push({ file, line: i+1, message: 'Double negative detected (prefer direct, positive phrasing)', text: l });
+      }
     }
     // Intensifiers (STRICT): very/so/really/extremely (warn for overuse)
     if (STRICT && /(\bvery\b|\breally\b|\bextremely\b|\bso\b\s+(?!that)\b\w+)/i.test(l)){

--- a/tests/resilience/token-bucket.interleaved.refill.cap.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.interleaved.refill.cap.fast.pbt.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('TokenBucket interleaved refill respects maxTokens (fast)', () => {
+  it('never exceeds capacity with interleaved remove/wait cycles', async () => {
+    const maxTokens = 4;
+    const rl = new TokenBucketRateLimiter({ tokensPerInterval: 2, interval: 5, maxTokens });
+    // remove 3 tokens if possible
+    rl.tryRemoveTokens(3);
+    // wait one interval
+    await new Promise(r => setTimeout(r, 6));
+    // attempt to remove > capacity
+    const over = rl.tryRemoveTokens(maxTokens + 1);
+    expect(over).toBe(false);
+    // exactly capacity should eventually work after refills
+    await new Promise(r => setTimeout(r, 6));
+    const ok = rl.tryRemoveTokens(maxTokens);
+    expect(ok).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- BDD lint STRICT: 'not only ... but also' を二重否定検出のホワイトリストに追加\n- Resilience fast: TokenBucket で remove/wait を交互に行っても maxTokens を超えないことを検証