### PR TITLE
chore: Summary adapter counts short/BDD 'should be able to'/Resilience HO th=1 close/AE‑IR meta.updated?

### DIFF
--- a/packages/spec-compiler/src/types.ts
+++ b/packages/spec-compiler/src/types.ts
@@ -13,7 +13,7 @@ export interface AEIR {
     description?: string;
     version?: string;
     created: string;
-    updated: string;
+    updated?: string;
   };
 
   /** Business glossary and terminology */

--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -77,6 +77,10 @@ function lintContent(content, file){
     if (STRICT && /\bshould\s+be\b/i.test(l)){
       violations.push({ file, line: i+1, message: 'Prefer declarative outcomes over "should be" phrasing', text: l });
     }
+    // "should be able to" (STRICT): prefer capability as acceptance criteria
+    if (STRICT && /\bshould\s+be\s+able\s+to\b/i.test(l)){
+      violations.push({ file, line: i+1, message: 'Prefer concrete, testable capability over "should be able to"', text: l });
+    }
     // Passive voice (STRICT): "is/are/was/were <verb>ed by"（false positive を避けるため by を必須に）
     if (STRICT && /(\bis\b|\bare\b|\bwas\b|\bwere\b)\s+\w+ed\s+by\b/i.test(l)){
       violations.push({ file, line: i+1, message: 'Passive voice detected (prefer active voice in steps)', text: l });

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -52,8 +52,8 @@ const ltlLine = ltlSug && typeof ltlSug.count === 'number'
   ? t(`LTL sugg: ${ltlSug.count}`, `LTL候補: ${ltlSug.count}`)
   : t('LTL sugg: n/a', 'LTL候補: なし');
 const adapterCountsLine = t(
-  `Adapters: ok=${statusCounts.ok||0}, warn=${statusCounts.warn||0}, error=${statusCounts.error||0}`,
-  `アダプタ: 正常=${statusCounts.ok||0}, 注意=${statusCounts.warn||0}, 失敗=${statusCounts.error||0}`
+  `Adapters ok/warn/err=${statusCounts.ok||0}/${statusCounts.warn||0}/${statusCounts.error||0}`,
+  `アダプタ 正常/注意/失敗=${statusCounts.ok||0}/${statusCounts.warn||0}/${statusCounts.error||0}`
 );
 const gwtLine = gwtCount 
   ? t(`GWT: ${gwtCount} (e.g., ${gwtFirst})`, `GWT: ${gwtCount}（例: ${gwtFirst}）`)

--- a/tests/resilience/circuit-breaker.halfopen-one-success-threshold1-closes.fast.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-one-success-threshold1-closes.fast.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker HALF_OPEN threshold=1 closes on first success (fast)', () => {
+  it('moves to CLOSED after one success when successThreshold=1', async () => {
+    const cb = new CircuitBreaker('cb-ho-th1-close', {
+      failureThreshold: 1,
+      successThreshold: 1,
+      halfOpenMaxCalls: 5,
+      resetTimeoutMs: 5,
+    } as any);
+
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+
+    await cb.execute(async () => 'ok');
+    await expect(cb.execute(async () => 'ok2')).resolves.toBe('ok2');
+  });
+});
+


### PR DESCRIPTION
- PR summary: Adapters 集計を ok/warn/err= の短縮表記に統一\n- BDD lint STRICT: 'should be able to' を警告（具体的な受入基準を促す）\n- Resilience fast: HALF_OPEN successThreshold=1 で1回の成功でCLOSEDに遷移するテストを追加（非ブロッキング）\n- AE‑IR types: metadata.updated を optional 化（最小）