### PR TITLE
feat(formal): add KvOnce PoC

### DIFF
--- a/package.json
+++ b/package.json
@@ -236,6 +236,8 @@
     "trace:validate": "node scripts/formal/trace-validate.mjs samples/conformance/sample-traces.json",
     "spec:check:tla": "node scripts/formal/spec-check-tla.mjs spec/tla/DomainSpec.tla",
     "spec:check:alloy": "node scripts/formal/spec-check-alloy.mjs spec/alloy/Domain.als",
+    "spec:kv-once:tlc": "node scripts/formal/verify-tla.mjs --engine=tlc --file specs/formal/10_abstract/KvOnce.tla --timeout 60000",
+    "spec:kv-once:apalache": "node scripts/formal/verify-tla.mjs --engine=apalache --file specs/formal/10_abstract/KvOnce.tla --timeout 60000",
     "quality:policy": "tsx src/cli/index.ts quality policy",
     "quality:validate": "tsx src/cli/index.ts quality validate",
     "quality:report": "tsx src/cli/index.ts quality report",

--- a/scripts/formal/verify-tla.mjs
+++ b/scripts/formal/verify-tla.mjs
@@ -23,7 +23,6 @@ function sh(cmd){ try { return execSync(cmd, {encoding:'utf8'}); } catch(e){ ret
 
 const args = parseArgs(process.argv);
 const timeoutSec = args.timeout ? Math.max(1, Math.floor(Number(args.timeout)/1000)) : 0;
-function has(cmd){ try { execSync(`bash -lc 'command -v ${cmd}'`, {stdio:'ignore'}); return true; } catch { return false; } }
 const haveTimeout = has('timeout');
 if (args.help){
   console.log(`Usage: node scripts/formal/verify-tla.mjs [--engine=tlc|apalache] [--file spec/tla/DomainSpec.tla] [--timeout <ms>]`);

--- a/specs/formal/10_abstract/KvOnce.tla
+++ b/specs/formal/10_abstract/KvOnce.tla
@@ -1,0 +1,29 @@
+--------------------------- MODULE KvOnce ---------------------------
+EXTENDS Naturals, Sequences
+
+CONSTANTS Keys, Values, NULL
+
+ASSUME NULL \notin Values
+VARIABLES store
+
+TypeInvariant ==
+  store \in [Keys -> [written: BOOLEAN, val: Values \cup {NULL}]]
+
+Init == store = [k \in Keys |-> [written |-> FALSE, val |-> NULL]]
+
+Put(k, v) ==
+  /\ k \in Keys
+  /\ v \in Values
+  /\ ~store[k].written
+  /\ store' = [store EXCEPT ![k] = [written |-> TRUE, val |-> v]]
+
+Next == \E k \in Keys, v \in Values: Put(k, v)
+
+NoOverwrite == \A k \in Keys: store[k].written => store[k].val # NULL
+
+Spec == Init /\ [][Next]_store
+
+Invariant == TypeInvariant /\ NoOverwrite
+
+THEOREM KvOnceSafety == Spec => []Invariant
+====================================================================

--- a/specs/formal/20_refined/KvOnceRefinement.tla
+++ b/specs/formal/20_refined/KvOnceRefinement.tla
@@ -1,0 +1,44 @@
+--------------------- MODULE KvOnceRefinement ---------------------
+EXTENDS Naturals, Sequences
+
+CONSTANTS Keys, Values, NULL, MAX_RETRIES
+VARIABLES store, retries
+
+ASSUME NULL \notin Values
+ASSUME MAX_RETRIES \in Nat
+
+Init ==
+  /\ store = [k \in Keys |-> [written |-> FALSE, val |-> NULL]]
+  /\ retries = [k \in Keys |-> 0]
+
+Put(k, v) ==
+  /\ k \in Keys
+  /\ v \in Values
+  /\ retries[k] < MAX_RETRIES
+  /\ ~store[k].written
+  /\ store' = [store EXCEPT ![k] = [written |-> TRUE, val |-> v]]
+  /\ retries' = [retries EXCEPT ![k] = retries[k] + 1]
+
+Retry(k) ==
+  /\ k \in Keys
+  /\ retries[k] < MAX_RETRIES
+  /\ store' = store
+  /\ retries' = [retries EXCEPT ![k] = retries[k] + 1]
+
+Next ==
+  \E k \in Keys, v \in Values: Put(k, v)
+  \/ \E k \in Keys: Retry(k)
+
+TypeInvariant ==
+  /\ store \in [Keys -> [written: BOOLEAN, val: Values \cup {NULL}]]
+  /\ retries \in [Keys -> Nat]
+  /\ \A k \in Keys: retries[k] <= MAX_RETRIES
+
+NoOverwrite == \A k \in Keys: store[k].written => store[k].val # NULL
+
+Spec == Init /\ [][Next]_{<<store, retries>>}
+
+Invariant == TypeInvariant /\ NoOverwrite
+
+THEOREM KvOnceRefinementSafety == Spec => []Invariant
+=================================================================

--- a/specs/formal/20_refined/KvOnceRefinement.tla
+++ b/specs/formal/20_refined/KvOnceRefinement.tla
@@ -1,5 +1,5 @@
 --------------------- MODULE KvOnceRefinement ---------------------
-EXTENDS Naturals, Sequences
+EXTENDS Naturals, Sequences, TLC
 
 CONSTANTS Keys, Values, NULL, MAX_RETRIES
 VARIABLES store, retries
@@ -17,7 +17,7 @@ Put(k, v) ==
   /\ retries[k] < MAX_RETRIES
   /\ ~store[k].written
   /\ store' = [store EXCEPT ![k] = [written |-> TRUE, val |-> v]]
-  /\ retries' = [retries EXCEPT ![k] = retries[k] + 1]
+  /\ retries' = retries
 
 Retry(k) ==
   /\ k \in Keys

--- a/specs/formal/30_impl/KvOnceImpl.tla
+++ b/specs/formal/30_impl/KvOnceImpl.tla
@@ -36,12 +36,16 @@ Failure(k, reason) ==
 Next ==
   \E k \in Keys, v \in Values: Put(k, v)
   \/ \E k \in Keys: Retry(k, "transient")
-  \/ \E k \in Keys: Failure(k, "duplicate")
+  \/ \E k \in Keys: store[k].written /\ Failure(k, "duplicate")
 
 TypeInvariant ==
   /\ store \in [Keys -> [written: BOOLEAN, val: Values \cup {NULL}]]
   /\ retries \in [Keys -> Nat]
-  /\ events \in Seq([type: {"success", "retry", "failure"}, key: Keys, value: Values \cup {NULL}, reason: STRING])
+  /\ events \in Seq(
+        [type: "success", key: Keys, value: Values]
+        \cup [type: "retry", key: Keys, reason: STRING]
+        \cup [type: "failure", key: Keys, reason: STRING]
+     )
 
 NoOverwrite == \A k \in Keys: store[k].written => store[k].val # NULL
 

--- a/specs/formal/30_impl/KvOnceImpl.tla
+++ b/specs/formal/30_impl/KvOnceImpl.tla
@@ -1,0 +1,55 @@
+------------------------- MODULE KvOnceImpl -------------------------
+EXTENDS Naturals, Sequences
+
+CONSTANTS Keys, Values, NULL, MAX_RETRIES
+VARIABLES store, retries, events
+
+ASSUME NULL \notin Values
+ASSUME MAX_RETRIES \in Nat
+
+Init ==
+  /\ store = [k \in Keys |-> [written |-> FALSE, val |-> NULL]]
+  /\ retries = [k \in Keys |-> 0]
+  /\ events = << >>
+
+Put(k, v) ==
+  /\ k \in Keys
+  /\ v \in Values
+  /\ ~store[k].written
+  /\ store' = [store EXCEPT ![k] = [written |-> TRUE, val |-> v]]
+  /\ retries' = retries
+  /\ events' = Append(events, [type |-> "success", key |-> k, value |-> v])
+
+Retry(k, reason) ==
+  /\ k \in Keys
+  /\ retries[k] < MAX_RETRIES
+  /\ store' = store
+  /\ retries' = [retries EXCEPT ![k] = retries[k] + 1]
+  /\ events' = Append(events, [type |-> "retry", key |-> k, reason |-> reason])
+
+Failure(k, reason) ==
+  /\ k \in Keys
+  /\ store' = store
+  /\ retries' = retries
+  /\ events' = Append(events, [type |-> "failure", key |-> k, reason |-> reason])
+
+Next ==
+  \E k \in Keys, v \in Values: Put(k, v)
+  \/ \E k \in Keys: Retry(k, "transient")
+  \/ \E k \in Keys: Failure(k, "duplicate")
+
+TypeInvariant ==
+  /\ store \in [Keys -> [written: BOOLEAN, val: Values \cup {NULL}]]
+  /\ retries \in [Keys -> Nat]
+  /\ events \in Seq([type: {"success", "retry", "failure"}, key: Keys, value: Values \cup {NULL}, reason: STRING])
+
+NoOverwrite == \A k \in Keys: store[k].written => store[k].val # NULL
+
+RetryBounded == \A k \in Keys: retries[k] <= MAX_RETRIES
+
+Spec == Init /\ [][Next]_{<<store, retries, events>>}
+
+Invariant == TypeInvariant /\ NoOverwrite /\ RetryBounded
+
+THEOREM KvOnceImplSafety == Spec => []Invariant
+===================================================================

--- a/specs/formal/configs/KvOnce.cfg
+++ b/specs/formal/configs/KvOnce.cfg
@@ -1,0 +1,6 @@
+SPECIFICATION Spec
+INVARIANT Invariant
+CONSTANTS
+  Keys <- {"k1", "k2"}
+  Values <- {"v1", "v2"}
+  NULL <- "__null"

--- a/specs/formal/configs/KvOnceImpl.cfg
+++ b/specs/formal/configs/KvOnceImpl.cfg
@@ -1,0 +1,7 @@
+SPECIFICATION Spec
+INVARIANT Invariant
+CONSTANTS
+  Keys <- {"k1", "k2"}
+  Values <- {"v1", "v2"}
+  NULL <- "__null"
+  MAX_RETRIES <- 3

--- a/specs/formal/configs/KvOnceImpl_apalache.cfg
+++ b/specs/formal/configs/KvOnceImpl_apalache.cfg
@@ -1,0 +1,8 @@
+INIT Init
+NEXT Next
+INVARIANTS Invariant
+CONSTANTS
+  Keys = {"k1", "k2"}
+  Values = {"v1", "v2"}
+  NULL = "__null"
+  MAX_RETRIES = 3

--- a/specs/formal/configs/KvOnceRefinement.cfg
+++ b/specs/formal/configs/KvOnceRefinement.cfg
@@ -1,0 +1,7 @@
+SPECIFICATION Spec
+INVARIANT Invariant
+CONSTANTS
+  Keys <- {"k1", "k2"}
+  Values <- {"v1", "v2"}
+  NULL <- "__null"
+  MAX_RETRIES <- 3

--- a/specs/formal/configs/KvOnceRefinement_apalache.cfg
+++ b/specs/formal/configs/KvOnceRefinement_apalache.cfg
@@ -1,0 +1,8 @@
+INIT Init
+NEXT Next
+INVARIANTS Invariant
+CONSTANTS
+  Keys = {"k1", "k2"}
+  Values = {"v1", "v2"}
+  NULL = "__null"
+  MAX_RETRIES = 3

--- a/specs/formal/configs/KvOnce_apalache.cfg
+++ b/specs/formal/configs/KvOnce_apalache.cfg
@@ -1,0 +1,7 @@
+INIT Init
+NEXT Next
+INVARIANTS Invariant
+CONSTANTS
+  Keys = {"k1", "k2"}
+  Values = {"v1", "v2"}
+  NULL = "__null"

--- a/specs/formal/mappings/KvOnce.impl.json
+++ b/specs/formal/mappings/KvOnce.impl.json
@@ -1,0 +1,29 @@
+{
+  "name": "KvOnce",
+  "description": "Single-write key-value store refinement mapping",
+  "modules": {
+    "abstract": "KvOnce",
+    "refined": "KvOnceRefinement",
+    "implementation": "KvOnceImpl"
+  },
+  "stateMapping": {
+    "abstract": {
+      "store": "store"
+    },
+    "implementation": {
+      "store": "store",
+      "retries": "retries",
+      "events": "events"
+    }
+  },
+  "invariants": [
+    "NoOverwrite",
+    "RetryBounded"
+  ],
+  "trace": {
+    "eventField": "type",
+    "successEvent": "success",
+    "retryEvent": "retry",
+    "failureEvent": "failure"
+  }
+}


### PR DESCRIPTION
## Summary
- add KvOnce abstract/refined/impl TLA+ specs with configs
- provide refinement mapping JSON for implementation alignment
- add npm scripts to run TLC/Apalache checks locally

## Testing
- pnpm run spec:kv-once:tlc