### PR TITLE
chore(bdd): skip structural lines in STRICT lint

### DIFF
--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -21,7 +21,15 @@ function lintContent(content, file){
   for (let i=0;i<lines.length;i++){
     const raw=lines[i];
     const l=raw.trim();
-    if (!l || l.startsWith('#') || l.startsWith('@') || /^Examples\b/i.test(l) || l.startsWith('|')) continue; // skip blank/comments/tags/examples/tables
+    if (
+      !l ||
+      l.startsWith('#') ||          // comments
+      l.startsWith('@') ||          // tags
+      /^Feature\b/i.test(l) ||      // feature header
+      /^Background\b/i.test(l) ||   // background section
+      /^Examples\b/i.test(l) ||     // examples header
+      l.startsWith('|')             // examples table rows
+    ) continue; // skip structural lines to reduce false positives
     if (/^When\b/i.test(l)){
       const ok = ROOTS.some(r=>r.test(l)) && !/\bset to\b/i.test(l);
       if (!ok) violations.push({ file, line: i+1, message: 'When must use Aggregate Root command and avoid direct state mutation', text: l });


### PR DESCRIPTION
- BDD lint STRICT: Feature/Background/Examples/表の構造行をスキップして誤検知をさらに低減\n- 既存の空行/コメント/@タグ除外に加えて適用