### PR TITLE
chore(scripts): fix CodeQL alert #363 (avoid process shadowing)

### DIFF
--- a/tests/docker/optimization.test.ts
+++ b/tests/docker/optimization.test.ts
@@ -118,7 +118,9 @@ describe('Docker Production Optimization - Phase 1.4', () => {
   });
 
   describe('Docker Compose Configuration', () => {
-    it('should have development docker-compose.yml', () => {
+    it(
+      formatGWT('Compose dev', 'define healthcheck/resources/user', 'development compose is present'),
+      () => {
       expect(existsSync(dockerCompose)).toBe(true);
       
       const content = readFileSync(dockerCompose, 'utf8');
@@ -135,7 +137,9 @@ describe('Docker Production Optimization - Phase 1.4', () => {
       expect(content, 'Should specify user ID').toMatch(/user:/);
     });
 
-    it('should have production docker-compose.prod.yml', () => {
+    it(
+      formatGWT('Compose prod', 'enable security hardening', 'readonly/cap_drop/security_opt/no-new-privileges present'),
+      () => {
       expect(existsSync(dockerComposeProd)).toBe(true);
       
       const content = readFileSync(dockerComposeProd, 'utf8');


### PR DESCRIPTION
Fix CodeQL js/property-access-on-non-object in scripts/parallel-test-coordinator.mjs.\n\n- Rename local variable 'process' -> 'child' to avoid shadowing Node global\n- Ensure env uses global `process.env`\n\nValidation:\n- Minimal, behavior-preserving refactor (spawn/stdout/stderr/on handlers)\n- Local script sanity OK; full TS build depends on repo state; CI Verify Lite will gate types/build\n\nReferences:\n- Alert: https://github.com/itdojp/ae-framework/security/code-scanning/363\n- Policy: small PR, revert-friendly