### PR TITLE
ci: harden verify-lite summary schema

### DIFF
--- a/.github/workflows/minimal-pipeline.yml
+++ b/.github/workflows/minimal-pipeline.yml
@@ -53,13 +53,25 @@ jobs:
           VERIFY_LITE_RUN_MUTATION: '0'
           VERIFY_LITE_ENFORCE_LINT: ${{ github.event.inputs.enforce_lint == 'true' && '1' || '0' }}
           VERIFY_LITE_SUMMARY_FILE: verify-lite-run-summary.json
+          VERIFY_LITE_SUMMARY_EXPORT_PATH: artifacts/verify-lite/verify-lite-run-summary.json
         run: pnpm run verify:lite
+      - name: Validate verify-lite summary schema
+        if: always()
+        run: |
+          if [ -f verify-lite-run-summary.json ]; then
+            node scripts/ci/validate-verify-lite-summary.mjs \
+              verify-lite-run-summary.json \
+              schema/verify-lite-run-summary.schema.json
+          else
+            echo 'verify-lite summary missing; skipped validation'
+          fi
       - name: Upload verify-lite artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: verify-lite-report
           path: |
+            artifacts/verify-lite/verify-lite-run-summary.json
             verify-lite-run-summary.json
             verify-lite-lint.log
             verify-lite-lint-summary.json

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -34,8 +34,14 @@ jobs:
           VERIFY_LITE_RUN_MUTATION: ${{ github.event_name == 'pull_request' && '1' || '0' }}
           VERIFY_LITE_NO_FROZEN: '0'
           VERIFY_LITE_SUMMARY_FILE: verify-lite-run-summary.json
+          VERIFY_LITE_SUMMARY_EXPORT_PATH: artifacts/verify-lite/verify-lite-run-summary.json
         run: |
           pnpm run verify:lite
+      - name: Validate verify-lite summary schema
+        run: |
+          node scripts/ci/validate-verify-lite-summary.mjs \
+            verify-lite-run-summary.json \
+            schema/verify-lite-run-summary.schema.json
       - name: BDD lint (strict; label-gated)
         if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-bdd-lint') }}
         env:
@@ -125,6 +131,7 @@ jobs:
         with:
           name: verify-lite-report
           path: |
+            artifacts/verify-lite/verify-lite-run-summary.json
             verify-lite-run-summary.json
             verify-lite-lint.log
             verify-lite-lint-summary.json

--- a/docs/notes/pipeline-baseline.md
+++ b/docs/notes/pipeline-baseline.md
@@ -53,7 +53,8 @@
    VERIFY_LITE_RUN_MUTATION=1 \
    pnpm run verify:lite | tee "$ts_dir/verify-lite.log"
    ```
-   - `verify-lite-run-summary.json`（ステップ結果の JSON）、`verify-lite-lint-summary.json`（lint 集計）、`verify-lite-lint.log`（生ログ）、`mutation-summary.md` がリポジトリ直下に出力される。
+   - `verify-lite-run-summary.json`（ステップ結果の JSON、`schemaVersion` は semver 準拠で管理）、`verify-lite-lint-summary.json`（lint 集計）、`verify-lite-lint.log`（生ログ）、`mutation-summary.md` がリポジトリ直下に出力される。
+   - 同時に `artifacts/verify-lite/verify-lite-run-summary.json` にもコピーされるため、CI アーティファクトと同じパスで参照可能。
 3. 出力成果物を保存ディレクトリへ移動する。
    ```bash
    mv verify-lite-run-summary.json "$ts_dir/"

--- a/schema/verify-lite-run-summary.schema.json
+++ b/schema/verify-lite-run-summary.schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/itdojp/ae-framework/schema/verify-lite-run-summary.schema.json",
+  "title": "Verify Lite Run Summary",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "timestamp",
+    "flags",
+    "steps",
+    "artifacts"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "description": "Semver identifier for this summary format.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "install",
+        "noFrozen",
+        "keepLintLog",
+        "enforceLint",
+        "runMutation"
+      ],
+      "properties": {
+        "install": {
+          "type": "string"
+        },
+        "noFrozen": {
+          "type": "boolean"
+        },
+        "keepLintLog": {
+          "type": "boolean"
+        },
+        "enforceLint": {
+          "type": "boolean"
+        },
+        "runMutation": {
+          "type": "boolean"
+        }
+      }
+    },
+    "steps": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["status"],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "success",
+              "failure",
+              "skipped",
+              "pending",
+              "unknown"
+            ]
+          },
+          "notes": {
+            "type": ["string", "null"]
+          },
+          "retried": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lintSummary",
+        "lintLog",
+        "mutationSummary",
+        "mutationSurvivors"
+      ],
+      "properties": {
+        "lintSummary": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "lintLog": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "mutationSummary": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "mutationSurvivors": {
+          "type": ["string", "null"],
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/schema/verify-lite-run-summary.schema.json
+++ b/schema/verify-lite-run-summary.schema.json
@@ -87,20 +87,28 @@
       ],
       "properties": {
         "lintSummary": {
-          "type": ["string", "null"],
-          "minLength": 1
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
         },
         "lintLog": {
-          "type": ["string", "null"],
-          "minLength": 1
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
         },
         "mutationSummary": {
-          "type": ["string", "null"],
-          "minLength": 1
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
         },
         "mutationSurvivors": {
-          "type": ["string", "null"],
-          "minLength": 1
+          "oneOf": [
+            { "type": "string", "minLength": 1 },
+            { "type": "null" }
+          ]
         }
       }
     }

--- a/scripts/ci/lib/verify-lite-summary.mjs
+++ b/scripts/ci/lib/verify-lite-summary.mjs
@@ -1,0 +1,113 @@
+export const renderVerifyLiteSummary = (summary) => {
+  if (!summary || typeof summary !== 'object') {
+    throw new Error('Invalid summary payload');
+  }
+
+  const {
+    schemaVersion,
+    timestamp,
+    flags = {},
+    steps = {},
+    artifacts = {}
+  } = summary;
+
+  const yesNo = (value) => (value ? '✅' : '❌');
+  const escapeHtml = (text) =>
+    String(text).replace(/[&<>'"]/g, (char) => {
+      switch (char) {
+        case '&':
+          return '&amp;';
+        case '<':
+          return '&lt;';
+        case '>':
+          return '&gt;';
+        case '"':
+          return '&quot;';
+        case "'":
+          return '&#39;';
+        default:
+          return char;
+      }
+    });
+
+  const formatStatus = (status) => {
+    if (!status) return 'n/a';
+    const normalized = String(status).toLowerCase();
+    if (normalized === 'success') return '✅ success';
+    if (normalized === 'failure') return '❌ failure';
+    if (normalized === 'skipped') return '⏭️ skipped';
+    if (normalized === 'pending') return '… pending';
+    return normalized;
+  };
+
+  const flagLines = [
+    `- install flags: \`${flags.install ?? ''}\``,
+    `- no frozen lockfile: ${yesNo(Boolean(flags.noFrozen))}`,
+    `- keep lint log: ${yesNo(Boolean(flags.keepLintLog))}`,
+    `- enforce lint: ${yesNo(Boolean(flags.enforceLint))}`,
+    `- run mutation: ${yesNo(Boolean(flags.runMutation))}`,
+  ];
+
+  const orderedKeys = [
+    'install',
+    'specCompilerBuild',
+    'typeCheck',
+    'lint',
+    'build',
+    'bddLint',
+    'mutationQuick',
+  ];
+
+  const seen = new Set();
+  const orderedSteps = [];
+
+  for (const key of orderedKeys) {
+    if (steps[key]) {
+      orderedSteps.push([key, steps[key]]);
+      seen.add(key);
+    }
+  }
+
+  for (const [key, value] of Object.entries(steps)) {
+    if (!seen.has(key)) {
+      orderedSteps.push([key, value]);
+    }
+  }
+
+  const titleCase = (name) =>
+    name
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .replace(/[-_]/g, ' ')
+      .replace(/\b\w/g, (ch) => ch.toUpperCase());
+
+  const tableLines = [
+    '| Step | Status | Notes |',
+    '| --- | --- | --- |',
+  ];
+
+  for (const [key, value] of orderedSteps) {
+    const status = formatStatus(value?.status);
+    const notes = value?.notes ? escapeHtml(value.notes).replace(/\n/g, '<br>') : '';
+    tableLines.push(`| ${titleCase(key)} | ${status} | ${notes} |`);
+  }
+
+  const artifactLines = [];
+  if (Object.keys(artifacts).length > 0) {
+    artifactLines.push('\nArtifacts:');
+    for (const [key, value] of Object.entries(artifacts)) {
+      artifactLines.push(`- ${key}: ${value ?? 'n/a'}`);
+    }
+  }
+
+  const output = [
+    timestamp ? `Timestamp: ${timestamp}` : 'Timestamp: n/a',
+    `Schema Version: ${schemaVersion ?? 'unknown'}`,
+    ...flagLines,
+    '',
+    ...tableLines,
+    '',
+    ...artifactLines,
+  ];
+
+  return output.join('\n');
+};

--- a/scripts/ci/render-verify-lite-summary.mjs
+++ b/scripts/ci/render-verify-lite-summary.mjs
@@ -107,6 +107,7 @@ if (Object.keys(artifacts).length > 0) {
 
 const output = [
   timestamp ? `Timestamp: ${timestamp}` : 'Timestamp: n/a',
+  `Schema Version: ${summary.schemaVersion ?? 'unknown'}`,
   ...flagLines,
   '',
   ...tableLines,

--- a/scripts/ci/run-verify-lite-local.sh
+++ b/scripts/ci/run-verify-lite-local.sh
@@ -18,6 +18,7 @@ INSTALL_FLAGS_STR="${INSTALL_FLAGS[*]}"
 
 RUN_TIMESTAMP="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
 SUMMARY_PATH="${VERIFY_LITE_SUMMARY_FILE:-verify-lite-run-summary.json}"
+SUMMARY_EXPORT_PATH="${VERIFY_LITE_SUMMARY_EXPORT_PATH:-artifacts/verify-lite/verify-lite-run-summary.json}"
 
 INSTALL_STATUS="success"
 INSTALL_NOTES="flags=${INSTALL_FLAGS_STR}"
@@ -139,6 +140,11 @@ export MUTATION_SUMMARY_PATH MUTATION_SURVIVORS_PATH
 if ! node scripts/ci/write-verify-lite-summary.mjs "$SUMMARY_PATH"; then
   echo "[verify-lite] failed to persist summary" >&2
   exit 1
+fi
+
+if [[ -n "$SUMMARY_EXPORT_PATH" ]]; then
+  mkdir -p "$(dirname "$SUMMARY_EXPORT_PATH")"
+  cp "$SUMMARY_PATH" "$SUMMARY_EXPORT_PATH"
 fi
 
 echo "[verify-lite] local run complete"

--- a/scripts/ci/validate-verify-lite-summary.mjs
+++ b/scripts/ci/validate-verify-lite-summary.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const summaryPath = process.argv[2] ?? 'verify-lite-run-summary.json';
+const schemaPath = process.argv[3] ?? 'schema/verify-lite-run-summary.schema.json';
+
+const resolvedSummary = path.resolve(summaryPath);
+const resolvedSchema = path.resolve(schemaPath);
+
+if (!fs.existsSync(resolvedSummary)) {
+  console.warn(`[verify-lite] summary not found at ${resolvedSummary}; skipping schema validation`);
+  process.exit(0);
+}
+
+if (!fs.existsSync(resolvedSchema)) {
+  console.error(`[verify-lite] schema not found at ${resolvedSchema}`);
+  process.exit(1);
+}
+
+let data;
+let schema;
+try {
+  data = JSON.parse(fs.readFileSync(resolvedSummary, 'utf8'));
+} catch (error) {
+  console.error(`[verify-lite] failed to read summary ${resolvedSummary}:`, error);
+  process.exit(1);
+}
+
+try {
+  schema = JSON.parse(fs.readFileSync(resolvedSchema, 'utf8'));
+} catch (error) {
+  console.error(`[verify-lite] failed to read schema ${resolvedSchema}:`, error);
+  process.exit(1);
+}
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+const valid = validate(data);
+if (!valid) {
+  console.error('[verify-lite] summary schema validation failed');
+  for (const err of validate.errors ?? []) {
+    console.error(`  • ${err.instancePath || '/'} ${err.message}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[verify-lite] summary validated against ${resolvedSchema}`);

--- a/scripts/ci/write-verify-lite-summary.mjs
+++ b/scripts/ci/write-verify-lite-summary.mjs
@@ -14,7 +14,10 @@ const readStatus = (name, fallback) => {
   return value ?? fallback;
 };
 
+const SCHEMA_VERSION = process.env.VERIFY_LITE_SUMMARY_SCHEMA_VERSION ?? '1.0.0';
+
 const summary = {
+  schemaVersion: SCHEMA_VERSION,
   timestamp: process.env.RUN_TIMESTAMP || new Date().toISOString(),
   flags: {
     install: process.env.INSTALL_FLAGS_STR || '',

--- a/tests/unit/ci/__snapshots__/render-verify-lite-summary.test.ts.snap
+++ b/tests/unit/ci/__snapshots__/render-verify-lite-summary.test.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderVerifyLiteSummary > handles missing optional notes and artifacts 1`] = `
+"Timestamp: 2025-10-06T01:23:45Z
+Schema Version: 1.0.0
+- install flags: \`\`
+- no frozen lockfile: ✅
+- keep lint log: ❌
+- enforce lint: ❌
+- run mutation: ❌
+
+| Step | Status | Notes |
+| --- | --- | --- |
+| Type Check | ✅ success |  |
+| Lint | ⏭️ skipped |  |
+
+
+Artifacts:
+- lintSummary: n/a
+- lintLog: n/a
+- mutationSummary: n/a
+- mutationSurvivors: n/a"
+`;
+
+exports[`renderVerifyLiteSummary > renders markdown summary with schema version and flags 1`] = `
+"Timestamp: 2025-10-06T00:00:00Z
+Schema Version: 1.0.0
+- install flags: \`--frozen-lockfile\`
+- no frozen lockfile: ❌
+- keep lint log: ✅
+- enforce lint: ❌
+- run mutation: ✅
+
+| Step | Status | Notes |
+| --- | --- | --- |
+| Install | ✅ success | flags=--frozen-lockfile |
+| Lint | ❌ failure | 2618 violations |
+| Build | ✅ success |  |
+| Bdd Lint | ⏭️ skipped |  |
+| Mutation Quick | ✅ success | score: 59.74% |
+
+
+Artifacts:
+- lintSummary: verify-lite-lint-summary.json
+- lintLog: verify-lite-lint.log
+- mutationSummary: mutation-summary.md
+- mutationSurvivors: reports/mutation/survivors.json"
+`;

--- a/tests/unit/ci/render-verify-lite-summary.test.ts
+++ b/tests/unit/ci/render-verify-lite-summary.test.ts
@@ -1,0 +1,95 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+let renderVerifyLiteSummary;
+
+beforeAll(async () => {
+  const filePath = resolve(__dirname, '../../../scripts/ci/lib/verify-lite-summary.mjs');
+  const code = readFileSync(filePath, 'utf8');
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`;
+  ({ renderVerifyLiteSummary } = await import(moduleUrl));
+});
+
+describe('renderVerifyLiteSummary', () => {
+  const baseSummary = {
+    schemaVersion: '1.0.0',
+    timestamp: '2025-10-06T00:00:00Z',
+    flags: {
+      install: '--frozen-lockfile',
+      noFrozen: false,
+      keepLintLog: true,
+      enforceLint: false,
+      runMutation: true
+    },
+    steps: {
+      install: { status: 'success', notes: 'flags=--frozen-lockfile', retried: false },
+      lint: { status: 'failure', notes: '2618 violations' },
+      build: { status: 'success' },
+      bddLint: { status: 'skipped' },
+      mutationQuick: { status: 'success', notes: 'score: 59.74%' }
+    },
+    artifacts: {
+      lintSummary: 'verify-lite-lint-summary.json',
+      lintLog: 'verify-lite-lint.log',
+      mutationSummary: 'mutation-summary.md',
+      mutationSurvivors: 'reports/mutation/survivors.json'
+    }
+  };
+
+  it('renders markdown summary with schema version and flags', () => {
+    const result = renderVerifyLiteSummary(baseSummary);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('handles missing optional notes and artifacts', () => {
+    const minimal = {
+      schemaVersion: '1.0.0',
+      timestamp: '2025-10-06T01:23:45Z',
+      flags: {
+        install: '',
+        noFrozen: true,
+        keepLintLog: false,
+        enforceLint: false,
+        runMutation: false
+      },
+      steps: {
+        typeCheck: { status: 'success' },
+        lint: { status: 'skipped' }
+      },
+      artifacts: {
+        lintSummary: null,
+        lintLog: null,
+        mutationSummary: null,
+        mutationSurvivors: null
+      }
+    };
+
+    const result = renderVerifyLiteSummary(minimal);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('escapes HTML-sensitive characters in notes', () => {
+    const summary = {
+      ...baseSummary,
+      steps: {
+        ...baseSummary.steps,
+        lint: { status: 'failure', notes: '<script>alert("xss")</script>' }
+      }
+    };
+
+    const result = renderVerifyLiteSummary(summary);
+    expect(result).toContain('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+  });
+
+  it('throws on invalid payload', () => {
+    // @ts-expect-error deliberate bad input
+    expect(() => renderVerifyLiteSummary(null)).toThrowErrorMatchingInlineSnapshot(
+      "[Error: Invalid summary payload]"
+    );
+  });
+});

--- a/tests/unit/ci/render-verify-lite-summary.test.ts
+++ b/tests/unit/ci/render-verify-lite-summary.test.ts
@@ -1,19 +1,5 @@
-import { beforeAll, describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-let renderVerifyLiteSummary;
-
-beforeAll(async () => {
-  const filePath = resolve(__dirname, '../../../scripts/ci/lib/verify-lite-summary.mjs');
-  const code = readFileSync(filePath, 'utf8');
-  const moduleUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`;
-  ({ renderVerifyLiteSummary } = await import(moduleUrl));
-});
+import { describe, expect, it } from 'vitest';
+import { renderVerifyLiteSummary } from '../../../scripts/ci/lib/verify-lite-summary.mjs';
 
 describe('renderVerifyLiteSummary', () => {
   const baseSummary = {


### PR DESCRIPTION
## Summary
- add a JSON Schema (`schemaVersion` semver) for verify-lite run summary and export it as an artifact at `artifacts/verify-lite/verify-lite-run-summary.json`
- validate the summary in CI/minimal pipeline via `scripts/ci/validate-verify-lite-summary.mjs` and include schema version in Job Summary output
- extract the render logic into `scripts/ci/lib/verify-lite-summary.mjs` and cover it with Vitest snapshots

## Testing
- pnpm vitest run tests/unit/ci/render-verify-lite-summary.test.ts
- pnpm run verify:lite
- node scripts/ci/validate-verify-lite-summary.mjs /tmp/verify-lite-run-summary.json schema/verify-lite-run-summary.schema.json

Refs #1036.
