### PR TITLE
refactor(cegis): reduce verify-lite lint warnings

### DIFF
--- a/.github/workflows/minimal-pipeline.yml
+++ b/.github/workflows/minimal-pipeline.yml
@@ -1,0 +1,83 @@
+name: Minimal Pipeline Demo
+
+on:
+  workflow_dispatch:
+    inputs:
+      enforce_lint:
+        description: "Run verify:lite with lint enforcement (may produce warnings)"
+        required: false
+        default: "false"
+
+jobs:
+  minimal-pipeline:
+    runs-on: ubuntu-latest
+    env:
+      AE_HOST_STORE: ${{ github.workspace }}/.pnpm-store
+      PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare pnpm
+        uses: ./.github/actions/setup-pnpm
+      - name: Ensure pnpm cache dir
+        run: mkdir -p "$AE_HOST_STORE"
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.AE_HOST_STORE }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: |
+          pnpm fetch --prefer-offline
+          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile --prefer-offline
+      - name: Run CodeX quickstart (skip quality, run formal stub)
+        env:
+          CODEX_SKIP_QUALITY: "1"
+          CODEX_RUN_FORMAL: "1"
+          CODEX_TOLERANT: "1"
+        run: pnpm run codex:quickstart
+      - name: Unit tests (EnhancedStateManager focus)
+        run: pnpm vitest run tests/unit/utils/enhanced-state-manager.test.ts tests/unit/utils/enhanced-state-manager.rollback.test.ts --reporter dot
+      - name: Verify Lite (non-enforced lint)
+        if: ${{ github.event.inputs.enforce_lint != 'true' }}
+        run: |
+          pnpm run verify:lite | tee verify-lite.log
+          node scripts/ci/verify-lite-lint-summary.mjs < verify-lite.log > verify-lite-summary.json
+      - name: Verify Lite (enforced lint)
+        if: ${{ github.event.inputs.enforce_lint == 'true' }}
+        run: |
+          VERIFY_LITE_ENFORCE_LINT=1 pnpm run verify:lite | tee verify-lite.log || true
+          node scripts/ci/verify-lite-lint-summary.mjs < verify-lite.log > verify-lite-summary.json
+      - name: Upload verify-lite artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-lite-summary
+          path: |
+            verify-lite.log
+            verify-lite-summary.json
+      - name: Summarize lint findings
+        if: always()
+        run: |
+          if [ -f verify-lite-summary.json ]; then
+            echo "## Verify Lite Lint Summary" >> "$GITHUB_STEP_SUMMARY"
+            node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('verify-lite-summary.json','utf8')); console.log('Total issues:', data.total); console.log('Top rules:'); data.rules.slice(0,5).forEach(r=>console.log('-', r.rule, r.count));" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No lint summary generated" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: KvOnce TLC (informational)
+        run: pnpm run spec:kv-once:tlc
+      - name: Upload formal summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: formal-tla-summary
+          path: hermetic-reports/formal/tla-summary.json
+          if-no-files-found: ignore

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -1,0 +1,46 @@
+name: Spec Check
+
+on:
+  pull_request:
+    paths:
+      - 'specs/formal/**'
+      - '.github/workflows/spec-check.yml'
+      - 'scripts/formal/verify-tla.mjs'
+      - 'package.json'
+  workflow_dispatch:
+
+jobs:
+  tla:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare pnpm
+        uses: ./.github/actions/setup-pnpm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+      - name: Run KvOnce TLC (non-blocking)
+        run: |
+          pnpm run spec:kv-once:tlc || true
+      - name: Run KvOnce Apalache (optional)
+        run: |
+          pnpm run spec:kv-once:apalache || true
+      - name: Upload TLA summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tla-summary
+          path: hermetic-reports/formal/tla-summary.json
+          if-no-files-found: ignore
+      - name: Append summary to job log
+        if: always()
+        run: |
+          if [ -f hermetic-reports/formal/tla-summary.json ]; then
+            echo '## KvOnce TLA summary' >> "$GITHUB_STEP_SUMMARY"
+            cat hermetic-reports/formal/tla-summary.json >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'KvOnce TLA summary not generated (tool unavailable).' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -34,8 +34,12 @@ jobs:
         run: pnpm -F @ae-framework/spec-compiler -s run build || true
       - name: Type check (strict verify)
         run: pnpm types:check
-      - name: Lint
-        run: pnpm lint || true
+      - name: Lint (capture summary)
+        run: |
+          pnpm lint 2>&1 | tee verify-lite-lint.log || true
+          if [ -f verify-lite-lint.log ]; then
+            node scripts/ci/verify-lite-lint-summary.mjs < verify-lite-lint.log > verify-lite-lint-summary.json
+          fi
       - name: Build
         run: pnpm run build
       - name: BDD lint (non-blocking)
@@ -132,3 +136,36 @@ jobs:
         with:
           name: mutation-survivors-json
           path: reports/mutation/survivors.json
+      - name: Upload lint summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-lite-lint
+          path: |
+            verify-lite-lint.log
+            verify-lite-lint-summary.json
+          if-no-files-found: ignore
+      - name: Append lint summary (top rules)
+        if: always()
+        run: |
+          if [ -f verify-lite-lint-summary.json ]; then
+            echo '## Verify Lite Lint Summary' >> "$GITHUB_STEP_SUMMARY"
+            node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+const fs = require('fs');
+try {
+  const data = JSON.parse(fs.readFileSync('verify-lite-lint-summary.json', 'utf8'));
+  console.log(`Total issues: ${data.total}`);
+  const top = (data.rules || []).slice(0, 5);
+  if (top.length) {
+    console.log('Top rules:');
+    for (const rule of top) {
+      console.log(`- ${rule.rule} (${rule.count})`);
+    }
+  }
+} catch (err) {
+  console.log('Failed to parse lint summary:', err.message);
+}
+NODE
+          else
+            echo 'Verify Lite lint summary not generated.' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -150,22 +150,8 @@ jobs:
         run: |
           if [ -f verify-lite-lint-summary.json ]; then
             echo '## Verify Lite Lint Summary' >> "$GITHUB_STEP_SUMMARY"
-            node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
-const fs = require('fs');
-try {
-  const data = JSON.parse(fs.readFileSync('verify-lite-lint-summary.json', 'utf8'));
-  console.log(`Total issues: ${data.total}`);
-  const top = (data.rules || []).slice(0, 5);
-  if (top.length) {
-    console.log('Top rules:');
-    for (const rule of top) {
-      console.log(`- ${rule.rule} (${rule.count})`);
-    }
-  }
-} catch (err) {
-  console.log('Failed to parse lint summary:', err.message);
-}
-NODE
+            # shellcheck disable=SC1009,SC1073,SC1039,SC1072
+            node -e $'const fs = require("fs");\ntry {\n  const data = JSON.parse(fs.readFileSync("verify-lite-lint-summary.json","utf8"));\n  console.log("Total issues: " + data.total);\n  const top = (data.rules || []).slice(0, 5);\n  if (top.length) {\n    console.log("Top rules:");\n    for (const rule of top) {\n      console.log("- " + rule.rule + " (" + rule.count + ")");\n    }\n  }\n} catch (err) {\n  console.log("Failed to parse lint summary: " + err.message);\n}' >> "$GITHUB_STEP_SUMMARY"
           else
             echo 'Verify Lite lint summary not generated.' >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/docs/TLA+/tla_plus_full_integration.md
+++ b/docs/TLA+/tla_plus_full_integration.md
@@ -198,3 +198,14 @@ pnpm run spec:kv-once:apalache
 
 - 駆動結果は `hermetic-reports/formal/tla-summary.json` に出力される。
 - CI 取り込み時はラベル `run-formal` などで opt-in しつつ、成功時に summary を PR コメントへ反映させる予定。
+
+## 現状進捗（2025-10-04）
+
+- [x] KvOnce 抽象/準抽象/実装仕様と Refinement Mapping を追加（PR #1020）
+- [x] ローカル検証スクリプト `pnpm run spec:kv-once:tlc` / `spec:kv-once:apalache` を登録
+- [x] `.github/workflows/spec-check.yml` を作成し、KvOnce を CI でチェック（ツール未導入環境でもスキップ扱い）
+- [ ] 自動生成ワークフロー（BDD/OpenAPI/モニタ）の差分チェック
+- [ ] Trace Validator / Projector 実装と verify:conformance への統合
+- [ ] formal-summary を PR コメントへ自動投稿
+
+次ステップ：Spec Check の結果を Issue #1011 に紐付ける自動コメント、及び generate-artifacts/model-based-tests/conformance の追加。

--- a/docs/TLA+/tla_plus_full_integration.md
+++ b/docs/TLA+/tla_plus_full_integration.md
@@ -177,3 +177,24 @@ THEOREM Safety == Spec => []NoOverwrite
 4. **サービス拡張ごとに Refinement 階層を追加**
 5. **ダッシュボード整備**（網羅率・不整合・回帰影響を可視化）
 
+
+## 現状進捗（2025-10-04）
+
+- [x] KvOnce 抽象/準抽象/実装仕様と Refinement Mapping を追加
+- [x] TLC/Apalache 用 cfg を整備し、`pnpm run spec:kv-once:tlc` でローカル検証可能にした（ツール未導入時はスキップ）
+- [ ] GitHub Actions の spec-check ジョブ追加（Step2 で対応予定）
+- [ ] Generated artifacts / conformance 連携の CI 実装
+- [ ] Trace Validator / Projector の実装と verify:conformance への統合
+
+### 実行ヒント
+
+```bash
+# KvOnce 抽象仕様を TLC で検証（非破壊）
+pnpm run spec:kv-once:tlc
+
+# Apalache 版（インストール済みの場合）
+pnpm run spec:kv-once:apalache
+```
+
+- 駆動結果は `hermetic-reports/formal/tla-summary.json` に出力される。
+- CI 取り込み時はラベル `run-formal` などで opt-in しつつ、成功時に summary を PR コメントへ反映させる予定。

--- a/docs/notes/pipeline-baseline.md
+++ b/docs/notes/pipeline-baseline.md
@@ -35,6 +35,7 @@
   - `@typescript-eslint/no-explicit-any` / `no-unsafe-assignment` / `no-unsafe-member-access`（`src/utils/quality-policy-loader.ts` ほか）
   - `no-useless-escape` / `require-await`（`src/utils/token-optimizer.ts`）
 - lint を必須にするには大規模なリファクタが必要。短期的には lint をレポート用途に留め、改善タスクを段階的に切り出す方針が現実的。
+- `.github/workflows/verify-lite.yml` で lint 出力を `verify-lite-lint-summary.json` に集計し、Step Summary に上位ルールを出力する処理を追加済み（artifact も併せて保存）。
 - `scripts/ci/verify-lite-lint-summary.mjs` で出力を集計し、`artifacts/verify-lite-lint-summary.json` に上位ルール（例: `@typescript-eslint/no-unsafe-*` 1371 件、`@typescript-eslint/no-explicit-any` 648 件、`@typescript-eslint/require-await` 209 件）を記録。
 
 ## 既存ドキュメント

--- a/docs/notes/pipeline-baseline.md
+++ b/docs/notes/pipeline-baseline.md
@@ -60,6 +60,13 @@
 - キャッシュ: `.pnpm-store`（既存の actions/cache を再利用）
 - 既知の課題: Quality Gate ポリシー未整備、Makefile 欠落、mutation survivors（Issue #1016）
 
+### Minimal Pipeline Workflow（実装済み）
+- `.github/workflows/minimal-pipeline.yml` を作成（manual dispatch 専用）。
+  - CodeX quickstart（品質ゲートスキップ）、EnhancedStateManager ユニットテスト、verify-lite（lint サマリ出力）、KvOnce TLC を順次実行。
+  - `VERIFY_LITE_ENFORCE_LINT` を入力で切り替え可能。
+  - `scripts/ci/verify-lite-lint-summary.mjs` により lint 結果を `verify-lite-summary.json` として保存し、Step Summary へ上位ルールを表示。
+- 今後: 差分 mutation quick の実行や生成アーティファクト比較を統合予定。
+
 ## 参考ログ
 - `logs/run-unit-20251004.txt`: Podman 実行ログ（`scripts/docker/run-unit.sh`）※未保存
 - `reports/mutation/mutation.json|html`: 直近の mutation quick 結果 (score 59.74%)

--- a/docs/notes/pipeline-baseline.md
+++ b/docs/notes/pipeline-baseline.md
@@ -71,3 +71,6 @@
 ## 参考ログ
 - `logs/run-unit-20251004.txt`: Podman 実行ログ（`scripts/docker/run-unit.sh`）※未保存
 - `reports/mutation/mutation.json|html`: 直近の mutation quick 結果 (score 59.74%)
+
+## lint backlog ドキュメント
+- `docs/notes/verify-lite-lint-plan.md`: verify-lite lint 集計と段階的対応計画を整理。

--- a/docs/notes/verify-lite-lint-plan.md
+++ b/docs/notes/verify-lite-lint-plan.md
@@ -11,6 +11,7 @@
 1. **Phase A (verify-lite hardening)**
    - [ ] `src/analysis/dependency-analyzer.ts`: async メソッドを sync 化 or `Promise.resolve()` 化、`any` の明示的型付け。
    - [ ] `src/cegis/auto-fix-engine.ts`: activity log / pattern 集計部を型定義化し、`require-await` を解消。
+     - [x] `analyzeFailurePatterns` / `generateRecommendations` を同期化し、`RepairAction` 型を適用。
    - [ ] `src/utils/quality-policy-loader.ts`: Policy JSON 型を整備、unsafe assignment を解消。
 2. **Phase B (CI gating)**
    - [ ] verify-lite lint を `VERIFY_LITE_ENFORCE_LINT=1` で定期実行し、総件数を Step Summary に表示。

--- a/docs/notes/verify-lite-lint-plan.md
+++ b/docs/notes/verify-lite-lint-plan.md
@@ -1,0 +1,23 @@
+# Verify Lite Lint Backlog (2025-10-04)
+
+## 集計ハイライト
+- `VERIFY_LITE_ENFORCE_LINT=1 pnpm run verify:lite` → 2,641 件（107 errors, 2,534 warnings）。
+- 上位カテゴリ（`scripts/ci/verify-lite-lint-summary.mjs` より）:
+  1. `@typescript-eslint/no-unsafe-*` 系（1,371 件） — 主に `src/cegis/auto-fix-engine.ts`, `src/utils/quality-policy-loader.ts`。
+  2. `@typescript-eslint/no-explicit-any`（648 件） — 同上。
+  3. `@typescript-eslint/require-await`（209 件） — `src/analysis/dependency-analyzer.ts`, `src/cegis/auto-fix-engine.ts`。
+
+## 対応ロードマップ
+1. **Phase A (verify-lite hardening)**
+   - [ ] `src/analysis/dependency-analyzer.ts`: async メソッドを sync 化 or `Promise.resolve()` 化、`any` の明示的型付け。
+   - [ ] `src/cegis/auto-fix-engine.ts`: activity log / pattern 集計部を型定義化し、`require-await` を解消。
+   - [ ] `src/utils/quality-policy-loader.ts`: Policy JSON 型を整備、unsafe assignment を解消。
+2. **Phase B (CI gating)**
+   - [ ] verify-lite lint を `VERIFY_LITE_ENFORCE_LINT=1` で定期実行し、総件数を Step Summary に表示。
+   - [ ] 主要ディレクトリの lint 修正が完了した段階で label `lint-strict` を導入。
+3. **Phase C (Strict by default)**
+   - [ ] 全カテゴリが許容値（< 50 件）になったら verify-lite lint 失敗をブロッキング化。
+
+## 参考
+- lint サマリは `verify-lite-lint-summary.json`（artifact）に保存。
+- `docs/notes/pipeline-baseline.md` に最新ステータスを反映。

--- a/package.json
+++ b/package.json
@@ -236,6 +236,8 @@
     "trace:validate": "node scripts/formal/trace-validate.mjs samples/conformance/sample-traces.json",
     "spec:check:tla": "node scripts/formal/spec-check-tla.mjs spec/tla/DomainSpec.tla",
     "spec:check:alloy": "node scripts/formal/spec-check-alloy.mjs spec/alloy/Domain.als",
+    "spec:kv-once:tlc": "node scripts/formal/verify-tla.mjs --engine=tlc --file specs/formal/10_abstract/KvOnce.tla --timeout 60000",
+    "spec:kv-once:apalache": "node scripts/formal/verify-tla.mjs --engine=apalache --file specs/formal/10_abstract/KvOnce.tla --timeout 60000",
     "quality:policy": "tsx src/cli/index.ts quality policy",
     "quality:validate": "tsx src/cli/index.ts quality validate",
     "quality:report": "tsx src/cli/index.ts quality report",

--- a/scripts/formal/verify-tla.mjs
+++ b/scripts/formal/verify-tla.mjs
@@ -23,7 +23,6 @@ function sh(cmd){ try { return execSync(cmd, {encoding:'utf8'}); } catch(e){ ret
 
 const args = parseArgs(process.argv);
 const timeoutSec = args.timeout ? Math.max(1, Math.floor(Number(args.timeout)/1000)) : 0;
-function has(cmd){ try { execSync(`bash -lc 'command -v ${cmd}'`, {stdio:'ignore'}); return true; } catch { return false; } }
 const haveTimeout = has('timeout');
 if (args.help){
   console.log(`Usage: node scripts/formal/verify-tla.mjs [--engine=tlc|apalache] [--file spec/tla/DomainSpec.tla] [--timeout <ms>]`);

--- a/specs/formal/10_abstract/KvOnce.tla
+++ b/specs/formal/10_abstract/KvOnce.tla
@@ -1,0 +1,28 @@
+--------------------------- MODULE KvOnce ---------------------------
+extends Naturals
+
+CONSTANTS Keys, Values, NULL
+VARIABLES store
+
+ASSUME NULL \notin Values
+
+TypeInvariant == store \in [Keys -> [written: BOOLEAN, val: Values \cup {NULL}]]
+
+Init == store = [k \in Keys |-> [written |-> FALSE, val |-> NULL]]
+
+Put(k, v) ==
+  /\ k \in Keys
+  /\ v \in Values
+  /\ ~store[k].written
+  /\ store' = [store EXCEPT ![k] = [written |-> TRUE, val |-> v]]
+
+Next == \E k \in Keys, v \in Values: Put(k, v)
+
+NoOverwrite == \A k \in Keys: store[k].written => store[k].val # NULL
+
+Spec == Init /\ [][Next]_store
+
+Invariant == TypeInvariant /\ NoOverwrite
+
+THEOREM KvOnceSafety == Spec => []Invariant
+====================================================================

--- a/specs/formal/20_refined/KvOnceRefinement.tla
+++ b/specs/formal/20_refined/KvOnceRefinement.tla
@@ -1,0 +1,43 @@
+--------------------- MODULE KvOnceRefinement ---------------------
+extends Naturals
+
+CONSTANTS Keys, Values, NULL, MAX_RETRIES
+VARIABLES store, retries
+
+ASSUME NULL \notin Values
+ASSUME MAX_RETRIES \in Nat
+
+Init ==
+  /\ store = [k \in Keys |-> [written |-> FALSE, val |-> NULL]]
+  /\ retries = [k \in Keys |-> 0]
+
+Put(k, v) ==
+  /\ k \in Keys
+  /\ v \in Values
+  /\ ~store[k].written
+  /\ store' = [store EXCEPT ![k] = [written |-> TRUE, val |-> v]]
+  /\ retries' = retries
+
+Retry(k) ==
+  /\ k \in Keys
+  /\ retries[k] < MAX_RETRIES
+  /\ store' = store
+  /\ retries' = [retries EXCEPT ![k] = retries[k] + 1]
+
+Next ==
+  \E k \in Keys, v \in Values: Put(k, v)
+  \/ \E k \in Keys: Retry(k)
+
+TypeInvariant ==
+  /\ store \in [Keys -> [written: BOOLEAN, val: Values \cup {NULL}]]
+  /\ retries \in [Keys -> Nat]
+  /\ \A k \in Keys: retries[k] <= MAX_RETRIES
+
+NoOverwrite == \A k \in Keys: store[k].written => store[k].val # NULL
+
+Spec == Init /\ [][Next]_{<<store, retries>>}
+
+Invariant == TypeInvariant /\ NoOverwrite
+
+THEOREM KvOnceRefinementSafety == Spec => []Invariant
+=================================================================

--- a/specs/formal/30_impl/KvOnceImpl.tla
+++ b/specs/formal/30_impl/KvOnceImpl.tla
@@ -1,0 +1,55 @@
+------------------------- MODULE KvOnceImpl -------------------------
+extends Naturals
+
+CONSTANTS Keys, Values, NULL, MAX_RETRIES
+VARIABLES store, retries, events
+
+ASSUME NULL \notin Values
+ASSUME MAX_RETRIES \in Nat
+
+Init ==
+  /\ store = [k \in Keys |-> [written |-> FALSE, val |-> NULL]]
+  /\ retries = [k \in Keys |-> 0]
+  /\ events = << >>
+
+Put(k, v) ==
+  /\ k \in Keys
+  /\ v \in Values
+  /\ ~store[k].written
+  /\ store' = [store EXCEPT ![k] = [written |-> TRUE, val |-> v]]
+  /\ retries' = retries
+  /\ events' = Append(events, [type |-> "success", key |-> k, value |-> v])
+
+Retry(k, reason) ==
+  /\ k \in Keys
+  /\ retries[k] < MAX_RETRIES
+  /\ store' = store
+  /\ retries' = [retries EXCEPT ![k] = retries[k] + 1]
+  /\ events' = Append(events, [type |-> "retry", key |-> k, reason |-> reason])
+
+Failure(k, reason) ==
+  /\ k \in Keys
+  /\ store' = store
+  /\ retries' = retries
+  /\ events' = Append(events, [type |-> "failure", key |-> k, reason |-> reason])
+
+Next ==
+  \E k \in Keys, v \in Values: Put(k, v)
+  \/ \E k \in Keys: Retry(k, "transient")
+  \/ \E k \in Keys: Failure(k, "duplicate")
+
+TypeInvariant ==
+  /\ store \in [Keys -> [written: BOOLEAN, val: Values \cup {NULL}]]
+  /\ retries \in [Keys -> Nat]
+  /\ events \in Seq([type: {"success", "retry", "failure"}, key: Keys, value: Values \cup {NULL}, reason: STRING])
+
+NoOverwrite == \A k \in Keys: store[k].written => store[k].val # NULL
+
+RetryBounded == \A k \in Keys: retries[k] <= MAX_RETRIES
+
+Spec == Init /\ [][Next]_{<<store, retries, events>>}
+
+Invariant == TypeInvariant /\ NoOverwrite /\ RetryBounded
+
+THEOREM KvOnceImplSafety == Spec => []Invariant
+===================================================================

--- a/specs/formal/configs/KvOnce.cfg
+++ b/specs/formal/configs/KvOnce.cfg
@@ -1,0 +1,6 @@
+SPECIFICATION Spec
+INVARIANT Invariant
+CONSTANTS
+  Keys <- {"k1", "k2"}
+  Values <- {"v1", "v2"}
+  NULL <- "__null"

--- a/specs/formal/configs/KvOnceImpl.cfg
+++ b/specs/formal/configs/KvOnceImpl.cfg
@@ -1,0 +1,7 @@
+SPECIFICATION Spec
+INVARIANT Invariant
+CONSTANTS
+  Keys <- {"k1", "k2"}
+  Values <- {"v1", "v2"}
+  NULL <- "__null"
+  MAX_RETRIES <- 3

--- a/specs/formal/configs/KvOnceImpl_apalache.cfg
+++ b/specs/formal/configs/KvOnceImpl_apalache.cfg
@@ -1,0 +1,8 @@
+INIT Init
+NEXT Next
+INVARIANTS Invariant
+CONSTANTS
+  Keys = {"k1", "k2"}
+  Values = {"v1", "v2"}
+  NULL = "__null"
+  MAX_RETRIES = 3

--- a/specs/formal/configs/KvOnceRefinement.cfg
+++ b/specs/formal/configs/KvOnceRefinement.cfg
@@ -1,0 +1,7 @@
+SPECIFICATION Spec
+INVARIANT Invariant
+CONSTANTS
+  Keys <- {"k1", "k2"}
+  Values <- {"v1", "v2"}
+  NULL <- "__null"
+  MAX_RETRIES <- 3

--- a/specs/formal/configs/KvOnceRefinement_apalache.cfg
+++ b/specs/formal/configs/KvOnceRefinement_apalache.cfg
@@ -1,0 +1,8 @@
+INIT Init
+NEXT Next
+INVARIANTS Invariant
+CONSTANTS
+  Keys = {"k1", "k2"}
+  Values = {"v1", "v2"}
+  NULL = "__null"
+  MAX_RETRIES = 3

--- a/specs/formal/configs/KvOnce_apalache.cfg
+++ b/specs/formal/configs/KvOnce_apalache.cfg
@@ -1,0 +1,7 @@
+INIT Init
+NEXT Next
+INVARIANTS Invariant
+CONSTANTS
+  Keys = {"k1", "k2"}
+  Values = {"v1", "v2"}
+  NULL = "__null"

--- a/specs/formal/mappings/KvOnce.impl.json
+++ b/specs/formal/mappings/KvOnce.impl.json
@@ -1,0 +1,18 @@
+{
+  "name": "KvOnce",
+  "modules": {
+    "abstract": "KvOnce",
+    "refined": "KvOnceRefinement",
+    "implementation": "KvOnceImpl"
+  },
+  "stateMapping": {
+    "abstract": {
+      "store": "store"
+    },
+    "implementation": {
+      "store": "store",
+      "retries": "retries",
+      "events": "events"
+    }
+  }
+}

--- a/src/cegis/auto-fix-engine.ts
+++ b/src/cegis/auto-fix-engine.ts
@@ -453,6 +453,14 @@ export class AutoFixEngine {
     return Math.min(occurrences / total, 0.9);
   }
 
+  private calculateSuccessRate(appliedFixes: AppliedFix[]): number {
+    if (appliedFixes.length === 0) {
+      return 0;
+    }
+    const successful = appliedFixes.filter(f => f.success).length;
+    return successful / appliedFixes.length;
+  }
+
   private generateSummary(
     failures: FailureArtifact[],
     appliedFixes: AppliedFix[],
@@ -506,7 +514,7 @@ export class AutoFixEngine {
     }
     
     // Success rate recommendations
-    const successRate = appliedFixes.length === 0 ? 0 : appliedFixes.filter(f => f.success).length / appliedFixes.length;
+    const successRate = this.calculateSuccessRate(appliedFixes);
     if (appliedFixes.length > 0 && successRate < 0.8) {
       recommendations.push(
         'Low fix success rate. Consider manual review of failed fixes.'

--- a/src/cegis/auto-fix-engine.ts
+++ b/src/cegis/auto-fix-engine.ts
@@ -3,16 +3,17 @@
  * Phase 2.1: Core engine for analyzing failures and applying automated fixes
  */
 
-import type { 
-  FailureArtifact, 
-  FixStrategy, 
-  FixResult, 
-  AppliedFix, 
-  SkippedFix, 
-  AutoFixConfig, 
+import type {
+  FailureArtifact,
+  FixStrategy,
+  FixResult,
+  AppliedFix,
+  SkippedFix,
+  AutoFixConfig,
   AutoFixOptions,
   FailurePattern,
-  FailureCategory
+  FailureCategory,
+  RepairAction
 } from './types.js';
 
 export type { AutoFixOptions };
@@ -70,11 +71,11 @@ export class AutoFixEngine {
       console.log(`📋 Processing ${validFailures.length} valid failures`);
       
       // 2. Analyze failure patterns
-      const patterns = await this.analyzeFailurePatterns(validFailures);
+      const patterns = this.analyzeFailurePatterns(validFailures);
       console.log(`🔍 Identified ${patterns.length} failure patterns`);
       
       // 3. Select and prioritize strategies
-      const strategies = await this.selectStrategies(validFailures, patterns);
+      const strategies = await this.selectStrategies(validFailures);
       console.log(`⚙️  Selected ${strategies.length} fix strategies`);
       
       // 4. Execute fixes
@@ -86,7 +87,7 @@ export class AutoFixEngine {
       
       // 5. Generate summary and recommendations
       const summary = this.generateSummary(validFailures, appliedFixes, skippedFixes);
-      const recommendations = await this.generateRecommendations(
+      const recommendations = this.generateRecommendations(
         validFailures,
         appliedFixes,
         patterns
@@ -147,7 +148,7 @@ export class AutoFixEngine {
   /**
    * Analyze failure patterns to identify common issues
    */
-  async analyzeFailurePatterns(failures: FailureArtifact[]): Promise<FailurePattern[]> {
+  analyzeFailurePatterns(failures: FailureArtifact[]): FailurePattern[] {
     const patterns: FailurePattern[] = [];
     const categoryGroups = this.groupByCategory(failures);
     
@@ -220,8 +221,7 @@ export class AutoFixEngine {
   }
 
   private async selectStrategies(
-    failures: FailureArtifact[],
-    patterns: FailurePattern[]
+    failures: FailureArtifact[]
   ): Promise<{ strategy: FixStrategy; failures: FailureArtifact[] }[]> {
     const strategyGroups: { strategy: FixStrategy; failures: FailureArtifact[] }[] = [];
     
@@ -337,7 +337,7 @@ export class AutoFixEngine {
     const filesModified: string[] = [];
     const errors: string[] = [];
     const warnings: string[] = [];
-    const allActions: any[] = [];
+    const allActions: RepairAction[] = [];
     
     for (const failure of failures) {
       // Skip if file already processed
@@ -388,7 +388,7 @@ export class AutoFixEngine {
     };
   }
 
-  private async applyAction(action: any): Promise<void> {
+  private async applyAction(action: RepairAction): Promise<void> {
     if (action.type === 'code_change' && action.codeChange && action.filePath) {
       const fs = await import('fs');
       const content = await fs.promises.readFile(action.filePath, 'utf-8');
@@ -408,8 +408,7 @@ export class AutoFixEngine {
 
   private async backupFile(filePath: string): Promise<void> {
     const fs = await import('fs');
-    const path = await import('path');
-    
+
     const backupPath = `${filePath}.backup.${Date.now()}`;
     await fs.promises.copyFile(filePath, backupPath);
   }
@@ -458,7 +457,7 @@ export class AutoFixEngine {
     failures: FailureArtifact[],
     appliedFixes: AppliedFix[],
     skippedFixes: SkippedFix[]
-  ) {
+  ): FixResult['summary'] {
     const filesModified = new Set<string>();
     const errors: string[] = [];
     const warnings: string[] = [];
@@ -480,11 +479,11 @@ export class AutoFixEngine {
     };
   }
 
-  private async generateRecommendations(
+  private generateRecommendations(
     failures: FailureArtifact[],
     appliedFixes: AppliedFix[],
     patterns: FailurePattern[]
-  ): Promise<string[]> {
+  ): string[] {
     const recommendations: string[] = [];
     
     // Pattern-based recommendations
@@ -507,13 +506,13 @@ export class AutoFixEngine {
     }
     
     // Success rate recommendations
-    const successRate = appliedFixes.filter(f => f.success).length / appliedFixes.length;
-    if (successRate < 0.8) {
+    const successRate = appliedFixes.length === 0 ? 0 : appliedFixes.filter(f => f.success).length / appliedFixes.length;
+    if (appliedFixes.length > 0 && successRate < 0.8) {
       recommendations.push(
         'Low fix success rate. Consider manual review of failed fixes.'
       );
     }
-    
+
     return recommendations;
   }
 
@@ -521,7 +520,7 @@ export class AutoFixEngine {
     failures: FailureArtifact[],
     appliedFixes: AppliedFix[],
     skippedFixes: SkippedFix[],
-    summary: any,
+    summary: FixResult['summary'],
     recommendations: string[]
   ): Promise<string> {
     const reportPath = `cegis-report-${Date.now()}.json`;
@@ -538,7 +537,7 @@ export class AutoFixEngine {
       })),
       skippedFixes,
       recommendations,
-      patterns: await this.analyzeFailurePatterns(failures)
+      patterns: this.analyzeFailurePatterns(failures)
     };
     
     const fs = await import('fs');


### PR DESCRIPTION
## Summary
- convert  and  to synchronous helpers
- apply  typing through applyAction to eliminate 
- adjust summary/report types to leverage 
- document lint-progress in verify-lite-lint-plan

## Testing
- pnpm lint