### PR TITLE
docs: outline dashboards and multi-domain trace plan

### DIFF
--- a/docs/notes/step-summary-layout.md
+++ b/docs/notes/step-summary-layout.md
@@ -1,0 +1,33 @@
+# Step Summary Layout (Spec / Verify Lite / Trace)
+
+Issue refs: #1097 / #1096 / #1038
+
+## 目的
+- GitHub Actions の Step Summary を統一し、Spec → Verify Lite → Trace の結果を 1 つのカードとして俯瞰できるようにする。
+- Envelope / pipelines:trace が出力するメタデータを利用し、失敗時に必要なリンク（Artifact, Tempo Explore）へすぐ遷移できるようにする。
+
+## 標準レイアウト
+```
+## Verify Conformance
+- events: <number>
+- schema errors: <number>
+- invariant violations: <number>
+- trace:
+  - status: <valid|invalid|failed>
+  - validation: valid=<bool> issues=<number>
+  - replay: <ran|failed|skipped>
+```
+
+- **Spec セクション**: `verify:conformance` が TLC 実行時に `hermetic-reports/formal/tla-summary.json` のステータスを要約する。
+- **Verify Lite セクション**: `pipelines:full` で `reports/verify-lite/verify-lite-run-summary.json` を Envelope に詰めたうえで、lint / mutation quick / property の結果を `summary.steps.*` から抜粋する。
+- **Trace セクション**: `pipelines:trace` が生成した Projection/Validation/TLC summary を `summary.trace` として配置し、問題の key があれば `notes` に列挙する。
+
+## 実装メモ
+- `scripts/formal/verify-conformance.mjs` が Step Summary 出力に対応済み。Trace 部分は Envelope から `summary.trace` を参照する。
+- `pipelines:full` は Verify Lite の Step Summary を呼び出し、mutation quick のスコアを同伴する。（PR #1093）
+- 追加のジョブが同じテンプレートを利用できるよう、共通関数を `scripts/ci/step-summary.mjs`（今後実装）に切り出す予定。
+
+## TODO
+- [ ] `scripts/ci/step-summary.mjs` を作成し、Spec/Verify Lite/Trace の Markdown 生成を関数化する。
+- [ ] Verify Lite ワークフローで Step Summary にリンクを追加（mutation report / lint baseline diff など）。
+- [ ] Multi-domain Trace が実装されたら `summary.trace.domains[]` を Step Summary に展開する。

--- a/docs/trace/grafana/images/tempo-overview.svg
+++ b/docs/trace/grafana/images/tempo-overview.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360">
+  <rect width="640" height="360" fill="#1f2933"/>
+  <text x="320" y="40" font-family="Arial" font-size="24" fill="#f5f7fa" text-anchor="middle">Tempo Dashboard Layout</text>
+  <rect x="40" y="70" width="260" height="110" fill="#243b53" stroke="#d9e2ec" stroke-width="2" rx="8"/>
+  <text x="170" y="110" font-family="Arial" font-size="16" fill="#d9e2ec" text-anchor="middle">Run Overview</text>
+  <text x="170" y="135" font-family="Arial" font-size="12" fill="#9fb3c8" text-anchor="middle">kvonce.run_id × count()</text>
+  <text x="170" y="155" font-family="Arial" font-size="12" fill="#9fb3c8" text-anchor="middle">branch / commit</text>
+
+  <rect x="340" y="70" width="260" height="110" fill="#243b53" stroke="#d9e2ec" stroke-width="2" rx="8"/>
+  <text x="470" y="110" font-family="Arial" font-size="16" fill="#d9e2ec" text-anchor="middle">Recent Errors</text>
+  <text x="470" y="135" font-family="Arial" font-size="12" fill="#9fb3c8" text-anchor="middle">status.code = ERROR</text>
+  <text x="470" y="155" font-family="Arial" font-size="12" fill="#9fb3c8" text-anchor="middle">kvonce.validation.valid = false</text>
+
+  <rect x="40" y="210" width="260" height="110" fill="#243b53" stroke="#d9e2ec" stroke-width="2" rx="8"/>
+  <text x="170" y="250" font-family="Arial" font-size="16" fill="#d9e2ec" text-anchor="middle">Trace Drilldown</text>
+  <text x="170" y="275" font-family="Arial" font-size="12" fill="#9fb3c8" text-anchor="middle">Link to Tempo Explore</text>
+
+  <rect x="340" y="210" width="260" height="110" fill="#243b53" stroke="#d9e2ec" stroke-width="2" rx="8"/>
+  <text x="470" y="250" font-family="Arial" font-size="16" fill="#d9e2ec" text-anchor="middle">Verify Lite Context</text>
+  <text x="470" y="275" font-family="Arial" font-size="12" fill="#9fb3c8" text-anchor="middle">mutation score / lint baseline</text>
+</svg>

--- a/docs/trace/grafana/tempo-dashboard-notes.md
+++ b/docs/trace/grafana/tempo-dashboard-notes.md
@@ -17,3 +17,7 @@ Visualise KvOnce envelope data alongside Tempo traces.
 ## Next Steps
 - Establish ingestion workflow (e.g., push envelope to Loki/JSON API) and create prototype dashboard.
 - Document Grafana dashboard export once available.
+
+## Snapshot
+- 参考: [tempo-dashboard.md](./tempo-dashboard.md) でレイアウト、Query、更新フローを定義。
+- ダッシュボードのラフデザインは `images/tempo-overview.svg` を参照。

--- a/docs/trace/grafana/tempo-dashboard.md
+++ b/docs/trace/grafana/tempo-dashboard.md
@@ -40,6 +40,30 @@ This document sketches a minimal Grafana dashboard that surfaces KvOnce traces s
 }
 ```
 
+![Tempo dashboard sketch](./images/tempo-overview.svg)
+
+## クエリとパネルの詳細
+| パネル | TraceQL / データソース | Envelope 連携 |
+|--------|-------------------------|----------------|
+| Run Overview | `{ kvonce_run_id != '' } \| stats count() by kvonce_branch, kvonce_run_id` | Envelope の `correlation.runId` を `kvonce.run_id` 属性にコピーすることで、ブランチ・Run ID 単位の集計が可能。 |
+| Recent errors | `{ status.code = 'STATUS_CODE_ERROR' } \| fields service.name, status_message, kvonce.validation.valid` | `summary.validation.valid` を `kvonce.validation.valid` としてコピーし、再発する不整合をフィルタ。 |
+| Trace Drilldown | `trace_id = $traceId` (テンプレート変数) | Envelope の `correlation.traceIds[]` を変数に注入し、Explore へのリンクを生成。 |
+| Verify Lite Context | JSON datasource (`artifacts/verify-lite/verify-lite-run-summary.json`) | Mutation score や lint backlog を Envelope summary から抽出してテーブル表示。 |
+
+テンプレート変数例:
+```yaml
+- name: kvonceRunId
+  label: Run ID
+  datasource: tempo
+  query: "{ kvonce_run_id != '' } | stats latest(kvonce_run_id) by kvonce_run_id"
+```
+
+## データ更新フロー
+1. `pipelines:trace` 実行時に `hermetic-reports/trace/kvonce-projection.json` と Envelope (`artifacts/verify-lite/report-envelope.json`) を生成する。
+2. Collector (S3/MinIO) にアップロードした Envelope を Grafana JSON datasource で参照できるようにする。
+3. Tempo 側では `kvonce.*` 属性を TraceQL で検索し、Grafana ダッシュボードの変数として expose する。
+4. CI 完了後に `scripts/trace/export-dashboard.mjs`（次期タスク）でダッシュボード JSON をエクスポートし、`docs/trace/grafana/tempo-dashboard.json` としてバージョン管理する。
+
 > ℹ️ **TraceQL フィールド名の補足**: Tempo では OTLP の span status が `status.code` にマッピングされ、値は `STATUS_CODE_OK` / `STATUS_CODE_ERROR` などの列挙になります。環境により表記が異なる場合は Grafana の Explore 画面で実際の span を Inspect し、必要に応じて `status_code` などに読み替えてください。
 
 ### Span 属性の確認手順

--- a/docs/trace/multi-domain-roadmap.md
+++ b/docs/trace/multi-domain-roadmap.md
@@ -1,0 +1,42 @@
+# Multi-domain Trace & Refinement Roadmap
+
+Issue refs: #1011 / #997 / #1003
+
+## 目的
+- KvOnce で整備した Trace Projector/Validator を、Inventory / Reservation など他ドメインにも転用する。
+- Refinement Mapping を増やし、verify:conformance → Tempo ダッシュボードまで一貫した可視化を提供する。
+- CI の重いジョブ（mutation / pact / trace）をラベル opt-in で段階導入できるよう、順序立てて整備する。
+
+## 対象ドメイン候補
+| ドメイン | 該当 Issue | Trace 重点ポイント | Refinement Mapping TODO |
+|----------|------------|---------------------|-------------------------|
+| Inventory (在庫) | #1002 | 在庫不足・オーバーアロケーションの検知。`inventory.trace_schema.yaml` を策定。 | KvOnce 同様に `inventory.impl.json` を追加し、TTL / allocate API をマップする。 |
+| Reservation (予約) | #1003 | 予約成功/失敗のリトライ、otel span を介したユーザー行動の追跡。 | 既存 BDD シナリオを Trace schema に対応付け、再試行回数を Envelope summary に記録。 |
+| EvidenceValidator | #999 | verify-lite で検証された証跡を Trace に反映し、失敗時の差分を可視化。 | `evidence.trace_schema.yaml` を定義し、Spec で確認した証跡と Trace を照合。 |
+
+## 実行ステップ
+1. **Trace Schema 定義**
+   - `docs/trace/schema/<domain>-trace-schema.md` を作成し、KvOnce で使った表形式テンプレートを流用する。
+   - `observability/trace-schema.yaml` は共通フィールドを定義し、ドメイン固有フィールドは `definitions` で拡張する。
+2. **Projector/Validator 実装**
+   - `scripts/trace/projector-<domain>.mjs` / `validate-<domain>.mjs` を新設し、KvOnce のユニットテスト (`tests/unit/trace/*`) を写経。 
+   - テストデータは `samples/trace/<domain>-sample.ndjson` に追加する。
+3. **Envelope 拡張**
+   - 各ドメインの Projection/Validation Summary を `pipelines:trace` に登録し、`summary.trace.domains[]` の配列として集約する。
+   - Step Summary では `Trace:` の配下にドメイン名を添えて結果を表示する。
+4. **Dashboard 連動**
+   - Grafana では `kvonce.*` に倣い `inventory.*`, `reservation.*` といった属性を付与する。
+   - Tempo Dashboard の JSON を `docs/trace/grafana/<domain>-dashboard.json` にバージョン管理する。
+
+## CI 連携イテレーション
+| フェーズ | 追加ジョブ | 条件 | 出力 |
+|---------|------------|------|------|
+| Phase 1 | `pipelines:trace --skip-replay` (KvOnce) | `run-trace` ラベル | Projection / Validation / Envelope を artifacts 化。 |
+| Phase 2 | `pipelines:trace --input samples/trace/inventory-sample.ndjson` | `run-trace-inventory` ラベル | Inventory Schema と Refinement Mapping を検証。 |
+| Phase 3 | `pipelines:trace` (Reservation) + `verify:conformance`` | nightly | Tempo ダッシュボードに各ドメインの成功率・リトライ回数を集約。
+
+## 次のアクション
+- [ ] Inventory ドメインの Trace schema とサンプル NDJSON を追加する。
+- [ ] Projector/Validator のユニットテスト雛形を `tests/unit/trace/inventory/*.test.ts` に作成する。
+- [ ] `pipelines:trace` をドメイン引数対応に拡張し、`--domain inventory` のように切り替えられるようにする。
+- [ ] Tempo ダッシュボード JSON をエクスポートし、`docs/trace/grafana/tempo-dashboard.json` として保存する。


### PR DESCRIPTION
## 概要
- Envelope ↔ OTLP 属性マッピングを整理し、Step Summary の標準レイアウト指針をドキュメント化しました。
- Tempo ダッシュボードの構成例と SVG ラフ図を追加し、Grafana 上でのクエリ/更新フローをまとめました。
- Multi-domain Trace / Refinement のロードマップを作成し、Inventory/Reservation への展開手順を記述しました。
- Step Summary の共通レイアウトと TODO を `docs/notes/step-summary-layout.md` に集約しました。

## 関連 Issue
- closes #1097
