### PR TITLE
Add GC logging coverage for EnhancedStateManager

### DIFF
--- a/docs/notes/mutation-coverage-plan.md
+++ b/docs/notes/mutation-coverage-plan.md
@@ -14,6 +14,10 @@
   - 走行時間: **約 2 分 54 秒**（incremental レポートをクリアしてフル quick ラン）
   - ミューテーションスコア: **65.51%**（killed 302 / survived 159 / no-cover 0 / errors 0）
   - `reviveEntryData` のレガシー配列復元と `createSnapshot` の phase/entity フィルタをテストでカバーし、Section2 のターゲットである 65% ラインを突破。
+- `STRYKER_TIME_LIMIT=420 npx stryker run configs/stryker.enhanced.config.js --mutate src/utils/enhanced-state-manager.ts --concurrency 1`（2025-10-06 17:02 開始）
+  - 走行時間: **約 11 分 19 秒**（DisableTypeChecks の warning は継続するが quick ランは安定）
+  - ミューテーションスコア: **67.25%**（killed 310 / survived 151 / no-cover 0 / errors 0）
+  - GC ログ分岐（`runGarbageCollection`）と TTL 失効パスをユニットテスト追加でカバーし、サバイバーが `normalizeImportedEntry` の Buffer 復元・checksum 再計算・optional chaining 分岐に集約された。
 - `./scripts/mutation/run-scoped.sh --quick --mutate src/api/server.ts`（2025-10-02 再実行）は **100.00%**（killed 155 / survived 0 / no-cover 0 / errors 0 / 実行 66s）。
 - `./scripts/mutation/run-scoped.sh --quick`（差分無しのデフォルト quick ラン）は 2025-10-02 10:43 時点で **完走 & score 100.00%**。TokenOptimizer が圧縮で空文字列化した際に元データへフォールバックするよう修正し、先の `seed:1083850253` failure を解消。
   - ただし `STRYKER_TIME_LIMIT=180` で再実行した際には `tests/property/token-optimizer.trim-edge.trailing-comma.boundary.pbt.test.ts` が sandbox で失敗し Dry run が中断。trim-edge 系プロパティの期待値調整が新たな課題。

--- a/tests/unit/utils/enhanced-state-manager.test.ts
+++ b/tests/unit/utils/enhanced-state-manager.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { gzipSync } from 'node:zlib';
@@ -1411,5 +1411,71 @@ describe('EnhancedStateManager persistence and shutdown', () => {
 
     logSpy.mockRestore();
     await manager.shutdown();
+  });
+});
+
+describe('EnhancedStateManager garbage collection logging', () => {
+  it('logs removal count when expired entries are collected', async () => {
+    vi.useFakeTimers();
+    const baseTime = new Date('2025-01-01T00:00:00.000Z');
+    vi.setSystemTime(baseTime);
+
+    const root = await mkdtemp(join(tmpdir(), 'ae-framework-gc-'));
+    tempRoots.push(root);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const manager = new EnhancedStateManager(root, {
+      databasePath: 'state.db',
+      enableTransactions: false,
+      gcInterval: 3600,
+    });
+
+    try {
+      await manager.initialize();
+      manager.stopGarbageCollection();
+      logSpy.mockClear();
+
+      await manager.saveSSOT('session', { id: 'stale' }, { ttl: 1, source: 'gc-test' });
+      vi.advanceTimersByTime(2000);
+
+      await manager.collectGarbage();
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('removed 1 expired entries'));
+      await expect(manager.loadSSOT('session')).resolves.toBeNull();
+    } finally {
+      logSpy.mockRestore();
+      await manager.shutdown();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not log when no entries expire during collection', async () => {
+    vi.useFakeTimers();
+    const baseTime = new Date('2025-01-01T12:00:00.000Z');
+    vi.setSystemTime(baseTime);
+
+    const root = await mkdtemp(join(tmpdir(), 'ae-framework-gc-clean-'));
+    tempRoots.push(root);
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const manager = new EnhancedStateManager(root, {
+      databasePath: 'state.db',
+      enableTransactions: false,
+      gcInterval: 3600,
+    });
+
+    try {
+      await manager.initialize();
+      manager.stopGarbageCollection();
+      logSpy.mockClear();
+
+      await manager.collectGarbage();
+
+      expect(logSpy).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+      await manager.shutdown();
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## 概要
- EnhancedStateManager のガーベジコレクションで TTL 失効したエントリを掃除した際のログを検証するユニットテストを追加
- 失効が発生しないケースではログが出力されないことも併せて確認
- `docs/notes/mutation-coverage-plan.md` を更新し、最新の Stryker 結果（67.25% / survived 151）と改善ポイントを追記

## テスト
- `pnpm vitest run tests/unit/utils/enhanced-state-manager.test.ts --reporter dot`
- `STRYKER_TIME_LIMIT=420 npx stryker run configs/stryker.enhanced.config.js --mutate src/utils/enhanced-state-manager.ts --concurrency 1`
