### PR TITLE
chore(bdd): skip Scenario/Outline/Rule lines in STRICT lint

### DIFF
--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -25,6 +25,9 @@ function lintContent(content, file){
       !l ||
       l.startsWith('#') ||          // comments
       l.startsWith('@') ||          // tags
+      /^Scenario\b/i.test(l) ||     // scenario title
+      /^Scenario Outline\b/i.test(l) || // scenario outline title
+      /^Rule\b/i.test(l) ||         // rule section
       /^Feature\b/i.test(l) ||      // feature header
       /^Background\b/i.test(l) ||   // background section
       /^Examples\b/i.test(l) ||     // examples header


### PR DESCRIPTION
- STRICT lint で Scenario/Scenario Outline/Rule の構造行をスキップ（誤検知の更なる低減）\n- 既存の空行/コメント/@タグ/Feature/Background/Examples/テーブル除外に追加