### PR TITLE
Wire payload metadata into trace envelope workflow

### DIFF
--- a/.github/workflows/spec-generate-model.yml
+++ b/.github/workflows/spec-generate-model.yml
@@ -269,6 +269,11 @@ jobs:
           REPORT_ENVELOPE_NOTES: |
             OTLP valid: ${{ steps.trace_summary.outputs.valid_otlp }}
             NDJSON valid: ${{ steps.trace_summary.outputs.valid_ndjson }}
+          REPORT_ENVELOPE_PAYLOAD_METADATA: hermetic-reports/trace/kvonce-payload-metadata.json
+          REPORT_ENVELOPE_EXTRA_ARTIFACTS: >-
+            artifacts/kvonce-trace-summary.json,
+            hermetic-reports/trace/otlp/kvonce-validation.json,
+            hermetic-reports/trace/ndjson/kvonce-validation.json
         run: |
           if [ -f artifacts/kvonce-trace-summary.json ]; then
             node ./scripts/trace/create-report-envelope.mjs \


### PR DESCRIPTION
## Summary
- export the kvonce payload metadata and validation reports as additional artifacts when generating the trace report envelope
- rely on REPORT_ENVELOPE_PAYLOAD_METADATA / REPORT_ENVELOPE_EXTRA_ARTIFACTS so downstream consumers always see kvonce-payload-metadata.json and validation outputs in the envelope

## Testing
- configuration change only (workflow)

Refs: #1036, #1038
