### PR TITLE
chore: enforce report envelope validation via ajv

### DIFF
--- a/.github/workflows/validate-artifacts-ajv.yml
+++ b/.github/workflows/validate-artifacts-ajv.yml
@@ -32,6 +32,24 @@ jobs:
       - name: Validate adapter summaries
         run: npx ajv -s docs/schemas/artifacts-adapter-summary.schema.json -d "artifacts/*/summary.json" --strict=false || true
         continue-on-error: ${{ github.ref != 'refs/heads/main' && needs.gate.outputs.strict != 'true' }}
+      - name: Validate report envelopes
+        run: |
+          shopt -s nullglob
+          files=(artifacts/**/report-envelope.json artifacts/**/*-envelope.json)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "[ajv] no report envelopes found"
+            exit 0
+          else
+            schema_path="schema/report-envelope.schema.json"
+            if [ ! -f "$schema_path" ] && [ -f docs/schemas/report-envelope.schema.json ]; then
+              schema_path="docs/schemas/report-envelope.schema.json"
+            fi
+            for file in "${files[@]}"; do
+              echo "[ajv] validating $file"
+              npx ajv -s "$schema_path" -d "$file" --strict=false;
+            done
+          fi
+        continue-on-error: ${{ github.ref != 'refs/heads/main' && needs.gate.outputs.strict != 'true' }}
       - name: Validate formal summary
         run: |
           if [ -f formal/summary.json ]; then npx ajv -s docs/schemas/formal-summary.schema.json -d formal/summary.json --strict=false; fi

--- a/docs/trace/grafana/tempo-dashboard-notes.md
+++ b/docs/trace/grafana/tempo-dashboard-notes.md
@@ -1,0 +1,19 @@
+# Tempo Dashboard Notes (Draft)
+
+Issue: #1038 / #1011
+
+## Objective
+Visualise KvOnce envelope data alongside Tempo traces.
+
+## Proposed Panels
+1. **Run Overview**
+   - datasource: JSON (report-envelopes via webhook) + Tempo
+   - fields: `correlation.runId`, `summary.cases[].issueCount`, envelope status badges.
+2. **Trace Drilldown**
+   - Use `traceIds` from envelope to jump into Tempo search (link panel).
+3. **Mutation / Lint context**
+   - embed verify-lite envelope metrics (lint issue counts, mutation score) as context for trace failures.
+
+## Next Steps
+- Establish ingestion workflow (e.g., push envelope to Loki/JSON API) and create prototype dashboard.
+- Document Grafana dashboard export once available.


### PR DESCRIPTION
## Summary
- extend `validate-artifacts-ajv.yml` to validate any `*-envelope.json` or `report-envelope.json` against the shared schema
- add Tempo dashboard notes describing envelope-driven panels

## Testing
- pnpm vitest run tests/unit/ci/validate-report-envelope.test.ts tests/unit/trace/create-report-envelope.test.ts --reporter dot
