### PR TITLE
Enhance runtime guard stats reporting

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -178,6 +178,12 @@ jobs:
             verify-lite-lint.log
             verify-lite-lint-summary.json
           if-no-files-found: ignore
+      - name: Upload runtime guard stats
+        if: ${{ always() && hashFiles('artifacts/runtime-guard/runtime-guard-stats.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-guard-stats
+          path: artifacts/runtime-guard/runtime-guard-stats.json
       - name: Append verify-lite run summary
         if: always()
         run: |
@@ -195,6 +201,10 @@ jobs:
           else
             echo 'Runtime contracts summary not generated.' >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Append runtime guard summary
+        if: ${{ always() && hashFiles('artifacts/runtime-guard/runtime-guard-stats.json') != '' }}
+        run: |
+          node scripts/telemetry/render-runtime-guard-summary.mjs artifacts/runtime-guard/runtime-guard-stats.json >> "$GITHUB_STEP_SUMMARY"
       - name: Append lint summary (top rules)
         if: always()
         run: |

--- a/docs/notes/mutation-coverage-plan.md
+++ b/docs/notes/mutation-coverage-plan.md
@@ -1,5 +1,15 @@
 # Mutation Coverage Improvement Plan (Week2)
 
+## CI 連携メモ（2025-10-07 更新）
+- `scripts/mutation/publish-survivors-report.mjs` を GitHub Actions（mutation-quick / verify-lite）から実行し、`reports/mutation/mutation-summary.json` を解析してサバイバー情報を自動的に Issue とラベルへ反映する仕組みを導入。
+- サバイバーが 0 件になった場合は既存 Issue の自動クローズと `mutation:survivors` ラベル解除を行うため、Round9 以降の手動トリアージが不要になり、優先度付けを Issue 側で継続管理できる。
+- verify-lite のサマリに `scripts/telemetry/render-runtime-guard-summary.mjs` が追加され、`artifacts/runtime-guard/runtime-guard-stats.json` を読み込んで直近 24h の違反件数・型別内訳・タイムライン・最新違反を Markdown でステップサマリへ出力する。
+
+## EnhancedStateManager 計測メモ（2025-10-07 更新）
+- `enablePerformanceMetrics` で `stringifyForStorage` の呼び出し時間・ペイロードサイズ・キャッシュヒット率・最近のサンプルを収集し、`getPerformanceMetrics()` で可視化できるようにした。直近 20 件のサンプルを保持し、`resetPerformanceMetrics()` でリセット可能。
+- `enableSerializationCache` を true にすると `WeakMap` ベースのキャッシュが有効化され、同一オブジェクトの連続保存で `stringify` をスキップする。測定結果は `stringifyCacheHits/Misses` に反映。
+- `skipUnchangedPersistence` により `persistToDisk` はエントリ・インデックス・オプションのハッシュが変化しない限りディスク書き込みを省略するため、反復保存時の IO を削減できる（`skippedPersistWrites` で確認可能）。
+
 ## 現状サマリ（2025-10-06 更新）
 - `./scripts/mutation/run-scoped.sh --quick --mutate src/utils/enhanced-state-manager.ts`（2025-10-02 10:50 開始）
   - 走行時間: **約 135 分**（time-limit 未指定のため全 457 ミュータントを順次実行）

--- a/scripts/telemetry/render-runtime-guard-summary.mjs
+++ b/scripts/telemetry/render-runtime-guard-summary.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const inputPath = resolve(process.argv[2] || 'artifacts/runtime-guard/runtime-guard-stats.json');
+
+if (!existsSync(inputPath)) {
+  console.log('Runtime guard stats not found. Skipping summary render.');
+  process.exit(0);
+}
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(inputPath, 'utf8'));
+} catch (error) {
+  console.error(`Failed to parse runtime guard stats at ${inputPath}:`, error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+const stats = payload.stats ?? payload;
+if (!stats || typeof stats !== 'object') {
+  console.log('Runtime guard stats payload is empty.');
+  process.exit(0);
+}
+
+const lines = [];
+lines.push('## Runtime Guard Statistics');
+if (payload.generatedAt) {
+  lines.push(`_Generated at ${payload.generatedAt}_`);
+}
+lines.push('');
+lines.push(`- Total violations: ${stats.total ?? 0}`);
+lines.push(`- Last 24h: ${stats.last24Hours?.total ?? 0}`);
+
+if (stats.byType) {
+  lines.push('');
+  lines.push('### Violations by Type');
+  lines.push('| Type | Total | Last 24h |');
+  lines.push('| --- | ---: | ---: |');
+  for (const [type, total] of Object.entries(stats.byType)) {
+    const last24 = stats.last24Hours?.byType?.[type] ?? 0;
+    lines.push(`| ${type} | ${total} | ${last24} |`);
+  }
+}
+
+if (stats.last24Hours?.hourlyBuckets?.length) {
+  lines.push('');
+  lines.push('### Last 24h Timeline');
+  const buckets = stats.last24Hours.hourlyBuckets.slice(-12);
+  for (const bucket of buckets) {
+    lines.push(`- ${bucket.hour}: ${bucket.count}`);
+  }
+}
+
+if (stats.byEndpoint && Object.keys(stats.byEndpoint).length > 0) {
+  lines.push('');
+  lines.push('### Top Endpoints');
+  lines.push('| Endpoint | Violations |');
+  lines.push('| --- | ---: |');
+  const topEndpoints = Object.entries(stats.byEndpoint).slice(0, 5);
+  for (const [endpoint, count] of topEndpoints) {
+    lines.push(`| ${endpoint} | ${count} |`);
+  }
+}
+
+if (Array.isArray(stats.recent) && stats.recent.length > 0) {
+  lines.push('');
+  lines.push('### Recent Violations');
+  const recent = stats.recent.slice(0, 5);
+  for (const violation of recent) {
+    const ts = violation.timestamp || 'unknown time';
+    const endpoint = violation.endpoint ?? 'unknown';
+    lines.push(`- ${ts} — ${violation.type} (${violation.severity}) @ ${endpoint}`);
+  }
+}
+
+console.log(lines.join('\n'));

--- a/src/telemetry/runtime-guards.ts
+++ b/src/telemetry/runtime-guards.ts
@@ -387,6 +387,9 @@ export class RuntimeGuard {
 
     for (let idx = this.violations.length - 1; idx >= 0; idx -= 1) {
       const violation = this.violations[idx];
+      if (!violation) {
+        continue;
+      }
       if (violation.timestamp < last24Threshold) {
         break;
       }
@@ -414,6 +417,9 @@ export class RuntimeGuard {
     const recent: ViolationStats['recent'] = [];
     for (let idx = this.violations.length - 1; idx >= 0 && recent.length < 10; idx -= 1) {
       const violation = this.violations[idx];
+      if (!violation) {
+        continue;
+      }
       recent.push({
         id: violation.id,
         type: violation.type,

--- a/src/telemetry/runtime-guards.ts
+++ b/src/telemetry/runtime-guards.ts
@@ -8,6 +8,8 @@ import type { FastifyRequest, FastifyReply } from 'fastify';
 import { enhancedTelemetry, TELEMETRY_ATTRIBUTES } from './enhanced-telemetry.js';
 import { trace, context } from '@opentelemetry/api';
 
+const HOUR_IN_MS = 60 * 60 * 1000;
+
 // Contract violation types
 export enum ViolationType {
   SCHEMA_VALIDATION = 'schema_validation',
@@ -35,6 +37,31 @@ export interface ContractViolation {
   requestId?: string;
   endpoint?: string;
   details?: Record<string, any>;
+}
+
+export interface HourlyViolationBucket {
+  hour: string;
+  count: number;
+}
+
+export interface ViolationStats {
+  total: number;
+  byType: Record<ViolationType, number>;
+  bySeverity: Record<ViolationSeverity, number>;
+  byEndpoint: Record<string, number>;
+  last24Hours: {
+    total: number;
+    byType: Record<ViolationType, number>;
+    bySeverity: Record<ViolationSeverity, number>;
+    hourlyBuckets: HourlyViolationBucket[];
+  };
+  recent: Array<{
+    id: string;
+    type: ViolationType;
+    severity: ViolationSeverity;
+    endpoint: string | null;
+    timestamp: string;
+  }>;
 }
 
 export interface ValidationResult {
@@ -327,41 +354,82 @@ export class RuntimeGuard {
   /**
    * Get violation statistics
    */
-  public getViolationStats(): {
-    total: number;
-    byType: Record<ViolationType, number>;
-    bySeverity: Record<ViolationSeverity, number>;
-    last24Hours: number;
-  } {
+  public getViolationStats(): ViolationStats {
     const now = new Date();
-    const last24Hours = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    
-    const byType = Object.values(ViolationType).reduce((acc, type) => {
+    const last24Threshold = new Date(now.getTime() - 24 * HOUR_IN_MS);
+
+    const initializeByType = () => Object.values(ViolationType).reduce((acc, type) => {
       acc[type] = 0;
       return acc;
     }, {} as Record<ViolationType, number>);
 
-    const bySeverity = Object.values(ViolationSeverity).reduce((acc, severity) => {
+    const initializeBySeverity = () => Object.values(ViolationSeverity).reduce((acc, severity) => {
       acc[severity] = 0;
       return acc;
     }, {} as Record<ViolationSeverity, number>);
 
-    let last24HoursCount = 0;
+    const byType = initializeByType();
+    const bySeverity = initializeBySeverity();
+    const byEndpoint = new Map<string, number>();
+    const last24ByType = initializeByType();
+    const last24BySeverity = initializeBySeverity();
+    const hourlyBuckets = new Map<string, number>();
 
-    this.violations.forEach(violation => {
-      byType[violation.type]++;
-      bySeverity[violation.severity]++;
-      
-      if (violation.timestamp >= last24Hours) {
-        last24HoursCount++;
+    let last24Total = 0;
+
+    for (const violation of this.violations) {
+      byType[violation.type] += 1;
+      bySeverity[violation.severity] += 1;
+
+      const endpointKey = violation.endpoint ?? 'unknown';
+      byEndpoint.set(endpointKey, (byEndpoint.get(endpointKey) ?? 0) + 1);
+
+      if (violation.timestamp >= last24Threshold) {
+        last24Total += 1;
+        last24ByType[violation.type] += 1;
+        last24BySeverity[violation.severity] += 1;
+
+        const bucketTime = new Date(Math.floor(violation.timestamp.getTime() / HOUR_IN_MS) * HOUR_IN_MS);
+        const bucketKey = bucketTime.toISOString();
+        hourlyBuckets.set(bucketKey, (hourlyBuckets.get(bucketKey) ?? 0) + 1);
       }
-    });
+    }
+
+    const byEndpointObject = Array.from(byEndpoint.entries())
+      .sort((a, b) => b[1] - a[1])
+      .reduce((acc, [key, value]) => {
+        acc[key] = value;
+        return acc;
+      }, {} as Record<string, number>);
+
+    const hourlyBucketsArray: HourlyViolationBucket[] = Array.from(hourlyBuckets.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([hour, count]) => ({ hour, count }));
+
+    const recent = this.violations
+      .slice()
+      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+      .slice(0, 10)
+      .map((violation) => ({
+        id: violation.id,
+        type: violation.type,
+        severity: violation.severity,
+        endpoint: violation.endpoint ?? null,
+        timestamp: violation.timestamp.toISOString(),
+      }));
 
     return {
       total: this.violations.length,
       byType,
       bySeverity,
-      last24Hours: last24HoursCount,
+      byEndpoint: byEndpointObject,
+      last24Hours: {
+        total: last24Total,
+        byType: last24ByType,
+        bySeverity: last24BySeverity,
+        hourlyBuckets: hourlyBucketsArray,
+      },
+      recent,
     };
   }
 


### PR DESCRIPTION
## Summary
- extend RuntimeGuard.getViolationStats to include 24h aggregates, endpoint tallies, hourly buckets, and recent violation listings
- persist unit-test stats to artifacts/runtime-guard/runtime-guard-stats.json and render them via scripts/telemetry/render-runtime-guard-summary.mjs
- surface the new summary in verify-lite GitHub step summaries and upload the stats as an artifact

## Testing
- pnpm vitest run tests/unit/api/server.test.ts --reporter dot --pool=threads --poolOptions.threads.maxWorkers=1
