### PR TITLE
telemetry: export runtime guard stats as CSV

### DIFF
--- a/docs/observability/runtime-guard-dashboard.md
+++ b/docs/observability/runtime-guard-dashboard.md
@@ -1,0 +1,24 @@
+# Runtime Guard ダッシュボード連携メモ
+
+## 目的
+Verify Lite で生成される `artifacts/runtime-guard/runtime-guard-stats.json` を時系列データとして可視化するための手順です。Grafana など任意のダッシュボードに取り込める CSV を生成します。
+
+## エクスポート手順
+```bash
+node scripts/telemetry/export-runtime-guard-timeseries.mjs artifacts/runtime-guard/runtime-guard-stats.json runtime-guard-last24h.csv
+```
+
+上記コマンドは 24 時間分の hourly bucket を `hour,count` 形式の CSV に変換します。出力例:
+
+```csv
+hour,count
+2025-10-07T08:00:00.000Z,3
+```
+
+## 可視化のアイディア
+- Grafana Loki / Prometheus 経由で `hour,count` を取り込み、違反件数の推移グラフを表示する。
+- 上記 CSV を GitHub Pages / Observable 等で読み込み、簡易的な折れ線グラフを描画する。
+- `byEndpoint` 集計と組み合わせて、エンドポイント別のヒートマップを作成し、ランタイムガードのホットスポットを即時に把握する。
+
+## フォローアップ
+- Verify Lite ワークフローで `export-runtime-guard-timeseries.mjs` を実行し、CSV をアーティファクトとして保存するタスクを追加予定。

--- a/scripts/telemetry/export-runtime-guard-timeseries.mjs
+++ b/scripts/telemetry/export-runtime-guard-timeseries.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const inputPath = resolve(process.argv[2] || 'artifacts/runtime-guard/runtime-guard-stats.json');
+const outputPath = process.argv[3] ? resolve(process.argv[3]) : null;
+
+if (!existsSync(inputPath)) {
+  console.error(`Runtime guard stats not found at ${inputPath}`);
+  process.exit(1);
+}
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(inputPath, 'utf8'));
+} catch (error) {
+  console.error(`Failed to parse runtime guard stats: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}
+
+const stats = payload.stats ?? payload;
+const buckets = stats?.last24Hours?.hourlyBuckets;
+if (!Array.isArray(buckets) || buckets.length === 0) {
+  console.error('No hourly bucket information found in runtime guard stats.');
+  process.exit(1);
+}
+
+const lines = [
+  'hour,count',
+  ...buckets.map((bucket) => `${bucket.hour},${bucket.count}`),
+];
+
+const csv = lines.join('\n');
+if (outputPath) {
+  writeFileSync(outputPath, csv, 'utf8');
+} else {
+  console.log(csv);
+}


### PR DESCRIPTION
## Summary
- runtime guard サマリから 24h timeline を CSV に変換するスクリプトを追加
- Grafana 等で読み込むための手順を `docs/observability/runtime-guard-dashboard.md` に整理
- Verify Lite 生成アーティファクトの活用例を具体化

## Testing
- `node scripts/telemetry/export-runtime-guard-timeseries.mjs artifacts/runtime-guard/runtime-guard-stats.json` (CSV 出力を目視確認)