### PR TITLE
chore: Temporal短文化/Resilience HO maxCalls=2 fast

### DIFF
--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -69,8 +69,8 @@ try {
     const ops = Array.isArray(temp.operators) ? temp.operators.join(', ') : '';
     const pops = Array.isArray(temp.pastOperators) ? temp.pastOperators.join(', ') : '';
     alloyTemporalLine = t(
-      `Alloy temporal: present=${!!temp.present}${ops? ` ops=[${ops}]`:''}${pops? ` past=[${pops}]`:''}`,
-      `Alloy時相: present=${!!temp.present}${ops? ` ops=[${ops}]`:''}${pops? ` past=[${pops}]`:''}`
+      `Temporal: present=${!!temp.present}${ops? ` ops=[${ops}]`:''}${pops? ` past=[${pops}]`:''}`,
+      `時相: present=${!!temp.present}${ops? ` ops=[${ops}]`:''}${pops? ` past=[${pops}]`:''}`
     );
   }
 } catch {}

--- a/tests/resilience/circuit-breaker.halfopen-maxcalls2-guard.fast.test.ts
+++ b/tests/resilience/circuit-breaker.halfopen-maxcalls2-guard.fast.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { CircuitBreaker } from '../../src/utils/circuit-breaker';
+
+describe('CircuitBreaker HALF_OPEN maxCalls=2 guard (fast)', () => {
+  it('allows two attempts, guards the third while HALF_OPEN', async () => {
+    const cb = new CircuitBreaker('cb-ho-max2', {
+      failureThreshold: 1,
+      successThreshold: 3,
+      halfOpenMaxCalls: 2,
+      resetTimeoutMs: 5,
+    } as any);
+
+    await expect(cb.execute(async () => { throw new Error('boom'); })).rejects.toBeTruthy();
+    await new Promise(r => setTimeout(r, 6));
+
+    // Two attempts allowed
+    try { await cb.execute(async () => 'ok1'); } catch {}
+    try { await cb.execute(async () => 'ok2'); } catch {}
+
+    // Third attempt in HALF_OPEN should be guarded
+    let guarded = false;
+    try { await cb.execute(async () => 'ok3'); } catch { guarded = true; }
+    expect(guarded).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- PR summary: Alloy temporal 表示を 'Temporal' に短文化\n- Resilience fast: HALF_OPEN で maxCalls=2 のguardを検証（非ブロッキング）