### PR TITLE
docs(trace): refresh tempo dashboard playbook

### DIFF
--- a/docs/trace/grafana/tempo-dashboard.md
+++ b/docs/trace/grafana/tempo-dashboard.md
@@ -1,80 +1,45 @@
-# Grafana Tempo Dashboard PoC
+# Grafana/Tempo Playbook for KvOnce Traces
 
-Issue refs: #1036 / #1011 / #1038
+Issue refs: #1036 / #1038 / #1011
 
-## Overview
-This document sketches a minimal Grafana dashboard that surfaces KvOnce traces stored in Tempo. It assumes the `docker/otlp-tempo` stack is running and KvOnce spans contain `kvonce_run_id`, `kvonce_branch`, and `kvonce_payload_sha` attributes (see `scripts/trace/run-kvonce-conformance.sh`).
+## データフロー概要
+1. `pnpm pipelines:trace --input samples/trace/kvonce-sample.ndjson` を実行すると、Projection / Validation / TLC の成果物に加え、`artifacts/trace/report-envelope.json` が自動生成される（PR #1103）。
+2. Envelope には `summary.trace`、`artifacts[]`（projection / validation / state sequence / replay）、`correlation.runId` などのメタデータが格納される。
+3. `pnpm verify:conformance --from-envelope artifacts/trace/report-envelope.json` で Envelope からサマリを再掲できるため、CI 外でも同じ情報を参照できる（PR #1102）。
+4. Tempo では `kvonce.*` 属性付きの span を収集する。Grafana ダッシュボードで Envelope と Tempo の両方を参照し、Run 単位での健全性を可視化する。
 
-## Tempo datasource configuration
-1. In Grafana, add a data source of type **Tempo** with the URL pointing to the Tempo instance (default `http://localhost:3200`).
-2. Enable TraceQL support.
+## Grafana データソース構成
+- **Tempo**: `docker/otlp-tempo/` のスタックなどで起動している Tempo を TraceQL モードで参照する。
+- **JSON / Static data source**: `artifacts/trace/report-envelope.json` を JSON データソースとして登録し、`summary.*` / `artifacts[]` を取得する。S3 などに保管する場合は Presigned URL を利用する。
+- **Optional**: Verify Lite の Envelope (`artifacts/report-envelope.json`) も同じダッシュボードに読み込むと、Lint / Mutation の指標を一望できる。
 
-## Dashboard JSON snippet
-```json
-{
-  "title": "KvOnce Trace Overview",
-  "panels": [
-    {
-      "title": "Trace counts by branch",
-      "type": "timeseries",
-      "targets": [
-        {
-          "datasource": { "type": "tempo", "uid": "tempo" },
-          "queryType": "traceql",
-          "query": "{ kvonce_run_id != '' } | stats count() by kvonce_branch"
-        }
-      ]
-    },
-    {
-      "title": "Recent errors",
-      "type": "table",
-      "targets": [
-        {
-          "datasource": { "type": "tempo", "uid": "tempo" },
-          "queryType": "traceql",
-          "query": "{ status.code = 'STATUS_CODE_ERROR' } | fields service.name, status_message, kvonce_run_id"
-        }
-      ]
-    }
-  ]
-}
-```
+## 属性マッピング
+| Envelope Field | Grafana での用途 | Tempo 側属性 | 備考 |
+|----------------|------------------|--------------|------|
+| `summary.trace.status` | ステータスカード | `kvonce.validation.valid` | Envelope では文字列、Tempo には boolean としてコピーする。 |
+| `summary.trace.projection.events` | イベント件数カード | `kvonce.projection.event_count` | イベント数の急増監視に利用。 |
+| `summary.trace.validation.issues` | テーブルの警告行 | - | Envelope のみで保持。Tempo のエラー span と突合せ。 |
+| `correlation.runId` | Tempo テンプレート変数 | `kvonce.run_id` | Run 単位でトレースを絞り込む。 |
+| `correlation.branch` | ブランチ切替用変数 | `kvonce.branch` | main / feature 毎の比較に活用。 |
+| `artifacts[].path` | ダウンロードリンク | `kvonce.artifact_path` | Projection / Validation / TLC summary へのリンク。 |
 
-![Tempo dashboard sketch](./images/tempo-overview.svg)
+## 推奨パネル
+1. **Trace Summary (Stat)** – データソース: JSON。`summary.trace.status` や `summary.trace.validation.issues` を表示し、status が `valid` 以外なら赤でハイライト。
+2. **Trace Count by Branch (Time series)** – データソース: Tempo。`{ kvonce_run_id != '' } | stats count() by kvonce_branch`。
+3. **Validation Issues Table** – データソース: Tempo。`{ status.code = 'STATUS_CODE_ERROR' } | fields service.name, status_message, kvonce_run_id`。Data Link で Envelope `artifacts[].path` に飛べるよう設定。
+4. **Artifact Download List** – データソース: JSON。`artifacts[].path` をテーブル表示し、S3/GitHub artifact へのリンクを付与。
 
-## クエリとパネルの詳細
-| パネル | TraceQL / データソース | Envelope 連携 |
-|--------|-------------------------|----------------|
-| Run Overview | `{ kvonce_run_id != '' } \| stats count() by kvonce_branch, kvonce_run_id` | Envelope の `correlation.runId` を `kvonce.run_id` 属性にコピーすることで、ブランチ・Run ID 単位の集計が可能。 |
-| Recent errors | `{ status.code = 'STATUS_CODE_ERROR' } \| fields service.name, status_message, kvonce.validation.valid` | `summary.validation.valid` を `kvonce.validation.valid` としてコピーし、再発する不整合をフィルタ。 |
-| Trace Drilldown | `trace_id = $traceId` (テンプレート変数) | Envelope の `correlation.traceIds[]` を変数に注入し、Explore へのリンクを生成。 |
-| Verify Lite Context | JSON datasource (`artifacts/verify-lite/verify-lite-run-summary.json`) | Mutation score や lint backlog を Envelope summary から抽出してテーブル表示。 |
+## ダッシュボードの更新手順
+1. `pnpm pipelines:trace --input ...` を実行し、Envelope と Tempo の両方に最新のデータを投入する。
+2. Envelope を JSON データソースに再読込させ、Run ID / status が反映されているか確認する。
+3. Tempo Explore で `kvonce_run_id = $runId` を検索し、span 属性に `kvonce.validation.valid` などが付与されているかをチェックする。
+4. 不整合が見つかった場合は Envelope の `summary.trace.validation.issues` と Tempo のエラー span を突合し、Projection/Validation の成果物（`artifacts[].path`）をダウンロードして調査する。
 
-テンプレート変数例:
-```yaml
-- name: kvonceRunId
-  label: Run ID
-  datasource: tempo
-  query: "{ kvonce_run_id != '' } | stats latest(kvonce_run_id) by kvonce_run_id"
-```
+## Export / Import
+- Grafana UI から JSON をエクスポートし、`docs/trace/grafana/tempo-dashboard.json` としてリポジトリ管理することを推奨。
+- 将来的には `scripts/trace/export-dashboard.mjs`（TODO）で CI からダッシュボードを自動エクスポートし、差分をレビューできるようにする。
 
-## データ更新フロー
-1. `pipelines:trace` 実行時に `hermetic-reports/trace/kvonce-projection.json` と Envelope (`artifacts/verify-lite/report-envelope.json`) を生成する。
-2. Collector (S3/MinIO) にアップロードした Envelope を Grafana JSON datasource で参照できるようにする。
-3. Tempo 側では `kvonce.*` 属性を TraceQL で検索し、Grafana ダッシュボードの変数として expose する。
-4. CI 完了後に `scripts/trace/export-dashboard.mjs`（次期タスク）でダッシュボード JSON をエクスポートし、`docs/trace/grafana/tempo-dashboard.json` としてバージョン管理する。
-
-> ℹ️ **TraceQL フィールド名の補足**: Tempo では OTLP の span status が `status.code` にマッピングされ、値は `STATUS_CODE_OK` / `STATUS_CODE_ERROR` などの列挙になります。環境により表記が異なる場合は Grafana の Explore 画面で実際の span を Inspect し、必要に応じて `status_code` などに読み替えてください。
-
-### Span 属性の確認手順
-
-KvOnce の収集スクリプト (`scripts/trace/run-kvonce-conformance.sh`) は、投影結果に `kvonce_run_id` / `kvonce_branch` / `kvonce_payload_sha` を付与することを前提にしています。Tempo に投入したデータでこれらが付与されているかを次の手順で確認できます。
-
-1. `pnpm tsx scripts/trace/run-kvonce-conformance.sh --output-dir hermetic-reports/trace` を実行し、`hermetic-reports/trace/kvonce-projection.json` を生成する。
-2. 生成された JSON で `kvonce_*` 属性が存在することを確認する。Grafana 側でも Explore で span を開き、Attributes タブに同じキーがあることをチェックする。
-3. 属性が欠落している場合は、`scripts/trace/prepare-otlp-trace.mjs` や `run-kvonce-conformance.sh` が参照する入力（S3 / GCS / ローカルファイル）が最新かを確認し、再収集する。
-
-## Next steps
-- [ ] Surface verify-lite envelope metrics alongside Tempo stats.
-- [ ] Add panels that highlight mutation survivors per run.
-- [ ] Provide `scripts/trace/export-dashboard.sh` to sync dashboards through CI.
+## TODO
+- [ ] Verify Lite Envelope を同じダッシュボードに統合し、Mutation/Lint 指標も可視化する。
+- [ ] `pipelines:trace` 実行時に Grafana Link パネル向け URL を Envelope の `notes` に追記する。
+- [ ] ダッシュボードの export/import スクリプトを `scripts/trace/` 配下に追加し、自動化する。


### PR DESCRIPTION
## Summary
- document the new pipelines:trace envelope flow and the verify:conformance --from-envelope replay path
- map envelope fields to kvonce.* Tempo attributes and suggest dashboard panels
- add operational checklist and TODOs for dashboard export automation

## Testing
- not run (documentation only)
