### PR TITLE
feat(codex): Phase-4 — Coverage/Adapters検出 + codex補助

### DIFF
--- a/codex/ae.playbook.yaml
+++ b/codex/ae.playbook.yaml
@@ -1,0 +1,8 @@
+version: "0.1"
+tasks:
+  playbook:light:
+    run: node scripts/codex/ae-playbook.mjs --resume --skip=formal
+    description: Run setup→qa→spec→sim; skip formal.
+  playbook:formal:
+    run: node scripts/codex/ae-playbook.mjs --resume --enable-formal --formal-timeout=60000
+    description: Run with formal (timeout 60s if available).

--- a/docs/codex/ae-playbook.md
+++ b/docs/codex/ae-playbook.md
@@ -39,9 +39,9 @@
    - `pnpm run test:fast`
    - `node dist/src/cli/index.js qa --light`（または `pnpm tsx src/cli/qa-cli.ts --light`）
    - 出力: `artifacts/ae/qa/qa.log`（任意）
-6) Coverage/Adapters（Phase-3以降, report-only）
-   - coverage: `artifacts/coverage/coverage-summary.json` を収集（既存と合流）
-   - adapters: `artifacts/adapters/{a11y.json,perf.json,lh.json}`
+6) Coverage/Adapters（Phase-4, report-only 検出）
+   - coverage: `coverage/coverage-summary.json`（優先）/ `artifacts/coverage/coverage-summary.json` を検出して context.json に反映
+   - adapters: `artifacts/adapters/**/summary.json` / `artifacts/lighthouse/summary.json` / `artifacts/adapters/{a11y.json,perf.json,lh.json}` を検出して context.json に反映
 7) Formal（Phase-3以降, opt-in / 非ブロッキング）
    - `node scripts/formal/verify-tla.mjs` → `artifacts/formal/tla-summary.json`
    - `node scripts/formal/verify-apalache.mjs`（存在時）→ `artifacts/formal/apalache-summary.json`
@@ -74,6 +74,11 @@ CodeX CLI 0.38 からの実行例
   - `codex run node scripts/codex/ae-playbook.mjs --resume --skip=formal,adapters`
 - Formal を含む
   - `codex run node scripts/codex/ae-playbook.mjs --enable-formal --formal-timeout=60000`
+  - Coverage/Adapters 検出のみを明示的に実行したい場合は `--skip` を併用（例: `--skip=setup,qa,spec,sim,formal`）
+
+補助（任意）
+- `package.json` に `codex:run`: `node scripts/codex/ae-playbook.mjs --resume` を追加
+- `codex/ae.playbook.yaml` に簡易タスクを定義（light/formal 等）
 
 実装ステップ（小PR分割）
 1) PR1（本PR）: 設計ドキュメント（本書）

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ae-server": "./dist/src/cli/server-runner.js"
   },
   "scripts": {
+    "codex:run": "node scripts/codex/ae-playbook.mjs --resume",
     "start:server": "tsx src/server.ts",
     "dev:server": "tsx watch src/server.ts",
     "dev": "tsx watch src/index.ts",


### PR DESCRIPTION
Issue: #603\n\n- Playbook: Coverage/Adapters（report-only）検出を追加（artifacts を探索し artifacts/ae/context.json に反映）\n  - coverage: coverage/coverage-summary.json（優先）/ artifacts/coverage/coverage-summary.json\n  - adapters: artifacts/adapters/**/summary.json, artifacts/lighthouse/summary.json, artifacts/adapters/{a11y.json,perf.json,lh.json}\n- Docs: 実行例・備考を更新\n- codex: codex/ae.playbook.yaml を追加（light/formal タスク）\n- package.json: scripts に codex:run を追加\n\n非ブロッキングの小変更です。/verify-lite でゲートします。\n\nBacklog: #937