### PR TITLE
feat: integrate trace pipeline with verify:conformance

### DIFF
--- a/docs/examples/full-e2e-demo.md
+++ b/docs/examples/full-e2e-demo.md
@@ -90,6 +90,7 @@ make test-api-fuzz
 6. `pnpm run contracts:verify`
 7. `make test-api-fuzz`
 8. `pnpm run mbt:cegis`
+9. `pnpm pipelines:trace --input samples/trace/kvonce-sample.ndjson --skip-replay`
 
 全て完了したら、`reports/` / `artifacts/` の差分を確認し、必要に応じて Issue / PR に最新状況をコメントしてください。
 
@@ -114,6 +115,7 @@ Verify Lite を起点に Pact / API fuzz / Mutation quick を順番に実行し�
   pnpm pipelines:pact --contract=contracts/reservations-consumer.json
   pnpm pipelines:api-fuzz --spec tests/cli/fuzz.spec.ts
   pnpm pipelines:mutation:quick -- --mutate src/utils/enhanced-state-manager.ts
+  pnpm pipelines:trace --input samples/trace/kvonce-sample.ndjson
   ```
 
 各ステップのレポート:

--- a/docs/notes/full-pipeline-restore.md
+++ b/docs/notes/full-pipeline-restore.md
@@ -40,6 +40,7 @@
 - `pnpm pipelines:api-fuzz`: Schemathesis ベースの API fuzz を pnpm コマンド化し、Podman/Docker なしでもローカルで再現可能にします。
 - `pnpm pipelines:mutation:quick` / `pipelines:mutation:enhanced`: mutation quick ランを pnpm から直接呼び出し、`--mutate` オプションを `--` 以降で渡せるようにしました。
 - `pnpm pipelines:full`: verify:lite → Pact → API fuzz → mutation quick を順次呼び出す統合ドライバー。`--skip=pact` や `--mutation-target=src/utils/enhanced-state-manager.ts` で柔軟に制御できます。
+- `pnpm pipelines:trace`: KvOnce trace を projector → validator → TLC リプレイまで流し、`hermetic-reports/trace/` に成果物を集約します。
 
 ### CI 組み込みメモ (2025-10-09)
 - `scripts/pipelines/run-full-pipeline.mjs` はステップごとの開始・終了ログを出力し、Verify Lite の Step Summary に転記しやすい形式を維持します。

--- a/docs/trace/step3-readiness.md
+++ b/docs/trace/step3-readiness.md
@@ -28,6 +28,7 @@
    - Envelope の `metadata` → Tempo span attributes のマッピング表を docs に追記。
 
 ## 推奨される次手順
+- `pnpm pipelines:trace --input samples/trace/kvonce-sample.ndjson` で projector → validator → TLC の最小フローを一括実行し、`hermetic-reports/trace/` 以下にレポートを生成する。
 - Issue #1011 を編集し、本ドキュメントの Step3 作業キューをチェックリスト化する。
 - Stage3 実装タスクを小さな PR 単位（Projector, Validator, CI, Dashboard）に分割。
 - Verify Lite ワークフローに `pipelines:full` の mutation quick 結果を Step Summary として添付。

--- a/package.json
+++ b/package.json
@@ -314,7 +314,8 @@
     "pipelines:mutation:quick": "bash scripts/mutation/run-scoped.sh --quick",
     "pipelines:mutation:enhanced": "bash scripts/mutation/run-scoped.sh --quick --mutate src/utils/enhanced-state-manager.ts",
     "pipelines:pact": "node scripts/pipelines/run-pact-contracts.mjs",
-    "pipelines:full": "node scripts/pipelines/run-full-pipeline.mjs"
+    "pipelines:full": "node scripts/pipelines/run-full-pipeline.mjs",
+    "pipelines:trace": "node scripts/pipelines/run-trace-conformance.mjs"
   },
   "dependencies": {
     "@ae-framework/spec-compiler": "file:./packages/spec-compiler",

--- a/scripts/formal/verify-conformance.mjs
+++ b/scripts/formal/verify-conformance.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
-// Minimal conformance check: validate trace schema and basic invariants
+// Conformance check with optional KvOnce trace pipeline integration
 import fs from 'node:fs';
 import path from 'node:path';
+import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import yaml from 'yaml';
 import Ajv from 'ajv';
@@ -9,119 +10,388 @@ import addFormats from 'ajv-formats';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
+const DEFAULT_TRACE_DIR = path.join('hermetic-reports', 'trace');
 
-function readYaml(p){ return yaml.parse(fs.readFileSync(p, 'utf8')); }
-function readJson(p){ return JSON.parse(fs.readFileSync(p, 'utf8')); }
-function writeJson(p,obj){ fs.mkdirSync(path.dirname(p),{recursive:true}); fs.writeFileSync(p, JSON.stringify(obj,null,2)); }
+function readYaml(p) {
+  return yaml.parse(fs.readFileSync(p, 'utf8'));
+}
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+function writeJson(p, obj) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(obj, null, 2));
+}
 
 function parseArgs(argv) {
   const args = { _: [] };
-  for (let i = 2; i < argv.length; i++) {
-    const a = argv[i];
-    if (a === '--help' || a === '-h') args.help = true;
-    else if ((a === '--in' || a === '-i') && argv[i+1]) { args.in = argv[++i]; }
-    else if (a.startsWith('--in=')) { args.in = a.slice(5); }
-    else if (a === '--out' && argv[i+1]) { args.out = argv[++i]; }
-    else if (a.startsWith('--out=')) { args.out = a.slice(6); }
-    else if (a === '--schema' && argv[i+1]) { args.schema = argv[++i]; }
-    else if (a.startsWith('--schema=')) { args.schema = a.slice(9); }
-    else if (a === '--disable-invariants' && argv[i+1]) { args.disable = argv[++i]; }
-    else if (a.startsWith('--disable-invariants=')) { args.disable = a.slice(21); }
-    else if (a === '--onhand-min' && argv[i+1]) { args.onhandMin = argv[++i]; }
-    else if (a.startsWith('--onhand-min=')) { args.onhandMin = a.slice(13); }
-    else { args._.push(a); }
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    } else if ((arg === '--in' || arg === '-i') && next) {
+      args.in = next;
+      i += 1;
+    } else if (arg.startsWith('--in=')) {
+      args.in = arg.slice(5);
+    } else if ((arg === '--out') && next) {
+      args.out = next;
+      i += 1;
+    } else if (arg.startsWith('--out=')) {
+      args.out = arg.slice(6);
+    } else if ((arg === '--schema') && next) {
+      args.schema = next;
+      i += 1;
+    } else if (arg.startsWith('--schema=')) {
+      args.schema = arg.slice(9);
+    } else if ((arg === '--disable-invariants' || arg === '--disable') && next) {
+      args.disable = next;
+      i += 1;
+    } else if (arg.startsWith('--disable-invariants=')) {
+      args.disable = arg.slice(21);
+    } else if ((arg === '--onhand-min') && next) {
+      args.onhandMin = next;
+      i += 1;
+    } else if (arg.startsWith('--onhand-min=')) {
+      args.onhandMin = arg.slice(13);
+    } else if ((arg === '--trace' || arg === '--envelope') && next) {
+      args.trace = next;
+      i += 1;
+    } else if (arg.startsWith('--trace=')) {
+      args.trace = arg.slice(8);
+    } else if (arg === '--trace-format' && next) {
+      args.traceFormat = next;
+      i += 1;
+    } else if (arg.startsWith('--trace-format=')) {
+      args.traceFormat = arg.slice(15);
+    } else if (arg === '--trace-output' && next) {
+      args.traceOutput = next;
+      i += 1;
+    } else if (arg.startsWith('--trace-output=')) {
+      args.traceOutput = arg.slice(15);
+    } else if (arg === '--trace-skip-replay' || arg === '--trace-no-replay') {
+      args.traceSkipReplay = true;
+    } else {
+      args._.push(arg);
+    }
   }
   return args;
 }
 
-const args = parseArgs(process.argv);
+function printHelp() {
+  console.log(`Usage: node scripts/formal/verify-conformance.mjs [options]
 
-if (args.help) {
-  console.log(`Usage: node scripts/formal/verify-conformance.mjs [options]\n\nOptions:\n  -i, --in <file>                Input events JSON (default: samples/conformance/sample-traces.json)\n  --schema <file>                Trace schema YAML (default: observability/trace-schema.yaml)\n  --out <file>                   Output summary JSON (default: hermetic-reports/conformance/summary.json)\n  --disable-invariants <list>    Comma-separated invariants to disable (allocated_le_onhand,onhand_min)\n  --onhand-min <number>          Minimum onHand for onhand_min invariant (default: 0)\n  -h, --help                     Show this help\n`);
-  process.exit(0);
+Options:
+  -i, --in <file>                Input events JSON (default: samples/conformance/sample-traces.json)
+  --schema <file>                Trace schema YAML (default: observability/trace-schema.yaml)
+  --out <file>                   Output summary JSON (default: hermetic-reports/conformance/summary.json)
+  --disable-invariants <list>    Comma-separated invariants to disable (allocated_le_onhand,onhand_min)
+  --onhand-min <number>          Minimum onHand for onhand_min invariant (default: 0)
+  --trace <file>                 KvOnce trace (NDJSON or OTLP JSON) to project/validate
+  --trace-format <fmt>           Trace format (ndjson|otlp|auto, default auto)
+  --trace-output <dir>           Trace artifacts output directory (default: hermetic-reports/trace)
+  --trace-skip-replay            Skip TLC replay step
+  -h, --help                     Show this help
+`);
 }
 
-const schemaPath = path.resolve(repoRoot, args.schema || path.join('observability', 'trace-schema.yaml'));
-const dataPath = path.resolve(repoRoot, args.in || path.join('samples', 'conformance', 'sample-traces.json'));
-const outFile = path.resolve(repoRoot, args.out || path.join('hermetic-reports', 'conformance', 'summary.json'));
-const outDir = path.dirname(outFile);
-
-if (!fs.existsSync(schemaPath)) {
-  console.error(`Schema not found: ${schemaPath}`);
-  process.exit(0); // non-blocking
+function runProcess(command, args, options = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? repoRoot,
+      env: { ...process.env, ...options.env },
+      stdio: ['inherit', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+      if (!options.quiet) process.stdout.write(data);
+    });
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+      if (!options.quiet) process.stderr.write(data);
+    });
+    child.on('close', (code) => {
+      resolve({ code: code ?? 0, stdout, stderr });
+    });
+  });
 }
-if (!fs.existsSync(dataPath)) {
-  console.error(`Data not found: ${dataPath}`);
-  process.exit(0);
+
+async function ensureNdjson(tracePath, format, outputDir) {
+  const resolvedTrace = path.resolve(repoRoot, tracePath);
+  const resolvedOutputDir = path.resolve(repoRoot, outputDir ?? DEFAULT_TRACE_DIR);
+  fs.mkdirSync(resolvedOutputDir, { recursive: true });
+  let finalFormat = format && format !== 'auto' ? format : undefined;
+  if (!finalFormat) {
+    finalFormat = resolvedTrace.endsWith('.ndjson') ? 'ndjson' : 'otlp';
+  }
+  const ndjsonPath = path.join(resolvedOutputDir, 'kvonce-events.ndjson');
+
+  if (finalFormat === 'otlp') {
+    const convertScript = path.join(repoRoot, 'scripts', 'trace', 'convert-otlp-kvonce.mjs');
+    const result = await runProcess(process.execPath, [convertScript, '--input', resolvedTrace, '--output', ndjsonPath]);
+    if (result.code === 2) {
+      return { status: 'no_events', format: finalFormat };
+    }
+    if (result.code !== 0) {
+      throw new Error(`convert-otlp-kvonce.mjs failed (exit ${result.code})`);
+    }
+    return { status: 'ok', format: finalFormat, ndjsonPath, sourcePath: ndjsonPath };
+  }
+  if (finalFormat === 'ndjson') {
+    const resolvedNdjson = path.resolve(repoRoot, ndjsonPath);
+    if (resolvedTrace !== resolvedNdjson) {
+      fs.copyFileSync(resolvedTrace, resolvedNdjson);
+    }
+    return { status: 'ok', format: finalFormat, ndjsonPath: resolvedNdjson, sourcePath: resolvedNdjson };
+  }
+  throw new Error(`Unsupported trace format: ${finalFormat}`);
 }
 
-const schema = readYaml(schemaPath);
-const data = readJson(dataPath);
-const events = Array.isArray(data) ? data : [data];
+async function runTracePipeline({ tracePath, format, outputDir, skipReplay }) {
+  const summary = {
+    input: path.relative(repoRoot, path.resolve(repoRoot, tracePath)),
+    outputDir: path.relative(repoRoot, path.resolve(repoRoot, outputDir ?? DEFAULT_TRACE_DIR)),
+    format: format || 'auto',
+    status: 'pending',
+  };
 
-const ajv = new Ajv({ allErrors: true, strict: false });
-addFormats(ajv);
-const validate = ajv.compile({
-  $id: 'TraceEvent',
-  type: 'object',
-  properties: schema.properties || {},
-  required: schema.required || [],
-  additionalProperties: true
-});
+  if (!fs.existsSync(path.resolve(repoRoot, tracePath))) {
+    summary.status = 'missing_input';
+    return summary;
+  }
 
-let schemaErrors = [];
-let invariantViolations = [];
-const byType = { onhand_min: 0, allocated_le_onhand: 0 };
-const disable = new Set((args.disable || '').split(',').map(s=>s.trim()).filter(Boolean));
-const onhandMin = Number.isFinite(Number(args.onhandMin)) ? Number(args.onhandMin) : 0;
+  try {
+    const ensured = await ensureNdjson(tracePath, format, outputDir);
+    if (ensured.status === 'no_events') {
+      summary.status = 'no_events';
+      return summary;
+    }
+    summary.format = ensured.format;
+    summary.ndjson = path.relative(repoRoot, ensured.ndjsonPath);
 
-for (let i = 0; i < events.length; i++) {
-  const ev = events[i];
-  const ok = validate(ev);
-  if (!ok) {
-    for (const err of validate.errors || []) {
-      schemaErrors.push({ index: i, path: err.instancePath, message: err.message });
+    const targetDir = path.resolve(repoRoot, outputDir ?? DEFAULT_TRACE_DIR);
+    const projectionPath = path.join(targetDir, 'kvonce-projection.json');
+    const validationPath = path.join(targetDir, 'kvonce-validation.json');
+
+    const projectorScript = path.join(repoRoot, 'scripts', 'trace', 'projector-kvonce.mjs');
+    const projectorResult = await runProcess(process.execPath, [projectorScript, '--input', ensured.sourcePath, '--output', projectionPath]);
+    if (projectorResult.code !== 0) {
+      summary.status = 'projection_failed';
+      summary.projection = { exitCode: projectorResult.code };
+      return summary;
+    }
+    const projection = JSON.parse(fs.readFileSync(projectionPath, 'utf8'));
+    summary.projection = {
+      path: path.relative(repoRoot, projectionPath),
+      events: projection.eventCount ?? (Array.isArray(projection.events) ? projection.events.length : 0),
+      keys: Object.keys(projection.perKey ?? {}).length,
+    };
+
+    const validatorScript = path.join(repoRoot, 'scripts', 'trace', 'validate-kvonce.mjs');
+    const validatorResult = await runProcess(process.execPath, [validatorScript, '--input', projectionPath, '--output', validationPath]);
+    const validation = JSON.parse(fs.readFileSync(validationPath, 'utf8'));
+    summary.validation = {
+      path: path.relative(repoRoot, validationPath),
+      exitCode: validatorResult.code,
+      valid: Boolean(validation.valid),
+      issues: Array.isArray(validation.issues) ? validation.issues.length : 0,
+    };
+    if (validatorResult.code !== 0) {
+      summary.status = 'validation_failed';
+      return summary;
+    }
+    if (!summary.validation.valid) {
+      summary.status = 'invalid';
+    } else {
+      summary.status = 'valid';
+    }
+
+    if (!skipReplay) {
+      const tlcResult = await runProcess('pnpm', ['run', 'spec:kv-once:tlc']);
+      summary.replay = {
+        exitCode: tlcResult.code,
+        status: tlcResult.code === 0 ? 'ran' : 'failed',
+      };
+      const tlaSummaryPath = path.join(repoRoot, 'hermetic-reports', 'formal', 'tla-summary.json');
+      if (fs.existsSync(tlaSummaryPath)) {
+        const replayTarget = path.join(targetDir, 'tla-summary.json');
+        fs.copyFileSync(tlaSummaryPath, replayTarget);
+        summary.replay.summaryPath = path.relative(repoRoot, replayTarget);
+        try {
+          const tlaSummary = JSON.parse(fs.readFileSync(replayTarget, 'utf8'));
+          summary.replay.status = tlaSummary.status ?? summary.replay.status;
+          summary.replay.engine = tlaSummary.engine;
+        } catch (error) {
+          summary.replay.summaryError = error.message;
+        }
+      }
+    } else {
+      summary.replay = { status: 'skipped' };
+    }
+  } catch (error) {
+    summary.status = 'error';
+    summary.error = error.message;
+  }
+
+  return summary;
+}
+
+function appendStepSummary(summary) {
+  if (!process.env.GITHUB_STEP_SUMMARY) return;
+  const lines = [
+    '## Verify Conformance',
+    `- events: ${summary.events}`,
+    `- schema errors: ${summary.schemaErrors}`,
+    `- invariant violations: ${summary.invariantViolations}`,
+  ];
+  if (summary.trace) {
+    lines.push('- trace:');
+    lines.push(`  - status: ${summary.trace.status}`);
+    if (summary.trace.validation) {
+      lines.push(`  - validation: valid=${summary.trace.validation.valid} issues=${summary.trace.validation.issues}`);
+    }
+    if (summary.trace.replay) {
+      lines.push(`  - replay: ${summary.trace.replay.status}`);
     }
   }
-  const st = ev && ev.state;
-  if (st && typeof st === 'object') {
-    const hasOnHand = typeof st.onHand === 'number';
-    const hasAllocated = typeof st.allocated === 'number';
-    if (!disable.has('onhand_min') && hasOnHand && st.onHand < onhandMin) {
-      invariantViolations.push({ index: i, type: 'onhand_min', invariant: `onHand >= ${onhandMin}`, actual: st.onHand });
-      byType.onhand_min++;
-    }
-    if (!disable.has('allocated_le_onhand') && hasOnHand && hasAllocated && st.allocated > st.onHand) {
-      invariantViolations.push({ index: i, type: 'allocated_le_onhand', invariant: 'allocated <= onHand', actual: { allocated: st.allocated, onHand: st.onHand } });
-      byType.allocated_le_onhand++;
-    }
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    printHelp();
+    return;
   }
+
+  const schemaPath = path.resolve(repoRoot, args.schema || path.join('observability', 'trace-schema.yaml'));
+  const dataPath = path.resolve(repoRoot, args.in || path.join('samples', 'conformance', 'sample-traces.json'));
+  const outFile = path.resolve(repoRoot, args.out || path.join('hermetic-reports', 'conformance', 'summary.json'));
+
+  const haveSchema = fs.existsSync(schemaPath);
+  const haveData = fs.existsSync(dataPath);
+  if (!haveSchema) {
+    console.error(`Schema not found: ${schemaPath}`);
+  }
+  if (!haveData) {
+    console.error(`Data not found: ${dataPath}`);
+  }
+
+  const disableList = (args.disable || '').split(',').map((s) => s.trim()).filter(Boolean);
+  const disableSet = new Set(disableList);
+  const onhandMin = Number.isFinite(Number(args.onhandMin)) ? Number(args.onhandMin) : 0;
+  const missingNotes = [];
+  if (!haveSchema) missingNotes.push('schema missing');
+  if (!haveData) missingNotes.push('input data missing');
+
+  let summary;
+
+  if (haveSchema && haveData) {
+    const schema = readYaml(schemaPath);
+    const data = readJson(dataPath);
+    const events = Array.isArray(data) ? data : [data];
+
+    const ajv = new Ajv({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile({
+      $id: 'TraceEvent',
+      type: 'object',
+      properties: schema.properties || {},
+      required: schema.required || [],
+      additionalProperties: true,
+      definitions: schema.definitions || undefined,
+      $defs: schema.$defs || undefined,
+    });
+
+    const schemaErrors = [];
+    const invariantViolations = [];
+    const byType = { onhand_min: 0, allocated_le_onhand: 0 };
+
+    for (let i = 0; i < events.length; i += 1) {
+      const ev = events[i];
+      const ok = validate(ev);
+      if (!ok) {
+        for (const err of validate.errors || []) {
+          schemaErrors.push({ index: i, path: err.instancePath, message: err.message });
+        }
+      }
+      const st = ev && ev.state;
+      if (st && typeof st === 'object') {
+        const hasOnHand = typeof st.onHand === 'number';
+        const hasAllocated = typeof st.allocated === 'number';
+        if (!disableSet.has('onhand_min') && hasOnHand && st.onHand < onhandMin) {
+          invariantViolations.push({ index: i, type: 'onhand_min', invariant: `onHand >= ${onhandMin}`, actual: st.onHand });
+          byType.onhand_min += 1;
+        }
+        if (!disableSet.has('allocated_le_onhand') && hasOnHand && hasAllocated && st.allocated > st.onHand) {
+          invariantViolations.push({ index: i, type: 'allocated_le_onhand', invariant: 'allocated <= onHand', actual: { allocated: st.allocated, onHand: st.onHand } });
+          byType.allocated_le_onhand += 1;
+        }
+      }
+    }
+
+    const totalEvents = events.length || 0;
+    const invCount = invariantViolations.length;
+    const violationRate = totalEvents > 0 ? +(invCount / totalEvents).toFixed(3) : 0;
+    const details = { schemaErrors, invariantViolations, options: { disable: disableList, onhandMin } };
+    if (missingNotes.length) details.notes = missingNotes;
+    summary = {
+      input: path.relative(repoRoot, dataPath),
+      events: totalEvents,
+      schemaErrors: schemaErrors.length,
+      invariantViolations: invCount,
+      violationRate,
+      timestamp: new Date().toISOString(),
+      firstInvariantViolation: invariantViolations[0] || null,
+      firstSchemaError: schemaErrors[0] || null,
+      byType,
+      details,
+    };
+  } else {
+    const details = { schemaErrors: [], invariantViolations: [], options: { disable: disableList, onhandMin } };
+    if (missingNotes.length) details.notes = missingNotes;
+    summary = {
+      input: haveData ? path.relative(repoRoot, dataPath) : '(missing)',
+      events: 0,
+      schemaErrors: 0,
+      invariantViolations: 0,
+      violationRate: 0,
+      timestamp: new Date().toISOString(),
+      firstInvariantViolation: null,
+      firstSchemaError: null,
+      byType: { onhand_min: 0, allocated_le_onhand: 0 },
+      details,
+    };
+  }
+
+  if (args.trace) {
+    summary.trace = await runTracePipeline({
+      tracePath: args.trace,
+      format: args.traceFormat,
+      outputDir: args.traceOutput,
+      skipReplay: Boolean(args.traceSkipReplay),
+    });
+  }
+
+  writeJson(outFile, summary);
+  console.log(`Conformance summary written: ${path.relative(repoRoot, outFile)}`);
+  console.log(`- input=${summary.input} schema=${path.relative(repoRoot, schemaPath)}`);
+  console.log(`- events=${summary.events} schemaErrors=${summary.schemaErrors} invariantViolations=${summary.invariantViolations}`);
+  if (summary.trace) {
+    console.log(`- trace status=${summary.trace.status} (output=${summary.trace.outputDir})`);
+  }
+
+  appendStepSummary(summary);
 }
 
-const totalEvents = events.length || 0;
-const invCount = invariantViolations.length;
-const violationRate = totalEvents > 0 ? +(invCount / totalEvents).toFixed(3) : 0;
-const summary = {
-  input: path.relative(repoRoot, dataPath),
-  events: totalEvents,
-  schemaErrors: schemaErrors.length,
-  invariantViolations: invCount,
-  violationRate,
-  timestamp: new Date().toISOString(),
-  firstInvariantViolation: invariantViolations[0] || null,
-  firstSchemaError: schemaErrors[0] || null,
-  byType,
-  details: { schemaErrors, invariantViolations, options: { disable: Array.from(disable), onhandMin } }
-};
-
-writeJson(outFile, summary);
-console.log(`Conformance summary written: ${path.relative(repoRoot, outFile)}`);
-console.log(`- input=${path.relative(repoRoot, dataPath)} schema=${path.relative(repoRoot, schemaPath)}`);
-console.log(`- events=${summary.events} schemaErrors=${summary.schemaErrors} invariantViolations=${summary.invariantViolations}`);
-if (args.disable || args.onhandMin !== undefined) {
-  const disableList = (args.disable || '').split(',').map(s=>s.trim()).filter(Boolean).join(',') || 'none';
-  console.log(`- options: disable=[${disableList}] onhandMin=${onhandMin}`);
-}
-
-// Non-blocking (label-gated workflow); always exit 0
-process.exit(0);
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('[verify:conformance] unexpected error', error);
+    process.exit(1);
+  });

--- a/scripts/pipelines/run-trace-conformance.mjs
+++ b/scripts/pipelines/run-trace-conformance.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+
+function parseArgs(argv) {
+  const options = {
+    input: null,
+    format: 'auto',
+    outputDir: path.join('hermetic-reports', 'trace'),
+    replay: true,
+    dryRun: false,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if ((arg === '--input' || arg === '-i') && next) {
+      options.input = next;
+      i += 1;
+    } else if ((arg === '--output-dir' || arg === '-o') && next) {
+      options.outputDir = next;
+      i += 1;
+    } else if ((arg === '--format' || arg === '-f') && next) {
+      options.format = next;
+      i += 1;
+    } else if (arg === '--skip-replay') {
+      options.replay = false;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    }
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: pnpm pipelines:trace [options]\n\nOptions:\n  -i, --input <file>        Trace file (NDJSON or OTLP JSON). Default: samples/trace/kvonce-sample.ndjson\n  -o, --output-dir <dir>    Output directory for artifacts (default: hermetic-reports/trace)\n  -f, --format <fmt>        Trace format (ndjson|otlp|auto). Default: auto\n      --skip-replay         Skip TLC replay step\n      --dry-run             Print the command without executing\n      --help                Show this message\n`);
+}
+
+const opts = parseArgs(process.argv);
+if (opts.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const command = ['pnpm', 'verify:conformance'];
+const inputPath = opts.input || path.join('samples', 'trace', 'kvonce-sample.ndjson');
+command.push('--trace', inputPath);
+if (opts.format) {
+  command.push('--trace-format', opts.format);
+}
+if (opts.outputDir) {
+  command.push('--trace-output', opts.outputDir);
+}
+if (!opts.replay) {
+  command.push('--trace-skip-replay');
+}
+
+if (opts.dryRun) {
+  console.log('[trace] dry-run:', command.join(' '));
+  process.exit(0);
+}
+
+const child = spawn(command[0], command.slice(1), {
+  cwd: repoRoot,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('close', (code) => {
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## 概要
-  に KvOnce trace projector/validator/TLC リプレイの実行をオプションで統合し、スキーマが無い時でも trace だけ検証できるようにしました。
- 
> ae-framework@1.0.0 pipelines:trace /home/devuser/work/CodeX/ae-frameworkA/ae-framework
> node scripts/pipelines/run-trace-conformance.mjs


> ae-framework@1.0.0 verify:conformance /home/devuser/work/CodeX/ae-frameworkA/ae-framework
> node scripts/formal/verify-conformance.mjs "--trace" "samples/trace/kvonce-sample.ndjson" "--trace-format" "auto" "--trace-output" "hermetic-reports/trace"


> ae-framework@1.0.0 spec:kv-once:tlc /home/devuser/work/CodeX/ae-frameworkA/ae-framework
> node scripts/formal/verify-tla.mjs --engine=tlc --file specs/formal/10_abstract/KvOnce.tla --timeout 60000

TLA summary written: hermetic-reports/formal/tla-summary.json
- engine=tlc file=specs/formal/10_abstract/KvOnce.tla status=ran
Conformance summary written: hermetic-reports/conformance/summary.json
- input=(missing) schema=observability/trace-schema.yaml
- events=0 schemaErrors=0 invariantViolations=0
- trace status=valid (output=hermetic-reports/trace) ラッパーを追加し、Verify Lite 後段で envelope → projection → validation → TLC を一括実行できるようにしました。
- Step3 ドキュメント／E2E デモ手順に新パイプラインを追記し、Week3/4 のハンドブックと連携させました。

## 動作確認
- pnpm verify:conformance --in temp-conformance.json --trace samples/trace/kvonce-sample.ndjson --trace-output hermetic-reports/trace/test --trace-skip-replay --out hermetic-reports/conformance/test-summary.json
- pnpm pipelines:trace --input samples/trace/kvonce-sample.ndjson --skip-replay --output-dir hermetic-reports/trace/demo

## 関連 Issue
- closes #1096
