### PR TITLE
chore(bdd/resilience): skip doc-strings/code fences & TokenBucket small-interval cap fast

### DIFF
--- a/scripts/bdd/lint.mjs
+++ b/scripts/bdd/lint.mjs
@@ -31,7 +31,9 @@ function lintContent(content, file){
       /^Feature\b/i.test(l) ||      // feature header
       /^Background\b/i.test(l) ||   // background section
       /^Examples\b/i.test(l) ||     // examples header
-      l.startsWith('|')             // examples table rows
+      l.startsWith('|') ||          // examples table rows
+      l.startsWith('"""') ||       // doc-string blocks
+      l.startsWith('```')           // fenced code blocks
     ) continue; // skip structural lines to reduce false positives
     if (/^When\b/i.test(l)){
       const ok = ROOTS.some(r=>r.test(l)) && !/\bset to\b/i.test(l);

--- a/tests/resilience/token-bucket.small-interval.burst-cap.fast.pbt.test.ts
+++ b/tests/resilience/token-bucket.small-interval.burst-cap.fast.pbt.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { TokenBucketRateLimiter } from '../../src/resilience/backoff-strategies';
+
+describe('TokenBucket small-interval burst respects cap (fast)', () => {
+  it('does not allow over-capacity removal after quick refills', async () => {
+    const max = 3;
+    const rl = new TokenBucketRateLimiter({ tokensPerInterval: 1, interval: 5, maxTokens: max });
+    // drain
+    rl.tryRemoveTokens(max);
+    // quick refills
+    await new Promise(r => setTimeout(r, 6));
+    await new Promise(r => setTimeout(r, 6));
+    // attempt over capacity
+    const over = rl.tryRemoveTokens(max + 1);
+    expect(over).toBe(false);
+    // exact capacity should work after another refill step
+    await new Promise(r => setTimeout(r, 6));
+    const exact = rl.tryRemoveTokens(max);
+    expect(exact).toBe(true);
+  });
+});
+


### PR DESCRIPTION
- BDD lint STRICT: """ および ``` で始まるdoc-string/コードフェンス行をスキップ（誤検知低減）\n- Resilience fast: small-interval burst でも cap を超えないことを検証