### PR TITLE
feat(trace): emit envelopes from pipelines trace

### DIFF
--- a/docs/examples/full-e2e-demo.md
+++ b/docs/examples/full-e2e-demo.md
@@ -117,6 +117,7 @@ Verify Lite を起点に Pact / API fuzz / Mutation quick を順番に実行し�
   pnpm pipelines:mutation:quick -- --mutate src/utils/enhanced-state-manager.ts
   pnpm pipelines:trace --input samples/trace/kvonce-sample.ndjson
   ```
+  - 実行後は `artifacts/trace/report-envelope.json` にトレース用 Envelope が生成され、`pnpm verify:conformance --from-envelope artifacts/trace/report-envelope.json` で結果を再利用できる。
 
 各ステップのレポート:
 - Verify Lite: `reports/verify-lite/`

--- a/docs/trace/step3-readiness.md
+++ b/docs/trace/step3-readiness.md
@@ -29,6 +29,7 @@
 
 ## 推奨される次手順
 - `pnpm pipelines:trace --input samples/trace/kvonce-sample.ndjson` で projector → validator → TLC の最小フローを一括実行し、`hermetic-reports/trace/` 以下にレポートを生成する。
+- パイプライン実行後は `artifacts/trace/report-envelope.json` に Envelope が自動生成されるため、`pnpm verify:conformance --from-envelope` でサマリを再掲できる。
 - Issue #1011 を編集し、本ドキュメントの Step3 作業キューをチェックリスト化する。
 - Stage3 実装タスクを小さな PR 単位（Projector, Validator, CI, Dashboard）に分割。
 - Verify Lite ワークフローに `pipelines:full` の mutation quick 結果を Step Summary として添付。

--- a/scripts/pipelines/run-trace-conformance.mjs
+++ b/scripts/pipelines/run-trace-conformance.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
 import path from 'node:path';
 
 const repoRoot = process.cwd();
@@ -9,6 +10,9 @@ function parseArgs(argv) {
     input: null,
     format: 'auto',
     outputDir: path.join('hermetic-reports', 'trace'),
+    summaryOut: null,
+    envelope: true,
+    envelopeOut: path.join('artifacts', 'trace', 'report-envelope.json'),
     replay: true,
     dryRun: false,
   };
@@ -26,6 +30,14 @@ function parseArgs(argv) {
       i += 1;
     } else if (arg === '--skip-replay') {
       options.replay = false;
+    } else if ((arg === '--summary-out' || arg === '--summary') && next) {
+      options.summaryOut = next;
+      i += 1;
+    } else if (arg === '--envelope-out' && next) {
+      options.envelopeOut = next;
+      i += 1;
+    } else if (arg === '--no-envelope') {
+      options.envelope = false;
     } else if (arg === '--dry-run') {
       options.dryRun = true;
     } else if (arg === '--help' || arg === '-h') {
@@ -43,6 +55,9 @@ function printHelp() {
     '  -i, --input <file>        Trace file (NDJSON or OTLP JSON). Default: samples/trace/kvonce-sample.ndjson',
     '  -o, --output-dir <dir>    Output directory for artifacts (default: hermetic-reports/trace)',
     '  -f, --format <fmt>        Trace format (ndjson|otlp|auto). Default: auto',
+    '      --summary-out <file>  Conformance summary JSON path (default: <output-dir>/kvonce-conformance-summary.json)',
+    '      --envelope-out <file> Report envelope output path (default: artifacts/trace/report-envelope.json)',
+    '      --no-envelope         Skip creating a report envelope',
     '      --skip-replay         Skip TLC replay step',
     '      --dry-run             Print the command without executing',
     '      --help                Show this message',
@@ -56,21 +71,30 @@ if (opts.help) {
   process.exit(0);
 }
 
+const traceOutputDir = path.resolve(repoRoot, opts.outputDir);
+const summaryOutPath = path.resolve(repoRoot, opts.summaryOut ?? path.join(opts.outputDir, 'kvonce-conformance-summary.json'));
+const summaryOutArg = path.relative(repoRoot, summaryOutPath);
+const traceOutputArg = path.relative(repoRoot, traceOutputDir);
+const envelopeOutPath = path.resolve(repoRoot, opts.envelopeOut);
+
 const command = ['pnpm', 'verify:conformance'];
 const inputPath = opts.input || path.join('samples', 'trace', 'kvonce-sample.ndjson');
 command.push('--trace', inputPath);
 if (opts.format) {
   command.push('--trace-format', opts.format);
 }
-if (opts.outputDir) {
-  command.push('--trace-output', opts.outputDir);
-}
+command.push('--trace-output', traceOutputArg);
+command.push('--out', summaryOutArg);
 if (!opts.replay) {
   command.push('--trace-skip-replay');
 }
 
 if (opts.dryRun) {
   console.log('[trace] dry-run:', command.join(' '));
+  console.log(`[trace] summary -> ${summaryOutArg}`);
+  if (opts.envelope) {
+    console.log(`[trace] envelope -> ${path.relative(repoRoot, envelopeOutPath)}`);
+  }
   process.exit(0);
 }
 
@@ -81,5 +105,53 @@ const child = spawn(command[0], command.slice(1), {
 });
 
 child.on('close', (code) => {
-  process.exit(code ?? 1);
+  const exitCode = code ?? 1;
+  if (opts.envelope) {
+    try {
+      if (!fs.existsSync(summaryOutPath)) {
+        console.warn(`[pipelines:trace] summary not found at ${summaryOutArg}; skipping envelope creation`);
+      } else {
+        const summary = JSON.parse(fs.readFileSync(summaryOutPath, 'utf8'));
+        const artifacts = new Set();
+        const pushArtifact = (maybePath) => {
+          if (!maybePath || typeof maybePath !== 'string') return;
+          const resolved = path.resolve(repoRoot, maybePath);
+          if (fs.existsSync(resolved)) {
+            artifacts.add(path.relative(repoRoot, resolved));
+          }
+        };
+
+        if (summary.trace) {
+          pushArtifact(summary.trace.ndjson);
+          pushArtifact(summary.trace.projection?.path);
+          pushArtifact(summary.trace.projection?.stateSequence);
+          pushArtifact(summary.trace.validation?.path);
+          pushArtifact(summary.trace.replay?.summaryPath);
+        }
+
+        const env = {
+          ...process.env,
+          REPORT_ENVELOPE_SUMMARY: summaryOutPath,
+          REPORT_ENVELOPE_OUTPUT: envelopeOutPath,
+          REPORT_ENVELOPE_SOURCE: 'pipelines:trace',
+        };
+        if (artifacts.size > 0) {
+          env.REPORT_ENVELOPE_EXTRA_ARTIFACTS = Array.from(artifacts).join(',');
+        }
+
+        const envelopeResult = spawnSync(process.execPath, [path.join('scripts', 'trace', 'create-report-envelope.mjs')], {
+          cwd: repoRoot,
+          env,
+          stdio: 'inherit',
+        });
+        if (envelopeResult.status !== 0) {
+          console.error('[pipelines:trace] failed to create report envelope');
+        }
+      }
+    } catch (error) {
+      console.error('[pipelines:trace] envelope creation failed:', error);
+    }
+  }
+
+  process.exit(exitCode);
 });

--- a/tests/unit/pipelines/run-trace-conformance.integration.test.ts
+++ b/tests/unit/pipelines/run-trace-conformance.integration.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, readFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+
+const execFileAsync = promisify(execFile);
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
+  const dir = await mkdtemp(join(tmpdir(), 'pipelines-trace-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('pipelines:trace', () => {
+  it('generates a summary and report envelope', async () => {
+    await withTempDir(async (dir) => {
+      const nodePath = process.execPath;
+      const scriptPath = resolve('scripts/pipelines/run-trace-conformance.mjs');
+      const traceOutputDir = join(dir, 'trace-output');
+      const summaryPath = join(dir, 'conformance-summary.json');
+      const envelopePath = join(dir, 'trace-envelope.json');
+
+      await mkdir(traceOutputDir, { recursive: true });
+
+      await execFileAsync(nodePath, [
+        scriptPath,
+        '--input',
+        'samples/trace/kvonce-sample.ndjson',
+        '--format',
+        'ndjson',
+        '--output-dir',
+        traceOutputDir,
+        '--summary-out',
+        summaryPath,
+        '--envelope-out',
+        envelopePath,
+        '--skip-replay',
+      ]);
+
+      const summary = JSON.parse(await readFile(summaryPath, 'utf8'));
+      expect(summary.trace).toBeDefined();
+
+      const envelope = JSON.parse(await readFile(envelopePath, 'utf8'));
+      expect(envelope.source).toBe('pipelines:trace');
+      expect(envelope.summary.trace.status).toBe(summary.trace.status);
+      expect(Array.isArray(envelope.artifacts)).toBe(true);
+      expect(envelope.artifacts.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend pipelines:trace to persist conformance summaries and create report envelopes automatically
- collect kvonce trace artifacts (projection, validation, replay) into the generated envelope
- document the reuse flow and add an integration test covering the new CLI options

## Testing
- pnpm vitest run tests/unit/pipelines/run-trace-conformance.integration.test.ts tests/unit/formal/verify-conformance.integration.test.ts tests/unit/trace/kvonce-conformance.integration.test.ts
