### PR TITLE
feat(reports): add top-level meta to reports per #917

### DIFF
--- a/src/benchmark/req2run/runners/BenchmarkRunner.ts
+++ b/src/benchmark/req2run/runners/BenchmarkRunner.ts
@@ -591,7 +591,10 @@ export class BenchmarkRunner {
   private async generateReport(results: BenchmarkResult[]): Promise<void> {
     try {
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const cm = getCommonMeta();
       const reportData = {
+        // New top-level meta (non-breaking addition)
+        meta: cm,
         metadata: {
           timestamp: new Date().toISOString(),
           totalProblems: results.length,

--- a/src/benchmark/req2run/runners/BenchmarkRunner.ts
+++ b/src/benchmark/req2run/runners/BenchmarkRunner.ts
@@ -17,6 +17,7 @@ import { AEFrameworkPhase, OutputType, BenchmarkCategory, DifficultyLevel, TestT
 import os from 'node:os';
 import fs from 'fs/promises';
 import yaml from 'yaml';
+import { getCommonMeta } from '../../../utils/report-meta.js';
 
 import { IntentAgent } from '../../../agents/intent-agent.js';
 import { NaturalLanguageTaskAdapter } from '../../../agents/natural-language-task-adapter.js';
@@ -599,7 +600,8 @@ export class BenchmarkRunner {
           averageScore: results.length > 0 ? results.reduce((sum, r) => sum + r.metrics.overallScore, 0) / results.length : 0,
           totalExecutionTime: results.reduce((sum, r) => sum + r.executionDetails.totalDuration, 0),
           framework: 'AE Framework v1.0.0',
-          benchmarkVersion: 'req2run-benchmark'
+          benchmarkVersion: 'req2run-benchmark',
+          ...getCommonMeta(),
         },
         configuration: this.config,
         results: results.map(result => ({

--- a/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
+++ b/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
@@ -39,6 +39,7 @@ import type {
   UIComponent
 } from '../../../agents/interfaces/standard-interfaces.js';
 import { BenchmarkCategory, DifficultyLevel, TestType, OutputType } from '../types/index.js';
+import { getCommonMeta } from '../../../utils/report-meta.js';
 
 // Minimal generated file descriptor used within this runner (file-local type)
 type GeneratedFile = { path: string; content: string; type: 'typescript' | 'markdown' | 'config' | string; size: number };
@@ -533,7 +534,8 @@ export class StandardizedBenchmarkRunner {
           framework: 'AE Framework v1.0.0 (Standardized Pipeline)',
           benchmarkVersion: 'req2run-benchmark',
           pipelineVersion: '1.0.0',
-          agentsUsed: ['IntentAgentAdapter', 'RequirementsAgentAdapter', 'UserStoriesAgentAdapter', 'ValidationAgentAdapter', 'DomainModelingAgentAdapter', 'UIUXAgentAdapter']
+          agentsUsed: ['IntentAgentAdapter', 'RequirementsAgentAdapter', 'UserStoriesAgentAdapter', 'ValidationAgentAdapter', 'DomainModelingAgentAdapter', 'UIUXAgentAdapter'],
+          ...getCommonMeta(),
         },
         configuration: this.config,
         analytics: this.generateAnalytics(results),

--- a/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
+++ b/src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
@@ -40,6 +40,7 @@ import type {
 } from '../../../agents/interfaces/standard-interfaces.js';
 import { BenchmarkCategory, DifficultyLevel, TestType, OutputType } from '../types/index.js';
 import { getCommonMeta } from '../../../utils/report-meta.js';
+import { getCommonMeta } from '../../../utils/report-meta.js';
 
 // Minimal generated file descriptor used within this runner (file-local type)
 type GeneratedFile = { path: string; content: string; type: 'typescript' | 'markdown' | 'config' | string; size: number };
@@ -523,7 +524,10 @@ export class StandardizedBenchmarkRunner {
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       
       // Enhanced report data with analytics
+      const cm = getCommonMeta();
       const reportData = {
+        // New top-level meta (non-breaking addition)
+        meta: cm,
         metadata: {
           timestamp: new Date().toISOString(),
           totalProblems: results.length,
@@ -535,7 +539,7 @@ export class StandardizedBenchmarkRunner {
           benchmarkVersion: 'req2run-benchmark',
           pipelineVersion: '1.0.0',
           agentsUsed: ['IntentAgentAdapter', 'RequirementsAgentAdapter', 'UserStoriesAgentAdapter', 'ValidationAgentAdapter', 'DomainModelingAgentAdapter', 'UIUXAgentAdapter'],
-          ...getCommonMeta(),
+          // keep per-file metadata as-is; common meta sits at top-level
         },
         configuration: this.config,
         analytics: this.generateAnalytics(results),

--- a/src/commands/bench/run.ts
+++ b/src/commands/bench/run.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { loadConfig } from '../../core/config.js';
 import { getSeed } from '../../core/seed.js';
+import { getCommonMeta } from '../../utils/report-meta.js';
 
 export async function benchRun() {
   const cfg = await loadConfig();
@@ -52,6 +53,7 @@ export async function benchRun() {
       date: new Date().toISOString(),
       env,
       config: cfg.bench,
+      ...getCommonMeta(),
     },
   };
   

--- a/src/commands/bench/run.ts
+++ b/src/commands/bench/run.ts
@@ -43,6 +43,7 @@ export async function benchRun() {
   }));
   
   // Ensure stable JSON schema with minimum required fields
+  const cm = getCommonMeta();
   const payload = {
     summary: summary.map(task => ({
       name: task.name,
@@ -53,7 +54,8 @@ export async function benchRun() {
       date: new Date().toISOString(),
       env,
       config: cfg.bench,
-      ...getCommonMeta(),
+      // additive, backward-compatible
+      ...cm,
     },
   };
   

--- a/src/utils/report-meta.ts
+++ b/src/utils/report-meta.ts
@@ -1,0 +1,58 @@
+import { execSync } from 'node:child_process';
+
+export type CommonReportMeta = {
+  agent: string | null;
+  model: string | null;
+  traceId: string | null;
+  runId: string | null;
+  commit: string | null;
+};
+
+function tryGitShortCommit(): string | null {
+  try {
+    const out = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build common meta fields to inject into reports.
+ * Source order is environment-first for portability; falls back to local git for commit.
+ * Fields are nullable for backward compatibility.
+ */
+export function getCommonMeta(): CommonReportMeta {
+  // Agent name (prefer explicit overrides)
+  const agent =
+    process.env['AE_AGENT'] ||
+    process.env['AE_AGENT_NAME'] ||
+    process.env['AE_ACTOR'] ||
+    'ae-framework';
+
+  // Model hints from common providers (best-effort)
+  const model =
+    process.env['OPENAI_MODEL'] ||
+    process.env['ANTHROPIC_MODEL'] ||
+    process.env['GEMINI_MODEL'] ||
+    null;
+
+  // Trace and run identifiers (CI-friendly)
+  const traceId = process.env['TRACE_ID'] || process.env['AE_TRACE_ID'] || null;
+  const runId =
+    process.env['GITHUB_RUN_ID'] ||
+    process.env['CI_RUN_ID'] ||
+    process.env['CI_PIPELINE_ID'] ||
+    process.env['BUILD_BUILDID'] ||
+    process.env['CI_JOB_ID'] ||
+    null;
+
+  // Commit from CI if present, otherwise from local git
+  const envSha = process.env['GITHUB_SHA'] || process.env['CI_COMMIT_SHA'] || process.env['GIT_COMMIT'];
+  const commit = (envSha ? envSha.slice(0, 7) : null) || tryGitShortCommit();
+
+  return { agent, model, traceId, runId, commit };
+}
+

--- a/src/utils/report-meta.ts
+++ b/src/utils/report-meta.ts
@@ -1,58 +1,80 @@
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
 export type CommonReportMeta = {
-  agent: string | null;
-  model: string | null;
-  traceId: string | null;
-  runId: string | null;
-  commit: string | null;
+  agent: { name: string; version?: string };
+  model?: { provider?: string; name?: string };
+  traceId?: string | null;
+  iteration?: string | number | null;
+  runId?: string | null;
+  commitSha: string | null;
+  branch: string | null;
+  environment: string;
+  createdAt: string;
 };
 
-function tryGitShortCommit(): string | null {
+function tryGit(cmd: string): string | null {
   try {
-    const out = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] })
-      .toString()
-      .trim();
+    const out = execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
     return out || null;
   } catch {
     return null;
   }
 }
 
-/**
- * Build common meta fields to inject into reports.
- * Source order is environment-first for portability; falls back to local git for commit.
- * Fields are nullable for backward compatibility.
- */
-export function getCommonMeta(): CommonReportMeta {
-  // Agent name (prefer explicit overrides)
-  const agent =
-    process.env['AE_AGENT'] ||
-    process.env['AE_AGENT_NAME'] ||
-    process.env['AE_ACTOR'] ||
-    'ae-framework';
-
-  // Model hints from common providers (best-effort)
-  const model =
-    process.env['OPENAI_MODEL'] ||
-    process.env['ANTHROPIC_MODEL'] ||
-    process.env['GEMINI_MODEL'] ||
-    null;
-
-  // Trace and run identifiers (CI-friendly)
-  const traceId = process.env['TRACE_ID'] || process.env['AE_TRACE_ID'] || null;
-  const runId =
-    process.env['GITHUB_RUN_ID'] ||
-    process.env['CI_RUN_ID'] ||
-    process.env['CI_PIPELINE_ID'] ||
-    process.env['BUILD_BUILDID'] ||
-    process.env['CI_JOB_ID'] ||
-    null;
-
-  // Commit from CI if present, otherwise from local git
-  const envSha = process.env['GITHUB_SHA'] || process.env['CI_COMMIT_SHA'] || process.env['GIT_COMMIT'];
-  const commit = (envSha ? envSha.slice(0, 7) : null) || tryGitShortCommit();
-
-  return { agent, model, traceId, runId, commit };
+function detectAgent(): { name: string; version?: string } {
+  const name = process.env['AE_AGENT'] || process.env['AE_AGENT_NAME'] || process.env['AE_ACTOR'] || 'ae-framework';
+  let version: string | undefined;
+  // Prefer explicit env, fallback to package.json version if readable
+  version = process.env['AE_AGENT_VERSION'] || undefined;
+  if (!version) {
+    try {
+      const pkgPath = path.join(process.cwd(), 'package.json');
+      const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
+      if (pkg?.version) version = pkg.version;
+    } catch {
+      // ignore
+    }
+  }
+  return { name, ...(version ? { version } : {}) };
 }
 
+function detectModel(): { provider?: string; name?: string } | undefined {
+  const provider =
+    (process.env['OPENAI_API_KEY'] || process.env['OPENAI_MODEL']) ? 'openai' :
+    (process.env['ANTHROPIC_API_KEY'] || process.env['ANTHROPIC_MODEL']) ? 'anthropic' :
+    (process.env['GEMINI_API_KEY'] || process.env['GEMINI_MODEL']) ? 'google' :
+    undefined;
+  const name = process.env['OPENAI_MODEL'] || process.env['ANTHROPIC_MODEL'] || process.env['GEMINI_MODEL'] || undefined;
+  if (!provider && !name) return undefined;
+  return { ...(provider ? { provider } : {}), ...(name ? { name } : {}) };
+}
+
+function detectEnvironment(): string {
+  if (process.env['GITHUB_ACTIONS'] === 'true') return 'github';
+  if (process.env['CI']) return 'ci';
+  return process.env['AE_QUALITY_PROFILE'] || process.env['NODE_ENV'] || 'local';
+}
+
+/** Build common meta object for report injection (non-breaking, additive). */
+export function getCommonMeta(): CommonReportMeta {
+  const createdAt = new Date().toISOString();
+  const traceId = process.env['TRACE_ID'] || process.env['AE_TRACE_ID'] || null;
+  const iteration = (process.env['AE_ITERATION'] ?? null) as string | number | null;
+  const runId = process.env['GITHUB_RUN_ID'] || process.env['CI_RUN_ID'] || process.env['CI_PIPELINE_ID'] || process.env['BUILD_BUILDID'] || process.env['CI_JOB_ID'] || null;
+  const commitSha = (process.env['GITHUB_SHA'] || process.env['CI_COMMIT_SHA'] || process.env['GIT_COMMIT']) || tryGit('git rev-parse HEAD');
+  const branch = process.env['GITHUB_REF_NAME'] || tryGit('git rev-parse --abbrev-ref HEAD');
+
+  return {
+    agent: detectAgent(),
+    ...(detectModel() ? { model: detectModel() } : {}),
+    traceId,
+    iteration,
+    runId,
+    commitSha: commitSha || null,
+    branch: branch || null,
+    environment: detectEnvironment(),
+    createdAt,
+  };
+}

--- a/tests/utils/report-meta.test.ts
+++ b/tests/utils/report-meta.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getCommonMeta } from '../../src/utils/report-meta.js';
+import { execSync } from 'node:child_process';
+
+const ENV_SNAPSHOT: NodeJS.ProcessEnv = { ...process.env };
+
+describe('getCommonMeta', () => {
+  beforeEach(() => {
+    process.env = { ...ENV_SNAPSHOT };
+  });
+  afterEach(() => {
+    process.env = { ...ENV_SNAPSHOT };
+  });
+
+  it('returns env-provided fields when present', () => {
+    process.env['AE_AGENT'] = 'test-agent';
+    process.env['OPENAI_MODEL'] = 'gpt-x';
+    process.env['TRACE_ID'] = 'trace-123';
+    process.env['GITHUB_RUN_ID'] = '99999';
+    process.env['GITHUB_SHA'] = 'abcdef0123456789';
+
+    const meta = getCommonMeta();
+    expect(meta.agent).toBe('test-agent');
+    expect(meta.model).toBe('gpt-x');
+    expect(meta.traceId).toBe('trace-123');
+    expect(meta.runId).toBe('99999');
+    expect(meta.commit).toBe('abcdef0');
+  });
+
+  it('falls back to git short commit when CI vars missing', () => {
+    delete process.env['GITHUB_SHA'];
+    delete process.env['CI_COMMIT_SHA'];
+    delete process.env['GIT_COMMIT'];
+
+    let short: string | null = null;
+    try {
+      short = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    } catch {
+      short = null;
+    }
+    const meta = getCommonMeta();
+    if (short) {
+      expect(meta.commit).toBe(short);
+    } else {
+      expect(meta.commit).toBeNull();
+    }
+  });
+});
+

--- a/tests/utils/report-meta.test.ts
+++ b/tests/utils/report-meta.test.ts
@@ -12,38 +12,44 @@ describe('getCommonMeta', () => {
     process.env = { ...ENV_SNAPSHOT };
   });
 
-  it('returns env-provided fields when present', () => {
+  it('returns env-provided fields when present (shape with nested agent/model)', () => {
     process.env['AE_AGENT'] = 'test-agent';
+    process.env['AE_AGENT_VERSION'] = '0.9.9-test';
     process.env['OPENAI_MODEL'] = 'gpt-x';
     process.env['TRACE_ID'] = 'trace-123';
     process.env['GITHUB_RUN_ID'] = '99999';
-    process.env['GITHUB_SHA'] = 'abcdef0123456789';
+    process.env['GITHUB_SHA'] = 'abcdef0123456789abcdef0123456789abcdef01';
+    process.env['GITHUB_REF_NAME'] = 'feat/test';
 
     const meta = getCommonMeta();
-    expect(meta.agent).toBe('test-agent');
-    expect(meta.model).toBe('gpt-x');
+    expect(meta.agent.name).toBe('test-agent');
+    expect(meta.agent.version).toBe('0.9.9-test');
+    expect(meta.model?.name).toBe('gpt-x');
+    expect(meta.model?.provider).toBe('openai');
     expect(meta.traceId).toBe('trace-123');
     expect(meta.runId).toBe('99999');
-    expect(meta.commit).toBe('abcdef0');
+    expect(meta.commitSha).toBe('abcdef0123456789abcdef0123456789abcdef01');
+    expect(meta.branch).toBe('feat/test');
+    expect(typeof meta.createdAt).toBe('string');
+    expect(typeof meta.environment).toBe('string');
   });
 
-  it('falls back to git short commit when CI vars missing', () => {
+  it('falls back to git full commit when CI vars missing', () => {
     delete process.env['GITHUB_SHA'];
     delete process.env['CI_COMMIT_SHA'];
     delete process.env['GIT_COMMIT'];
 
-    let short: string | null = null;
+    let full: string | null = null;
     try {
-      short = execSync('git rev-parse --short HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+      full = execSync('git rev-parse HEAD', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
     } catch {
-      short = null;
+      full = null;
     }
     const meta = getCommonMeta();
-    if (short) {
-      expect(meta.commit).toBe(short);
+    if (full) {
+      expect(meta.commitSha).toBe(full);
     } else {
-      expect(meta.commit).toBeNull();
+      expect(meta.commitSha).toBeNull();
     }
   });
 });
-


### PR DESCRIPTION
Implements #917: Add a top-level meta to generated reports with agent/model/traceId/iteration/runId/commitSha/branch/environment/createdAt. Non-breaking addition.

Scope
- Bench JSON (extends existing top-level meta): src/commands/bench/run.ts
- Req2Run Benchmark JSON (adds new top-level meta while keeping existing metadata):
  - src/benchmark/req2run/runners/BenchmarkRunner.ts
  - src/benchmark/req2run/runners/StandardizedBenchmarkRunner.ts
- Utility: src/utils/report-meta.ts builds common meta from env/CI/git; agent version from package.json when available.
- Tests: tests/utils/report-meta.test.ts (env overrides, git fallback)

Before (bench.json excerpt)
{
  "meta": {
    "date": "2025-09-20T00:00:00.000Z",
    "env": {"node":"v22.x", ...},
    "config": {"iterations":30, ...}
  },
  "summary": [...]
}

After (bench.json excerpt)
{
  "meta": {
    "date": "2025-09-20T00:00:00.000Z",
    "env": {"node":"v22.x", ...},
    "config": {"iterations":30, ...},
    "agent": {"name":"ae-framework","version":"1.0.0"},
    "model": {"provider":"openai","name":"gpt-4o-mini"},
    "traceId": null,
    "iteration": null,
    "runId": "123456",
    "commitSha": "abcdef0123456789...",
    "branch": "feat/917-meta",
    "environment": "github",
    "createdAt": "2025-09-20T00:00:00.000Z"
  },
  "summary": [...]
}

After (req2run JSON excerpt)
{
  "meta": { "agent": {...}, "model": {...}, "runId": ..., "commitSha": ..., "branch": ..., "environment": ..., "createdAt": ... },
  "metadata": { "timestamp": ..., "totalProblems": ..., ... },
  "configuration": { ... },
  "results": [ ... ]
}

Notes
- All fields are additive; no breaking changes to existing consumers.
- commitSha prefers CI (GITHUB_SHA/CI_COMMIT_SHA) then falls back to git; branch prefers GITHUB_REF_NAME then git.
- environment derived from CI or AE_QUALITY_PROFILE/NODE_ENV; createdAt is ISO timestamp.
- Agent defaults to ae-framework; version from package.json if available; model inferred from env.

Testing
- Unit: vitest run tests/utils/report-meta.test.ts (green)
- Full test suite is large; can run selectively as needed.