### PR TITLE
feat(ci): share step summary utilities

### DIFF
--- a/scripts/ci/step-summary.mjs
+++ b/scripts/ci/step-summary.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function ensureSummaryPath() {
+  const target = process.env.GITHUB_STEP_SUMMARY;
+  if (!target) return null;
+  const dir = path.dirname(target);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  return target;
+}
+
+export function appendSection(title, lines = []) {
+  const summaryPath = ensureSummaryPath();
+  if (!summaryPath) return;
+  const content = [`## ${title}`, ...lines].join('\n') + '\n';
+  fs.appendFileSync(summaryPath, content);
+}
+
+export function formatKeyValue(entries) {
+  return entries.map(([key, value]) => `- ${key}: ${value}`);
+}
+
+export function bulletList(items) {
+  return items.map((item) => `- ${item}`);
+}

--- a/scripts/formal/verify-conformance.mjs
+++ b/scripts/formal/verify-conformance.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import yaml from 'yaml';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
+import { appendSection } from '../ci/step-summary.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
@@ -243,9 +244,7 @@ async function runTracePipeline({ tracePath, format, outputDir, skipReplay }) {
 }
 
 function appendStepSummary(summary) {
-  if (!process.env.GITHUB_STEP_SUMMARY) return;
   const lines = [
-    '## Verify Conformance',
     `- events: ${summary.events}`,
     `- schema errors: ${summary.schemaErrors}`,
     `- invariant violations: ${summary.invariantViolations}`,
@@ -260,7 +259,7 @@ function appendStepSummary(summary) {
       lines.push(`  - replay: ${summary.trace.replay.status}`);
     }
   }
-  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+  appendSection('Verify Conformance', lines);
 }
 
 async function main() {


### PR DESCRIPTION
## 概要
- Step Summary 共有ユーティリティ  を追加し、GitHub Actions の書き込みを共通化しました。
-  からヘッダー生成・書き込み処理を切り出し、Step Summary レイアウトに沿った出力を行うようにしました。

## 動作確認
- pnpm pipelines:trace --dry-run
- echo [] > temp-conformance.json && pnpm verify:conformance --in temp-conformance.json --trace samples/trace/kvonce-sample.ndjson --trace-output hermetic-reports/trace/test --trace-skip-replay --out hermetic-reports/conformance/test-summary.json
