### PR TITLE
CI: generate-artifacts drift gate と KvOnce モデルテストの最小導入

### DIFF
--- a/.github/workflows/generate-artifacts-preview.yml
+++ b/.github/workflows/generate-artifacts-preview.yml
@@ -39,13 +39,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'pnpm'
       - name: Enable corepack
         run: corepack enable
       - name: Install dependencies
         run: |
           pnpm fetch --prefer-offline
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile --prefer-offline
+          pnpm install --frozen-lockfile
       - name: Preview generated artifacts
         run: pnpm run generate:artifacts:preview
       - name: Summarize diff
@@ -114,15 +113,14 @@ NODE
                 }
               }
             }
-            const body = lines.join('
-');
+            const body = lines.join("\n");
             const { data: existing } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number
             });
             const marker = '<!-- generate-artifacts-preview -->';
-            const previous = existing.find((c) => c.user.login === context.actor && c.body.includes(marker));
+            const previous = existing.find((c) => c.user.login === 'github-actions[bot]' && c.body.includes(marker));
             if (previous) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,

--- a/.github/workflows/generate-artifacts-preview.yml
+++ b/.github/workflows/generate-artifacts-preview.yml
@@ -85,3 +85,60 @@ NODE
           name: generate-artifacts-preview
           path: hermetic-reports/spec/generate-artifacts-diff.json
           if-no-files-found: error
+
+      - name: Comment diff on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'hermetic-reports/spec/generate-artifacts-diff.json';
+            const summary = fs.existsSync(path) ? JSON.parse(fs.readFileSync(path, 'utf8')) : null;
+            const lines = [];
+            lines.push('### Generate Artifacts Preview');
+            if (!summary) {
+              lines.push('No diff summary generated.');
+            } else {
+              lines.push(`Generated at: ${summary.generatedAt}`);
+              for (const target of summary.targets || []) {
+                const status = target.hasChanges ? 'CHANGED' : 'clean';
+                lines.push(`- ${target.path}: ${status}`);
+                if (target.hasChanges && target.files) {
+                  const sample = target.files.slice(0, 10);
+                  for (const file of sample) {
+                    lines.push(`  - ${file.status} ${file.file}`);
+                  }
+                  if (target.files.length > sample.length) {
+                    lines.push(`  - … (${target.files.length - sample.length} more)`);
+                  }
+                }
+              }
+            }
+            const body = lines.join('
+');
+            const { data: existing } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const marker = '<!-- generate-artifacts-preview -->';
+            const previous = existing.find((c) => c.user.login === context.actor && c.body.includes(marker));
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body: `${body}
+
+${marker}`
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `${body}
+
+${marker}`
+              });
+            }

--- a/.github/workflows/spec-generate-model.yml
+++ b/.github/workflows/spec-generate-model.yml
@@ -1,0 +1,151 @@
+name: Spec Generate & Model Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'specs/**'
+      - 'templates/**'
+      - 'scripts/**'
+      - 'docs/**'
+      - 'tests/**'
+      - 'artifacts/**'
+      - '.github/workflows/spec-generate-model.yml'
+
+permissions:
+  contents: read
+  actions: read
+  id-token: none
+
+jobs:
+  generate-artifacts:
+    runs-on: ubuntu-latest
+    env:
+      AE_HOST_STORE: ${{ github.workspace }}/.pnpm-store
+      PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare pnpm
+        uses: ./.github/actions/setup-pnpm
+      - name: Ensure pnpm cache dir
+        run: mkdir -p "$AE_HOST_STORE"
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.AE_HOST_STORE }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: |
+          pnpm fetch --prefer-offline
+          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile --prefer-offline
+      - name: Generate artifacts preview
+        run: pnpm run generate:artifacts:preview
+      - name: Check diff summary
+        id: diffcheck
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const summaryFile = 'hermetic-reports/spec/generate-artifacts-diff.json';
+          const stepSummary = process.env.GITHUB_STEP_SUMMARY;
+          const appendSummary = (lines) => {
+            if (!stepSummary) return;
+            fs.appendFileSync(stepSummary, lines.join('
+') + '
+');
+          };
+          if (!fs.existsSync(summaryFile)) {
+            console.log('No summary generated.');
+            appendSummary(['## Generate Artifacts Drift', '- summary file missing']);
+            process.exitCode = 1;
+            return;
+          }
+          const summary = JSON.parse(fs.readFileSync(summaryFile, 'utf8'));
+          const changed = (summary.targets || []).filter(t => t.hasChanges);
+          if (changed.length === 0) {
+            const lines = ['## Generate Artifacts Drift', '- clean'];
+            console.log('No generate-artifacts drift detected.');
+            appendSummary(lines);
+            return;
+          }
+          const lines = ['## Generate Artifacts Drift', `Generated at: ${summary.generatedAt || 'unknown'}`];
+          console.log('Detected drift in generated artifacts:');
+          for (const target of changed) {
+            console.log(`- ${target.path}`);
+            lines.push(`- ${target.path}: CHANGED`);
+            if (Array.isArray(target.files)) {
+              for (const file of target.files.slice(0, 10)) {
+                console.log(`  ${file.status} ${file.file}`);
+                lines.push(`  - ${file.status} ${file.file}`);
+              }
+              if (target.files.length > 10) {
+                const more = `  - … (${target.files.length - 10} more)`;
+                console.log(more.trim());
+                lines.push(more);
+              }
+            }
+          }
+          appendSummary(lines);
+          process.exitCode = 1;
+          NODE
+      - name: Upload diff summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: generate-artifacts-diff
+          path: hermetic-reports/spec/generate-artifacts-diff.json
+          if-no-files-found: warn
+
+  model-based-tests:
+    runs-on: ubuntu-latest
+    needs: generate-artifacts
+    env:
+      AE_HOST_STORE: ${{ github.workspace }}/.pnpm-store
+      PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare pnpm
+        uses: ./.github/actions/setup-pnpm
+      - name: Ensure pnpm cache dir
+        run: mkdir -p "$AE_HOST_STORE"
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.AE_HOST_STORE }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: |
+          pnpm fetch --prefer-offline
+          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile --prefer-offline
+      - name: Run KvOnce property suite
+        run: pnpm vitest run tests/property/kvonce.safety.property.test.ts --reporter dot
+      - name: Summarize model-based run
+        if: always()
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const summary = process.env.GITHUB_STEP_SUMMARY;
+          if (!summary) {
+            process.exit(0);
+          }
+          const lines = [
+            '## Model-based Tests',
+            '- kvonce.safety property suite executed (see job log for details).'
+          ];
+          fs.appendFileSync(summary, lines.join('\n') + '\n');
+          NODE

--- a/.github/workflows/spec-generate-model.yml
+++ b/.github/workflows/spec-generate-model.yml
@@ -15,7 +15,6 @@ on:
 permissions:
   contents: read
   actions: read
-  id-token: none
 
 jobs:
   generate-artifacts:
@@ -39,13 +38,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'pnpm'
       - name: Enable corepack
         run: corepack enable
       - name: Install dependencies
         run: |
           pnpm fetch --prefer-offline
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile --prefer-offline
+          pnpm install --frozen-lockfile
       - name: Generate artifacts preview
         run: pnpm run generate:artifacts:preview
       - name: Check diff summary
@@ -56,10 +54,10 @@ jobs:
           const summaryFile = 'hermetic-reports/spec/generate-artifacts-diff.json';
           const stepSummary = process.env.GITHUB_STEP_SUMMARY;
           const appendSummary = (lines) => {
-            if (!stepSummary) return;
-            fs.appendFileSync(stepSummary, lines.join('
-') + '
-');
+            if (!stepSummary) {
+              return;
+            }
+            fs.appendFileSync(stepSummary, lines.join("\n") + "\n");
           };
           if (!fs.existsSync(summaryFile)) {
             console.log('No summary generated.');
@@ -68,7 +66,7 @@ jobs:
             return;
           }
           const summary = JSON.parse(fs.readFileSync(summaryFile, 'utf8'));
-          const changed = (summary.targets || []).filter(t => t.hasChanges);
+          const changed = (summary.targets || []).filter((t) => t.hasChanges);
           if (changed.length === 0) {
             const lines = ['## Generate Artifacts Drift', '- clean'];
             console.log('No generate-artifacts drift detected.');
@@ -125,13 +123,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'pnpm'
       - name: Enable corepack
         run: corepack enable
       - name: Install dependencies
         run: |
           pnpm fetch --prefer-offline
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile --prefer-offline
+          pnpm install --frozen-lockfile
       - name: Run KvOnce property suite
         run: pnpm vitest run tests/property/kvonce.safety.property.test.ts --reporter dot
       - name: Summarize model-based run
@@ -147,5 +144,5 @@ jobs:
             '## Model-based Tests',
             '- kvonce.safety property suite executed (see job log for details).'
           ];
-          fs.appendFileSync(summary, lines.join('\n') + '\n');
+          fs.appendFileSync(summary, lines.join("\n") + "\n");
           NODE

--- a/docs/TLA+/kv-once-poc.md
+++ b/docs/TLA+/kv-once-poc.md
@@ -42,5 +42,6 @@ pnpm run spec:kv-once:apalache
 ## 参考
 - `docs/TLA+/tla_plus_full_integration.md` — 全体ロードマップ
 - `scripts/trace/projector-kvonce.mjs`, `scripts/trace/validate-kvonce.mjs` — NDJSON ログを射影・検証する雛形（例: `hermetic-reports/trace/kvonce-sample.ndjson`).
+- `tests/property/kvonce.safety.property.test.ts` — PoC の振る舞いを確認する property テスト。minimal pipeline で実行されます。
 - `docs/notes/verify-lite-lint-plan.md` — verify-lite lint 改善計画
 - `.github/workflows/minimal-pipeline.yml` — TLC/Apalache を含む最小パイプライン

--- a/docs/TLA+/tla_plus_full_integration.md
+++ b/docs/TLA+/tla_plus_full_integration.md
@@ -190,6 +190,7 @@ THEOREM Safety == Spec => []NoOverwrite
 - 自動生成ワークフロー（BDD/OpenAPI/モニタ）の差分チェック
 - Trace Validator / Projector の実装と `verify:conformance` への統合
 - formal-summary を PR コメントへ自動投稿
+- generate-artifacts / model-based-tests の最小ゲート `.github/workflows/spec-generate-model.yml` を運用し、対象を段階的に拡充
 
 ### 実行ヒント
 
@@ -205,3 +206,8 @@ pnpm run spec:kv-once:apalache
 - CI 取り込み時はラベル `run-formal` などで opt-in しつつ、成功時に summary を PR コメントへ反映させる予定。
 
 次ステップ：Spec Check の結果を Issue #1011 に紐付ける自動コメント、及び generate-artifacts/model-based-tests/conformance の追加。
+
+### 省略予定 (Phase C)
+- Projector / Validator を本運用に載せる前に必要なトレーススキーマ詳細設計（Issue #1011 ステップ3へ委譲）
+- 自動生成 BDD/contract テスト全体の差分チェックと整合性検証（今後の generate-artifacts 拡張で対応）
+- conformance ジョブにおける OTLP 収集とダッシュボード可視化（Issue #1011 ステップ5にて計画）

--- a/docs/notes/issue-progress.md
+++ b/docs/notes/issue-progress.md
@@ -13,7 +13,7 @@
 
 ### Latest PR / Follow-ups
 - Podman/WSL ランタイム最適化: PR [#1014](https://github.com/itdojp/ae-framework/pull/1014)
-- Spec generate/model gating: PR (TBD) — `.github/workflows/spec-generate-model.yml` introduces drift fail-fast + KvOnce property run
+- Spec generate/model gating: PR [#1023](https://github.com/itdojp/ae-framework/pull/1023) — `.github/workflows/spec-generate-model.yml` introduces drift fail-fast + KvOnce property run
 - ネイティブ compose 検証: Issue [#1015](https://github.com/itdojp/ae-framework/issues/1015)
 - Mutation survivor 削減タスク: Issue [#1016](https://github.com/itdojp/ae-framework/issues/1016)
 

--- a/docs/notes/issue-progress.md
+++ b/docs/notes/issue-progress.md
@@ -13,6 +13,7 @@
 
 ### Latest PR / Follow-ups
 - Podman/WSL ランタイム最適化: PR [#1014](https://github.com/itdojp/ae-framework/pull/1014)
+- Spec generate/model gating: PR (TBD) — `.github/workflows/spec-generate-model.yml` introduces drift fail-fast + KvOnce property run
 - ネイティブ compose 検証: Issue [#1015](https://github.com/itdojp/ae-framework/issues/1015)
 - Mutation survivor 削減タスク: Issue [#1016](https://github.com/itdojp/ae-framework/issues/1016)
 

--- a/docs/notes/pipeline-baseline.md
+++ b/docs/notes/pipeline-baseline.md
@@ -19,6 +19,7 @@
 | Verify Lite | `pnpm run verify:lite` | 2025-10-04 | ✅ | ローカルスクリプト追加済。TypeScript エラーを解消し exit 0 を確認（lint は非強制のため警告のみ出力）。実行前に `.stryker-tmp` を自動削除するよう対応。 |
 | Make targets | `make test-*` 系 | 未 | ⛔ | ルートに Makefile が存在せず、直近のテーブルは `docs/notes/full-pipeline-restore.md` の古い情報。Phase A で Makefile 復元可否を調査する。 |
 | CI | `.github/workflows/pr-verify.yml` | 2025-10-04 | ✅ | Podman cache 導入の PR #1014 でローカル確認。CI 側での成功は PR マージ後に要確認。 |
+| CI | `.github/workflows/spec-generate-model.yml` | 2025-10-04 | ✅ | generate-artifacts drift を fail fast し、KvOnce property suite を実行。後続のモデルベース拡張は Issue #1011 で管理。 |
 | CI | `.github/workflows/ci.yml` | 2025-10-04 | ⚠️ | pnpm cache を追加。現状の main ブランチでの成功状況は未確認。CI 再実行後にログをレビューする。 |
 
 ### 未検証だが Phase A で確認が必要なコマンド

--- a/docs/notes/spec-driven-ci-roadmap.md
+++ b/docs/notes/spec-driven-ci-roadmap.md
@@ -9,12 +9,26 @@
 ### 1. generate-artifacts ジョブ
 - プロトタイプ: `pnpm run generate:artifacts:preview` と `.github/workflows/generate-artifacts-preview.yml` で quickstart を実行し、`hermetic-reports/spec/generate-artifacts-diff.json` に差分サマリを出力。
   - サンプル: 差分が無い場合は `{ "targets": [{ "path": ..., "hasChanges": false }] }` のような JSON が出力され、差分がある場合は `files` に `NAME	path` が列挙される。
+  - 直近のサマリ例:
+
+    ```json
+    {
+      "generatedAt": "2025-10-04T06:21:09.137Z",
+      "targets": [
+        { "path": "tests/api/generated", "hasChanges": false },
+        { "path": "artifacts/codex", "hasChanges": false },
+        { "path": "artifacts/spec", "hasChanges": false }
+      ]
+    }
+    ```
 - 入力: `specs/formal/**`, `templates/**`, `ae-framework.yml`
 - 出力: `tests/api/generated/**`, `artifacts/formal/**`, `artifacts/spec/**`
 - 残課題
   - [ ] 生成物の整合性チェック（`git diff --exit-code` ではなく JSON/YAML 正規化）
   - [ ] CI 上での大量出力対策（`artifacts/spec` のフィルタリング）
   - [ ] `scripts/adapters/aggregate-artifacts.mjs` の再確認（依存コマンド現状未整備）
+
+- ✅ ミニマムゲートとして `.github/workflows/spec-generate-model.yml` を追加し、`pnpm run generate:artifacts:preview` のドリフト検知と KvOnce property suite を fail fast で実行できるようにした。
 
 ### 2. model-based-tests ジョブ
 - 目的: 仕様から生成された BDD / property / contract テストを最小構成で実行
@@ -40,6 +54,8 @@
 - 長期: ダッシュボード（Issue #1011 ステップ5）に引き継ぐ
 
 ## 次アクション候補
+4. generate-artifacts-preview の PR トリガーは Step Summary にサマリを出すだけなので、将来的に PR コメントへ自動投稿するジョブ (comment drift) を導入予定。
 1. Q4 中に generate-artifacts ジョブを設計するための spike ブランチを切り、差分検出方法を評価。
 2. モデルベーステスト対象を `kv-once` のみで実行できるよう `tests/property/reservation-schema.property.test.ts` を分割・軽量化。
 3. トレーススキーマのドラフトを `docs/TLA+/kv-once-poc.md` から派生させ、Issue #1011 に共有。
+5. 自動生成された BDD/contract テストを対象に追加し、`model-based-tests` ジョブの網羅範囲を段階的に拡張。


### PR DESCRIPTION
## 概要
- `.github/workflows/spec-generate-model.yml` を追加し、`pnpm run generate:artifacts:preview` のドリフト検知をFail Fast化、KvOnce propertyテストをモデルベースジョブとして自動実行するようにしました。
- 既存の preview ワークフローにPRコメント更新ステップを加えて、差分サマリを自動で通知します。
- `docs/notes/spec-driven-ci-roadmap.md` / `docs/TLA+/tla_plus_full_integration.md` / `docs/notes/pipeline-baseline.md` などを更新し、ISSUE #1011/#1012 のPhase進捗と後回し項目を明示しました。

## テスト
- `pnpm run generate:artifacts:preview`
- `pnpm vitest run tests/property/kvonce.safety.property.test.ts --reporter dot`

## 関連Issue
- refs #1011
- refs #1012
