### PR TITLE
chore: surface mutation quick artifacts in verify-lite

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -153,6 +153,14 @@ jobs:
           else
             printf "%s\n" "No mutation report found; skipped survivors extraction." >> "$GITHUB_STEP_SUMMARY"
           fi
+      - name: Upload mutation quick report
+        if: ${{ github.event_name == 'pull_request' && hashFiles('reports/mutation/mutation.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-quick-report
+          path: |
+            reports/mutation/mutation.json
+            reports/mutation/index.html
       - name: Upload mutation survivors artifact
         if: ${{ github.event_name == 'pull_request' && hashFiles('reports/mutation/survivors.json') != '' }}
         uses: actions/upload-artifact@v4

--- a/docs/examples/full-e2e-demo.md
+++ b/docs/examples/full-e2e-demo.md
@@ -1,0 +1,98 @@
+# Full E2E Demo: Spec → Tests → Runtime
+
+このドキュメントは、`ae-framework` のサンプル資産を組み合わせて「仕様→テスト→コード→検証」までを一貫して再現する手順をまとめたものです。Verify Lite / Mutation Quick / Pact / MBT / BDD を連携させたいときの素振り用チェックリストとして利用できます。
+
+> **前提**
+> - Node.js 20 / pnpm 8 系が利用可能であること
+> - `pnpm install` 済み
+> - Podman もしくは Docker Desktop が動作すること（Pact / API fuzz のコンテナ系タスクで利用）
+
+## 1. 仕様と生成物の確認
+
+1. KvOnce 仕様 (TLA+) を TLC/Apalache で実行:
+   ```bash
+   pnpm run spec:kv-once:tlc
+   pnpm run spec:kv-once:apalache # ツール導入済みの場合
+   ```
+2. 生成物 (BDD/OpenAPI/モニタ) を差分チェック:
+   ```bash
+   pnpm run generate:artifacts -- --dry-run
+   ```
+3. 生成物の検証結果は `artifacts/` 配下と `reports/formal/` に保存される。CI では `spec-generate-model.yml` が同じ流れを実行する。
+
+## 2. Verify Lite (ユニット/Property/Mutation)
+
+1. Verify Lite を実行し、ユニット・Property・Mutation quick (差分) をまとめて検証:
+   ```bash
+   pnpm run verify:lite
+   ```
+2. 実行結果:
+   - `verify-lite-run-summary.json` / `verify-lite-lint-summary.json`
+   - Mutation quick レポート `reports/mutation/mutation.json`
+   - Step Summary 用 `mutation-summary.md` (Verify Lite のラッパーが生成)
+3. CI (`verify-lite.yml`) では上記成果物をレポート Envelope 化し、`mutation-quick-report` / `mutation-survivors-json` をアーティファクトとして添付する。
+
+## 3. Mutation Quick の個別実行
+
+Verify Lite から切り離して Mutation Quick のみを検証したい場合は、以下を利用する。
+
+```bash
+./scripts/mutation/run-scoped.sh --quick --mutate src/utils/enhanced-state-manager.ts
+# 差分パターンを自動抽出
+./scripts/mutation/run-scoped.sh --quick --auto-diff
+```
+
+生成物:
+- `reports/mutation/mutation.json`
+- `reports/mutation/index.html`
+- `reports/mutation/survivors.json`
+
+GitHub Actions (`mutation-quick.yml`) では手動トリガーで同じコマンドを実行し、アーティファクトとしてアップロードする。
+
+## 4. BDD / Pact / API Fuzz
+
+### 4.1 BDD テスト
+```bash
+pnpm run bdd:test
+```
+- `tests/bdd/` 配下のシナリオを Vitest 経由で実行。
+- Lint/Step lint は `pnpm run bdd:lint` / `pnpm run bdd:step-lint` で個別実行可能。
+
+### 4.2 Pact Provider 検証
+```bash
+pnpm run contracts:verify # scripts/contracts/verify-reservation-contract.ts
+```
+- Pact ファイルは `artifacts/pacts/` に配置。
+- 追加契約を検証したい場合は `contracts/` 配下に JSON を追加し、同スクリプトに渡す。
+
+### 4.3 API Fuzz / Schemathesis
+```bash
+make test-api-fuzz
+```
+- Fastify スタブを起動し、Schemathesis コンテナで OpenAPI 仕様に対する fuzz を実行。
+- ログとレポートは `reports/api-fuzz/` に保存。
+
+## 5. MBT (Model-Based Testing)
+
+1. CEGIS を利用した生成テスト:
+   ```bash
+   pnpm run mbt:cegis
+   ```
+2. 生成されたケースは `artifacts/mbt/` に格納され、Verify Lite からも再利用可能。
+
+## 6. End-to-End チェックリスト
+
+1. `pnpm run spec:kv-once:tlc` / `pnpm run spec:kv-once:apalache`
+2. `pnpm run generate:artifacts -- --dry-run`
+3. `pnpm run verify:lite`
+4. (任意) `./scripts/mutation/run-scoped.sh --quick --auto-diff`
+5. `pnpm run bdd:test`
+6. `pnpm run contracts:verify`
+7. `make test-api-fuzz`
+8. `pnpm run mbt:cegis`
+
+全て完了したら、`reports/` / `artifacts/` の差分を確認し、必要に応じて Issue / PR に最新状況をコメントしてください。
+
+---
+
+この手順に沿って実施し、成果物をリンク付きで Issue #999 / #1001 / #1002 / #1003 へコメントすれば、Week2〜Week4 トラッカーの「エンドツーエンドデモ」要件を満たせます。

--- a/docs/notes/mutation-coverage-plan.md
+++ b/docs/notes/mutation-coverage-plan.md
@@ -80,7 +80,7 @@
 - [x] Stryker の vitest ランナーに `configs/vitest.mutation.config.ts` を強制適用（`configFile` 設定 or command runner への切り替え）。
 - [ ] EnhancedStateManager survivor（`versionIndex` / `stateImported` / `findKeyByVersion`）向けユニットテストを追加。
 - [ ] TokenOptimizer trim-edge 系プロパティの sandbox failure を解消（trailing comma の期待値/実装を見直す）。
-- [ ] Quick ランが復旧したら `reports/mutation/mutation.json` を Step Summary / Artifact に再添付。
+- [x] Quick ランが復旧したら `reports/mutation/mutation.json` を Step Summary / Artifact に再添付。（verify-lite / mutation-quick ワークフローで Artifact アップロードを再有効化）
 - [ ] 一括モードの mutate 対象を差分ベースで自動抽出し、実行時間を短縮する。
 - [x] `tests/property/token-optimizer.priority.order.pbt.test.ts` の仕様を再定義し、Stryker サンドボックスでも deterministic に通るよう fast-check ジェネレータとアサーションを調整する（2025-10-02: フォールバック実装 & 追加ユニットテストでケア）。
 - [x] `src/api/server.ts` survivor のうち `span` 欠損時のガードを追加検証（no-span でも TypeError が出ないことをテストで保証）。
@@ -100,6 +100,7 @@
 - [ ] 永続化（`persistToDisk` / `shutdown`）時のエラー処理とログ出力を property-based テストで補強。
 
 ## 備考
+- 2025-10-08: EnhancedStateManager のバイナリ encode/round-trip テストを追加し、quick run スコアが 67.39%（killed 465 / survived 225）に到達。`verify-lite` ワークフローで mutation レポートを Step Summary とアーティファクトに再添付する整備を進める。
 - TokenOptimizer テスト緑化の詳細は `docs/notes/token-optimizer-test-status.md` にまとめ済み。
 - Podman rootless + compose での Stryker 実行は問題なし。Quick ランが緑化した段階で CI へ組み戻す。
 


### PR DESCRIPTION
## 概要
- Verify Lite ワークフローに Mutation Quick の JSON/HTML をアーティファクトとして再添付するステップを追加し、Step Summary へのサマリ記録との一貫性を確保
- `docs/notes/mutation-coverage-plan.md` を 2025-10-08 の状況に更新し、最新スコア (67.39%) と再添付作業を記録
- `docs/examples/full-e2e-demo.md` を新設し、Spec → Verify Lite → Mutation Quick → BDD/Pact/MBT/API Fuzz までを通す一貫手順を整理

## テスト
- `pnpm vitest --run tests/unit/utils/enhanced-state-manager.test.ts`
