### PR TITLE
ci: emit verify-lite run summary and refresh docs (#1012)

### DIFF
--- a/docs/notes/verify-lite-lint-plan.md
+++ b/docs/notes/verify-lite-lint-plan.md
@@ -19,6 +19,19 @@
 3. **Phase C (Strict by default)**
    - [ ] 全カテゴリが許容値（< 50 件）になったら verify-lite lint 失敗をブロッキング化。
 
+## Issue 連携
+- Issue #1012 Phase A: `docs/notes/pipeline-baseline.md` の手順に従い、Verify Lite ローカル実行ログ（lint サマリ・mutation survivors）を保存し、進捗報告に添付する。
+- Issue #1016 Lint/Muation backlog:
+  - [ ] 上記 Phase A タスクが完了したら survivors 上位 10 件を再計測し、Issue コメントに貼り付ける。
+  - [ ] Mutation Quick（59.74% → 65% 以上）が達成できたら Phase B へ移行する旨を更新。
+  - [ ] Lint suppression の恒久対応（型定義追加 or アーキテクチャ整理）が必要な場合は、Issue 内で新規サブタスクに分解して記録する。
+
+## ログ保存ポリシー
+- `VERIFY_LITE_KEEP_LINT_LOG=1` で `pnpm run verify:lite` を実行し、生成された `verify-lite-lint-summary.json` / `verify-lite-lint.log` を `reports/verify-lite/<timestamp>/` に保管する。
+- Mutation Quick を併走させる場合は `VERIFY_LITE_RUN_MUTATION=1` を指定し、`reports/mutation/survivors.json` と `mutation-summary.md` を同一ディレクトリに移動する（Phase A の進捗エビデンスとして必須）。
+- CI の Step Summary とローカルログの内容が乖離した場合は、Issue #1016 のコメントに原因と対処方針を追記する。
+- `verify-lite-run-summary.json` に各ステップの成功/失敗が出力されるため、Issue への報告時は JSON の添付または主要ステータスの抜粋を行う。
+
 ## 参考
 - lint サマリは `verify-lite-lint-summary.json`（artifact）に保存。
 - `docs/notes/pipeline-baseline.md` に最新ステータスを反映。

--- a/scripts/ci/run-verify-lite-local.sh
+++ b/scripts/ci/run-verify-lite-local.sh
@@ -14,18 +14,54 @@ INSTALL_FLAGS=(--frozen-lockfile)
 if [[ "${VERIFY_LITE_NO_FROZEN:-0}" == "1" ]]; then
   INSTALL_FLAGS=(--no-frozen-lockfile)
 fi
+INSTALL_FLAGS_STR="${INSTALL_FLAGS[*]}"
+
+RUN_TIMESTAMP="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
+SUMMARY_PATH="${VERIFY_LITE_SUMMARY_FILE:-verify-lite-run-summary.json}"
+
+INSTALL_STATUS="success"
+INSTALL_NOTES="flags=${INSTALL_FLAGS_STR}"
+INSTALL_RETRIED=0
+SPEC_COMPILER_STATUS="skipped"
+TYPECHECK_STATUS="pending"
+LINT_STATUS="skipped"
+BUILD_STATUS="pending"
+BDD_LINT_STATUS="skipped"
+MUTATION_STATUS="skipped"
+MUTATION_NOTES=""
+LINT_LOG_EXPORT=""
+LINT_SUMMARY_PATH=""
+MUTATION_SUMMARY_PATH=""
+MUTATION_SURVIVORS_PATH=""
 
 echo "[verify-lite] installing dependencies (${INSTALL_FLAGS[*]})"
 if ! pnpm install "${INSTALL_FLAGS[@]}"; then
+  INSTALL_RETRIED=1
+  INSTALL_NOTES+=";retry-with=--no-frozen-lockfile"
   echo "[verify-lite] initial pnpm install failed, retrying with --no-frozen-lockfile" >&2
-  pnpm install --no-frozen-lockfile
+  if ! pnpm install --no-frozen-lockfile; then
+    INSTALL_STATUS="failure"
+    INSTALL_NOTES+=";retry_failed"
+    echo "[verify-lite] pnpm install failed after retry" >&2
+    exit 1
+  fi
 fi
 
 echo "[verify-lite] building spec-compiler types (non-blocking)"
-pnpm -F @ae-framework/spec-compiler -s run build || true
+if pnpm -F @ae-framework/spec-compiler -s run build; then
+  SPEC_COMPILER_STATUS="success"
+else
+  SPEC_COMPILER_STATUS="failure"
+fi
 
 echo "[verify-lite] running type checks"
-pnpm types:check
+if pnpm types:check; then
+  TYPECHECK_STATUS="success"
+else
+  TYPECHECK_STATUS="failure"
+  echo "[verify-lite] type check failed" >&2
+  exit 1
+fi
 
 echo "[verify-lite] linting"
 LINT_LOG_FILE="$(mktemp)"
@@ -36,33 +72,116 @@ cleanup_lint() {
 }
 trap cleanup_lint EXIT
 
-pnpm lint 2>&1 | tee "$LINT_LOG_FILE" || true
+if pnpm lint 2>&1 | tee "$LINT_LOG_FILE"; then
+  LINT_STATUS="success"
+else
+  LINT_STATUS="failure"
+fi
 if [[ -s "$LINT_LOG_FILE" ]]; then
-  node scripts/ci/verify-lite-lint-summary.mjs < "$LINT_LOG_FILE" > verify-lite-lint-summary.json || true
+  if node scripts/ci/verify-lite-lint-summary.mjs < "$LINT_LOG_FILE" > verify-lite-lint-summary.json; then
+    LINT_SUMMARY_PATH="verify-lite-lint-summary.json"
+  fi
   if [[ ${VERIFY_LITE_KEEP_LINT_LOG:-0} == "1" ]]; then
     cp "$LINT_LOG_FILE" verify-lite-lint.log
+    LINT_LOG_EXPORT="verify-lite-lint.log"
   fi
 fi
 
 echo "[verify-lite] building project"
-pnpm run build
+if pnpm run build; then
+  BUILD_STATUS="success"
+else
+  BUILD_STATUS="failure"
+  echo "[verify-lite] build failed" >&2
+  exit 1
+fi
 
 echo "[verify-lite] optional BDD lint"
 if [[ -f scripts/bdd/lint.mjs ]]; then
-  node scripts/bdd/lint.mjs || true
+  if node scripts/bdd/lint.mjs; then
+    BDD_LINT_STATUS="success"
+  else
+    BDD_LINT_STATUS="failure"
+  fi
 fi
 
 echo "[verify-lite] mutation quick (non-blocking)"
 if [[ ${VERIFY_LITE_RUN_MUTATION:-0} == "1" && -x scripts/mutation/run-scoped.sh ]]; then
-  ./scripts/mutation/run-scoped.sh --quick --auto-diff || true
+  if ./scripts/mutation/run-scoped.sh --quick --auto-diff; then
+    MUTATION_STATUS="success"
+  else
+    MUTATION_STATUS="failure"
+    MUTATION_NOTES="run-scoped.sh exit != 0"
+  fi
 else
   echo "[verify-lite] skipping mutation quick"
 fi
 
 echo "[verify-lite] summarising mutation survivors"
 if [[ -f reports/mutation/mutation.json ]]; then
-  node scripts/mutation/post-quick-summary.mjs | tee mutation-summary.md || true
-  node scripts/mutation/list-survivors.mjs --limit 25 > reports/mutation/survivors.json || true
+  if node scripts/mutation/post-quick-summary.mjs | tee mutation-summary.md; then
+    MUTATION_SUMMARY_PATH="mutation-summary.md"
+  fi
+  if node scripts/mutation/list-survivors.mjs --limit 25 > reports/mutation/survivors.json; then
+    MUTATION_SURVIVORS_PATH="reports/mutation/survivors.json"
+  fi
 fi
+
+export RUN_TIMESTAMP
+export SUMMARY_PATH
+export INSTALL_STATUS INSTALL_NOTES INSTALL_RETRIED
+export SPEC_COMPILER_STATUS TYPECHECK_STATUS LINT_STATUS BUILD_STATUS BDD_LINT_STATUS
+export MUTATION_STATUS MUTATION_NOTES
+export INSTALL_FLAGS_STR
+export LINT_SUMMARY_PATH LINT_LOG_EXPORT
+export MUTATION_SUMMARY_PATH MUTATION_SURVIVORS_PATH
+
+node <<'NODE'
+const fs = require('fs');
+
+const bool = (value) => value === '1';
+const existsOrNull = (p) => (p && fs.existsSync(p) ? p : null);
+
+const summary = {
+  timestamp: process.env.RUN_TIMESTAMP,
+  flags: {
+    install: process.env.INSTALL_FLAGS_STR || '',
+    noFrozen: bool(process.env.VERIFY_LITE_NO_FROZEN || '0'),
+    keepLintLog: bool(process.env.VERIFY_LITE_KEEP_LINT_LOG || '0'),
+    enforceLint: bool(process.env.VERIFY_LITE_ENFORCE_LINT || '0'),
+    runMutation: bool(process.env.VERIFY_LITE_RUN_MUTATION || '0'),
+  },
+  steps: {
+    install: {
+      status: process.env.INSTALL_STATUS,
+      notes: process.env.INSTALL_NOTES,
+      retried: process.env.INSTALL_RETRIED === '1',
+    },
+    specCompilerBuild: { status: process.env.SPEC_COMPILER_STATUS },
+    typeCheck: { status: process.env.TYPECHECK_STATUS },
+    lint: { status: process.env.LINT_STATUS },
+    build: { status: process.env.BUILD_STATUS },
+    bddLint: { status: process.env.BDD_LINT_STATUS },
+    mutationQuick: {
+      status: process.env.MUTATION_STATUS,
+      notes: process.env.MUTATION_NOTES || null,
+    },
+  },
+  artifacts: {
+    lintSummary: existsOrNull(process.env.LINT_SUMMARY_PATH),
+    lintLog: existsOrNull(process.env.LINT_LOG_EXPORT),
+    mutationSummary: existsOrNull(process.env.MUTATION_SUMMARY_PATH),
+    mutationSurvivors: existsOrNull(process.env.MUTATION_SURVIVORS_PATH),
+  },
+};
+
+try {
+  fs.writeFileSync(process.env.SUMMARY_PATH, JSON.stringify(summary, null, 2));
+  console.log(`[verify-lite] summary written to ${process.env.SUMMARY_PATH}`);
+} catch (error) {
+  console.error('[verify-lite] failed to write summary', error);
+  process.exitCode = 1;
+}
+NODE
 
 echo "[verify-lite] local run complete"

--- a/scripts/ci/write-verify-lite-summary.mjs
+++ b/scripts/ci/write-verify-lite-summary.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const summaryPathFromArg = process.argv[2];
+const summaryPath = summaryPathFromArg ?? process.env.VERIFY_LITE_SUMMARY_FILE ?? 'verify-lite-run-summary.json';
+const resolvedPath = path.resolve(summaryPath);
+
+const bool = (value) => value === '1' || value === true || value === 'true';
+const existsOrNull = (p) => (p && fs.existsSync(p) ? p : null);
+
+const readStatus = (name, fallback) => {
+  const value = process.env[name];
+  return value ?? fallback;
+};
+
+const summary = {
+  timestamp: process.env.RUN_TIMESTAMP || new Date().toISOString(),
+  flags: {
+    install: process.env.INSTALL_FLAGS_STR || '',
+    noFrozen: bool(process.env.VERIFY_LITE_NO_FROZEN || '0'),
+    keepLintLog: bool(process.env.VERIFY_LITE_KEEP_LINT_LOG || '0'),
+    enforceLint: bool(process.env.VERIFY_LITE_ENFORCE_LINT || '0'),
+    runMutation: bool(process.env.VERIFY_LITE_RUN_MUTATION || '0'),
+  },
+  steps: {
+    install: {
+      status: readStatus('INSTALL_STATUS', 'unknown'),
+      notes: process.env.INSTALL_NOTES || null,
+      retried: readStatus('INSTALL_RETRIED', '0') === '1',
+    },
+    specCompilerBuild: { status: readStatus('SPEC_COMPILER_STATUS', 'skipped') },
+    typeCheck: { status: readStatus('TYPECHECK_STATUS', 'unknown') },
+    lint: { status: readStatus('LINT_STATUS', 'unknown') },
+    build: { status: readStatus('BUILD_STATUS', 'unknown') },
+    bddLint: { status: readStatus('BDD_LINT_STATUS', 'skipped') },
+    mutationQuick: {
+      status: readStatus('MUTATION_STATUS', 'skipped'),
+      notes: process.env.MUTATION_NOTES || null,
+    },
+  },
+  artifacts: {
+    lintSummary: existsOrNull(process.env.LINT_SUMMARY_PATH),
+    lintLog: existsOrNull(process.env.LINT_LOG_EXPORT),
+    mutationSummary: existsOrNull(process.env.MUTATION_SUMMARY_PATH),
+    mutationSurvivors: existsOrNull(process.env.MUTATION_SURVIVORS_PATH),
+  },
+};
+
+try {
+  fs.writeFileSync(resolvedPath, JSON.stringify(summary, null, 2));
+  console.log(`[verify-lite] summary written to ${resolvedPath}`);
+} catch (error) {
+  console.error('[verify-lite] failed to write summary', error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add per-step status tracking to `scripts/ci/run-verify-lite-local.sh` and emit `verify-lite-run-summary.json` so Phase A runs can be shared as evidence for #1012
- document the log collection workflow (with the new summary output) and connect the lint/mutation backlog plan to Issues #1012 / #1016 for Phase C hand-off
- note the JSON summary requirement when reporting verify-lite results so upcoming trace integration (#1011) can reuse the same data set

## Testing
- VERIFY_LITE_NO_FROZEN=1 VERIFY_LITE_KEEP_LINT_LOG=1 pnpm run verify:lite

Resolves #1012. Refs #1011.
