### PR TITLE
feat(reports): inject common meta (agent/model/traceId/runId/commit)

### DIFF
--- a/src/benchmark/req2run/runners/BenchmarkRunner.ts
+++ b/src/benchmark/req2run/runners/BenchmarkRunner.ts
@@ -17,6 +17,7 @@ import { AEFrameworkPhase, OutputType, BenchmarkCategory, DifficultyLevel, TestT
 import os from 'node:os';
 import fs from 'fs/promises';
 import yaml from 'yaml';
+import { getCommonMeta } from '../../../utils/report-meta.js';
 
 import { IntentAgent } from '../../../agents/intent-agent.js';
 import { NaturalLanguageTaskAdapter } from '../../../agents/natural-language-task-adapter.js';
@@ -599,7 +600,8 @@ export class BenchmarkRunner {
           averageScore: results.length > 0 ? results.reduce((sum, r) => sum + r.metrics.overallScore, 0) / results.length : 0,
           totalExecutionTime: results.reduce((sum, r) => sum + r.executionDetails.totalDuration, 0),
           framework: 'AE Framework v1.0.0',
-          benchmarkVersion: 'req2run-benchmark'
+          benchmarkVersion: 'req2run-benchmark',
+          ...getCommonMeta(),
         },
         configuration: this.config,
         results: results.map(result => ({

--- a/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
+++ b/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
@@ -39,6 +39,7 @@ import type {
   UIComponent
 } from '../../../agents/interfaces/standard-interfaces.js';
 import { BenchmarkCategory, DifficultyLevel, TestType, OutputType } from '../types/index.js';
+import { getCommonMeta } from '../../../utils/report-meta.js';
 
 // Minimal generated file descriptor used within this runner (file-local type)
 type GeneratedFile = { path: string; content: string; type: 'typescript' | 'markdown' | 'config' | string; size: number };
@@ -533,7 +534,8 @@ export class StandardizedBenchmarkRunner {
           framework: 'AE Framework v1.0.0 (Standardized Pipeline)',
           benchmarkVersion: 'req2run-benchmark',
           pipelineVersion: '1.0.0',
-          agentsUsed: ['IntentAgentAdapter', 'RequirementsAgentAdapter', 'UserStoriesAgentAdapter', 'ValidationAgentAdapter', 'DomainModelingAgentAdapter', 'UIUXAgentAdapter']
+          agentsUsed: ['IntentAgentAdapter', 'RequirementsAgentAdapter', 'UserStoriesAgentAdapter', 'ValidationAgentAdapter', 'DomainModelingAgentAdapter', 'UIUXAgentAdapter'],
+          ...getCommonMeta(),
         },
         configuration: this.config,
         analytics: this.generateAnalytics(results),

--- a/src/commands/bench/run.ts
+++ b/src/commands/bench/run.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { loadConfig } from '../../core/config.js';
 import { getSeed } from '../../core/seed.js';
+import { getCommonMeta } from '../../utils/report-meta.js';
 
 export async function benchRun() {
   const cfg = await loadConfig();
@@ -52,6 +53,7 @@ export async function benchRun() {
       date: new Date().toISOString(),
       env,
       config: cfg.bench,
+      ...getCommonMeta(),
     },
   };
   

--- a/src/utils/report-meta.ts
+++ b/src/utils/report-meta.ts
@@ -1,0 +1,58 @@
+import { execSync } from 'node:child_process';
+
+export type CommonReportMeta = {
+  agent: string | null;
+  model: string | null;
+  traceId: string | null;
+  runId: string | null;
+  commit: string | null;
+};
+
+function tryGitShortCommit(): string | null {
+  try {
+    const out = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build common meta fields to inject into reports.
+ * Source order is environment-first for portability; falls back to local git for commit.
+ * Fields are nullable for backward compatibility.
+ */
+export function getCommonMeta(): CommonReportMeta {
+  // Agent name (prefer explicit overrides)
+  const agent =
+    process.env['AE_AGENT'] ||
+    process.env['AE_AGENT_NAME'] ||
+    process.env['AE_ACTOR'] ||
+    'ae-framework';
+
+  // Model hints from common providers (best-effort)
+  const model =
+    process.env['OPENAI_MODEL'] ||
+    process.env['ANTHROPIC_MODEL'] ||
+    process.env['GEMINI_MODEL'] ||
+    null;
+
+  // Trace and run identifiers (CI-friendly)
+  const traceId = process.env['TRACE_ID'] || process.env['AE_TRACE_ID'] || null;
+  const runId =
+    process.env['GITHUB_RUN_ID'] ||
+    process.env['CI_RUN_ID'] ||
+    process.env['CI_PIPELINE_ID'] ||
+    process.env['BUILD_BUILDID'] ||
+    process.env['CI_JOB_ID'] ||
+    null;
+
+  // Commit from CI if present, otherwise from local git
+  const envSha = process.env['GITHUB_SHA'] || process.env['CI_COMMIT_SHA'] || process.env['GIT_COMMIT'];
+  const commit = (envSha ? envSha.slice(0, 7) : null) || tryGitShortCommit();
+
+  return { agent, model, traceId, runId, commit };
+}
+

--- a/tests/utils/report-meta.test.ts
+++ b/tests/utils/report-meta.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getCommonMeta } from '../../src/utils/report-meta.js';
+import { execSync } from 'node:child_process';
+
+const ENV_SNAPSHOT: NodeJS.ProcessEnv = { ...process.env };
+
+describe('getCommonMeta', () => {
+  beforeEach(() => {
+    process.env = { ...ENV_SNAPSHOT };
+  });
+  afterEach(() => {
+    process.env = { ...ENV_SNAPSHOT };
+  });
+
+  it('returns env-provided fields when present', () => {
+    process.env['AE_AGENT'] = 'test-agent';
+    process.env['OPENAI_MODEL'] = 'gpt-x';
+    process.env['TRACE_ID'] = 'trace-123';
+    process.env['GITHUB_RUN_ID'] = '99999';
+    process.env['GITHUB_SHA'] = 'abcdef0123456789';
+
+    const meta = getCommonMeta();
+    expect(meta.agent).toBe('test-agent');
+    expect(meta.model).toBe('gpt-x');
+    expect(meta.traceId).toBe('trace-123');
+    expect(meta.runId).toBe('99999');
+    expect(meta.commit).toBe('abcdef0');
+  });
+
+  it('falls back to git short commit when CI vars missing', () => {
+    delete process.env['GITHUB_SHA'];
+    delete process.env['CI_COMMIT_SHA'];
+    delete process.env['GIT_COMMIT'];
+
+    let short: string | null = null;
+    try {
+      short = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    } catch {
+      short = null;
+    }
+    const meta = getCommonMeta();
+    if (short) {
+      expect(meta.commit).toBe(short);
+    } else {
+      expect(meta.commit).toBeNull();
+    }
+  });
+});
+


### PR DESCRIPTION
Implements #917: inject common meta (agent/model/traceId/runId/commit) into reports with backward compatibility.

Changes:
- Add util: src/utils/report-meta.ts to assemble {agent, model, traceId, runId, commit} from env/CI/git.
- Inject meta into:
  - src/commands/bench/run.ts (extends existing meta)
  - src/benchmark/req2run/runners/BenchmarkRunner.ts (under metadata)
  - src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts (under metadata)
- Tests: tests/utils/report-meta.test.ts

Notes:
- Backward-compatible: only additive fields; existing shapes remain usable.
- Values are best-effort (env-first, fallback to git for commit).