### PR TITLE
feat(trace): capture projected state sequence

### DIFF
--- a/docs/trace/kvonce-trace-schema.md
+++ b/docs/trace/kvonce-trace-schema.md
@@ -27,6 +27,8 @@
 ## Projector / Validator
 - `scripts/trace/projector-kvonce.mjs`
   - NDJSON を読み込み、キー単位の成功回数・再試行回数・失敗理由一覧、直近の `value` を集計します。
+  - `stats` にイベント種別の件数・ユニークキー数・成功率などを格納し、Envelope から簡易チェックが可能です。
+  - `--state-output hermetic-reports/trace/projected/kvonce-state-sequence.json` を指定すると、イベントごとの射影状態（`store[key]` の `written` / `value` / `retries` など）を別ファイルとして書き出します。
   - `retryContexts` / `successContexts` / `failureContexts` として、元イベントの `context` を配列で保持します。
 - `scripts/trace/validate-kvonce.mjs`
   - KvOnce の安全性（1回書き込み・再試行上限）を確認し、`kvonce-validation.json` に集計結果を出力します。

--- a/docs/trace/step3-readiness.md
+++ b/docs/trace/step3-readiness.md
@@ -16,7 +16,7 @@
 1. Projector v1
    - NDJSON → spec state 射影。
    - スキーマ: `docs/trace/kvonce-trace-schema.md`
-   - 出力: `hermetic-reports/trace/projected/*.json`
+   - 出力: `hermetic-reports/trace/kvonce-projection.json` / `hermetic-reports/trace/projected/kvonce-state-sequence.json`
 2. Validator v1
    - Projector 出力を TLC/Apalache に投入し、不変条件と遷移差分を比較。
    - CLI: `pnpm verify:conformance --from-envelope`

--- a/scripts/formal/verify-conformance.mjs
+++ b/scripts/formal/verify-conformance.mjs
@@ -192,6 +192,22 @@ async function runTracePipeline({ tracePath, format, outputDir, skipReplay }) {
       events: projection.eventCount ?? (Array.isArray(projection.events) ? projection.events.length : 0),
       keys: Object.keys(projection.perKey ?? {}).length,
     };
+    if (projection.stats) {
+      summary.projection.stats = projection.stats;
+      if (typeof projection.stats.stateSequenceLength === 'number') {
+        summary.projection.stateSequenceLength = projection.stats.stateSequenceLength;
+      }
+    }
+    const stateOutput = projection.outputs?.stateSequence;
+    if (stateOutput) {
+      summary.projection.stateSequence = stateOutput;
+    } else if (Array.isArray(projection.stateSequence)) {
+      const projectedDir = path.join(targetDir, 'projected');
+      fs.mkdirSync(projectedDir, { recursive: true });
+      const sequencePath = path.join(projectedDir, 'kvonce-state-sequence.json');
+      fs.writeFileSync(sequencePath, JSON.stringify(projection.stateSequence, null, 2));
+      summary.projection.stateSequence = path.relative(repoRoot, sequencePath);
+    }
 
     const validatorScript = path.join(repoRoot, 'scripts', 'trace', 'validate-kvonce.mjs');
     const validatorResult = await runProcess(process.execPath, [validatorScript, '--input', projectionPath, '--output', validationPath]);

--- a/scripts/trace/build-kvonce-envelope-summary.mjs
+++ b/scripts/trace/build-kvonce-envelope-summary.mjs
@@ -40,12 +40,15 @@ for (const item of cases) {
     key: issue.key ?? 'unknown',
     message: issue.message ?? ''
   }));
+  const projectionStats = projection?.stats ?? undefined;
+  const stateSequencePath = projection?.outputs?.stateSequence ?? undefined;
   casesSummary.push({
     format: item.key,
     valid: Boolean(validation.valid),
     issueCount: issues.length,
     issues: trimmedIssues,
-    projectionStats: projection?.stats ?? undefined
+    projectionStats,
+    ...(stateSequencePath ? { stateSequencePath } : {})
   });
 }
 

--- a/scripts/trace/projector-kvonce.mjs
+++ b/scripts/trace/projector-kvonce.mjs
@@ -4,17 +4,19 @@ import path from 'node:path';
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const result = { input: null, output: null };
+  const result = { input: null, output: null, stateOutput: null };
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if ((arg === '--input' || arg === '-i') && args[i + 1]) {
       result.input = args[++i];
     } else if ((arg === '--output' || arg === '-o') && args[i + 1]) {
       result.output = args[++i];
+    } else if ((arg === '--state-output' || arg === '--states') && args[i + 1]) {
+      result.stateOutput = args[++i];
     }
   }
   if (!result.input) {
-    console.error('Usage: projector-kvonce --input <ndjson> [--output <json>]');
+    console.error('Usage: projector-kvonce --input <ndjson> [--output <json>] [--state-output <json>]');
     process.exit(1);
   }
   return result;
@@ -35,53 +37,182 @@ function readNdjson(file) {
     });
 }
 
+function initialEntry() {
+  return {
+    successCount: 0,
+    retries: 0,
+    failureReasons: [],
+    retryContexts: [],
+    successContexts: [],
+    failureContexts: [],
+    value: null,
+    firstTimestamp: null,
+    lastTimestamp: null,
+    lastType: null,
+    lastFailureReason: null,
+  };
+}
+
+function initialKeyState() {
+  return {
+    written: false,
+    value: null,
+    retries: 0,
+    failures: 0,
+    lastFailureReason: null,
+    lastSuccessAt: null,
+  };
+}
+
+function cloneStateMap(map) {
+  return Object.fromEntries(
+    Array.from(map.entries()).map(([key, value]) => [key, { ...value }]),
+  );
+}
+
 function buildProjection(events) {
   const perKey = new Map();
-  for (const event of events) {
+  const stateByKey = new Map();
+  const stateSequence = [];
+  const notes = [];
+
+  let successCount = 0;
+  let retryCount = 0;
+  let failureCount = 0;
+  let unknownTypeCount = 0;
+
+  const duplicateKeys = new Set();
+  const failureKeys = new Set();
+
+  events.forEach((event, index) => {
     const key = event.key ?? 'unknown';
+    const type = event.type ?? 'unknown';
     if (!perKey.has(key)) {
-      perKey.set(key, {
-        successCount: 0,
-        retries: 0,
-        failureReasons: [],
-        retryContexts: [],
-        successContexts: [],
-        failureContexts: [],
-      });
+      perKey.set(key, initialEntry());
     }
     const entry = perKey.get(key);
-    if (event.type === 'success') {
-      entry.successCount += 1;
-      entry.value = event.value ?? null;
-      if (event.context !== undefined) {
-        entry.successContexts.push(event.context);
-      }
+    if (!stateByKey.has(key)) {
+      stateByKey.set(key, initialKeyState());
     }
-    if (event.type === 'retry') {
-      entry.retries += 1;
-      if (event.context !== undefined) {
-        entry.retryContexts.push(event.context);
-      }
-    }
-    if (event.type === 'failure') {
-      entry.failureReasons.push(event.reason ?? 'unknown');
-      if (event.context !== undefined) {
-        entry.failureContexts.push(event.context);
-      }
-    }
-  }
+    const keyState = stateByKey.get(key);
 
-  return {
+    entry.firstTimestamp ??= event.timestamp ?? null;
+    if (event.timestamp) {
+      entry.lastTimestamp = event.timestamp;
+    }
+    entry.lastType = type;
+
+    switch (type) {
+      case 'success':
+        entry.successCount += 1;
+        successCount += 1;
+        entry.value = event.value ?? entry.value ?? null;
+        if (event.context !== undefined) {
+          entry.successContexts.push(event.context);
+        }
+        keyState.written = true;
+        if (event.value !== undefined) {
+          keyState.value = event.value;
+        }
+        keyState.lastSuccessAt = event.timestamp ?? keyState.lastSuccessAt;
+        break;
+      case 'retry':
+        entry.retries += 1;
+        retryCount += 1;
+        if (event.context !== undefined) {
+          entry.retryContexts.push(event.context);
+        }
+        keyState.retries += 1;
+        break;
+      case 'failure':
+        failureCount += 1;
+        failureKeys.add(key);
+        entry.failureReasons.push(event.reason ?? 'unknown');
+        if ((event.reason ?? '').toLowerCase() === 'duplicate') {
+          duplicateKeys.add(key);
+        }
+        if (event.context !== undefined) {
+          entry.failureContexts.push(event.context);
+        }
+        entry.lastFailureReason = event.reason ?? entry.lastFailureReason;
+        keyState.failures += 1;
+        keyState.lastFailureReason = event.reason ?? keyState.lastFailureReason;
+        break;
+      default:
+        unknownTypeCount += 1;
+        notes.push({ index, issue: 'unknown_event_type', type, key });
+        break;
+    }
+
+    keyState.value ??= null;
+
+    const storeSnapshot = cloneStateMap(stateByKey);
+    const totals = {
+      success: successCount,
+      retry: retryCount,
+      failure: failureCount,
+    };
+
+    stateSequence.push({
+      index,
+      timestamp: event.timestamp ?? null,
+      type,
+      key,
+      event,
+      store: storeSnapshot,
+      totals,
+    });
+  });
+
+  const stats = {
+    totalEvents: events.length,
+    uniqueKeys: perKey.size,
+    byType: {
+      success: successCount,
+      retry: retryCount,
+      failure: failureCount,
+      unknown: unknownTypeCount,
+    },
+    keysWithSuccess: Array.from(perKey.entries()).filter(([, value]) => (value.successCount ?? 0) > 0).length,
+    keysWithRetries: Array.from(perKey.entries()).filter(([, value]) => (value.retries ?? 0) > 0).length,
+    keysWithFailures: failureKeys.size,
+    duplicateFailureKeys: duplicateKeys.size,
+  };
+  stats.successRate = stats.totalEvents > 0 ? +(stats.byType.success / stats.totalEvents).toFixed(3) : 0;
+
+  const projection = {
+    schemaVersion: 'kvonce/v1',
     generatedAt: new Date().toISOString(),
     eventCount: events.length,
     events,
     perKey: Object.fromEntries(perKey.entries()),
+    stats,
   };
+
+  if (notes.length > 0) {
+    projection.notes = notes;
+  }
+
+  return { projection, stateSequence };
 }
 
-const { input, output } = parseArgs();
+const { input, output, stateOutput } = parseArgs();
 const events = readNdjson(input);
-const projection = buildProjection(events);
+const { projection, stateSequence } = buildProjection(events);
+
+const resolvedStateOutput = stateOutput ? path.resolve(stateOutput) : null;
+if (resolvedStateOutput) {
+  fs.mkdirSync(path.dirname(resolvedStateOutput), { recursive: true });
+  fs.writeFileSync(resolvedStateOutput, JSON.stringify(stateSequence, null, 2));
+  projection.outputs = {
+    ...(projection.outputs ?? {}),
+    stateSequence: path.relative(process.cwd(), resolvedStateOutput),
+  };
+  projection.stats.stateSequenceLength = stateSequence.length;
+} else {
+  projection.stateSequence = stateSequence;
+  projection.stats.stateSequenceLength = stateSequence.length;
+}
 
 const json = JSON.stringify(projection, null, 2);
 if (output) {

--- a/scripts/trace/run-kvonce-conformance.sh
+++ b/scripts/trace/run-kvonce-conformance.sh
@@ -80,6 +80,8 @@ mkdir -p "${OUTPUT_DIR}"
 NDJSON_PATH="${OUTPUT_DIR}/kvonce-events.ndjson"
 PROJECTION_PATH="${OUTPUT_DIR}/kvonce-projection.json"
 VALIDATION_PATH="${OUTPUT_DIR}/kvonce-validation.json"
+PROJECTED_DIR="${OUTPUT_DIR}/projected"
+STATE_SEQUENCE_PATH="${PROJECTED_DIR}/kvonce-state-sequence.json"
 
 echo "[kvonce-conformance] input=${INPUT} format=${FORMAT} output_dir=${OUTPUT_DIR}"
 
@@ -121,7 +123,8 @@ else
   exit 1
 fi
 
-node "${SCRIPT_DIR}/projector-kvonce.mjs" --input "${SOURCE_NDJSON}" --output "${PROJECTION_PATH}"
+mkdir -p "${PROJECTED_DIR}"
+node "${SCRIPT_DIR}/projector-kvonce.mjs" --input "${SOURCE_NDJSON}" --output "${PROJECTION_PATH}" --state-output "${STATE_SEQUENCE_PATH}"
 node "${SCRIPT_DIR}/validate-kvonce.mjs" --input "${PROJECTION_PATH}" --output "${VALIDATION_PATH}"
 
 if command -v jq >/dev/null 2>&1; then

--- a/tests/unit/trace/kvonce-conformance.integration.test.ts
+++ b/tests/unit/trace/kvonce-conformance.integration.test.ts
@@ -26,11 +26,18 @@ describe('run-kvonce-conformance.sh', () => {
       await execFileAsync('bash', [scriptPath, '--input', 'samples/trace/kvonce-sample.ndjson', '--format', 'ndjson', '--output-dir', outputDir]);
 
       const projection = JSON.parse(await readFile(join(outputDir, 'kvonce-projection.json'), 'utf8'));
+      const stateSequencePath = projection.outputs?.stateSequence
+        ? resolve(process.cwd(), projection.outputs.stateSequence)
+        : join(outputDir, 'projected/kvonce-state-sequence.json');
+      const stateSequence = JSON.parse(await readFile(stateSequencePath, 'utf8'));
       const validation = JSON.parse(await readFile(join(outputDir, 'kvonce-validation.json'), 'utf8'));
 
       expect(validation.valid).toBe(true);
       expect(projection.eventCount).toBeGreaterThan(0);
       expect(Object.keys(projection.perKey)).toContain('alpha');
+      expect(projection.stats).toBeDefined();
+      expect(Array.isArray(stateSequence)).toBe(true);
+      expect(stateSequence.length).toBe(projection.stats?.stateSequenceLength ?? projection.eventCount);
     });
   });
 


### PR DESCRIPTION
## Summary
- extend KvOnce projector to emit stats and per-step state sequence output
- record the projected artifact path in the conformance pipeline and envelope summary
- document the new projector options and guard with the updated integration test

## Testing
- pnpm vitest run tests/unit/trace/kvonce-conformance.integration.test.ts
