### PR TITLE
ci: share verify-lite run summary in CI

### DIFF
--- a/.github/workflows/minimal-pipeline.yml
+++ b/.github/workflows/minimal-pipeline.yml
@@ -47,23 +47,20 @@ jobs:
         run: pnpm vitest run tests/unit/utils/enhanced-state-manager.test.ts tests/unit/utils/enhanced-state-manager.rollback.test.ts --reporter dot
       - name: Property tests (KvOnce PoC)
         run: pnpm vitest run tests/property/kvonce.safety.property.test.ts --reporter dot
-      - name: Verify Lite (non-enforced lint)
-        if: ${{ github.event.inputs.enforce_lint != 'true' }}
-        run: |
-          pnpm run verify:lite | tee verify-lite-lint.log
-          node scripts/ci/verify-lite-lint-summary.mjs < verify-lite-lint.log > verify-lite-lint-summary.json
-      - name: Verify Lite (enforced lint)
-        if: ${{ github.event.inputs.enforce_lint == 'true' }}
-        run: |
-          set -o pipefail
-          VERIFY_LITE_ENFORCE_LINT=1 pnpm run verify:lite | tee verify-lite-lint.log
-          node scripts/ci/verify-lite-lint-summary.mjs < verify-lite-lint.log > verify-lite-lint-summary.json
+      - name: Verify Lite (script)
+        env:
+          VERIFY_LITE_KEEP_LINT_LOG: '1'
+          VERIFY_LITE_RUN_MUTATION: '0'
+          VERIFY_LITE_ENFORCE_LINT: ${{ github.event.inputs.enforce_lint == 'true' && '1' || '0' }}
+          VERIFY_LITE_SUMMARY_FILE: verify-lite-run-summary.json
+        run: pnpm run verify:lite
       - name: Upload verify-lite artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: verify-lite-lint
+          name: verify-lite-report
           path: |
+            verify-lite-run-summary.json
             verify-lite-lint.log
             verify-lite-lint-summary.json
       - name: Summarize lint findings
@@ -74,6 +71,15 @@ jobs:
             node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('verify-lite-lint-summary.json','utf8')); console.log('Total issues:', data.total); console.log('Top rules:'); data.rules.slice(0,5).forEach(r=>console.log('-', r.rule, r.count));" | tee -a "$GITHUB_STEP_SUMMARY"
           else
             echo "No lint summary generated" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Append verify-lite run summary
+        if: always()
+        run: |
+          if [ -f verify-lite-run-summary.json ]; then
+            echo '## Verify Lite Run Summary' >> "$GITHUB_STEP_SUMMARY"
+            node scripts/ci/render-verify-lite-summary.mjs verify-lite-run-summary.json >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'Verify Lite run summary not generated.' >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: KvOnce TLC (informational)
         run: |

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -28,24 +28,14 @@ jobs:
         with:
           node-version: '20'
           cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
-      - name: Pre-build workspace types (spec-compiler)
-        run: pnpm -F @ae-framework/spec-compiler -s run build || true
-      - name: Type check (strict verify)
-        run: pnpm types:check
-      - name: Lint (capture summary)
+      - name: Run verify-lite pipeline
+        env:
+          VERIFY_LITE_KEEP_LINT_LOG: '1'
+          VERIFY_LITE_RUN_MUTATION: ${{ github.event_name == 'pull_request' && '1' || '0' }}
+          VERIFY_LITE_NO_FROZEN: '0'
+          VERIFY_LITE_SUMMARY_FILE: verify-lite-run-summary.json
         run: |
-          pnpm lint 2>&1 | tee verify-lite-lint.log || true
-          if [ -f verify-lite-lint.log ]; then
-            node scripts/ci/verify-lite-lint-summary.mjs < verify-lite-lint.log > verify-lite-lint-summary.json
-          fi
-      - name: Build
-        run: pnpm run build
-      - name: BDD lint (non-blocking)
-        continue-on-error: true
-        run: |
-          if [ -f scripts/bdd/lint.mjs ]; then node scripts/bdd/lint.mjs; else printf "No BDD linter\n"; fi
+          pnpm run verify:lite
       - name: BDD lint (strict; label-gated)
         if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-bdd-lint') }}
         env:
@@ -96,19 +86,12 @@ jobs:
         run: |
           if [ -f scripts/summary/render-pr-summary.mjs ]; then node scripts/summary/render-pr-summary.mjs; fi
           [ -f artifacts/summary/PR_SUMMARY.md ] && cat artifacts/summary/PR_SUMMARY.md >> "$GITHUB_STEP_SUMMARY" || true
-      - name: Mutation quick (auto-diff)
-        if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
-        run: |
-          if [ -x scripts/mutation/run-scoped.sh ]; then
-            ./scripts/mutation/run-scoped.sh --quick --auto-diff || true
-          else
-            echo "scripts/mutation/run-scoped.sh not available; skipping mutation quick run"
-          fi
       - name: Mutation quick summary
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-          if [ -f reports/mutation/mutation.json ]; then
+          if [ -f mutation-summary.md ]; then
+            cat mutation-summary.md >> "$GITHUB_STEP_SUMMARY"
+          elif [ -f reports/mutation/mutation.json ]; then
             node scripts/mutation/post-quick-summary.mjs | tee mutation-summary.md
             cat mutation-summary.md >> "$GITHUB_STEP_SUMMARY"
           else
@@ -136,15 +119,25 @@ jobs:
         with:
           name: mutation-survivors-json
           path: reports/mutation/survivors.json
-      - name: Upload lint summary
+      - name: Upload verify-lite report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: verify-lite-lint
+          name: verify-lite-report
           path: |
+            verify-lite-run-summary.json
             verify-lite-lint.log
             verify-lite-lint-summary.json
           if-no-files-found: ignore
+      - name: Append verify-lite run summary
+        if: always()
+        run: |
+          if [ -f verify-lite-run-summary.json ]; then
+            echo '## Verify Lite Run Summary' >> "$GITHUB_STEP_SUMMARY"
+            node scripts/ci/render-verify-lite-summary.mjs verify-lite-run-summary.json >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'Verify Lite run summary not generated.' >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Append lint summary (top rules)
         if: always()
         run: |

--- a/docs/notes/verify-lite-lint-plan.md
+++ b/docs/notes/verify-lite-lint-plan.md
@@ -19,6 +19,19 @@
 3. **Phase C (Strict by default)**
    - [ ] 全カテゴリが許容値（< 50 件）になったら verify-lite lint 失敗をブロッキング化。
 
+## Issue 連携
+- Issue #1012 Phase A: `docs/notes/pipeline-baseline.md` の手順に従い、Verify Lite ローカル実行ログ（lint サマリ・mutation survivors）を保存し、進捗報告に添付する。
+- Issue #1016 Lint/Muation backlog:
+  - [ ] 上記 Phase A タスクが完了したら survivors 上位 10 件を再計測し、Issue コメントに貼り付ける。
+  - [ ] Mutation Quick（59.74% → 65% 以上）が達成できたら Phase B へ移行する旨を更新。
+  - [ ] Lint suppression の恒久対応（型定義追加 or アーキテクチャ整理）が必要な場合は、Issue 内で新規サブタスクに分解して記録する。
+
+## ログ保存ポリシー
+- `VERIFY_LITE_KEEP_LINT_LOG=1` で `pnpm run verify:lite` を実行し、生成された `verify-lite-lint-summary.json` / `verify-lite-lint.log` を `reports/verify-lite/<timestamp>/` に保管する。
+- Mutation Quick を併走させる場合は `VERIFY_LITE_RUN_MUTATION=1` を指定し、`reports/mutation/survivors.json` と `mutation-summary.md` を同一ディレクトリに移動する（Phase A の進捗エビデンスとして必須）。
+- CI の Step Summary とローカルログの内容が乖離した場合は、Issue #1016 のコメントに原因と対処方針を追記する。
+- `verify-lite-run-summary.json` に各ステップの成功/失敗が出力されるため、Issue への報告時は JSON の添付または主要ステータスの抜粋を行う。
+
 ## 参考
 - lint サマリは `verify-lite-lint-summary.json`（artifact）に保存。
 - `docs/notes/pipeline-baseline.md` に最新ステータスを反映。

--- a/scripts/ci/render-verify-lite-summary.mjs
+++ b/scripts/ci/render-verify-lite-summary.mjs
@@ -22,6 +22,23 @@ try {
 const { timestamp, flags = {}, steps = {}, artifacts = {} } = summary;
 
 const yesNo = (value) => (value ? '✅' : '❌');
+const escapeHtml = (text) =>
+  String(text).replace(/[&<>'"]/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return char;
+    }
+  });
 const formatStatus = (status) => {
   if (!status) return 'n/a';
   const normalized = String(status).toLowerCase();
@@ -76,7 +93,7 @@ const tableLines = [
 ];
 for (const [key, value] of orderedSteps) {
   const status = formatStatus(value?.status);
-  const notes = value?.notes ? String(value.notes).replace(/\n/g, '<br>') : '';
+  const notes = value?.notes ? escapeHtml(value.notes).replace(/\n/g, '<br>') : '';
   tableLines.push(`| ${titleCase(key)} | ${status} | ${notes} |`);
 }
 

--- a/scripts/ci/render-verify-lite-summary.mjs
+++ b/scripts/ci/render-verify-lite-summary.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const summaryPath = process.argv[2] ?? 'verify-lite-run-summary.json';
+const resolved = path.resolve(summaryPath);
+
+if (!fs.existsSync(resolved)) {
+  console.log(`Verify Lite run summary not found: ${summaryPath}`);
+  process.exit(0);
+}
+
+let summary;
+try {
+  const raw = fs.readFileSync(resolved, 'utf8');
+  summary = JSON.parse(raw);
+} catch (error) {
+  console.error(`Failed to read summary ${summaryPath}: ${error.message}`);
+  process.exit(1);
+}
+
+const { timestamp, flags = {}, steps = {}, artifacts = {} } = summary;
+
+const yesNo = (value) => (value ? '✅' : '❌');
+const formatStatus = (status) => {
+  if (!status) return 'n/a';
+  const normalized = String(status).toLowerCase();
+  if (normalized === 'success') return '✅ success';
+  if (normalized === 'failure') return '❌ failure';
+  if (normalized === 'skipped') return '⏭️ skipped';
+  if (normalized === 'pending') return '… pending';
+  return normalized;
+};
+
+const flagLines = [
+  `- install flags: \`${flags.install ?? ''}\``,
+  `- no frozen lockfile: ${yesNo(flags.noFrozen)}`,
+  `- keep lint log: ${yesNo(flags.keepLintLog)}`,
+  `- enforce lint: ${yesNo(flags.enforceLint)}`,
+  `- run mutation: ${yesNo(flags.runMutation)}`,
+];
+
+const stepEntries = Object.entries(steps);
+const orderedKeys = [
+  'install',
+  'specCompilerBuild',
+  'typeCheck',
+  'lint',
+  'build',
+  'bddLint',
+  'mutationQuick',
+];
+const seen = new Set();
+const orderedSteps = [];
+for (const key of orderedKeys) {
+  if (steps[key]) {
+    orderedSteps.push([key, steps[key]]);
+    seen.add(key);
+  }
+}
+for (const [key, value] of stepEntries) {
+  if (!seen.has(key)) {
+    orderedSteps.push([key, value]);
+  }
+}
+
+const titleCase = (name) =>
+  name
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+
+const tableLines = [
+  '| Step | Status | Notes |',
+  '| --- | --- | --- |',
+];
+for (const [key, value] of orderedSteps) {
+  const status = formatStatus(value?.status);
+  const notes = value?.notes ? String(value.notes).replace(/\n/g, '<br>') : '';
+  tableLines.push(`| ${titleCase(key)} | ${status} | ${notes} |`);
+}
+
+const artifactLines = [];
+if (Object.keys(artifacts).length > 0) {
+  artifactLines.push('\nArtifacts:');
+  for (const [key, value] of Object.entries(artifacts)) {
+    artifactLines.push(`- ${key}: ${value ?? 'n/a'}`);
+  }
+}
+
+const output = [
+  timestamp ? `Timestamp: ${timestamp}` : 'Timestamp: n/a',
+  ...flagLines,
+  '',
+  ...tableLines,
+  '',
+  ...artifactLines,
+];
+
+console.log(output.join('\n'));

--- a/scripts/ci/run-verify-lite-local.sh
+++ b/scripts/ci/run-verify-lite-local.sh
@@ -14,18 +14,54 @@ INSTALL_FLAGS=(--frozen-lockfile)
 if [[ "${VERIFY_LITE_NO_FROZEN:-0}" == "1" ]]; then
   INSTALL_FLAGS=(--no-frozen-lockfile)
 fi
+INSTALL_FLAGS_STR="${INSTALL_FLAGS[*]}"
+
+RUN_TIMESTAMP="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
+SUMMARY_PATH="${VERIFY_LITE_SUMMARY_FILE:-verify-lite-run-summary.json}"
+
+INSTALL_STATUS="success"
+INSTALL_NOTES="flags=${INSTALL_FLAGS_STR}"
+INSTALL_RETRIED=0
+SPEC_COMPILER_STATUS="skipped"
+TYPECHECK_STATUS="pending"
+LINT_STATUS="skipped"
+BUILD_STATUS="pending"
+BDD_LINT_STATUS="skipped"
+MUTATION_STATUS="skipped"
+MUTATION_NOTES=""
+LINT_LOG_EXPORT=""
+LINT_SUMMARY_PATH=""
+MUTATION_SUMMARY_PATH=""
+MUTATION_SURVIVORS_PATH=""
 
 echo "[verify-lite] installing dependencies (${INSTALL_FLAGS[*]})"
 if ! pnpm install "${INSTALL_FLAGS[@]}"; then
+  INSTALL_RETRIED=1
+  INSTALL_NOTES+=";retry_with=--no-frozen-lockfile"
   echo "[verify-lite] initial pnpm install failed, retrying with --no-frozen-lockfile" >&2
-  pnpm install --no-frozen-lockfile
+  if ! pnpm install --no-frozen-lockfile; then
+    INSTALL_STATUS="failure"
+    INSTALL_NOTES+=";retry_status=failed"
+    echo "[verify-lite] pnpm install failed after retry" >&2
+    exit 1
+  fi
 fi
 
 echo "[verify-lite] building spec-compiler types (non-blocking)"
-pnpm -F @ae-framework/spec-compiler -s run build || true
+if pnpm -F @ae-framework/spec-compiler -s run build; then
+  SPEC_COMPILER_STATUS="success"
+else
+  SPEC_COMPILER_STATUS="failure"
+fi
 
 echo "[verify-lite] running type checks"
-pnpm types:check
+if pnpm types:check; then
+  TYPECHECK_STATUS="success"
+else
+  TYPECHECK_STATUS="failure"
+  echo "[verify-lite] type check failed" >&2
+  exit 1
+fi
 
 echo "[verify-lite] linting"
 LINT_LOG_FILE="$(mktemp)"
@@ -36,33 +72,73 @@ cleanup_lint() {
 }
 trap cleanup_lint EXIT
 
-pnpm lint 2>&1 | tee "$LINT_LOG_FILE" || true
+if pnpm lint 2>&1 | tee "$LINT_LOG_FILE"; then
+  LINT_STATUS="success"
+else
+  LINT_STATUS="failure"
+fi
 if [[ -s "$LINT_LOG_FILE" ]]; then
-  node scripts/ci/verify-lite-lint-summary.mjs < "$LINT_LOG_FILE" > verify-lite-lint-summary.json || true
+  if node scripts/ci/verify-lite-lint-summary.mjs < "$LINT_LOG_FILE" > verify-lite-lint-summary.json; then
+    LINT_SUMMARY_PATH="verify-lite-lint-summary.json"
+  fi
   if [[ ${VERIFY_LITE_KEEP_LINT_LOG:-0} == "1" ]]; then
     cp "$LINT_LOG_FILE" verify-lite-lint.log
+    LINT_LOG_EXPORT="verify-lite-lint.log"
   fi
 fi
 
 echo "[verify-lite] building project"
-pnpm run build
+if pnpm run build; then
+  BUILD_STATUS="success"
+else
+  BUILD_STATUS="failure"
+  echo "[verify-lite] build failed" >&2
+  exit 1
+fi
 
 echo "[verify-lite] optional BDD lint"
 if [[ -f scripts/bdd/lint.mjs ]]; then
-  node scripts/bdd/lint.mjs || true
+  if node scripts/bdd/lint.mjs; then
+    BDD_LINT_STATUS="success"
+  else
+    BDD_LINT_STATUS="failure"
+  fi
 fi
 
 echo "[verify-lite] mutation quick (non-blocking)"
 if [[ ${VERIFY_LITE_RUN_MUTATION:-0} == "1" && -x scripts/mutation/run-scoped.sh ]]; then
-  ./scripts/mutation/run-scoped.sh --quick --auto-diff || true
+  if ./scripts/mutation/run-scoped.sh --quick --auto-diff; then
+    MUTATION_STATUS="success"
+  else
+    MUTATION_STATUS="failure"
+    MUTATION_NOTES="run-scoped.sh exit != 0"
+  fi
 else
   echo "[verify-lite] skipping mutation quick"
 fi
 
 echo "[verify-lite] summarising mutation survivors"
 if [[ -f reports/mutation/mutation.json ]]; then
-  node scripts/mutation/post-quick-summary.mjs | tee mutation-summary.md || true
-  node scripts/mutation/list-survivors.mjs --limit 25 > reports/mutation/survivors.json || true
+  if node scripts/mutation/post-quick-summary.mjs | tee mutation-summary.md; then
+    MUTATION_SUMMARY_PATH="mutation-summary.md"
+  fi
+  if node scripts/mutation/list-survivors.mjs --limit 25 > reports/mutation/survivors.json; then
+    MUTATION_SURVIVORS_PATH="reports/mutation/survivors.json"
+  fi
+fi
+
+export RUN_TIMESTAMP
+export SUMMARY_PATH
+export INSTALL_STATUS INSTALL_NOTES INSTALL_RETRIED
+export SPEC_COMPILER_STATUS TYPECHECK_STATUS LINT_STATUS BUILD_STATUS BDD_LINT_STATUS
+export MUTATION_STATUS MUTATION_NOTES
+export INSTALL_FLAGS_STR
+export LINT_SUMMARY_PATH LINT_LOG_EXPORT
+export MUTATION_SUMMARY_PATH MUTATION_SURVIVORS_PATH
+
+if ! node scripts/ci/write-verify-lite-summary.mjs "$SUMMARY_PATH"; then
+  echo "[verify-lite] failed to persist summary" >&2
+  exit 1
 fi
 
 echo "[verify-lite] local run complete"

--- a/scripts/ci/write-verify-lite-summary.mjs
+++ b/scripts/ci/write-verify-lite-summary.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const summaryPathFromArg = process.argv[2];
+const summaryPath = summaryPathFromArg ?? process.env.VERIFY_LITE_SUMMARY_FILE ?? 'verify-lite-run-summary.json';
+const resolvedPath = path.resolve(summaryPath);
+
+const bool = (value) => value === '1' || value === true || value === 'true';
+const existsOrNull = (p) => (p && fs.existsSync(p) ? p : null);
+
+const readStatus = (name, fallback) => {
+  const value = process.env[name];
+  return value ?? fallback;
+};
+
+const summary = {
+  timestamp: process.env.RUN_TIMESTAMP || new Date().toISOString(),
+  flags: {
+    install: process.env.INSTALL_FLAGS_STR || '',
+    noFrozen: bool(process.env.VERIFY_LITE_NO_FROZEN || '0'),
+    keepLintLog: bool(process.env.VERIFY_LITE_KEEP_LINT_LOG || '0'),
+    enforceLint: bool(process.env.VERIFY_LITE_ENFORCE_LINT || '0'),
+    runMutation: bool(process.env.VERIFY_LITE_RUN_MUTATION || '0'),
+  },
+  steps: {
+    install: {
+      status: readStatus('INSTALL_STATUS', 'unknown'),
+      notes: process.env.INSTALL_NOTES || null,
+      retried: readStatus('INSTALL_RETRIED', '0') === '1',
+    },
+    specCompilerBuild: { status: readStatus('SPEC_COMPILER_STATUS', 'skipped') },
+    typeCheck: { status: readStatus('TYPECHECK_STATUS', 'unknown') },
+    lint: { status: readStatus('LINT_STATUS', 'unknown') },
+    build: { status: readStatus('BUILD_STATUS', 'unknown') },
+    bddLint: { status: readStatus('BDD_LINT_STATUS', 'skipped') },
+    mutationQuick: {
+      status: readStatus('MUTATION_STATUS', 'skipped'),
+      notes: process.env.MUTATION_NOTES || null,
+    },
+  },
+  artifacts: {
+    lintSummary: existsOrNull(process.env.LINT_SUMMARY_PATH),
+    lintLog: existsOrNull(process.env.LINT_LOG_EXPORT),
+    mutationSummary: existsOrNull(process.env.MUTATION_SUMMARY_PATH),
+    mutationSurvivors: existsOrNull(process.env.MUTATION_SURVIVORS_PATH),
+  },
+};
+
+try {
+  fs.writeFileSync(resolvedPath, JSON.stringify(summary, null, 2));
+  console.log(`[verify-lite] summary written to ${resolvedPath}`);
+} catch (error) {
+  console.error('[verify-lite] failed to write summary', error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- switch Verify Lite workflow to run the scripted pipeline once and emit `verify-lite-run-summary.json`, then surface the JSON in Step Summary and artifacts
- update the minimal pipeline demo to use the same script, keeping Verify Lite reports consistent across local runs and CI
- add `scripts/ci/render-verify-lite-summary.mjs` so both workflows can render a markdown table of per-step statuses

## Testing
- pnpm run verify:lite
- node scripts/ci/render-verify-lite-summary.mjs reports/verify-lite/20251006-060513/verify-lite-run-summary.json

Resolves #1012. Refs #1011.
