### PR TITLE
Document Phase C status and envelope progress

### DIFF
--- a/docs/TLA+/tla_plus_full_integration.md
+++ b/docs/TLA+/tla_plus_full_integration.md
@@ -208,6 +208,12 @@ THEOREM Safety == Spec => []NoOverwrite
    - mutation/coverage/trace 成果をまとめる可視化ダッシュボードを構築。  
    - 再開条件: Week2 以降の運用 Issues (#999/#1001) のクリティカル項目が解消されていること。
 
+#### Phase C 棚卸しメモ (2025-10-06)
+- ✅ Report Envelope スキーマと AJV 検証を整備し、Verify Lite / Trace conformance の両ジョブで `REPORT_ENVELOPE_*` を発行（PR #1043, #1044, #1049）。
+- ✅ Stage2 (collector) PoC を MinIO で再現できるようにし、payload メタデータを Envelope に添付する道筋を確立（PR #1045〜#1051）。
+- ⏳ 残るボトルネックは EnhancedStateManager 周辺の mutation survivors (#1016) と生成成果物ゲートの昇格。これらが収束した段階で、上記 Phase C TODO を再開する。
+- ⏳ ダッシュボード統合は Tempo/Jaeger PoC と Grafana ノートを基に、Week3/4 トラッカー (#1002/#1003) で具体的なパネル設計を進める。
+
 ### 実行ヒント
 
 ```bash

--- a/docs/notes/issue-progress.md
+++ b/docs/notes/issue-progress.md
@@ -1,21 +1,24 @@
-# Issue Progress Snapshot (2025-10-05)
+# Issue Progress Snapshot (2025-10-06)
 
 | Issue | Theme | Status | Latest Notes |
 |-------|-------|--------|--------------|
 | #997 | Week1: フルパイプライン復元の詳細化 | ⏳ 継続 | Resilience／Telemetry／Property 系の回帰を解消し、Bulkhead 統合テストも通過。`pnpm test:ci` は緑化済み。`PODMAN_COMPOSE_PROVIDER=podman-compose make test-docker-all` の順次成功と Podman 手順整備が完了し、現在は mutation survivor 解消と Verify ワークフロー拡張が主な残課題。Fail-Fast Spec ビルドの sparse checkout を調整し、ローカルアクション不足で落ちる事象を解消。|
-| #999 | Week2: 継続運用計画の具体化 | ⏳ 継続 | Verify Lite / mutation-quick GitHub Check を整備済み。TokenOptimizer quick run は 100% を維持。EnhancedStateManager quick run は rollback 系テスト追加後も **59.74%**（survived 184）。Podman unit compose は `AE_HOST_STORE` キャッシュ導入で 45 秒程度まで短縮。`scripts/ci/run-verify-lite-local.sh` の追加に加え、`scripts/trace/run-kvonce-trace-replay.mjs` でトレース検証→TLC リプレイを自動化。残課題はトランザクション／スナップショット／復元系のサバイバー解消。|
-| #1001 | Week2 Tracker | ✅ 進捗記録中 | `src/api/server.ts` の Mutation quick を 47%→67%→81%→88%→94%→98.69%→100% まで引き上げ。TokenOptimizer quick は 32.12%、EnhancedStateManager quick は rollback/initialize/legacy Buffer テスト追加後も **59.74%**（survived 184）。性能プロジェクトは `vitest --passWithNoTests` 化してゲート継続、イベント/rollback 付近のフォローアップを継続する。Trace まわりは Projector/Validator/OTLP 変換の CLI テストと conformance 連結テストを追加済み。|
+| #999 | Week2: 継続運用計画の具体化 | ⏳ 継続 | Verify Lite / mutation-quick GitHub Check を整備済み。TokenOptimizer quick run は 100% を維持。EnhancedStateManager quick run は import 系テスト追加で **67.90%**（killed 313 / survived 148）まで向上。Podman unit compose は `AE_HOST_STORE` キャッシュ導入で 45 秒程度まで短縮。`scripts/ci/run-verify-lite-local.sh` の追加に加え、`scripts/trace/run-kvonce-trace-replay.mjs` でトレース検証→TLC リプレイを自動化。残課題はトランザクション／rollback 系サバイバーと Verify Lite のラベル制御の本運用化。|
+| #1001 | Week2 Tracker | ✅ 進捗記録中 | `src/api/server.ts` の Mutation quick を 47%→67%→81%→88%→94%→98.69%→100% まで引き上げ。TokenOptimizer quick は 32.12%、EnhancedStateManager quick は import/gc テスト追加で **67.90%**（survived 148）。性能プロジェクトは `vitest --passWithNoTests` 化してゲート継続、イベント/rollback 付近のフォローアップを継続する。Trace まわりは Projector/Validator/OTLP 変換の CLI テストと conformance 連結テストを追加済み。|
 | #1002 | Week3 準備 (予定) | 💤 未着手 | Week2 の残課題（Docker 実行環境整備・mutation survivors 対応）完了後に着手予定。現時点では準備メモのみ。|
 | #1003 | Week3 Tracker | 💤 未着手 | Week3 の進行条件となる CI/テスト基盤の整備待ち。前段となる #999/#1001 の完了がブロッカー。|
 |
 
-> メモ内容は GitHub Issues (#997, #999, #1001, #1002, #1003) にもコメントとして反映済み（2025-10-05 更新）。
+> メモ内容は GitHub Issues (#997, #999, #1001, #1002, #1003) にもコメントとして反映済み（2025-10-06 更新）。
 
 ### Latest PR / Follow-ups
 - Podman/WSL ランタイム最適化: PR [#1014](https://github.com/itdojp/ae-framework/pull/1014)
 - Spec generate/model gating: PR [#1023](https://github.com/itdojp/ae-framework/pull/1023) — `.github/workflows/spec-generate-model.yml` introduces drift fail-fast + KvOnce property run
 - Spec trace conformance gating: PR [#1024](https://github.com/itdojp/ae-framework/pull/1024) — merged。KvOnce trace validation job + NDJSON schema docsが main に反映済み。
 - OTLP trace conversion: PR [#1025](https://github.com/itdojp/ae-framework/pull/1025) — merged。OTLP→NDJSON converter + workflow integration が landing。
+- Grafana Tempo dashboard note: PR [#1052](https://github.com/itdojp/ae-framework/pull/1052) — TraceQL クエリ/属性確認手順を追記。
+- GC logging coverage: PR [#1054](https://github.com/itdojp/ae-framework/pull/1054) — EnhancedStateManager の TTL 失効ログをテスト化。
+- Import edge-case coverage: PR [#1055](https://github.com/itdojp/ae-framework/pull/1055) — compressed Buffer／checksum フォールバックのテスト追加、mutation score 67.90%。
 - ネイティブ compose 検証: Issue [#1015](https://github.com/itdojp/ae-framework/issues/1015)
 - Mutation survivor 削減タスク: Issue [#1016](https://github.com/itdojp/ae-framework/issues/1016)
 ## Pipeline Health (2025-10-05)
@@ -44,7 +47,7 @@
 
 ### #1001 Week2 Tracker
 - [x] 予約キャンセルフローと各種テスト資産の実装
-- [x] Mutation quick (API server 100% / EnhancedStateManager 58.33%) の結果ドキュメント化
+- [x] Mutation quick (API server 100% / EnhancedStateManager 67.90%) の結果ドキュメント化
 - [ ] EnhancedStateManager 残存ミュータント（`versionIndex` / `stateImported` / `findKeyByVersion`）に対するテスト実装
 - [ ] tinypool クラッシュ回避策の検証（Node 20 切替または Vitest 設定調整）
 - [x] ResilientHttpClient / IntelligentTestSelection / EvidenceValidator のテスト修正と再実行

--- a/docs/trace/REPORT_ENVELOPE.md
+++ b/docs/trace/REPORT_ENVELOPE.md
@@ -136,8 +136,8 @@ Issue: #1011 / #1012 / #1036 / #1038
 3. Trace 系ジョブでは、Collector から取得した payload のメタデータ (`kvonce-payload-metadata.json`) を artifacts 配列に追加し、`scripts/trace/build-kvonce-envelope-summary.mjs` で集計したサマリを `scripts/trace/create-report-envelope.mjs` でラップする。
 4. Dashboard / Tempo 連携は Envelope を単位としてインジェストし、必要に応じて `traceIds` から関連 span を引き直す。
 
-## TODO
-- [ ] JSON Schema を `schema/report-envelope.schema.json` として整備し、AJV で検証する。
-- [ ] Verify Lite ワークフローで Envelope 生成＋ Artifact アップロードまで自動化する (#1036 Section3)。
-- [ ] Trace conformance ジョブで Projector/Validator の出力を Envelope にまとめ、Issue #1011 Step3 の完了条件に組み込む。
+## TODO / 状態
+- [x] JSON Schema を `schema/report-envelope.schema.json` として整備し、AJV で検証する。（PR #1043）
+- [x] Verify Lite ワークフローで Envelope 生成＋ Artifact アップロードまで自動化する（PR #1044, #1048）。
+- [x] Trace conformance ジョブで Projector/Validator の出力を Envelope にまとめ、Issue #1011 Step3 の完了条件に組み込む（PR #1049）。
 - [ ] 将来的に `artifacts` へ S3 Presigned URL を許容する場合の署名方式を整理する。


### PR DESCRIPTION
## 概要
- `docs/TLA+/tla_plus_full_integration.md` に Phase C 棚卸しメモを追記し、Envelope/Stage2 PoC の現状と残課題をまとめました。
- `docs/trace/REPORT_ENVELOPE.md` の TODO を更新し、スキーマ整備・Verify Lite/trace-conformance 連携が完了したことを明記しました。
- `docs/notes/issue-progress.md` を 2025-10-06 時点に更新し、EnhancedStateManager mutation quick (67.90%) など最新状況を反映しました。

## テスト
- Docs only

## 関連
- Updates #1038 / #1012 / #1011 / #997
