### PR TITLE
chore: Summary replay短縮/BDD skip comments/TokenBucket burst-refill fast

### DIFF
--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -19,7 +19,9 @@ function lintContent(content, file){
   const lines=content.split(/\r?\n/);
   const violations=[];
   for (let i=0;i<lines.length;i++){
-    const l=lines[i].trim();
+    const raw=lines[i];
+    const l=raw.trim();
+    if (!l || l.startsWith('#')) continue; // skip blank/comments
     if (/^When\b/i.test(l)){
       const ok = ROOTS.some(r=>r.test(l)) && !/\bset to\b/i.test(l);
       if (!ok) violations.push({ file, line: i+1, message: 'When must use Aggregate Root command and avoid direct state mutation', text: l });

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -32,7 +32,7 @@ if (formalObj?.traceId) traceIds.add(formalObj.traceId);
 if (replay?.traceId) traceIds.add(replay.traceId);
 for (const p of props) if (p?.traceId) traceIds.add(p.traceId);
 const replayLine = replay.totalEvents!==undefined 
-  ? t(`Replay: ${replay.totalEvents} events, ${(replay.violatedInvariants||[]).length} violations`, `リプレイ: ${replay.totalEvents}件, 違反 ${(replay.violatedInvariants||[]).length}件`)
+  ? t(`Replay ev/viol=${replay.totalEvents}/${(replay.violatedInvariants||[]).length}`, `リプレイ ev/viol=${replay.totalEvents}/${(replay.violatedInvariants||[]).length}`)
   : t('Replay: n/a','リプレイ: なし');
 // Properties (PBT) quick count: prefer aggregate 'count' or fallback to array length
 let propsCount = 0;

--- a/tests/resilience/token-bucket.burst-then-refill.cap.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.burst-then-refill.cap.fast.pbt.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('TokenBucket burst then refill capacity cap (fast)', () => {
+  it('rejects over-capacity bursts and allows exact after refills', async () => {
+    const max = 6;
+    const rl = new TokenBucketRateLimiter({ tokensPerInterval: 2, interval: 5, maxTokens: max });
+    // initial burst over capacity should fail
+    const over = rl.tryRemoveTokens(max + 2);
+    expect(over).toBe(false);
+    // wait multiple intervals to refill
+    for (let i = 0; i < 3; i++) await new Promise(r => setTimeout(r, 6));
+    // exact capacity should be allowed
+    const exact = rl.tryRemoveTokens(max);
+    expect(exact).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- PR summary: Replay 行を ev/viol=X/Y に短縮\n- BDD lint: 空行/コメント(#)をスキップして誤検知を回避\n- Resilience fast: TokenBucket の burst→refill cap を検証（非ブロッキング）