### PR TITLE
ci: add verify-lite lint baseline enforcement

### DIFF
--- a/.github/workflows/minimal-pipeline.yml
+++ b/.github/workflows/minimal-pipeline.yml
@@ -54,6 +54,7 @@ jobs:
           VERIFY_LITE_ENFORCE_LINT: ${{ github.event.inputs.enforce_lint == 'true' && '1' || '0' }}
           VERIFY_LITE_SUMMARY_FILE: verify-lite-run-summary.json
           VERIFY_LITE_SUMMARY_EXPORT_PATH: artifacts/verify-lite/verify-lite-run-summary.json
+          VERIFY_LITE_LINT_BASELINE: config/verify-lite-lint-baseline.json
         run: pnpm run verify:lite
       - name: Validate verify-lite summary schema
         if: always()
@@ -83,6 +84,20 @@ jobs:
             node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync('verify-lite-lint-summary.json','utf8')); console.log('Total issues:', data.total); console.log('Top rules:'); data.rules.slice(0,5).forEach(r=>console.log('-', r.rule, r.count));" | tee -a "$GITHUB_STEP_SUMMARY"
           else
             echo "No lint summary generated" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Verify lite lint baseline
+        if: always()
+        env:
+          VERIFY_LITE_LINT_ENFORCE: ${{ github.event.inputs.enforce_lint == 'true' && '1' || '0' }}
+        run: |
+          if [ -f verify-lite-lint-summary.json ]; then
+            set -o pipefail
+            node scripts/ci/enforce-verify-lite-lint.mjs \
+              verify-lite-lint-summary.json \
+              config/verify-lite-lint-baseline.json | tee /tmp/lint-baseline-report.txt
+            cat /tmp/lint-baseline-report.txt >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'verify-lite lint summary missing; skipped baseline enforcement' | tee -a "$GITHUB_STEP_SUMMARY"
           fi
       - name: Append verify-lite run summary
         if: always()

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -35,8 +35,24 @@ jobs:
           VERIFY_LITE_NO_FROZEN: '0'
           VERIFY_LITE_SUMMARY_FILE: verify-lite-run-summary.json
           VERIFY_LITE_SUMMARY_EXPORT_PATH: artifacts/verify-lite/verify-lite-run-summary.json
+          VERIFY_LITE_LINT_BASELINE: config/verify-lite-lint-baseline.json
+          VERIFY_LITE_LINT_ENFORCE: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-verify-lite-lint') && '1' || '0' }}
         run: |
           pnpm run verify:lite
+      - name: Verify-lite lint baseline
+        if: always()
+        env:
+          VERIFY_LITE_LINT_ENFORCE: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-verify-lite-lint') && '1' || '0' }}
+        run: |
+          if [ -f verify-lite-lint-summary.json ]; then
+            set -o pipefail
+            node scripts/ci/enforce-verify-lite-lint.mjs \
+              verify-lite-lint-summary.json \
+              config/verify-lite-lint-baseline.json | tee /tmp/lint-baseline-report.txt
+            cat /tmp/lint-baseline-report.txt >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'verify-lite lint summary missing; skipped baseline enforcement' | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Validate verify-lite summary schema
         run: |
           node scripts/ci/validate-verify-lite-summary.mjs \

--- a/config/verify-lite-lint-baseline.json
+++ b/config/verify-lite-lint-baseline.json
@@ -1,0 +1,15 @@
+{
+  "total": 2618,
+  "rules": {
+    "Unsafe": 1357,
+    "Unexpected": 645,
+    "Async": 205,
+    "'error'": 49,
+    "This": 39,
+    "'context'": 32,
+    "Invalid": 27,
+    "Switch": 20,
+    "'result'": 13,
+    "Promise": 13
+  }
+}

--- a/docs/notes/verify-lite-lint-plan.md
+++ b/docs/notes/verify-lite-lint-plan.md
@@ -31,6 +31,7 @@
 - Mutation Quick を併走させる場合は `VERIFY_LITE_RUN_MUTATION=1` を指定し、`reports/mutation/survivors.json` と `mutation-summary.md` を同一ディレクトリに移動する（Phase A の進捗エビデンスとして必須）。
 - CI の Step Summary とローカルログの内容が乖離した場合は、Issue #1016 のコメントに原因と対処方針を追記する。
 - `verify-lite-run-summary.json` に各ステップの成功/失敗が出力されるため、Issue への報告時は JSON の添付または主要ステータスの抜粋を行う。
+- `config/verify-lite-lint-baseline.json` に基準値を保存し、`enforce-verify-lite-lint` ラベル付き PR では Verify Lite ワークフローが基準超過時に失敗するように構成されている。
 
 ## 参考
 - lint サマリは `verify-lite-lint-summary.json`（artifact）に保存。

--- a/scripts/ci/enforce-verify-lite-lint.mjs
+++ b/scripts/ci/enforce-verify-lite-lint.mjs
@@ -40,7 +40,8 @@ let violations = 0;
 if (typeof summary.total === 'number' && typeof baseline.total === 'number') {
   const delta = summary.total - baseline.total;
   const status = delta <= 0 ? '✅' : '❌';
-  messages.push(`${status} Total issues: ${summary.total} (baseline ${baseline.total}${delta >= 0 ? `, +${delta}` : ''})`);
+  const formattedDelta = delta >= 0 ? `, +${delta}` : `, ${delta}`;
+  messages.push(`${status} Total issues: ${summary.total} (baseline ${baseline.total}${formattedDelta})`);
   if (delta > 0) violations += delta;
 }
 
@@ -49,7 +50,8 @@ for (const [rule, limit] of Object.entries(baselineRules)) {
   const actual = summaryRules.get(rule) ?? 0;
   const delta = actual - limit;
   const status = delta <= 0 ? '✅' : '❌';
-  messages.push(`${status} ${rule}: ${actual} (baseline ${limit}${delta >= 0 ? `, +${delta}` : ''})`);
+  const formattedRuleDelta = delta >= 0 ? `, +${delta}` : `, ${delta}`;
+  messages.push(`${status} ${rule}: ${actual} (baseline ${limit}${formattedRuleDelta})`);
   if (delta > 0) {
     violations += delta;
   }

--- a/scripts/ci/enforce-verify-lite-lint.mjs
+++ b/scripts/ci/enforce-verify-lite-lint.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const summaryPath = process.argv[2] ?? 'verify-lite-lint-summary.json';
+const baselinePath = process.argv[3] ?? 'config/verify-lite-lint-baseline.json';
+const resolvedSummary = path.resolve(summaryPath);
+const resolvedBaseline = path.resolve(baselinePath);
+
+if (!fs.existsSync(resolvedSummary)) {
+  console.error(`[verify-lite] lint summary not found at ${resolvedSummary}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(resolvedBaseline)) {
+  console.error(`[verify-lite] lint baseline not found at ${resolvedBaseline}`);
+  process.exit(1);
+}
+
+const parseJson = (file) => {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    console.error(`[verify-lite] failed to parse ${file}:`, error);
+    process.exit(1);
+  }
+};
+
+const summary = parseJson(resolvedSummary);
+const baseline = parseJson(resolvedBaseline);
+const enforce = process.env.VERIFY_LITE_LINT_ENFORCE === '1';
+const summaryRules = new Map();
+for (const entry of summary.rules ?? []) {
+  summaryRules.set(entry.rule, entry.count);
+}
+
+const messages = [];
+let violations = 0;
+
+if (typeof summary.total === 'number' && typeof baseline.total === 'number') {
+  const delta = summary.total - baseline.total;
+  const status = delta <= 0 ? '✅' : '❌';
+  messages.push(`${status} Total issues: ${summary.total} (baseline ${baseline.total}${delta >= 0 ? `, +${delta}` : ''})`);
+  if (delta > 0) violations += delta;
+}
+
+const baselineRules = baseline.rules ?? {};
+for (const [rule, limit] of Object.entries(baselineRules)) {
+  const actual = summaryRules.get(rule) ?? 0;
+  const delta = actual - limit;
+  const status = delta <= 0 ? '✅' : '❌';
+  messages.push(`${status} ${rule}: ${actual} (baseline ${limit}${delta >= 0 ? `, +${delta}` : ''})`);
+  if (delta > 0) {
+    violations += delta;
+  }
+}
+
+if (Object.keys(baselineRules).length === 0) {
+  messages.push('ℹ️ No per-rule baselines defined.');
+}
+
+const enforcementNote = enforce ? 'ENFORCED' : 'WARN-ONLY';
+messages.unshift(`### Verify Lite Lint Baseline (${enforcementNote})`);
+
+console.log(messages.join('\n'));
+
+if (enforce && violations > 0) {
+  process.exit(1);
+}

--- a/scripts/ci/run-verify-lite-local.sh
+++ b/scripts/ci/run-verify-lite-local.sh
@@ -19,6 +19,8 @@ INSTALL_FLAGS_STR="${INSTALL_FLAGS[*]}"
 RUN_TIMESTAMP="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
 SUMMARY_PATH="${VERIFY_LITE_SUMMARY_FILE:-verify-lite-run-summary.json}"
 SUMMARY_EXPORT_PATH="${VERIFY_LITE_SUMMARY_EXPORT_PATH:-artifacts/verify-lite/verify-lite-run-summary.json}"
+LINT_BASELINE_PATH="${VERIFY_LITE_LINT_BASELINE:-config/verify-lite-lint-baseline.json}"
+VERIFY_LITE_LINT_ENFORCE="${VERIFY_LITE_LINT_ENFORCE:-${VERIFY_LITE_ENFORCE_LINT:-0}}"
 
 INSTALL_STATUS="success"
 INSTALL_NOTES="flags=${INSTALL_FLAGS_STR}"
@@ -145,6 +147,17 @@ fi
 if [[ -n "$SUMMARY_EXPORT_PATH" ]]; then
   mkdir -p "$(dirname "$SUMMARY_EXPORT_PATH")"
   cp "$SUMMARY_PATH" "$SUMMARY_EXPORT_PATH"
+fi
+
+if [[ -n "$LINT_SUMMARY_PATH" && -f "$LINT_SUMMARY_PATH" ]]; then
+  if node scripts/ci/enforce-verify-lite-lint.mjs "$LINT_SUMMARY_PATH" "$LINT_BASELINE_PATH"; then
+    true
+  else
+    status=$?
+    if [[ ${VERIFY_LITE_LINT_ENFORCE:-0} == "1" ]]; then
+      exit "$status"
+    fi
+  fi
 fi
 
 echo "[verify-lite] local run complete"


### PR DESCRIPTION
## Summary
- record the current verify-lite lint totals in `config/verify-lite-lint-baseline.json` and introduce `scripts/ci/enforce-verify-lite-lint.mjs` to compare summaries against the baseline
- wire enforcement into `scripts/ci/run-verify-lite-local.sh`, `verify-lite.yml`, and `minimal-pipeline.yml`, with label `enforce-verify-lite-lint` (or workflow input) enabling blocking mode
- document the baseline/label workflow in `docs/notes/verify-lite-lint-plan.md`

## Testing
- pnpm vitest run tests/unit/ci/render-verify-lite-summary.test.ts
- VERIFY_LITE_KEEP_LINT_LOG=1 VERIFY_LITE_RUN_MUTATION=0 VERIFY_LITE_NO_FROZEN=1 pnpm run verify:lite

Refs #1036, #1019.
