### PR TITLE
feat(formal): allow verify-conformance to read envelopes

### DIFF
--- a/docs/trace/REPORT_ENVELOPE.md
+++ b/docs/trace/REPORT_ENVELOPE.md
@@ -132,6 +132,7 @@ Issue: #1011 / #1012 / #1036 / #1038
 1. CI では `scripts/trace/create-report-envelope.mjs` を利用し、Verify Lite などのサマリを Envelope 化して `artifacts/report-envelope.json` に保存する。
    - スキーマは `schema/report-envelope.schema.json` で管理し、`scripts/ci/validate-report-envelope.mjs` で検証する。
    - 追加の成果物を添付する場合は `REPORT_ENVELOPE_PAYLOAD_METADATA`（単一ファイル）や `REPORT_ENVELOPE_EXTRA_ARTIFACTS`（カンマ区切りのパス列）を指定すると自動的に `artifacts` 配列へ追記される。
+   - Envelope が揃っている場合は `pnpm verify:conformance --from-envelope artifacts/report-envelope.json` でトレースサマリを再掲でき、CI なしの環境でも Step Summary を再利用できる。
 2. Envelope の生成時に `GITHUB_RUN_ID` / `GITHUB_WORKFLOW` / `GITHUB_SHA` / `GITHUB_REF` を自動埋め込み、他の CI でも環境変数から補完できるようにする。
 3. Trace 系ジョブでは、Collector から取得した payload のメタデータ (`kvonce-payload-metadata.json`) を artifacts 配列に追加し、`scripts/trace/build-kvonce-envelope-summary.mjs` で集計したサマリを `scripts/trace/create-report-envelope.mjs` でラップする。
 4. Dashboard / Tempo 連携は Envelope を単位としてインジェストし、必要に応じて `traceIds` から関連 span を引き直す。

--- a/tests/unit/formal/verify-conformance.integration.test.ts
+++ b/tests/unit/formal/verify-conformance.integration.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+
+const execFileAsync = promisify(execFile);
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
+  const dir = await mkdtemp(join(tmpdir(), 'verify-conformance-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('verify-conformance --from-envelope', () => {
+  it('replays summary data from an existing envelope', async () => {
+    await withTempDir(async (dir) => {
+      const nodePath = process.execPath;
+      const scriptPath = resolve('scripts/formal/verify-conformance.mjs');
+      const schemaPath = resolve('observability/trace-schema.yaml');
+      const eventsPath = join(dir, 'events.json');
+      const summaryPath = join(dir, 'summary.json');
+      const traceOutputDir = join(dir, 'trace');
+
+      const events = [
+        {
+          traceId: 'trace-1',
+          timestamp: '2025-10-08T10:40:00.000Z',
+          actor: 'checkout-service',
+          event: 'OrderPlaced',
+          state: { onHand: 10, allocated: 2 },
+        },
+      ];
+      await writeFile(eventsPath, JSON.stringify(events), 'utf8');
+
+      await execFileAsync(nodePath, [
+        scriptPath,
+        '--in',
+        eventsPath,
+        '--schema',
+        schemaPath,
+        '--out',
+        summaryPath,
+        '--trace',
+        'samples/trace/kvonce-sample.ndjson',
+        '--trace-format',
+        'ndjson',
+        '--trace-output',
+        traceOutputDir,
+        '--trace-skip-replay',
+      ]);
+
+      const summary = JSON.parse(await readFile(summaryPath, 'utf8'));
+      expect(summary.events).toBe(1);
+      expect(summary.trace?.status).toBeDefined();
+
+      const envelopePath = join(dir, 'envelope.json');
+      const envelope = {
+        schemaVersion: '1.0.0',
+        source: 'unit-test',
+        generatedAt: new Date().toISOString(),
+        summary,
+        artifacts: [],
+      };
+      await writeFile(envelopePath, JSON.stringify(envelope, null, 2), 'utf8');
+
+      const replaySummaryPath = join(dir, 'summary-from-envelope.json');
+      await execFileAsync(nodePath, [
+        scriptPath,
+        '--from-envelope',
+        envelopePath,
+        '--out',
+        replaySummaryPath,
+      ]);
+
+      const replaySummary = JSON.parse(await readFile(replaySummaryPath, 'utf8'));
+      expect(replaySummary.events).toBe(summary.events);
+      expect(replaySummary.schemaErrors).toBe(summary.schemaErrors);
+      expect(replaySummary.envelopePath).toBeDefined();
+      expect(replaySummary.trace?.status).toBe(summary.trace?.status);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a --from-envelope option to reuse trace summaries without re-running the pipeline
- hydrate Verify Conformance step summaries and logs from stored envelope data
- cover the new workflow with a vitest integration test and document the CLI usage

## Testing
- pnpm vitest run tests/unit/trace/kvonce-conformance.integration.test.ts tests/unit/formal/verify-conformance.integration.test.ts
