### PR TITLE
qa: treat ae.config thresholds as hints; policy is source of truth

### DIFF
--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -138,6 +138,10 @@ This document defines CI policies to keep PR experience fast and stable while ma
 ### QA CLI
 - `ae qa --light`: 軽量 QA 実行（`vitest` の `test:fast` を実行）。`ae-ci` の QA ステップで使用。
 
+Note
+- Coverage thresholds are sourced from `policy/quality.json` (single source of truth).
+- Values in `ae.config.ts` are hints only. When they differ from policy, the CLI will warn and enforce policy thresholds.
+
 ### セキュリティ/コンプライアンス
 - 既定では PR で非必須（`run-security` ラベル時のみ実行）。結果は artifacts に集約
 - `run-security` ラベル時は、依存脆弱性のサマリと上位ライセンスの簡易サマリを PR コメントに自動投稿（非ブロッキング）

--- a/docs/contributing/PR_TEMPLATE.md
+++ b/docs/contributing/PR_TEMPLATE.md
@@ -63,6 +63,11 @@ export default {
 };
 ```
 
+Note
+- The values under `qa.coverageThreshold` in `ae.config.ts` are treated as hints for local visibility.
+- Enforcement uses the centralized policy at `policy/quality.json` (profile via `AE_QUALITY_PROFILE` or `CI` → `ci`).
+- If `ae.config.ts` differs from policy, the QA CLI prints a warning and uses the policy thresholds as the source of truth.
+
 ## ✅ 検証結果
 
 ### 動作確認ログ

--- a/src/commands/qa/run.ts
+++ b/src/commands/qa/run.ts
@@ -1,17 +1,32 @@
 import { execa } from 'execa';
-import { loadConfig } from '../../core/config.js';
+import { loadConfig, type AeConfig } from '../../core/config.js';
 import { readFile, stat } from 'node:fs/promises';
+import { getQualityGate } from '../../utils/quality-policy-loader.js';
 
 export async function qaRun(options?: { light?: boolean }) {
   const cfg = await loadConfig();
+  const envProfile = process.env['AE_QUALITY_PROFILE'] || (process.env['CI'] === 'true' ? 'ci' : 'development');
+  const { effective, hint, mismatch } = await resolveCoverageThresholds(cfg, envProfile);
   const pm = (await detectPM()) ?? 'npm';
   const runner = await detectRunner();
   const light = Boolean(options?.light || process.env['AE_QA_LIGHT'] === '1' || process.env['CI'] === 'true');
   
   console.log(`[ae:qa] running QA with ${runner} via ${pm}${light ? ' (light mode)' : ''}`);
+  console.log(`[ae:qa] Using coverage thresholds from policy/quality.json (profile: ${envProfile})`);
+  console.log(`[ae:qa] thresholds → lines=${effective.lines}, functions=${effective.functions}, branches=${effective.branches}, statements=${effective.statements}`);
+  if (hint) {
+    if (mismatch) {
+      console.warn('[ae:qa] WARN: ae.config.qa.coverageThreshold is treated as a hint and differs from policy. Policy is the source of truth.');
+      console.warn(`[ae:qa] hint → lines=${hint.lines}, functions=${hint.functions}, branches=${hint.branches}, statements=${hint.statements}`);
+      console.warn('[ae:qa] To change enforcement, update policy/quality.json (coverage.thresholds.*) or set AE_QUALITY_PROFILE.');
+    } else {
+      console.log('[ae:qa] Note: ae.config.qa.coverageThreshold is treated as a hint; policy governs enforcement.');
+    }
+  }
   
   if (runner === 'jest') {
-    const threshold = JSON.stringify({ global: cfg.qa.coverageThreshold });
+    // Inject effective thresholds from policy into Jest
+    const threshold = JSON.stringify({ global: effective });
     try {
       if (light) {
         // Fallback to fast suite when available
@@ -41,6 +56,46 @@ export async function qaRun(options?: { light?: boolean }) {
   }
   
   console.log('[ae:qa] QA checks completed');
+}
+
+export type CoverageThresholds = { branches: number; lines: number; functions: number; statements: number };
+
+/**
+ * Resolve effective coverage thresholds from centralized policy, treating ae.config as a hint.
+ * Falls back to ae.config when policy load fails.
+ */
+export async function resolveCoverageThresholds(cfg: AeConfig, envProfile: string): Promise<{
+  effective: CoverageThresholds;
+  hint: CoverageThresholds | null;
+  mismatch: boolean;
+}> {
+  const hint = cfg?.qa?.coverageThreshold ?? null;
+  try {
+    const gate = getQualityGate('coverage', envProfile);
+    const eff: CoverageThresholds = {
+      lines: Number(gate.thresholds.lines ?? 80),
+      functions: Number(gate.thresholds.functions ?? 80),
+      branches: Number(gate.thresholds.branches ?? 80),
+      statements: Number(gate.thresholds.statements ?? 80),
+    };
+    const mismatch = hint ? (
+      hint.lines !== eff.lines ||
+      hint.functions !== eff.functions ||
+      hint.branches !== eff.branches ||
+      hint.statements !== eff.statements
+    ) : false;
+    return { effective: eff, hint, mismatch };
+  } catch (e) {
+    // Policy load failed — fall back to config hint with a warning
+    if (hint) {
+      console.warn('[ae:qa] WARN: Failed to load policy/quality.json. Falling back to ae.config.qa.coverageThreshold.');
+      return { effective: hint, hint, mismatch: false };
+    }
+    // Final fallback
+    const eff: CoverageThresholds = { lines: 80, functions: 80, branches: 80, statements: 80 };
+    console.warn('[ae:qa] WARN: No policy and no ae.config thresholds found. Falling back to defaults (80%).');
+    return { effective: eff, hint: null, mismatch: false };
+  }
 }
 
 async function detectPM(): Promise<'pnpm' | 'npm' | 'yarn' | null> {

--- a/tests/commands/qa/config-hints.test.ts
+++ b/tests/commands/qa/config-hints.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../src/utils/quality-policy-loader.js', async () => {
+  // default mock; individual tests will override via mockImplementation
+  const getQualityGate = vi.fn().mockReturnValue({
+    thresholds: { lines: 85, functions: 85, branches: 80, statements: 85 },
+    enforcement: 'strict',
+  });
+  return { getQualityGate };
+});
+
+// Import after mocking to ensure the mocked module is used
+import { resolveCoverageThresholds } from '../../src/commands/qa/run.js';
+
+// Access mocked module for overriding implementations per test
+import * as policyMod from '../../src/utils/quality-policy-loader.js';
+
+describe('qa config hints vs policy thresholds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses policy thresholds as source of truth and reports mismatch when ae.config differs', async () => {
+    // Policy returns 85/85/80/85 by default per vi.mock above
+    const cfg: any = {
+      qa: { coverageThreshold: { lines: 90, functions: 90, branches: 90, statements: 90 } },
+    };
+
+    const { effective, hint, mismatch } = await resolveCoverageThresholds(cfg, 'ci');
+
+    expect(effective).toEqual({ lines: 85, functions: 85, branches: 80, statements: 85 });
+    expect(hint).toEqual({ lines: 90, functions: 90, branches: 90, statements: 90 });
+    expect(mismatch).toBe(true);
+  });
+
+  it('does not report mismatch when ae.config matches policy thresholds', async () => {
+    // Ensure policy returns specific thresholds
+    (policyMod.getQualityGate as any).mockReturnValueOnce({
+      thresholds: { lines: 90, functions: 90, branches: 90, statements: 90 },
+      enforcement: 'strict',
+    });
+
+    const cfg: any = {
+      qa: { coverageThreshold: { lines: 90, functions: 90, branches: 90, statements: 90 } },
+    };
+
+    const { effective, hint, mismatch } = await resolveCoverageThresholds(cfg, 'ci');
+    expect(effective).toEqual({ lines: 90, functions: 90, branches: 90, statements: 90 });
+    expect(hint).toEqual({ lines: 90, functions: 90, branches: 90, statements: 90 });
+    expect(mismatch).toBe(false);
+  });
+
+  it('falls back to ae.config hint when policy fails to load', async () => {
+    (policyMod.getQualityGate as any).mockImplementationOnce(() => {
+      throw new Error('load error');
+    });
+    const cfg: any = {
+      qa: { coverageThreshold: { lines: 70, functions: 70, branches: 70, statements: 70 } },
+    };
+    const { effective, hint, mismatch } = await resolveCoverageThresholds(cfg, 'ci');
+    expect(effective).toEqual({ lines: 70, functions: 70, branches: 70, statements: 70 });
+    expect(hint).toEqual({ lines: 70, functions: 70, branches: 70, statements: 70 });
+    expect(mismatch).toBe(false);
+  });
+
+  it('falls back to defaults when neither policy nor ae.config thresholds are available', async () => {
+    (policyMod.getQualityGate as any).mockImplementationOnce(() => {
+      throw new Error('load error');
+    });
+    const cfg: any = { qa: {} };
+    const { effective, hint, mismatch } = await resolveCoverageThresholds(cfg, 'development');
+    expect(effective).toEqual({ lines: 80, functions: 80, branches: 80, statements: 80 });
+    expect(hint).toBeNull();
+    expect(mismatch).toBe(false);
+  });
+});
+


### PR DESCRIPTION
- Switch QA CLI to use policy/quality.json coverage thresholds (profile via AE_QUALITY_PROFILE/CI)\n- Treat ae.config.ts qa.coverageThreshold as hints only; emit warning if differs\n- Update docs (ci-policy, PR template)\n- Add tests for resolution/mismatch\n\nRefs: #