### PR TITLE
chore(ci): PM daily summary automation (schedule + manual)

### DIFF
--- a/.ae/enhanced-state.db
+++ b/.ae/enhanced-state.db
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0.0",
-    "timestamp": "2025-09-18T07:17:11.977Z",
+    "timestamp": "2025-09-19T17:23:26.308Z",
     "options": {
       "databasePath": ".ae/enhanced-state.db",
       "enableCompression": true,
@@ -14,9 +14,9 @@
   },
   "entries": [
     {
-      "id": "5f9445d6-18e6-4169-97f3-339b9f3b9e86",
+      "id": "f92e9726-4053-4fb4-af9e-22a96e6d53d9",
       "logicalKey": "integration-ready",
-      "timestamp": "2025-09-18T07:17:11.977Z",
+      "timestamp": "2025-09-19T17:23:26.308Z",
       "version": 1,
       "checksum": "0094478148422a83dc50a368102314e8ddf937293f6679096c4b66f5d989afcb",
       "data": {
@@ -28,8 +28,8 @@
       "ttl": 604800,
       "metadata": {
         "size": 28,
-        "created": "2025-09-18T07:17:11.977Z",
-        "accessed": "2025-09-18T07:17:11.977Z",
+        "created": "2025-09-19T17:23:26.308Z",
+        "accessed": "2025-09-19T17:23:26.308Z",
         "source": "unknown"
       }
     }
@@ -37,7 +37,7 @@
   "indices": {
     "keyIndex": {
       "integration-ready": [
-        "integration-ready_2025-09-18T07:17:11.977Z"
+        "integration-ready_2025-09-19T17:23:26.308Z"
       ]
     },
     "versionIndex": {

--- a/.ae/phase-state.json
+++ b/.ae/phase-state.json
@@ -1,0 +1,130 @@
+{
+  "projectId": "22b77d5e-e89d-41f7-874c-6a8cfd74dc05",
+  "projectName": "phase1-integration",
+  "createdAt": "2025-09-19T17:23:26.306Z",
+  "updatedAt": "2025-09-19T17:23:26.769Z",
+  "currentPhase": "intent",
+  "phaseStatus": {
+    "intent": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "formal": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "test": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "code": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "verify": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    },
+    "operate": {
+      "completed": false,
+      "approved": false,
+      "artifacts": []
+    }
+  },
+  "approvalsRequired": true,
+  "metadata": {
+    "integration-test": {
+      "ready": true
+    },
+    "test-agent_task_started_1758302606749": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.749Z",
+      "taskId": "test-task-1",
+      "type": "code-generation"
+    },
+    "test-agent_task_completed_1758302606751": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.751Z",
+      "taskId": "test-task-1",
+      "success": true,
+      "executionTime": 2
+    },
+    "test-agent_task_started_1758302606758": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.758Z",
+      "taskId": "tdd-task",
+      "type": "test-generation"
+    },
+    "test-agent_task_completed_1758302606759": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.759Z",
+      "taskId": "tdd-task",
+      "success": true,
+      "executionTime": 1
+    },
+    "test-agent_task_started_1758302606762": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.762Z",
+      "taskId": "validation-test",
+      "type": "validation"
+    },
+    "test-agent_task_completed_1758302606763": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.763Z",
+      "taskId": "validation-test",
+      "success": true,
+      "executionTime": 1
+    },
+    "test-agent_task_started_1758302606764": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.764Z",
+      "taskId": "coverage-test",
+      "type": "quality-assurance"
+    },
+    "test-agent_task_completed_1758302606765": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.765Z",
+      "taskId": "coverage-test",
+      "success": true,
+      "executionTime": 1
+    },
+    "test-agent_task_started_1758302606768": {
+      "activity": "task_started",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.768Z",
+      "taskId": "phase-transition",
+      "type": "phase-validation"
+    },
+    "test-agent_task_completed_1758302606769": {
+      "activity": "task_completed",
+      "agentId": "test-agent",
+      "agentType": "code-generation",
+      "timestamp": "2025-09-19T17:23:26.769Z",
+      "taskId": "phase-transition",
+      "success": true,
+      "executionTime": 1
+    }
+  }
+}

--- a/.github/workflows/pm-daily-summary.yml
+++ b/.github/workflows/pm-daily-summary.yml
@@ -1,0 +1,129 @@
+name: PM Daily Summary
+
+on:
+  schedule:
+    - cron: '30 23 * * *' # 08:30 JST daily
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force run now'
+        required: false
+        default: 'true'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+env:
+  ROOT_ISSUE: '898'
+  POLICY_ISSUE: '963'
+  CHILD_ISSUES: '958,959,960,961,962,963,964'
+  DAILY_HEADER: '<!-- AE-PM-DAILY -->'
+
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize Sprint 0 status and upsert comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const ROOT_ISSUE = process.env.ROOT_ISSUE;
+            const POLICY_ISSUE = process.env.POLICY_ISSUE;
+            const CHILD_ISSUES = process.env.CHILD_ISSUES.split(',').map(s => s.trim()).filter(Boolean);
+            const HEADER = process.env.DAILY_HEADER;
+
+            async function ensureStartOnPolicyIssue() {
+              try {
+                const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: Number(POLICY_ISSUE), per_page: 100 });
+                const hasStart = comments.some(c => (c.body || '').includes('/start'));
+                if (!hasStart) {
+                  await github.rest.issues.createComment({ owner, repo, issue_number: Number(POLICY_ISSUE), body: '/start' });
+                }
+              } catch (e) {
+                core.warning(`Failed to ensure /start on #${POLICY_ISSUE}: ${e.message}`);
+              }
+            }
+
+            async function fetchIssue(number) {
+              const { data } = await github.rest.issues.get({ owner, repo, issue_number: Number(number) });
+              return data;
+            }
+
+            async function findOpenDraftPRsReferencing(issueNumber) {
+              const q = `repo:${owner}/${repo} type:pr is:open ${issueNumber}`;
+              const res = await github.rest.search.issuesAndPullRequests({ q, per_page: 10 });
+              const items = res.data.items || [];
+              const prs = [];
+              for (const it of items) {
+                if (!('pull_request' in it)) continue;
+                const prNum = it.number;
+                const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNum });
+                if (pr.state === 'open') {
+                  prs.push({ number: pr.number, title: pr.title, head: pr.head.ref, draft: pr.draft, html_url: pr.html_url, updated_at: pr.updated_at });
+                }
+              }
+              // prefer one PR; if multiple, keep the most recently updated
+              prs.sort((a,b) => new Date(b.updated_at) - new Date(a.updated_at));
+              return prs;
+            }
+
+            function fmtDate(iso) {
+              if (!iso) return '';
+              const d = new Date(iso);
+              return d.toISOString().replace('T',' ').replace('Z',' UTC');
+            }
+
+            await ensureStartOnPolicyIssue();
+
+            const lines = [];
+            lines.push(HEADER);
+            lines.push('Sprint 0 — Daily Summary (auto)');
+            lines.push('');
+            lines.push('Scope');
+            lines.push('- #915 / #917 / #918 / #916');
+            lines.push('- Child: #' + CHILD_ISSUES.join(' / #'));
+            lines.push('');
+            lines.push('Status');
+
+            for (const id of CHILD_ISSUES) {
+              try {
+                const issue = await fetchIssue(id);
+                const prs = await findOpenDraftPRsReferencing(id);
+                const prLine = prs.length
+                  ? `PR #${prs[0].number} (${prs[0].draft ? 'Draft' : 'Open'}) · ${prs[0].head} · ${fmtDate(prs[0].updated_at)} · ${prs[0].html_url}`
+                  : 'No open PR linked';
+                const labels = (issue.labels || []).map(l => typeof l === 'string' ? l : l.name).join(', ');
+                lines.push(`- #${id}: ${issue.title} · ${issue.state} · ${labels} · ${fmtDate(issue.updated_at)}\n  - ${prLine}`);
+              } catch (e) {
+                lines.push(`- #${id}: fetch error: ${e.message}`);
+              }
+            }
+
+            lines.push('');
+            lines.push('Priorities');
+            lines.push('- Verify Lite baseline (#958) and actionlint/printf (#959) first.');
+            lines.push('- CI/Security policy (#963), then slash-command mappings (#962).');
+            lines.push('');
+            lines.push('Risks/Blockers');
+            lines.push('- None marked by automation. Post /block on impacted issue if CI repeatedly fails or permissions block.');
+            lines.push('');
+            lines.push('Next Actions');
+            lines.push('- Keep one Draft PR per child issue. Flip to ready-for-review after green on Verify Lite.');
+
+            const body = lines.join('\n');
+
+            // Upsert comment on ROOT_ISSUE using HEADER marker
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: Number(ROOT_ISSUE), per_page: 100 });
+            const mine = comments.find(c => (c.body || '').startsWith(HEADER));
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: Number(ROOT_ISSUE), body });
+            }
+
+            core.notice('Daily summary upserted.');

--- a/artifacts/domain/replay.summary.json
+++ b/artifacts/domain/replay.summary.json
@@ -1,0 +1,1 @@
+{"traceId":"t-1","totalEvents":3,"violatedInvariants":[]}

--- a/hermetic-reports/formal/conformance-summary.json
+++ b/hermetic-reports/formal/conformance-summary.json
@@ -1,0 +1,16 @@
+{
+  "tool": "conformance-driver",
+  "ran": true,
+  "ok": true,
+  "timeMs": 0,
+  "errors": [],
+  "traceId": "t-1",
+  "events": 3,
+  "violatedInvariants": [],
+  "spec": "n/a",
+  "timestamp": "2025-09-19T17:23:34.772Z",
+  "runtimeHooks": null,
+  "runtimeHooksCompare": null,
+  "hookReplayMatchRate": null,
+  "hookStats": null
+}

--- a/reports/benchmark/req2run-benchmark-2025-09-19T17-23-28-550Z.json
+++ b/reports/benchmark/req2run-benchmark-2025-09-19T17-23-28-550Z.json
@@ -1,0 +1,84 @@
+{
+  "metadata": {
+    "timestamp": "2025-09-19T17:23:28.551Z",
+    "totalProblems": 0,
+    "successfulRuns": 0,
+    "failedRuns": 0,
+    "averageScore": 0,
+    "totalExecutionTime": 0,
+    "framework": "AE Framework v1.0.0",
+    "benchmarkVersion": "req2run-benchmark"
+  },
+  "configuration": {
+    "req2runRepository": "https://github.com/itdojp/req2run-benchmark.git",
+    "problems": [
+      {
+        "id": "test-problem-001",
+        "enabled": true,
+        "timeoutMs": 60000,
+        "retries": 1,
+        "category": "web-api",
+        "difficulty": "basic"
+      }
+    ],
+    "execution": {
+      "parallel": false,
+      "maxConcurrency": 1,
+      "resourceLimits": {
+        "maxMemoryMB": 1024,
+        "maxCpuPercent": 50,
+        "maxDiskMB": 1024,
+        "maxExecutionTimeMs": 300000
+      },
+      "environment": "test",
+      "docker": {
+        "enabled": false,
+        "image": "node:18-alpine",
+        "volumes": [],
+        "ports": []
+      }
+    },
+    "evaluation": {
+      "weights": {
+        "functional": 0.35,
+        "performance": 0.15,
+        "quality": 0.2,
+        "security": 0.15,
+        "testing": 0.15
+      },
+      "thresholds": {
+        "minOverallScore": 60,
+        "minFunctionalCoverage": 70,
+        "maxResponseTime": 2000,
+        "minCodeQuality": 75,
+        "maxVulnerabilities": 5
+      },
+      "scoring": {
+        "algorithm": "weighted-average",
+        "penalties": {
+          "timeoutPenalty": 0.5,
+          "errorPenalty": 0.3,
+          "qualityPenalty": 0.2
+        },
+        "bonuses": {
+          "performanceBonus": 0.1,
+          "qualityBonus": 0.1,
+          "securityBonus": 0.05
+        }
+      }
+    },
+    "reporting": {
+      "formats": [
+        "json"
+      ],
+      "destinations": [],
+      "dashboard": {
+        "enabled": false,
+        "port": 3001,
+        "refreshInterval": 30000,
+        "charts": []
+      }
+    }
+  },
+  "results": []
+}

--- a/reports/benchmark/req2run-benchmark-2025-09-19T17-23-28-550Z.md
+++ b/reports/benchmark/req2run-benchmark-2025-09-19T17-23-28-550Z.md
@@ -1,0 +1,13 @@
+# Req2Run Benchmark Report
+
+Generated: 2025-09-19T17:23:28.551Z
+
+## Summary
+- **Total Problems**: 0
+- **Successful Runs**: 0
+- **Failed Runs**: 0
+- **Average Score**: 0.00/100
+- **Total Execution Time**: 0ms
+
+## Individual Results
+

--- a/reports/benchmark/req2run-benchmark-2025-09-19T17-23-28-871Z.json
+++ b/reports/benchmark/req2run-benchmark-2025-09-19T17-23-28-871Z.json
@@ -1,0 +1,115 @@
+{
+  "metadata": {
+    "timestamp": "2025-09-19T17:23:28.871Z",
+    "totalProblems": 3,
+    "successfulRuns": 0,
+    "failedRuns": 3,
+    "averageScore": 0,
+    "totalExecutionTime": 4,
+    "framework": "AE Framework v1.0.0",
+    "benchmarkVersion": "req2run-benchmark"
+  },
+  "configuration": {
+    "req2runRepository": "https://github.com/itdojp/req2run-benchmark.git",
+    "problems": [
+      {
+        "id": "test-problem-001",
+        "enabled": true,
+        "timeoutMs": 60000,
+        "retries": 1,
+        "category": "web-api",
+        "difficulty": "basic"
+      }
+    ],
+    "execution": {
+      "parallel": false,
+      "maxConcurrency": 1,
+      "resourceLimits": {
+        "maxMemoryMB": 1024,
+        "maxCpuPercent": 50,
+        "maxDiskMB": 1024,
+        "maxExecutionTimeMs": 300000
+      },
+      "environment": "test",
+      "docker": {
+        "enabled": false,
+        "image": "node:18-alpine",
+        "volumes": [],
+        "ports": []
+      }
+    },
+    "evaluation": {
+      "weights": {
+        "functional": 0.35,
+        "performance": 0.15,
+        "quality": 0.2,
+        "security": 0.15,
+        "testing": 0.15
+      },
+      "thresholds": {
+        "minOverallScore": 60,
+        "minFunctionalCoverage": 70,
+        "maxResponseTime": 2000,
+        "minCodeQuality": 75,
+        "maxVulnerabilities": 5
+      },
+      "scoring": {
+        "algorithm": "weighted-average",
+        "penalties": {
+          "timeoutPenalty": 0.5,
+          "errorPenalty": 0.3,
+          "qualityPenalty": 0.2
+        },
+        "bonuses": {
+          "performanceBonus": 0.1,
+          "qualityBonus": 0.1,
+          "securityBonus": 0.05
+        }
+      }
+    },
+    "reporting": {
+      "formats": [
+        "json"
+      ],
+      "destinations": [],
+      "dashboard": {
+        "enabled": false,
+        "port": 3001,
+        "refreshInterval": 30000,
+        "charts": []
+      }
+    }
+  },
+  "results": [
+    {
+      "problemId": "problem-1",
+      "success": false,
+      "score": 0,
+      "executionTime": 2,
+      "phases": [],
+      "errors": [
+        "Failed to load problem spec for problem-1: Problem specification not found for problem-1"
+      ]
+    },
+    {
+      "problemId": "problem-2",
+      "success": false,
+      "score": 0,
+      "executionTime": 1,
+      "phases": [],
+      "errors": [
+        "Failed to load problem spec for problem-2: Problem specification not found for problem-2"
+      ]
+    },
+    {
+      "problemId": "problem-3",
+      "success": false,
+      "score": 0,
+      "executionTime": 1,
+      "phases": [],
+      "errors": [
+        "Failed to load problem spec for problem-3: Problem specification not found for problem-3"
+      ]
+    }
+  ]
+}

--- a/reports/benchmark/req2run-benchmark-2025-09-19T17-23-28-871Z.md
+++ b/reports/benchmark/req2run-benchmark-2025-09-19T17-23-28-871Z.md
@@ -1,0 +1,29 @@
+# Req2Run Benchmark Report
+
+Generated: 2025-09-19T17:23:28.871Z
+
+## Summary
+- **Total Problems**: 3
+- **Successful Runs**: 0
+- **Failed Runs**: 3
+- **Average Score**: 0.00/100
+- **Total Execution Time**: 4ms
+
+## Individual Results
+### problem-1
+- **Status**: ❌ Failed
+- **Score**: 0/100
+- **Execution Time**: 2ms
+- **Errors**: Failed to load problem spec for problem-1: Problem specification not found for problem-1
+
+### problem-2
+- **Status**: ❌ Failed
+- **Score**: 0/100
+- **Execution Time**: 1ms
+- **Errors**: Failed to load problem spec for problem-2: Problem specification not found for problem-2
+
+### problem-3
+- **Status**: ❌ Failed
+- **Score**: 0/100
+- **Execution Time**: 1ms
+- **Errors**: Failed to load problem spec for problem-3: Problem specification not found for problem-3

--- a/reports/benchmark/req2run-benchmark-2025-09-19T17-23-29-681Z.json
+++ b/reports/benchmark/req2run-benchmark-2025-09-19T17-23-29-681Z.json
@@ -1,0 +1,105 @@
+{
+  "metadata": {
+    "timestamp": "2025-09-19T17:23:29.681Z",
+    "totalProblems": 2,
+    "successfulRuns": 0,
+    "failedRuns": 2,
+    "averageScore": 0,
+    "totalExecutionTime": 3,
+    "framework": "AE Framework v1.0.0",
+    "benchmarkVersion": "req2run-benchmark"
+  },
+  "configuration": {
+    "req2runRepository": "https://github.com/itdojp/req2run-benchmark.git",
+    "problems": [
+      {
+        "id": "test-problem-001",
+        "enabled": true,
+        "timeoutMs": 60000,
+        "retries": 1,
+        "category": "web-api",
+        "difficulty": "basic"
+      }
+    ],
+    "execution": {
+      "parallel": true,
+      "maxConcurrency": 2,
+      "resourceLimits": {
+        "maxMemoryMB": 1024,
+        "maxCpuPercent": 50,
+        "maxDiskMB": 1024,
+        "maxExecutionTimeMs": 300000
+      },
+      "environment": "test",
+      "docker": {
+        "enabled": false,
+        "image": "node:18-alpine",
+        "volumes": [],
+        "ports": []
+      }
+    },
+    "evaluation": {
+      "weights": {
+        "functional": 0.35,
+        "performance": 0.15,
+        "quality": 0.2,
+        "security": 0.15,
+        "testing": 0.15
+      },
+      "thresholds": {
+        "minOverallScore": 60,
+        "minFunctionalCoverage": 70,
+        "maxResponseTime": 2000,
+        "minCodeQuality": 75,
+        "maxVulnerabilities": 5
+      },
+      "scoring": {
+        "algorithm": "weighted-average",
+        "penalties": {
+          "timeoutPenalty": 0.5,
+          "errorPenalty": 0.3,
+          "qualityPenalty": 0.2
+        },
+        "bonuses": {
+          "performanceBonus": 0.1,
+          "qualityBonus": 0.1,
+          "securityBonus": 0.05
+        }
+      }
+    },
+    "reporting": {
+      "formats": [
+        "json"
+      ],
+      "destinations": [],
+      "dashboard": {
+        "enabled": false,
+        "port": 3001,
+        "refreshInterval": 30000,
+        "charts": []
+      }
+    }
+  },
+  "results": [
+    {
+      "problemId": "problem-1",
+      "success": false,
+      "score": 0,
+      "executionTime": 1,
+      "phases": [],
+      "errors": [
+        "Failed to load problem spec for problem-1: Problem specification not found for problem-1"
+      ]
+    },
+    {
+      "problemId": "problem-2",
+      "success": false,
+      "score": 0,
+      "executionTime": 2,
+      "phases": [],
+      "errors": [
+        "Failed to load problem spec for problem-2: Problem specification not found for problem-2"
+      ]
+    }
+  ]
+}

--- a/reports/benchmark/req2run-benchmark-2025-09-19T17-23-29-681Z.md
+++ b/reports/benchmark/req2run-benchmark-2025-09-19T17-23-29-681Z.md
@@ -1,0 +1,23 @@
+# Req2Run Benchmark Report
+
+Generated: 2025-09-19T17:23:29.681Z
+
+## Summary
+- **Total Problems**: 2
+- **Successful Runs**: 0
+- **Failed Runs**: 2
+- **Average Score**: 0.00/100
+- **Total Execution Time**: 3ms
+
+## Individual Results
+### problem-1
+- **Status**: ❌ Failed
+- **Score**: 0/100
+- **Execution Time**: 1ms
+- **Errors**: Failed to load problem spec for problem-1: Problem specification not found for problem-1
+
+### problem-2
+- **Status**: ❌ Failed
+- **Score**: 0/100
+- **Execution Time**: 2ms
+- **Errors**: Failed to load problem spec for problem-2: Problem specification not found for problem-2

--- a/src/utils/comparator.ts
+++ b/src/utils/comparator.ts
@@ -1,0 +1,189 @@
+export type ComparatorOp = '>=' | '<=' | '>' | '<' | '==' | '!=';
+
+export interface ParsedComparator {
+  op: ComparatorOp;
+  value: number;
+  unit?: string;
+}
+
+type ValueWithKind = {
+  value: number;
+  // canonical kinds used internally for comparison
+  kind: 'none' | 'ratio' | 'ms' | 'rps';
+};
+
+const OP_REGEX = /^(>=|<=|==|!=|>|<)\s*(.+)$/;
+
+function normalizeUnit(unit?: string): string | undefined {
+  if (!unit) return undefined;
+  const u = unit.trim().toLowerCase();
+  if (u === '%') return '%';
+  if (u === 'ms' || u === 's' || u === 'm' || u === 'h') return u;
+  if (u === 'rps') return 'rps';
+  return u;
+}
+
+function parseNumericWithUnit(input: string): { value: number; unit?: string; kind: ValueWithKind['kind'] } {
+  const raw = input.trim();
+  // Percentage: e.g., 90%
+  if (/^[-+]?\d*\.?\d+\s*%$/.test(raw)) {
+    const num = parseFloat(raw.replace('%', '').trim());
+    return { value: num / 100, unit: undefined, kind: 'ratio' };
+  }
+
+  // Generic number with optional unit
+  const m = raw.match(/^([-+]?\d*\.?\d+)\s*([a-z%]+)?$/i);
+  if (!m) {
+    throw new Error(`Invalid value: ${input}`);
+  }
+  const val = parseFloat(m[1]);
+  const unit = normalizeUnit(m[2]);
+
+  // Time normalization to ms
+  if (unit === 'ms' || unit === 's' || unit === 'm' || unit === 'h') {
+    let ms = val;
+    if (unit === 's') ms = val * 1000;
+    else if (unit === 'm') ms = val * 60 * 1000;
+    else if (unit === 'h') ms = val * 60 * 60 * 1000;
+    return { value: ms, unit: 'ms', kind: 'ms' };
+  }
+
+  if (unit === 'rps') {
+    return { value: val, unit: 'rps', kind: 'rps' };
+  }
+
+  if (unit === '%' || unit === 'percent' || unit === 'pct') {
+    return { value: val / 100, unit: undefined, kind: 'ratio' };
+  }
+
+  // Plain number (unit-less)
+  return { value: val, unit: undefined, kind: 'none' };
+}
+
+function ensureComparableKinds(a: ValueWithKind['kind'], b: ValueWithKind['kind']): boolean {
+  if (a === b) return true;
+  // Allow ratio vs none (treat numbers as already-ratio if expr expects ratio)
+  if ((a === 'ratio' && b === 'none') || (a === 'none' && b === 'ratio')) return true;
+  // Allow ms vs none (treat unit-less actual as ms if comparator expects time)
+  if ((a === 'ms' && b === 'none') || (a === 'none' && b === 'ms')) return true;
+  // Allow rps vs none (treat unit-less actual as rps if comparator expects rps)
+  if ((a === 'rps' && b === 'none') || (a === 'none' && b === 'rps')) return true;
+  return false;
+}
+
+export function parseComparator(expr: string): ParsedComparator {
+  const trimmed = expr.trim();
+  const m = trimmed.match(OP_REGEX);
+  if (!m) throw new Error(`Invalid comparator expression: ${expr}`);
+  const op = m[1] as ComparatorOp;
+  const rest = m[2];
+  const { value, unit, kind } = parseNumericWithUnit(rest);
+  // Percent is normalized to ratio (unit undefined). Time normalized to ms.
+  // Return unit only when meaningful (ms or rps)
+  return { op, value, unit: kind === 'ms' ? 'ms' : kind === 'rps' ? 'rps' : undefined };
+}
+
+function toCanonical(actual: number | string | { value: number; unit?: string }): ValueWithKind {
+  if (typeof actual === 'number') {
+    return { value: actual, kind: 'none' };
+  }
+  if (typeof actual === 'string') {
+    const { value, kind } = parseNumericWithUnit(actual);
+    return { value, kind };
+  }
+  // object form
+  const { value, unit } = actual;
+  if (unit) {
+    const normalized = parseNumericWithUnit(`${value}${unit}`);
+    return { value: normalized.value, kind: normalized.kind };
+  }
+  return { value, kind: 'none' };
+}
+
+function compareNumbers(a: number, b: number, op: ComparatorOp): boolean {
+  switch (op) {
+    case '>=':
+      return a >= b;
+    case '>':
+      return a > b;
+    case '<=':
+      return a <= b;
+    case '<':
+      return a < b;
+    case '==':
+      return a === b;
+    case '!=':
+      return a !== b;
+  }
+}
+
+export function compare(
+  actual: { value: number; unit?: string } | number | string,
+  expr: string
+): boolean {
+  const cmp = parseComparator(expr);
+  const act = toCanonical(actual);
+
+  // Determine compatibility of kinds
+  const cmpKind: ValueWithKind['kind'] = cmp.unit === 'ms' ? 'ms' : cmp.unit === 'rps' ? 'rps' : 'ratio';
+
+  // If expr had no explicit unit and did not look like ratio, treat as 'none'
+  if (!cmp.unit && !expr.trim().endsWith('%') && !/\d\s*%/.test(expr)) {
+    // The comparator is unit-less numeric
+    return compareNumbers(act.value, cmp.value, cmp.op);
+  }
+
+  if (!ensureComparableKinds(act.kind, cmpKind)) {
+    throw new Error(`Incompatible units: actual kind ${act.kind} vs comparator kind ${cmpKind}`);
+  }
+
+  // Align unit-less actual to comparator kind if needed (no scaling needed since comparator already normalized)
+  return compareNumbers(act.value, cmp.value, cmp.op);
+}
+
+export function strictest(a: string, b: string): string {
+  const ca = parseComparator(a);
+  const cb = parseComparator(b);
+
+  const kindA: ValueWithKind['kind'] = ca.unit === 'ms' ? 'ms' : ca.unit === 'rps' ? 'rps' : 'ratio';
+  const kindB: ValueWithKind['kind'] = cb.unit === 'ms' ? 'ms' : cb.unit === 'rps' ? 'rps' : 'ratio';
+
+  if (!ensureComparableKinds(kindA, kindB)) {
+    throw new Error('Cannot determine strictest: incompatible units');
+  }
+
+  const isGreaterOp = (op: ComparatorOp) => op === '>' || op === '>=';
+  const isLessOp = (op: ComparatorOp) => op === '<' || op === '<=';
+
+  // Same direction comparisons
+  if (isGreaterOp(ca.op) && isGreaterOp(cb.op)) {
+    if (ca.value === cb.value) {
+      // At equal threshold, '>' is stricter than '>='
+      if (ca.op === '>' && cb.op === '>=') return a;
+      if (cb.op === '>' && ca.op === '>=') return b;
+      // Same op, equal threshold -> either, return first for stability
+      return a;
+    }
+    return ca.value > cb.value ? a : b;
+  }
+
+  if (isLessOp(ca.op) && isLessOp(cb.op)) {
+    if (ca.value === cb.value) {
+      if (ca.op === '<' && cb.op === '<=') return a;
+      if (cb.op === '<' && ca.op === '<=') return b;
+      return a;
+    }
+    return ca.value < cb.value ? a : b;
+  }
+
+  // Equality comparisons: if one is equality and the other includes that exact value, equality is stricter
+  if (ca.op === '==' && (isGreaterOp(cb.op) || isLessOp(cb.op))) {
+    if (compare(ca.value, `${cb.op} ${cb.value}${cb.unit ? cb.unit : ''}`)) return a;
+  }
+  if (cb.op === '==' && (isGreaterOp(ca.op) || isLessOp(ca.op))) {
+    if (compare(cb.value, `${ca.op} ${ca.value}${ca.unit ? ca.unit : ''}`)) return b;
+  }
+
+  // Not supported to determine strictest reliably
+  throw new Error('Cannot determine strictest for given expressions');
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ export { SteeringLoader } from './steering-loader.js';
 export { EvidenceValidator } from './evidence-validator.js';
 export { TokenOptimizer } from './token-optimizer.js';
 export { ContextManager } from './context-manager.js';
+export { parseComparator, compare, strictest } from './comparator.js';
 
 // Smart Persona System (Phase 2)
 export { PersonaManager } from './persona-manager.js';

--- a/tests/golden/snapshots/codegen-snapshot.json
+++ b/tests/golden/snapshots/codegen-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-09-18T07:17:11.813Z",
+  "timestamp": "2025-09-19T17:23:26.214Z",
   "version": "1.0.0",
   "files": {
     "examples/inventory/apps/web/components/ProductForm.tsx": {
@@ -93,18 +93,18 @@
       "typeScriptErrors": 1,
       "eslintErrors": 0
     },
-    "examples/inventory/apps/web/app/customer/page.tsx": {
-      "hash": "9889197ef585928b8a3d03a201f2df7d1dec53af82d475b495e1b48354b0011c",
-      "lineCount": 108,
-      "ariaAttributeCount": 0,
-      "typeScriptErrors": 0,
-      "eslintErrors": 0
-    },
     "examples/inventory/apps/web/app/order/page.tsx": {
       "hash": "9b1dc2fa35a32648d7c4ec5186df715a8c6d37b7ebe17aed14fe2fda193bb9bf",
       "lineCount": 118,
       "ariaAttributeCount": 0,
       "typeScriptErrors": 1,
+      "eslintErrors": 0
+    },
+    "examples/inventory/apps/web/app/customer/page.tsx": {
+      "hash": "9889197ef585928b8a3d03a201f2df7d1dec53af82d475b495e1b48354b0011c",
+      "lineCount": 108,
+      "ariaAttributeCount": 0,
+      "typeScriptErrors": 0,
       "eslintErrors": 0
     },
     "examples/inventory/apps/web/app/product/new/page.tsx": {
@@ -121,20 +121,6 @@
       "typeScriptErrors": 1,
       "eslintErrors": 0
     },
-    "examples/inventory/apps/web/app/customer/new/page.tsx": {
-      "hash": "ddaf62479aa61e9eaa97d021c29c05d438bf740c1964a91f75eada1da6ed6263",
-      "lineCount": 75,
-      "ariaAttributeCount": 0,
-      "typeScriptErrors": 0,
-      "eslintErrors": 0
-    },
-    "examples/inventory/apps/web/app/customer/[id]/page.tsx": {
-      "hash": "2a001e47fd626011516478ac7f1f6930ee748e6e68a37c02a3c3c68c98e4c5e4",
-      "lineCount": 214,
-      "ariaAttributeCount": 0,
-      "typeScriptErrors": 0,
-      "eslintErrors": 0
-    },
     "examples/inventory/apps/web/app/order/new/page.tsx": {
       "hash": "b62a69782240c7feb695b07f38478fdf9585bb68b7f6375ec4e6a02fc0b9263e",
       "lineCount": 85,
@@ -147,6 +133,20 @@
       "lineCount": 305,
       "ariaAttributeCount": 0,
       "typeScriptErrors": 1,
+      "eslintErrors": 0
+    },
+    "examples/inventory/apps/web/app/customer/new/page.tsx": {
+      "hash": "ddaf62479aa61e9eaa97d021c29c05d438bf740c1964a91f75eada1da6ed6263",
+      "lineCount": 75,
+      "ariaAttributeCount": 0,
+      "typeScriptErrors": 0,
+      "eslintErrors": 0
+    },
+    "examples/inventory/apps/web/app/customer/[id]/page.tsx": {
+      "hash": "2a001e47fd626011516478ac7f1f6930ee748e6e68a37c02a3c3c68c98e4c5e4",
+      "lineCount": 214,
+      "ariaAttributeCount": 0,
+      "typeScriptErrors": 0,
       "eslintErrors": 0
     },
     "examples/inventory/src/ui/components/generated/apps/web/components/ProductForm.tsx": {

--- a/tests/utils/comparator.test.ts
+++ b/tests/utils/comparator.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { parseComparator, compare, strictest } from '../../src/utils/comparator.js';
+
+describe('utils/comparator', () => {
+  describe('parseComparator', () => {
+    it('parses percentage and normalizes to ratio', () => {
+      const c = parseComparator('>= 90%');
+      expect(c).toEqual({ op: '>=', value: 0.9, unit: undefined });
+    });
+
+    it('parses time and normalizes to ms', () => {
+      const gt = parseComparator('>1s');
+      expect(gt).toEqual({ op: '>', value: 1000, unit: 'ms' });
+
+      const le = parseComparator('<= 500ms');
+      expect(le).toEqual({ op: '<=', value: 500, unit: 'ms' });
+    });
+
+    it('parses rps unit', () => {
+      const eq = parseComparator('== 200 rps');
+      expect(eq).toEqual({ op: '==', value: 200, unit: 'rps' });
+    });
+  });
+
+  describe('compare', () => {
+    it('compares ratio against percentage expression', () => {
+      expect(compare(0.95, '>= 90%')).toBe(true);
+      expect(compare(0.89, '>= 90%')).toBe(false);
+    });
+
+    it('compares percentage actual string against numeric expression', () => {
+      expect(compare('95%', '>= 0.9')).toBe(true);
+      expect(compare('80%', '>= 0.9')).toBe(false);
+    });
+
+    it('compares time across mixed units', () => {
+      expect(compare('950ms', '< 1s')).toBe(true);
+      expect(compare({ value: 1, unit: 's' }, '<= 1000ms')).toBe(true);
+      expect(compare({ value: 2, unit: 's' }, '<= 1500ms')).toBe(false);
+    });
+
+    it('compares rps unit', () => {
+      expect(compare({ value: 120, unit: 'rps' }, '>= 100 rps')).toBe(true);
+      expect(compare(80, '>= 100 rps')).toBe(false);
+    });
+  });
+
+  describe('strictest', () => {
+    it('returns stricter for greater-direction comparators', () => {
+      expect(strictest('>= 90%', '>= 95%')).toBe('>= 95%');
+      expect(strictest('> 10 rps', '>= 10 rps')).toBe('> 10 rps');
+    });
+
+    it('returns stricter for less-direction comparators', () => {
+      expect(strictest('< 500ms', '<= 1s')).toBe('< 500ms');
+      expect(strictest('<= 400ms', '<= 1s')).toBe('<= 400ms');
+    });
+  });
+});
+


### PR DESCRIPTION
What
- Add scheduled + manual workflow to auto-post a daily Sprint 0 summary to #898.
- Ensures #963 has /start (idempotent) and maintains an upserted summary comment with header <!-- AE-PM-DAILY -->.
- Scans child issues #958–#964, finds the most recent open draft PR referencing each, and includes status lines.

Why
- Automate PM cadence expected for Sprint 0: daily status, priorities, risks, and next actions.

How
- GitHub Actions (actions/github-script) with schedule at 23:30 UTC (~08:30 JST) + workflow_dispatch.
- No outputs/env writes needed; actionlint-friendly.

Notes
- Assignment/handoff/block automation can be layered later with minimal tweaks and optional config.

Refs
- #898, #963
