### PR TITLE
test: cover binary encode/decode for enhanced state

### DIFF
--- a/docs/TLA+/tla_plus_full_integration.md
+++ b/docs/TLA+/tla_plus_full_integration.md
@@ -194,25 +194,27 @@ THEOREM Safety == Spec => []NoOverwrite
 - KvOnce のトレース検証 (`scripts/trace/run-kvonce-conformance.sh`) を CI ジョブに組み込み、NDJSON スキーマを `docs/trace/kvonce-trace-schema.md` に記録
 - KvOnce トレースを TLC へリプレイするプロトタイプ (`scripts/trace/run-kvonce-trace-replay.mjs`) を追加し、Spec Generate & Model workflow でサマリを取得
 
-### Phase C: 後回し項目と再開条件
-1. **生成成果物の完全ゲート化**  
-   - `generate-artifacts` ワークフローを必須チェックへ昇格する前に、生成差分のホワイトリスト運用と、誤検知を抑えるテンプレート整理を実施。  
-   - 再開条件: 仕様変更時の差分が安定してレビュー可能であること、Issue #1011 ステップ2の残タスクが収束していること。
-2. **Projector → Validator → TLC のトレースリプレイ**  
-   - 実装ログから自動抽出した NDJSON を TLC/Apalache で検証する再実行パイプラインを整備。  
-   - 再開条件: 現行 PoC (KvOnce) の end-to-end テストが緑化し、追加ドメインのトレース要件が確定していること。
-3. **BDD 生成フローの再導入**  
-   - TLA+ の Action から BDD ステップを再生成し、`tests/bdd` を自動更新する。  
-   - 再開条件: サンプル生成の品質が reviewer 合意を得られる水準となり、verify-lite lint backlog の整理計画 (#1016) が進んでいること。
-4. **ダッシュボード統合**  
-   - mutation/coverage/trace 成果をまとめる可視化ダッシュボードを構築。  
-   - 再開条件: Week2 以降の運用 Issues (#999/#1001) のクリティカル項目が解消されていること。
+### Phase C: 後回し項目と再開条件 (2025-10-08 更新)
+1. **Step2: Spec-driven CI の再構築**  
+   - [ ] `generate-artifacts` / `model-based-tests` / `conformance` ジョブを GitHub Actions に復帰させる。  
+   - [ ] 生成物差分のホワイトリスト化とテンプレート整理を完了し、必須チェック昇格の基準を明文化する。  
+   - ⚠️ ブロッカー: Verify Lite lint backlog (#1016) と EnhancedStateManager mutation survivor の整理が未完。
+2. **Step3: Trace Projector / Validator 本運用**  
+   - [ ] KvOnce で検証した Report Envelope / NDJSON スキーマを ISSUE #1011 の Step3 コメントに反映する。  
+   - [ ] Projector → Validator → TLC リプレイの CI テンプレートを整備し、PoC ログを自動検証できるようにする。  
+   - ✅ 進捗: Report Envelope スキーマと AJV 検証（PR #1043, #1044, #1049）、MinIO collector PoC（PR #1045〜#1051）。
+3. **Step4: verify:conformance 連携**  
+   - [ ] 仕様→BDD 生成を `tests/bdd` に再導入し、差分検証ルールを定義する。  
+   - [ ] 実装ログを Trace Validator へ入力するワークフローを設計し、CI レポート統合方針をまとめる。
+4. **Step5: 拡張と可視化**  
+   - [ ] 追加ドメイン仕様の候補と Refinement Mapping 拡張案を整理する。  
+   - [ ] mutation / coverage / trace 指標を集約するダッシュボード設計を Week3/4 トラッカー (#1002/#1003) で具体化する。
 
-#### Phase C 棚卸しメモ (2025-10-06)
-- ✅ Report Envelope スキーマと AJV 検証を整備し、Verify Lite / Trace conformance の両ジョブで `REPORT_ENVELOPE_*` を発行（PR #1043, #1044, #1049）。
-- ✅ Stage2 (collector) PoC を MinIO で再現できるようにし、payload メタデータを Envelope に添付する道筋を確立（PR #1045〜#1051）。
-- ⏳ 残るボトルネックは EnhancedStateManager 周辺の mutation survivors (#1016) と生成成果物ゲートの昇格。これらが収束した段階で、上記 Phase C TODO を再開する。
-- ⏳ ダッシュボード統合は Tempo/Jaeger PoC と Grafana ノートを基に、Week3/4 トラッカー (#1002/#1003) で具体的なパネル設計を進める。
+#### Phase C 棚卸しメモ (2025-10-08)
+- ✅ Verify Lite / Trace conformance ジョブの Report Envelope 出力と AJV 検証を整備（PR #1043, #1044, #1049）。
+- ✅ Stage2 (collector) PoC を MinIO 上で再現し、Envelope に payload メタデータを添付する道筋を確立（PR #1045〜#1051）。
+- ⏳ EnhancedStateManager 周辺の mutation survivors (#1016) と generate-artifacts の差分運用整理が Step2 復帰の条件。
+- ⏳ ダッシュボード統合は Tempo/Jaeger PoC と Grafana ノートをベースに Week3/4 トラッカー (#1002/#1003) で設計を継続する。
 
 ### 実行ヒント
 

--- a/docs/notes/issue-progress.md
+++ b/docs/notes/issue-progress.md
@@ -1,20 +1,14 @@
-# Issue Progress Snapshot (2025-10-06)
+# Issue Progress Snapshot (2025-10-08)
 
 | Issue | Theme | Status | Latest Notes |
 |-------|-------|--------|--------------|
-| #997 | Week1: フルパイプライン復元の詳細化 | ⏳ 継続 | Resilience／Telemetry／Property 系の回帰を解消し、Bulkhead 統合テストも通過。`pnpm test:ci` は緑化済み。`PODMAN_COMPOSE_PROVIDER=podman-compose make test-docker-all` の順次成功と Podman 手順整備が完了し、現在は mutation survivor 解消と Verify ワークフロー拡張が主な残課題。Fail-Fast Spec ビルドの sparse checkout を調整し、ローカルアクション不足で落ちる事象を解消。|
-<<<<<<< HEAD
-| #999 | Week2: 継続運用計画の具体化 | ⏳ 継続 | Verify Lite / mutation-quick GitHub Check を整備済み。TokenOptimizer quick run は 100% を維持。EnhancedStateManager quick run は logicalKey 欠落・TTL 未指定・object 圧縮パス等のテスト拡充で **71.15%**（killed 328 / survived 133）を記録。Podman unit compose は `AE_HOST_STORE` キャッシュ導入で 45 秒程度まで短縮。`scripts/ci/run-verify-lite-local.sh` の追加に加え、`scripts/trace/run-kvonce-trace-replay.mjs` でトレース検証→TLC リプレイを自動化。残課題は versionIndex 周りのサバイバーと Verify Lite のラベル制御の本運用化。|
-| #1001 | Week2 Tracker | ✅ 進捗記録中 | `src/api/server.ts` の Mutation quick を 47%→67%→81%→88%→94%→98.69%→100% まで引き上げ。TokenOptimizer quick は 32.12%、EnhancedStateManager quick は import/gc/index テスト＋論理キー/TTL ガードで **71.15%**（survived 133）。性能プロジェクトは `vitest --passWithNoTests` 化してゲート継続、イベント/rollback 付近のフォローアップを継続する。Trace まわりは Projector/Validator/OTLP 変換の CLI テストと conformance 連結テストを追加済み。|
-=======
-| #999 | Week2: 継続運用計画の具体化 | ⏳ 継続 | Verify Lite / mutation-quick GitHub Check を整備済み。TokenOptimizer quick run は 100% を維持。EnhancedStateManager quick run は import 系テスト追加で **72.02%**（killed 332 / survived 129）まで向上。Podman unit compose は `AE_HOST_STORE` キャッシュ導入で 45 秒程度まで短縮。`scripts/ci/run-verify-lite-local.sh` の追加に加え、`scripts/trace/run-kvonce-trace-replay.mjs` でトレース検証→TLC リプレイを自動化。残課題はトランザクション／rollback 系サバイバーと Verify Lite のラベル制御の本運用化。|
-| #1001 | Week2 Tracker | ✅ 進捗記録中 | `src/api/server.ts` の Mutation quick を 47%→67%→81%→88%→94%→98.69%→100% まで引き上げ。TokenOptimizer quick は 32.12%、EnhancedStateManager quick は import/gc テスト追加で **72.02%**（survived 129）。性能プロジェクトは `vitest --passWithNoTests` 化してゲート継続、イベント/rollback 付近のフォローアップを継続する。Trace まわりは Projector/Validator/OTLP 変換の CLI テストと conformance 連結テストを追加済み。|
->>>>>>> 9cf6584 (test: capture missing key/version import cases)
-| #1002 | Week3 準備 (予定) | 💤 未着手 | Week2 の残課題（Docker 実行環境整備・mutation survivors 対応）完了後に着手予定。現時点では準備メモのみ。|
-| #1003 | Week3 Tracker | 💤 未着手 | Week3 の進行条件となる CI/テスト基盤の整備待ち。前段となる #999/#1001 の完了がブロッカー。|
+| #997 | Week1: フルパイプライン復元の詳細化 | ⏳ 継続 | Podman/Compose 手順と `make test-docker-all` は安定。mutation survivor の整理と Verify Lite ⇔ フルパイプライン連携の再整備が残課題。Spec ビルド sparse checkout やローカルアクション不足による失敗は解消済み。|
+| #999 | Week2: 継続運用計画の具体化 | ⏳ 継続 | Verify Lite / mutation-quick GitHub Check は main へ復帰済み。TokenOptimizer quick は 64.78% → 100%（PR #1091）、EnhancedStateManager quick は 64.78%（survived 243）。Step Summary/Artifact 再出力とラベル運用の本格化が残タスク。|
+| #1001 | Week2 Tracker | ✅ 進捗記録中 | API server mutation スコア 100% を維持しつつ、TokenOptimizer/CircuitBreaker PBT 安定化 (#1091) を完了。EnhancedStateManager survivor (`versionIndex` / `stateImported` / `findKeyByVersion`) 対策と tinypool 障害調査が継続タスク。|
+| #1002 | Week3 準備 (予定) | 💤 未着手 | Week2 の残課題（EnhancedStateManager survivor、Verify Lite lint backlog）を整理した後に着手予定。Trace ダッシュボード案と Docker ジョブ計画書のドラフト化が必要。|
+| #1003 | Week3 Tracker | 💤 未着手 | Week3 着手条件（Docker runtime, tinypool 安定化, mutation 整理）が揃っていないため、Issue コメントと手順書は更新保留。|
 |
-
-> メモ内容は GitHub Issues (#997, #999, #1001, #1002, #1003) にもコメントとして反映済み（2025-10-06 更新）。
+> メモ内容は GitHub Issues (#997, #999, #1001, #1002, #1003) にもコメントとして反映済み（2025-10-08 更新）。
 
 ### Latest PR / Follow-ups
 - Podman/WSL ランタイム最適化: PR [#1014](https://github.com/itdojp/ae-framework/pull/1014)


### PR DESCRIPTION
## 概要
- TLA+ Phase C の棚卸し結果を `docs/TLA+/tla_plus_full_integration.md` に反映し、Step2〜Step5 の後回し項目とブロッカーを明文化
- 進捗スナップショット (`docs/notes/issue-progress.md`) を 2025-10-08 版へ更新し、#999/#1001/#1002 の現状と残タスクを整理
- EnhancedStateManager のバイナリ系エンコードを検証するユニットテストを追加し、Buffer/TypedArray/DataView/ArrayBuffer/SharedArrayBuffer の round-trip を担保
- `stringifyForStorage` の出力を直接検証するテストを追加し、特殊バイナリのエンコード結果に `__ae_type` マーカーが付与されることを保証
- Stryker quick run のスコアが 64.78% → **65.51%** （killed 447→452）まで向上

## テスト
- `pnpm vitest --run tests/unit/utils/enhanced-state-manager.test.ts`
- `STRYKER_FORCE=1 STRYKER_CONCURRENCY=1 STRYKER_TIMEOUT=10000 npx stryker run configs/stryker.enhanced.config.js`（結果: 65.51%）
