### PR TITLE
feat: integrate report envelopes into verify-lite and trace pipelines

### DIFF
--- a/.github/workflows/minimal-pipeline.yml
+++ b/.github/workflows/minimal-pipeline.yml
@@ -66,6 +66,28 @@ jobs:
           else
             echo 'verify-lite summary missing; skipped validation'
           fi
+      - name: Create verify-lite report envelope
+        if: always()
+        env:
+          REPORT_ENVELOPE_SOURCE: verify-lite
+        run: |
+          if [ -f artifacts/verify-lite/verify-lite-run-summary.json ]; then
+            node scripts/trace/create-report-envelope.mjs \
+              artifacts/verify-lite/verify-lite-run-summary.json \
+              artifacts/report-envelope.json
+          elif [ -f verify-lite-run-summary.json ]; then
+            node scripts/trace/create-report-envelope.mjs \
+              verify-lite-run-summary.json \
+              artifacts/report-envelope.json
+          else
+            echo 'verify-lite summary missing; skipped envelope generation'
+          fi
+      - name: Validate report envelope schema
+        if: always()
+        run: |
+          node scripts/ci/validate-report-envelope.mjs \
+            artifacts/report-envelope.json \
+            schema/report-envelope.schema.json
       - name: Upload verify-lite artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -73,6 +95,7 @@ jobs:
           name: verify-lite-report
           path: |
             artifacts/verify-lite/verify-lite-run-summary.json
+            artifacts/report-envelope.json
             verify-lite-run-summary.json
             verify-lite-lint.log
             verify-lite-lint-summary.json

--- a/.github/workflows/spec-generate-model.yml
+++ b/.github/workflows/spec-generate-model.yml
@@ -247,6 +247,32 @@ jobs:
       - name: Summarize trace validation
         id: trace_summary
         run: node ./scripts/trace/render-trace-summary.mjs
+      - name: Build KvOnce report envelope summary
+        if: always()
+        run: |
+          node ./scripts/trace/build-kvonce-envelope-summary.mjs \
+            artifacts/kvonce-trace-summary.json
+      - name: Create KvOnce trace envelope
+        if: always()
+        env:
+          REPORT_ENVELOPE_SOURCE: trace-conformance
+          REPORT_ENVELOPE_NOTES: |
+            OTLP valid: ${{ steps.trace_summary.outputs.valid_otlp }}
+            NDJSON valid: ${{ steps.trace_summary.outputs.valid_ndjson }}
+        run: |
+          if [ -f artifacts/kvonce-trace-summary.json ]; then
+            node ./scripts/trace/create-report-envelope.mjs \
+              artifacts/kvonce-trace-summary.json \
+              artifacts/kvonce-trace-envelope.json
+          else
+            echo '[trace] kvonce summary missing; skipped envelope generation'
+          fi
+      - name: Validate trace envelope schema
+        if: always()
+        run: |
+          node ./scripts/ci/validate-report-envelope.mjs \
+            artifacts/kvonce-trace-envelope.json \
+            schema/report-envelope.schema.json
       - name: Upload trace artifacts
         if: always()
         uses: actions/upload-artifact@v4
@@ -255,6 +281,8 @@ jobs:
           path: |
             hermetic-reports/trace/collected-kvonce-otlp.json
             hermetic-reports/trace/kvonce-payload-metadata.json
+            artifacts/kvonce-trace-summary.json
+            artifacts/kvonce-trace-envelope.json
             hermetic-reports/trace/otlp/kvonce-events.ndjson
             hermetic-reports/trace/otlp/kvonce-projection.json
             hermetic-reports/trace/otlp/kvonce-validation.json

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -58,6 +58,24 @@ jobs:
           node scripts/ci/validate-verify-lite-summary.mjs \
             verify-lite-run-summary.json \
             schema/verify-lite-run-summary.schema.json
+      - name: Create verify-lite report envelope
+        if: always()
+        env:
+          REPORT_ENVELOPE_SOURCE: verify-lite
+        run: |
+          if [ -f artifacts/verify-lite/verify-lite-run-summary.json ]; then
+            node scripts/trace/create-report-envelope.mjs \
+              artifacts/verify-lite/verify-lite-run-summary.json \
+              artifacts/report-envelope.json
+          else
+            echo 'verify-lite summary missing; skipped envelope generation'
+          fi
+      - name: Validate report envelope schema
+        if: always()
+        run: |
+          node scripts/ci/validate-report-envelope.mjs \
+            artifacts/report-envelope.json \
+            schema/report-envelope.schema.json
       - name: BDD lint (strict; label-gated)
         if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-bdd-lint') }}
         env:
@@ -148,6 +166,7 @@ jobs:
           name: verify-lite-report
           path: |
             artifacts/verify-lite/verify-lite-run-summary.json
+            artifacts/report-envelope.json
             verify-lite-run-summary.json
             verify-lite-lint.log
             verify-lite-lint-summary.json

--- a/docs/trace/REPORT_ENVELOPE.md
+++ b/docs/trace/REPORT_ENVELOPE.md
@@ -130,8 +130,9 @@ Issue: #1011 / #1012 / #1036 / #1038
 
 ## 運用ガイドライン
 1. CI では `scripts/trace/create-report-envelope.mjs` を利用し、Verify Lite などのサマリを Envelope 化して `artifacts/report-envelope.json` に保存する。
+   - スキーマは `schema/report-envelope.schema.json` で管理し、`scripts/ci/validate-report-envelope.mjs` で検証する。
 2. Envelope の生成時に `GITHUB_RUN_ID` / `GITHUB_WORKFLOW` / `GITHUB_SHA` / `GITHUB_REF` を自動埋め込み、他の CI でも環境変数から補完できるようにする。
-3. Trace 系ジョブでは、Collector から取得した payload のメタデータ (`kvonce-payload-metadata.json`) を artifacts 配列に追加し、Projector/Validator の出力も同一 Envelope へまとめる。
+3. Trace 系ジョブでは、Collector から取得した payload のメタデータ (`kvonce-payload-metadata.json`) を artifacts 配列に追加し、`scripts/trace/build-kvonce-envelope-summary.mjs` で集計したサマリを `scripts/trace/create-report-envelope.mjs` でラップする。
 4. Dashboard / Tempo 連携は Envelope を単位としてインジェストし、必要に応じて `traceIds` から関連 span を引き直す。
 
 ## TODO

--- a/schema/report-envelope.schema.json
+++ b/schema/report-envelope.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AE Framework Report Envelope",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "source",
+    "generatedAt",
+    "correlation",
+    "summary",
+    "artifacts"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "correlation": {
+      "type": "object",
+      "required": ["runId", "workflow", "commit", "branch"],
+      "properties": {
+        "runId": { "type": "string", "minLength": 1 },
+        "workflow": { "type": "string", "minLength": 1 },
+        "commit": { "type": "string", "minLength": 1 },
+        "branch": { "type": "string", "minLength": 1 },
+        "traceIds": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "additionalProperties": false
+    },
+    "summary": {
+      "type": "object"
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["type", "path"],
+        "properties": {
+          "type": { "type": "string", "minLength": 1 },
+          "path": { "type": "string", "minLength": 1 },
+          "checksum": {
+            "type": ["string", "null"],
+            "pattern": "^sha256:[0-9a-f]{64}$"
+          },
+          "description": { "type": ["string", "null"], "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ci/validate-report-envelope.mjs
+++ b/scripts/ci/validate-report-envelope.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const envelopePath = process.argv[2] ?? 'artifacts/report-envelope.json';
+const schemaPath = process.argv[3] ?? 'schema/report-envelope.schema.json';
+
+const resolvedEnvelope = path.resolve(envelopePath);
+const resolvedSchema = path.resolve(schemaPath);
+
+if (!fs.existsSync(resolvedEnvelope)) {
+  console.warn(`[report-envelope] envelope not found at ${resolvedEnvelope}; skipping validation`);
+  process.exit(0);
+}
+
+if (!fs.existsSync(resolvedSchema)) {
+  console.error(`[report-envelope] schema not found at ${resolvedSchema}`);
+  process.exit(1);
+}
+
+let envelope;
+let schema;
+try {
+  envelope = JSON.parse(fs.readFileSync(resolvedEnvelope, 'utf8'));
+} catch (error) {
+  console.error(`[report-envelope] failed to parse ${resolvedEnvelope}:`, error);
+  process.exit(1);
+}
+
+try {
+  schema = JSON.parse(fs.readFileSync(resolvedSchema, 'utf8'));
+} catch (error) {
+  console.error(`[report-envelope] failed to parse schema ${resolvedSchema}:`, error);
+  process.exit(1);
+}
+
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+addFormats(ajv);
+const validate = ajv.compile(schema);
+
+if (!validate(envelope)) {
+  console.error('[report-envelope] envelope schema validation failed');
+  for (const err of validate.errors ?? []) {
+    console.error(`  • ${err.instancePath || '/'} ${err.message}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[report-envelope] envelope validated against ${resolvedSchema}`);

--- a/scripts/trace/build-kvonce-envelope-summary.mjs
+++ b/scripts/trace/build-kvonce-envelope-summary.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const outputPath = process.argv[2] ?? 'artifacts/kvonce-trace-summary.json';
+const baseDir = path.join('hermetic-reports', 'trace');
+const cases = [
+  { key: 'otlp', label: 'OTLP payload', dir: path.join(baseDir, 'otlp') },
+  { key: 'ndjson', label: 'NDJSON sample', dir: path.join(baseDir, 'ndjson') }
+];
+
+const readJsonSafe = (file) => {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    return null;
+  }
+};
+
+const metadata = readJsonSafe(path.join(baseDir, 'kvonce-payload-metadata.json')) ?? {};
+const casesSummary = [];
+
+for (const item of cases) {
+  const reportPath = path.join(item.dir, 'kvonce-validation.json');
+  const projectionPath = path.join(item.dir, 'kvonce-projection.json');
+  const validation = readJsonSafe(reportPath);
+  const projection = readJsonSafe(projectionPath);
+  if (!validation) {
+    casesSummary.push({
+      format: item.key,
+      status: 'missing',
+      issues: [],
+      note: 'validation file missing'
+    });
+    continue;
+  }
+  const issues = Array.isArray(validation.issues) ? validation.issues : [];
+  const trimmedIssues = issues.slice(0, 10).map((issue) => ({
+    type: issue.type ?? 'unknown',
+    key: issue.key ?? 'unknown',
+    message: issue.message ?? ''
+  }));
+  casesSummary.push({
+    format: item.key,
+    valid: Boolean(validation.valid),
+    issueCount: issues.length,
+    issues: trimmedIssues,
+    projectionStats: projection?.stats ?? undefined
+  });
+}
+
+const summary = {
+  schemaVersion: '1.0.0',
+  generatedAt: new Date().toISOString(),
+  payloadMetadata: {
+    sourceType: metadata.sourceType ?? null,
+    sourceDetail: metadata.sourceDetail ?? null,
+    sha256: metadata.sha256 ?? null,
+    sizeBytes: metadata.sizeBytes ?? null
+  },
+  cases: casesSummary
+};
+
+const destDir = path.dirname(outputPath);
+if (!fs.existsSync(destDir)) {
+  fs.mkdirSync(destDir, { recursive: true });
+}
+
+fs.writeFileSync(outputPath, JSON.stringify(summary, null, 2));
+console.log(`[trace] wrote kvonce summary to ${outputPath}`);

--- a/tests/unit/ci/validate-report-envelope.test.ts
+++ b/tests/unit/ci/validate-report-envelope.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const validateScript = join(process.cwd(), 'scripts/ci/validate-report-envelope.mjs');
+const createEnvelope = join(process.cwd(), 'scripts/trace/create-report-envelope.mjs');
+const schemaPath = join(process.cwd(), 'schema/report-envelope.schema.json');
+
+describe('validate-report-envelope CLI', () => {
+  let workdir: string;
+
+  beforeEach(async () => {
+    workdir = await mkdtemp(join(tmpdir(), 'report-envelope-validate-'));
+  });
+
+  afterEach(async () => {
+    await rm(workdir, { recursive: true, force: true });
+  });
+
+  it('accepts a valid envelope', async () => {
+    const summaryPath = join(workdir, 'summary.json');
+    const envelopePath = join(workdir, 'envelope.json');
+
+    const summary = {
+      schemaVersion: '1.0.0',
+      payload: 'example'
+    };
+
+    await writeFile(summaryPath, JSON.stringify(summary));
+
+    const createResult = spawnSync(process.execPath, [createEnvelope, summaryPath, envelopePath], {
+      cwd: workdir,
+      env: {
+        ...process.env,
+        REPORT_ENVELOPE_SOURCE: 'unit-test',
+        GITHUB_RUN_ID: 'run-123',
+        GITHUB_WORKFLOW: 'validate-report-envelope-test',
+        GITHUB_SHA: 'abc1234',
+        GITHUB_REF: 'refs/heads/test'
+      }
+    });
+
+    expect(createResult.status).toBe(0);
+    const envelope = JSON.parse(await readFile(envelopePath, 'utf8'));
+    expect(envelope.source).toBe('unit-test');
+
+    const validateResult = spawnSync(process.execPath, [validateScript, envelopePath, schemaPath], {
+      cwd: workdir
+    });
+
+    expect(validateResult.status).toBe(0);
+    expect(validateResult.stderr.toString()).toBe('');
+  });
+
+  it('skips when envelope file is absent', () => {
+    const validateResult = spawnSync(process.execPath, [validateScript, 'missing.json', schemaPath], {
+      cwd: workdir
+    });
+
+    expect(validateResult.status).toBe(0);
+    expect(validateResult.stderr.toString()).toContain('skipping');
+  });
+});


### PR DESCRIPTION
## Summary
- add `schema/report-envelope.schema.json` と `scripts/ci/validate-report-envelope.mjs` で Report Envelope のスキーマ／検証を実装
- verify-lite / minimal-pipeline ワークフローに Envelope 生成・検証・アーティファクト出力を組み込み
- KvOnce trace conformance から envelope summary を構築し、trace 用の Report Envelope を生成・アップロード

## Testing
- pnpm vitest run tests/unit/trace/create-report-envelope.test.ts tests/unit/ci/validate-report-envelope.test.ts --reporter dot
