### PR TITLE
test: guard enhanced state import edge cases

### DIFF
--- a/tests/unit/utils/enhanced-state-manager.test.ts
+++ b/tests/unit/utils/enhanced-state-manager.test.ts
@@ -1333,8 +1333,6 @@ describe('EnhancedStateManager persistence and shutdown', () => {
     await manager.shutdown();
   });
 
-<<<<<<< HEAD
-=======
   it('infers version index when metadata map is absent', async () => {
     const root = await mkdtemp(join(tmpdir(), 'ae-framework-import-no-versionindex-'));
     tempRoots.push(root);


### PR DESCRIPTION
## Summary
- add regression tests for logicalKey 欠落、TTL 未指定、compressed object payload などの import edge ケース
- introduce InternalManager helpers (`getVersionIndex` など) を活用し、decompress の呼び出し有無を検証
- document 最新の mutation quick スコア (71.15%) と Week2 issue progress を更新

## Issue
- Closes #1038

## Testing
- pnpm vitest run tests/unit/utils/enhanced-state-manager.test.ts --reporter dot
- STRYKER_TIME_LIMIT=420 npx stryker run configs/stryker.enhanced.config.js --mutate src/utils/enhanced-state-manager.ts --concurrency 1
