### PR TITLE
feat(trace): kvonce conformance runner accepts NDJSON

### DIFF
--- a/docs/trace/kvonce-trace-schema.md
+++ b/docs/trace/kvonce-trace-schema.md
@@ -15,7 +15,7 @@
 | `context` | object | 任意 | 追加メタデータ |
 
 ## サンプル (NDJSON)
-- `samples/trace/kvonce-sample.ndjson`
+- `samples/trace/kvonce-sample.ndjson`（リポジトリに同梱。`--format ndjson` で即座に投入可能）
 
 ```ndjson
 {"timestamp":"2025-10-04T06:00:00.000Z","type":"success","key":"alpha","value":"v1"}
@@ -28,7 +28,7 @@
 - `scripts/trace/mock-otlp-service.mjs` — Fastify + OpenTelemetry SDK を利用して ResourceSpans を生成。
 - `scripts/trace/prepare-otlp-trace.mjs` — `KVONCE_OTLP_PAYLOAD` で指定された外部ログを優先し、未指定時はサンプルまたはモックサービスで payload を準備。
 - `scripts/trace/convert-otlp-kvonce.mjs` — OTLP JSON を NDJSON に変換。`startTimeUnixNano` を ISO8601 に変換し、安全な整数範囲外は例外扱い。
-- `scripts/trace/run-kvonce-conformance.sh` — NDJSON/OTLP を入力に Projection → Validation を実施し、`hermetic-reports/trace/kvonce-validation.json` を出力。
+- `scripts/trace/run-kvonce-conformance.sh` — NDJSON/OTLP を入力に Projection → Validation を実施し、`hermetic-reports/trace/kvonce-validation.json` を出力。`--input` / `--output-dir` / `--format` を指定して手元ログや外部 Collector 出力を検証できる。
 
 ## CI への組み込み
 - `.github/workflows/spec-generate-model.yml` の `trace-conformance` ジョブが `prepare-otlp-trace.mjs` → `run-kvonce-conformance.sh` のパイプラインを実行し、Step Summary および PR コメントに結果を出力。

--- a/samples/trace/kvonce-sample.ndjson
+++ b/samples/trace/kvonce-sample.ndjson
@@ -1,0 +1,4 @@
+{"timestamp":"2025-10-04T06:00:00.000Z","type":"success","key":"alpha","value":"v1"}
+{"timestamp":"2025-10-04T06:00:02.000Z","type":"failure","key":"beta","reason":"duplicate"}
+{"timestamp":"2025-10-04T06:00:03.000Z","type":"retry","key":"beta"}
+{"timestamp":"2025-10-04T06:00:04.000Z","type":"success","key":"beta","value":"v2"}

--- a/scripts/trace/convert-otlp-kvonce.mjs
+++ b/scripts/trace/convert-otlp-kvonce.mjs
@@ -95,6 +95,8 @@ function extractEvents(otlp) {
         if (value !== undefined) event.value = value;
         const reason = attrs["kvonce.event.reason"];
         if (reason !== undefined) event.reason = reason;
+        const context = attrs["kvonce.event.context"];
+        if (context !== undefined) event.context = context;
         events.push(event);
       }
     }
@@ -103,6 +105,9 @@ function extractEvents(otlp) {
 }
 
 function toNdjson(events) {
+  if (events.length === 0) {
+    return "";
+  }
   return events.map((event) => JSON.stringify(event)).join("\n") + "\n";
 }
 

--- a/scripts/trace/run-kvonce-conformance.sh
+++ b/scripts/trace/run-kvonce-conformance.sh
@@ -2,38 +2,147 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-TRACE_DIR="${REPO_ROOT}/hermetic-reports/trace"
-OTLP_PAYLOAD="${TRACE_DIR}/collected-kvonce-otlp.json"
-NDJSON_EVENTS="${TRACE_DIR}/kvonce-events.ndjson"
-PROJECTION_JSON="${TRACE_DIR}/kvonce-projection.json"
-VALIDATION_JSON="${TRACE_DIR}/kvonce-validation.json"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DEFAULT_TRACE_DIR="${PROJECT_ROOT}/hermetic-reports/trace"
+DEFAULT_OTLP_PAYLOAD="${DEFAULT_TRACE_DIR}/collected-kvonce-otlp.json"
 
-mkdir -p "${TRACE_DIR}"
-
-log() {
-  printf '[trace-conformance] %s\n' "$1"
+usage() {
+  cat <<'USAGE'
+Usage: run-kvonce-conformance.sh [--input <file>] [--output-dir <dir>] [--format ndjson|otlp]
+  --input       Path to KvOnce trace (NDJSON or OTLP JSON). Omit to use prepared payload.
+  --output-dir  Directory where projection/validation outputs are written (default: hermetic-reports/trace).
+  --format      Explicit input format. If omitted, inferred from file extension (.ndjson => ndjson).
+USAGE
 }
 
-log "preparing OTLP payload"
-node "${SCRIPT_DIR}/prepare-otlp-trace.mjs"
+INPUT=""
+OUTPUT_DIR="${DEFAULT_TRACE_DIR}"
+FORMAT="auto"
 
-log "converting OTLP to NDJSON events"
-set +e
-node "${SCRIPT_DIR}/convert-otlp-kvonce.mjs" --input "${OTLP_PAYLOAD}" --output "${NDJSON_EVENTS}"
-status=$?
-set -e
-if [[ ${status} -ne 0 ]]; then
-  if [[ ${status} -eq 2 ]]; then
-    log "no kvonce events found in OTLP payload"
-  fi
-  exit ${status}
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input|-i)
+      if [[ $# -lt 2 ]]; then
+        echo "[kvonce-conformance] missing value for $1" >&2
+        usage
+        exit 1
+      fi
+      INPUT="$2"
+      shift 2
+      ;;
+    --output-dir|-o)
+      if [[ $# -lt 2 ]]; then
+        echo "[kvonce-conformance] missing value for $1" >&2
+        usage
+        exit 1
+      fi
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --format|-f)
+      if [[ $# -lt 2 ]]; then
+        echo "[kvonce-conformance] missing value for $1" >&2
+        usage
+        exit 1
+      fi
+      FORMAT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[kvonce-conformance] unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${INPUT}" ]]; then
+  INPUT="${DEFAULT_OTLP_PAYLOAD}"
+  node "${SCRIPT_DIR}/prepare-otlp-trace.mjs"
 fi
 
-log "projecting NDJSON events"
-node "${SCRIPT_DIR}/projector-kvonce.mjs" --input "${NDJSON_EVENTS}" --output "${PROJECTION_JSON}"
+if [[ "${FORMAT}" == "auto" ]]; then
+  if [[ "${INPUT}" == *.ndjson ]]; then
+    FORMAT="ndjson"
+  else
+    FORMAT="otlp"
+  fi
+fi
 
-log "validating projection"
-node "${SCRIPT_DIR}/validate-kvonce.mjs" --input "${PROJECTION_JSON}" --output "${VALIDATION_JSON}"
+mkdir -p "${OUTPUT_DIR}"
+NDJSON_PATH="${OUTPUT_DIR}/kvonce-events.ndjson"
+PROJECTION_PATH="${OUTPUT_DIR}/kvonce-projection.json"
+VALIDATION_PATH="${OUTPUT_DIR}/kvonce-validation.json"
 
-log "validation complete -> ${VALIDATION_JSON}"
+echo "[kvonce-conformance] input=${INPUT} format=${FORMAT} output_dir=${OUTPUT_DIR}"
+
+TEMP_FILE=""
+cleanup() {
+  if [[ -n "${TEMP_FILE}" && -f "${TEMP_FILE}" ]]; then
+    rm -f "${TEMP_FILE}"
+  fi
+}
+trap cleanup EXIT
+
+SOURCE_NDJSON="${INPUT}"
+
+if [[ "${FORMAT}" == "otlp" ]]; then
+  TEMP_FILE="$(mktemp "${TMPDIR:-/tmp}/kvonce-events-XXXXXX.ndjson")"
+  set +e
+  node "${SCRIPT_DIR}/convert-otlp-kvonce.mjs" --input "${INPUT}" --output "${TEMP_FILE}"
+  status=$?
+  set -e
+  if [[ ${status} -ne 0 ]]; then
+    if [[ ${status} -eq 2 ]]; then
+      echo "[kvonce-conformance] no kvonce events found in OTLP payload" >&2
+    fi
+    exit ${status}
+  fi
+  cp "${TEMP_FILE}" "${NDJSON_PATH}"
+  SOURCE_NDJSON="${NDJSON_PATH}"
+elif [[ "${FORMAT}" == "ndjson" ]]; then
+  if [[ "${INPUT}" != "${NDJSON_PATH}" ]]; then
+    cp "${INPUT}" "${NDJSON_PATH}"
+    SOURCE_NDJSON="${NDJSON_PATH}"
+  fi
+else
+  echo "[kvonce-conformance] unsupported format: ${FORMAT}" >&2
+  exit 1
+fi
+
+node "${SCRIPT_DIR}/projector-kvonce.mjs" --input "${SOURCE_NDJSON}" --output "${PROJECTION_PATH}"
+node "${SCRIPT_DIR}/validate-kvonce.mjs" --input "${PROJECTION_PATH}" --output "${VALIDATION_PATH}"
+
+if command -v jq >/dev/null 2>&1; then
+  VALID=$(jq -r '.valid' "${VALIDATION_PATH}" 2>/dev/null || echo unknown)
+else
+  VALID=$(node - "${VALIDATION_PATH}" <<'NODE'
+import fs from "node:fs";
+const file = process.argv[2];
+try {
+  const json = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (json.valid === true) {
+    console.log("true");
+  } else if (json.valid === false) {
+    console.log("false");
+  } else {
+    console.log("unknown");
+  }
+} catch (error) {
+  console.log("unknown");
+}
+NODE
+)
+fi
+
+if [[ "${VALID}" != "true" ]]; then
+  echo "[kvonce-conformance] validation failed (valid=${VALID}). See ${VALIDATION_PATH}" >&2
+  exit 1
+fi
+
+echo "[kvonce-conformance] projection -> ${PROJECTION_PATH}"
+echo "[kvonce-conformance] validation -> ${VALIDATION_PATH}"


### PR DESCRIPTION
## 概要
- trace conformance シェルを引数対応させ、OTLP/NDJSON どちらでも検証できるようにした
- OTLP 変換器で context フィールドを抽出し、イベント不在時は空文字を返すよう調整
- KvOnce のサンプル NDJSON を追加し、ドキュメントを CLI オプションに合わせて補足

## テスト
- scripts/trace/run-kvonce-conformance.sh
- scripts/trace/run-kvonce-conformance.sh --input samples/trace/kvonce-otlp.json --format otlp --output-dir tmp/trace-test
- scripts/trace/run-kvonce-conformance.sh --input tmp/kvonce.ndjson --format ndjson --output-dir tmp/trace-ndjson

## 関連Issue
- refs #1011
- refs #1012
