### PR TITLE
Add MinIO PoC for Stage2 trace payloads

### DIFF
--- a/.github/workflows/spec-generate-model.yml
+++ b/.github/workflows/spec-generate-model.yml
@@ -269,6 +269,11 @@ jobs:
           REPORT_ENVELOPE_NOTES: |
             OTLP valid: ${{ steps.trace_summary.outputs.valid_otlp }}
             NDJSON valid: ${{ steps.trace_summary.outputs.valid_ndjson }}
+          REPORT_ENVELOPE_PAYLOAD_METADATA: hermetic-reports/trace/kvonce-payload-metadata.json
+          REPORT_ENVELOPE_EXTRA_ARTIFACTS: >-
+            artifacts/kvonce-trace-summary.json,
+            hermetic-reports/trace/otlp/kvonce-validation.json,
+            hermetic-reports/trace/ndjson/kvonce-validation.json
         run: |
           if [ -f artifacts/kvonce-trace-summary.json ]; then
             node ./scripts/trace/create-report-envelope.mjs \

--- a/docker/trace-s3/docker-compose.yml
+++ b/docker/trace-s3/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-09-16T01-00-00Z
+    command: server /data --console-address :9001
+    environment:
+      MINIO_ROOT_USER: kvonce
+      MINIO_ROOT_PASSWORD: kvonce-secret
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  setup:
+    image: minio/mc:RELEASE.2025-09-17T20-08-00Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MC_HOST_kvonce: http://kvonce:kvonce-secret@minio:9000
+      PAYLOAD_SOURCE: /workspace/samples/trace/kvonce-otlp.json
+      PAYLOAD_TARGET: s3://kvonce-trace/kvonce-stage2/payload.json
+    volumes:
+      - ../../:/workspace:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      mc alias set kvonce http://minio:9000 kvonce kvonce-secret >/dev/null && \
+      mc mb --ignore-existing kvonce/kvonce-trace && \
+      mc cp "${PAYLOAD_SOURCE}" "${PAYLOAD_TARGET}" && \
+      echo "Upload complete"
+
+volumes:
+  minio-data:

--- a/docs/trace/otlp-collector-plan.md
+++ b/docs/trace/otlp-collector-plan.md
@@ -56,3 +56,18 @@ Issue: #1011 / #1012
 | `KVONCE_OTLP_S3_USE_SSL` | `false` で TLS を無効化 | ローカル MinIO 用 |
 | `KVONCE_OTLP_S3_MOCK_DIR` | ローカル検証/テスト用のモックディレクトリ | `<dir>/<bucket>/<key>` を直接読み込み |
 | `KVONCE_OTLP_PAYLOAD_URL` | 事前署名 URL など HTTP 経由の取得 | Stage1/Artifacts 経路と互換 |
+
+
+### Local MinIO PoC
+
+- `./scripts/trace/run-minio-poc.sh` で `docker/trace-s3/docker-compose.yml` を起動し、MinIO に `samples/trace/kvonce-otlp.json` を投入できる。
+- 実行後は以下の環境変数を設定すれば、CI と同じ S3 経路をローカルで検証できる。
+  ```bash
+  export AWS_ACCESS_KEY_ID=kvonce
+  export AWS_SECRET_ACCESS_KEY=kvonce-secret
+  export KVONCE_OTLP_S3_ENDPOINT=http://127.0.0.1:9000
+  export KVONCE_OTLP_S3_URI=s3://kvonce-trace/kvonce-stage2/payload.json
+  export KVONCE_OTLP_S3_USE_SSL=false
+  export KVONCE_OTLP_S3_FORCE_PATH_STYLE=true
+  ```
+- コンテナ停止は `./scripts/trace/run-minio-poc.sh down`。MinIO コンソール (http://localhost:9001) では `kvonce` / `kvonce-secret` で確認できる。

--- a/scripts/trace/run-minio-poc.sh
+++ b/scripts/trace/run-minio-poc.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMPOSE_FILE="$(dirname "$0")/../../docker/trace-s3/docker-compose.yml"
+PROJECT_DIR="$(cd "$(dirname "$0")/../../" && pwd)"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[trace-minio] docker command not found" >&2
+  exit 1
+fi
+
+export COMPOSE_PROJECT_NAME="kvonce-trace"
+
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down --remove-orphans >/dev/null 2>&1 || true
+}
+
+if [[ "${1:-}" == "down" ]]; then
+  cleanup
+  exit 0
+fi
+
+trap cleanup EXIT
+
+echo "[trace-minio] starting minio..."
+docker compose -f "$COMPOSE_FILE" up -d minio
+
+echo "[trace-minio] provisioning payload..."
+docker compose -f "$COMPOSE_FILE" run --rm setup >/dev/null
+
+echo
+cat <<MSG
+MinIO mock is ready.
+
+Export the following variables before running trace workflows:
+
+  export AWS_ACCESS_KEY_ID=kvonce
+  export AWS_SECRET_ACCESS_KEY=kvonce-secret
+  export KVONCE_OTLP_S3_ENDPOINT=http://127.0.0.1:9000
+  export KVONCE_OTLP_S3_URI=s3://kvonce-trace/kvonce-stage2/payload.json
+  export KVONCE_OTLP_S3_USE_SSL=false
+  export KVONCE_OTLP_S3_FORCE_PATH_STYLE=true
+
+Open http://localhost:9001 with user 'kvonce' and password 'kvonce-secret' to inspect objects.
+
+Run './scripts/trace/run-minio-poc.sh down' to stop and clean up containers once finished.
+MSG
+
+docker compose -f "$COMPOSE_FILE" logs -f minio


### PR DESCRIPTION
## Summary
- add docker/trace-s3/docker-compose.yml to spin up a local MinIO instance with a seeded kvonce payload
- introduce scripts/trace/run-minio-poc.sh to provision the mock S3 data and print the environment variables required by fetch-otlp-payload.mjs
- document the local workflow in docs/trace/otlp-collector-plan.md so Stage2 flows can be exercised without touching AWS

## Testing
- scripts/trace/run-minio-poc.sh (manual)
- docker compose -f docker/trace-s3/docker-compose.yml run --rm setup

Refs: #1036, #1038
