### PR TITLE
ci/docs: slash command mapping and workflow aliases (refs #962)

### DIFF
--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -86,6 +86,7 @@ jobs:
                 await removeLabel('ci-non-blocking');
                 return reply('Label `ci-non-blocking` removed. Jobs will be blocking as configured.');
               case '/ready':
+              case '/ready-for-review':
                 await removeLabel('do-not-merge');
                 return reply('Label `do-not-merge` removed. PR is ready for merge gates.');
               case '/run-hermetic':
@@ -145,6 +146,12 @@ jobs:
                 const ref = pr.data.head.ref;
                 await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'ae-ci.yml', ref });
                 return reply(`Dispatched ae-ci (QA) on ${ref}`);
+              }
+              case '/run-security-dispatch': {
+              }
+              case '/enforce-security': {
+                await addLabels(['enforce-security']);
+                return reply('Label `enforce-security` added. Security/SBOM/cedar gates may enforce thresholds.');
               }
               case '/run-security-dispatch': {
                 if (!context.payload.issue.pull_request) return reply('Not a PR');

--- a/docs/ci/slash-commands.md
+++ b/docs/ci/slash-commands.md
@@ -1,0 +1,54 @@
+# Slash Commands Mapping (Issue #962)
+
+Status: Draft (docs-only)
+Scope: Command → labels/dispatch mapping used by agent-commands.yml.
+
+Comment scope
+- Commands are processed on PR comments (workflow `agent-commands.yml`). Issue-only commands are out of scope.
+
+Core commands
+- `/run-qa` → label `run-qa`
+- `/run-security` → label `run-security`
+- `/run-cedar` → label `run-cedar`
+- `/non-blocking` → label `ci-non-blocking`
+- `/blocking` → remove `ci-non-blocking`
+- `/ready` → remove `do-not-merge` (alias: `/ready-for-review`)
+- `/handoff A|B|C` → label `handoff:agent-a|b|c`
+
+Coverage/perf/lighthouse
+- `/coverage <pct|clear>` → set `coverage:<pct>` (clears existing coverage:*)
+- `/enforce-coverage` → label `enforce-coverage`
+- `/perf <pct|clear>` → set `perf:<pct>`
+- `/enforce-perf` → label `enforce-perf`
+- `/lh <pct|clear>` → set `lh:<pct>`
+- `/enforce-lh` → label `enforce-lh`
+
+Formal
+- `/run-formal` → label `run-formal`
+- `/enforce-formal` → label `enforce-formal`
+- `/formal-help` `/formal-quickstart` → reply with quick tips/docs
+- `/formal-aggregate-dispatch` → dispatch `formal-aggregate.yml` on PR head (upsert AE-FORMAL-AGGREGATE comment)
+- `/formal-verify-dispatch` → dispatch `formal-verify.yml` on PR head (optional `inputs.target`)
+- `/formal-apalache-dispatch` → dispatch `formal-verify.yml` with `inputs.target=apalache`
+
+Security/SBOM
+- `/run-security-dispatch` → dispatch `sbom-generation.yml` on PR head
+- `/enforce-security` → label `enforce-security` (enforcement in cedar/sbom gates)
+
+QA batches
+- `/run-qa:commands` → label `qa-batch:commands`
+- `/run-qa:cli` → label `qa-batch:cli`
+- `/run-qa:property` → label `qa-batch:property`
+- `/run-qa:agents` → label `qa-batch:agents`
+
+Misc dispatchers
+- `/verify-lite` → dispatch `verify-lite.yml` on PR head
+- `/run-qa-dispatch` → dispatch `ae-ci.yml` on PR head
+- `/ci-fast-dispatch` → dispatch `ci-fast.yml` on PR head
+- `/run-flake-dispatch` → dispatch `flake-detect.yml` on PR head
+- `/spec-validation-dispatch` → dispatch `spec-validation.yml` on PR head
+- `/run-cedar-dispatch` → dispatch `cedar-quality-gates.yml` on PR head
+
+Notes
+- All comments from the bot include header `<!-- AE-AGENTS-REPLY -->` to reduce noise.
+- See also: `docs/ci-policy.md`, `AGENTS.md`.

--- a/docs/quality/formal-aggregate-comment.md
+++ b/docs/quality/formal-aggregate-comment.md
@@ -1,0 +1,90 @@
+# Formal Aggregate PR Comment — Spec and Upsert Guide (Issue #961)
+
+Status: Draft (docs-only)
+Scope: Define a consistent, upserted PR comment for formal aggregate results.
+
+Header and Upsert
+- Fixed header: `<!-- AE-FORMAL-AGGREGATE -->`
+- Upsert: find existing comment starting with the header; update if present, otherwise create.
+- One comment per PR; re-runs overwrite content under the same header to avoid noise.
+
+Sources and Minimal JSON
+- Primary source: `artifacts/formal/formal-aggregate.json`
+  - Minimal shape (example):
+  ```json
+  {
+    "info": {
+      "present": { "conformance": true, "smt": true, "alloy": false, "tla": true, "apalache": false },
+      "presentCount": 3,
+      "ranOk": { "apalache": false },
+      "errors": [
+        { "tool": "apalache", "kind": "parse", "message": "...", "snippet": "..." }
+      ]
+    },
+    "byType": { "conformance": { "schemaErrors": 0, "invariantViolations": 3, "violationRate": 0.30 } }
+  }
+  ```
+- Secondary data (optional): `hermetic-reports/formal/summary.json` for concise one-line console summary.
+
+Clamp and Limits (env)
+- `FORMAL_AGG_LINE_CLAMP` (default 200): line clamp for long lines in comment body.
+- `FORMAL_AGG_ERRORS_LIMIT` (default 5): max number of error fragments to include.
+- `FORMAL_AGG_SNIPPET_MAX_LINES` (default 20): clamp for multi-line error snippets.
+
+Comment Structure (recommended)
+1) Present — a compact presence tally and list
+   - Format: `Present: <count>/5 (conformance, smt, alloy, tla, apalache)`
+2) Summary — key numbers from `byType` when available
+   - Example: `Conformance: schemaErrors=0, invariantViolations=3, rate=0.300`
+3) By-type present — list tools present (same order), with quick statuses
+   - Example: `By-type present: conformance, smt, tla`
+4) Apalache ran/ok — single-line status if available
+   - Example: `Apalache: ran=false, ok=false` (when present)
+5) Meta — Tools/Reproduce/Policy/Clamp/Generated
+   - Tools: present flags; Reproduce: short CLI (verify:tla/smt/alloy); Policy: label-gated, non-blocking; Clamp: env values; Generated: timestamp
+
+One-line Summary (top)
+- Optional first line: `Formal aggregate: Present 3/5 | Conformance iv=3 (rate=0.300) | Apalache ran=false`
+- Keep within clamp; reduce detail if exceeded.
+
+Sample Body
+```
+<!-- AE-FORMAL-AGGREGATE -->
+Formal aggregate: Present 3/5 | Conformance iv=3 (rate=0.300) | Apalache ran=false
+
+Present
+- conformance, smt, tla (3/5)
+
+Summary
+- Conformance: schemaErrors=0, invariantViolations=3, rate=0.300, first=allocated_le_onhand@2, byType(onhand_min=1, allocated_le_onhand=2)
+
+Apalache
+- ran=false, ok=false
+
+Meta
+- Tools: present={conformance,smt,tla}, alloy/apalache absent
+- Reproduce: `pnpm run verify:tla -- --engine=tlc` | `pnpm run verify:smt -- --solver=z3` | `pnpm run verify:alloy`
+- Policy: non-blocking (label-gated: run-formal; enforce: enforce-formal)
+- Clamp: FORMAL_AGG_LINE_CLAMP=200, FORMAL_AGG_ERRORS_LIMIT=5, FORMAL_AGG_SNIPPET_MAX_LINES=20
+- Generated: 2025-09-20T12:34:56Z
+```
+
+Upsert Snippet (GitHub Script)
+```js
+const header = '<!-- AE-FORMAL-AGGREGATE -->';
+const { owner, repo } = context.repo;
+const issue_number = context.issue.number;
+const comments = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+const existing = comments.data.find(c => typeof c.body === 'string' && c.body.startsWith(header));
+const body = header + '\n' + renderAggregateBody();
+if (existing) {
+  await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+} else {
+  await github.rest.issues.createComment({ owner, repo, issue_number, body });
+}
+```
+
+Consistency
+- Aligns with: `docs/quality/formal-runbook.md` guidance and `AGENTS.md` comment header policy。
+- Non-blocking by default; labels: `run-formal` (run), `enforce-formal` (optional enforcement).
+

--- a/docs/rfc/rfc-composite-dod.md
+++ b/docs/rfc/rfc-composite-dod.md
@@ -1,0 +1,192 @@
+# RFC: Composite Definition of Done (DoD) — policy-loader 合成 + 優先順位/厳しさマージ（policy > AE-IR > ae.config）
+
+Status: Draft
+Issue: #916
+
+Summary
+- Introduce a composite DoD computed from three sources: policy/quality.json, AE‑IR (optional dod), and ae.config.*
+- Merge with “strictest wins” semantics per metric; precedence fallback: policy > AE‑IR > ae.config
+- Provide a comparator expression spec (ops, units, normalization) reusable by #915
+- Define conflict logging policy (logs + PR comment upsert with stable headers)
+- Backward-compatible introduction with phased migration
+
+Goals
+- Single effective DoD visible to CI and local tools
+- Central baseline in policy with spec intent (AE‑IR) and repo pragmatics (ae.config)
+- Strictness cannot be weakened by lower layers; overridable upwards only
+
+Scope
+- In-repo policy-loader to read/compose: policy/quality.json, .ae/ae-ir.json, ae.config.*
+- Effective DoD surfaced in: Verify Lite logs, coverage-check logs, and PR comments
+- Non-goals: org-wide distribution/governance, secrets management
+
+Terminology
+- Strictest merge: choose the stricter value per metric; examples below
+- Precedence fallback: when metrics are incomparable or missing → policy > AE‑IR > ae.config
+- Enforcement order: strict > warn > off
+
+**Policy Shape (quality.json) — Composite DoD anchors**
+- Existing policy file provides categories, thresholds, enforcement, and environment overrides.
+- This RFC standardizes gate references and clarifies thresholds for composite computation.
+
+**Example (excerpt) — policy/quality.json**
+```
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework.com/schemas/quality-policy.json",
+  "title": "AE-Framework Quality Gates Policy",
+  "quality": {
+    "coverage": {
+      "description": "Code coverage requirements",
+      "gates": ["coverage-check / gate", "verify-lite / coverage-note"],
+      "enforcement": "strict",
+      "thresholds": { "lines": 80, "functions": 80, "branches": 80, "statements": 80 },
+      "tools": ["nyc", "vitest"],
+      "phases": ["phase-3", "phase-4", "phase-5", "phase-6"]
+    },
+    "formal": {
+      "gates": ["verify:conformance", "verify:alloy", "verify:tla", "verify:smt"],
+      "enforcement": "warn",
+      "thresholds": { "present": 1 }
+    },
+    "accessibility": {
+      "gates": ["adapter-thresholds / a11y"],
+      "enforcement": "strict",
+      "thresholds": { "critical": 0, "serious": 2, "moderate": 3, "minor": 5, "total_warnings": 5 }
+    },
+    "lighthouse": {
+      "gates": ["adapter-thresholds / lighthouse"],
+      "enforcement": "warn",
+      "thresholds": { "performance": 90, "accessibility": 95, "bestPractices": 85, "seo": 80, "pwa": "off" }
+    }
+  },
+  "environments": {
+    "ci": {
+      "overrides": {
+        "coverage.thresholds.lines": 85,
+        "coverage.thresholds.functions": 85,
+        "coverage.thresholds.statements": 85,
+        "linting.thresholds.errors": 0
+      }
+    }
+  }
+}
+```
+
+**AE‑IR Extension (optional; backward‑compatible)**
+- Add an optional dod section expressing spec intent. Absent fields are ignored.
+
+TypeScript shape (fragment)
+```
+export interface AEIR_DOD {
+  enforcement?: 'off' | 'warn' | 'strict';
+  coverage?: { enforcement?: 'off' | 'warn' | 'strict'; thresholds?: { lines?: number; functions?: number; branches?: number; statements?: number } };
+  formal?:   { enforcement?: 'off' | 'warn' | 'strict'; gates?: Array<'conformance' | 'alloy' | 'tla' | 'smt'> };
+  accessibility?: { enforcement?: 'off' | 'warn' | 'strict'; thresholds?: { critical?: number; serious?: number; moderate?: number; minor?: number; total_warnings?: number } };
+  lighthouse?:   { enforcement?: 'off' | 'warn' | 'strict'; thresholds?: { performance?: number; accessibility?: number; bestPractices?: number; seo?: number; pwa?: number | 'off' } };
+}
+export interface AEIR { /* existing */ dod?: AEIR_DOD }
+```
+
+JSON fragment (example)
+```
+{
+  "version": "0.2",
+  "metadata": { "name": "checkout" },
+  "dod": {
+    "enforcement": "strict",
+    "coverage": { "thresholds": { "lines": 88, "branches": 85 } },
+    "formal":   { "enforcement": "warn", "gates": ["conformance", "alloy"] }
+  }
+}
+```
+
+**ae.config (repo pragmatics)**
+- Continue to support qa.coverageThreshold and similar knobs. These are lowest‑precedence on fallback and never soften stricter values from policy/AE‑IR under strictest merge.
+
+**Strictest Merge Rule**
+- Enforcement resolution: strict > warn > off; any strict yields strict effective enforcement.
+- Coverage (higher is stricter): effective = max(policy, AE‑IR, ae.config) per key (lines, branches, functions, statements).
+- A11y/Security budgets (lower is stricter): effective = min(policy, AE‑IR, ae.config).
+- Incomparable metrics (unit/shape mismatch): fallback to precedence (policy > AE‑IR > ae.config) and log rationale.
+
+Examples
+- Coverage: policy lines ≥ 80, AE‑IR ≥ 85, ae.config ≥ 90 → effective lines ≥ 90
+- Formal: policy=warn, AE‑IR=strict, ae.config=off → effective=strict
+- A11y serious: policy ≤ 0, AE‑IR absent, ae.config ≤ 1 → effective ≤ 0
+- Mismatch: AE‑IR dod.lighthouse.thresholds.pwa = "off" (categorical) vs policy numeric → use policy via precedence, log reason
+
+**Conflict Logging Policy**
+- Always log per‑metric source values and decision path.
+- PR comment upsert with stable header (e.g., <!-- AE-DOD-COMPOSITE -->) shows:
+  - Threshold (effective), Derived (by layer), Policy, Policy source
+- In logs: include “fallback(precedence)” when unit/shape mismatch causes precedence to be used.
+- Never downgrade stricter values; warn if a lower layer is attempting to soften a stricter policy value.
+
+**Comparator Expression Spec (shared with #915)**
+- Purpose: unify comparisons across gates with consistent ops/units and normalization.
+- Expression forms:
+  - JSON: { "metric": "coverage.lines", "op": ">=", "value": 90, "unit": "pct" }
+  - String: "coverage.lines >= 90%"
+- Operators: >, >=, <, <=, ==, !=
+- Units and normalization:
+  - pct: accept 0..100 (e.g., 90) or 0..1 (e.g., 0.9) → canonical is percent (0..100)
+  - count: non‑negative integer
+  - ms: milliseconds (integers); allow s suffix in string form, normalize to ms
+  - score: 0..100 (Lighthouse); if 0..1 given, multiply by 100
+- Coercion examples:
+  - "88%" → { unit: "pct", value: 88 }
+  - 0.93 with unit pct → 93
+  - "750ms" → 750; "1.5s" → 1500
+- Comparison evaluation:
+  - Normalize actual and target to canonical unit; apply op; produce tri‑state result { pass|fail, reason }
+- Mapping to policy categories:
+  - coverage.lines → pct (higher stricter)
+  - accessibility.serious → count (lower stricter)
+  - lighthouse.performance → score (higher stricter)
+
+**Policy‑loader (composition)**
+- Inputs: policy (with env overrides), AE‑IR.dod (optional), ae.config (optional)
+- Steps:
+  1) Load policy → apply environment overrides (e.g., ci)
+  2) Extract per‑category thresholds/enforcement (policy layer)
+  3) Read AE‑IR.dod and ae.config knobs (if present)
+  4) Merge per metric using strictest rules; if incomparable, precedence fallback
+  5) Emit effective DoD + derived values; log decisions and conflicts
+- Output shape (example, coverage only):
+```
+{
+  "effective": {
+    "enforcement": "strict",
+    "coverage": { "lines": 90, "functions": 90, "branches": 85, "statements": 90 }
+  },
+  "derived": {
+    "policy":    { "coverage": { "lines": 80, "functions": 80, "branches": 80, "statements": 80 }, "enforcement": "strict" },
+    "aeir":      { "coverage": { "lines": 88, "branches": 85 }, "enforcement": "warn" },
+    "ae.config": { "coverage": { "lines": 90, "functions": 90, "statements": 90 } }
+  },
+  "decisions": [
+    { "metric": "coverage.lines", "rule": "higher-stricter", "selected": 90, "from": "ae.config" },
+    { "metric": "coverage.branches", "rule": "higher-stricter", "selected": 85, "from": "aeir" }
+  ]
+}
+```
+
+**Migration & Backward‑Compat**
+- Phase 0 (visibility only): compute and print effective DoD in Verify Lite / coverage‑check logs; PR comment upsert. No gating changes.
+- Phase 1 (coverage): use effective coverage thresholds in coverage‑check; still label‑gated enforcement (enforce‑coverage, coverage:<pct>) and main enforcement via repo vars.
+- Phase 2 (formal, a11y, lighthouse): extend strictest merge; keep label‑gated enforcement; ensure no softening vs policy.
+- AE‑IR dod is optional; existing AE‑IR remains valid.
+- ae.config continues to work; treated as least‑precedence fallback and cannot override to weaken stricter baselines.
+- policy/quality.json remains canonical; environment overrides still apply.
+
+**Open Questions**
+- AE‑IR key name: dod vs quality — proposal keeps dod for scope clarity
+- Comment headers: consolidate under <!-- AE-DOD-COMPOSITE --> or keep per‑gate headers (e.g., AE‑COVERAGE‑SUMMARY)
+- Additional metrics to standardize in comparator spec (mutationScore, visual pixelDifference)
+
+Appendix — File references
+- policy file: policy/quality.json
+- AE config: ae.config.ts
+- Verify Lite workflow: .github/workflows/verify-lite.yml
+- Coverage check: .github/workflows/coverage-check.yml


### PR DESCRIPTION
Adds docs/ci/slash-commands.md (command→label/dispatch table) and updates agent-commands.yml with /ready-for-review alias and /enforce-security. Docs + workflow only; no runtime code impacted.