### PR TITLE
docs(ci): update step summary layout plan

### DIFF
--- a/docs/notes/step-summary-layout.md
+++ b/docs/notes/step-summary-layout.md
@@ -18,16 +18,19 @@ Issue refs: #1097 / #1096 / #1038
   - replay: <ran|failed|skipped>
 ```
 
-- **Spec セクション**: `verify:conformance` が TLC 実行時に `hermetic-reports/formal/tla-summary.json` のステータスを要約する。
+- **Spec セクション**: `verify:conformance` が TLC 実行時に `hermetic-reports/formal/tla-summary.json` のステータスを要約する（ツールが未導入の場合は `status: tool_not_available` を表示）。
 - **Verify Lite セクション**: `pipelines:full` で `reports/verify-lite/verify-lite-run-summary.json` を Envelope に詰めたうえで、lint / mutation quick / property の結果を `summary.steps.*` から抜粋する。
-- **Trace セクション**: `pipelines:trace` が生成した Projection/Validation/TLC summary を `summary.trace` として配置し、問題の key があれば `notes` に列挙する。
+- **Trace セクション**: `verify:conformance` または `verify:conformance --from-envelope` の `summary.trace` を描画し、Projection/Validation/TLC の結果と issues 数を列挙する。
 
-## 実装メモ
-- `scripts/formal/verify-conformance.mjs` が Step Summary 出力に対応済み。Trace 部分は Envelope から `summary.trace` を参照する。
-- `pipelines:full` は Verify Lite の Step Summary を呼び出し、mutation quick のスコアを同伴する。（PR #1093）
-- 追加のジョブが同じテンプレートを利用できるよう、共通関数を `scripts/ci/step-summary.mjs`（今後実装）に切り出す予定。
+## 実装メモ (2025-10-09)
+- `scripts/ci/step-summary.mjs` が `appendSection` などの共通ユーティリティを提供し、`verify-conformance`・`pipelines:trace`・CI スクリプトから同じ Markdown フォーマットで出力できる。
+- `scripts/formal/verify-conformance.mjs` は `--from-envelope` オプションに対応し、既存の report-envelope から Step Summary を再掲できる（PR #1102）。
+- `pipelines:trace` は conformance summary と report envelope を生成し、CI 以外の環境でも Envelope → Step Summary を再利用できるようになった（PR #1103）。
+- Verify Lite 側の Step Summary も Envelope 経由で統合済み（PR #1093）。
+- Tempo / Grafana へリンクを貼る場合は `docs/trace/grafana/tempo-dashboard.md` のプレイブックに沿って Data Link を設定する。
 
 ## TODO
-- [ ] `scripts/ci/step-summary.mjs` を作成し、Spec/Verify Lite/Trace の Markdown 生成を関数化する。
-- [ ] Verify Lite ワークフローで Step Summary にリンクを追加（mutation report / lint baseline diff など）。
-- [ ] Multi-domain Trace が実装されたら `summary.trace.domains[]` を Step Summary に展開する。
+- [ ] Verify Lite ワークフローの Step Summary に mutation report / lint baseline diff へのリンクを追加する。
+- [ ] Trace Envelope の `artifacts[]` から Tempo / S3 への Data Link を生成し、Step Summary から直接遷移できるようにする。
+- [ ] Multi-domain Trace が実装されたら `summary.trace.domains[]` をサポートする。
+- [ ] Step Summary 再利用手順（`--from-envelope`）を CI ガイドラインに反映し、手動トラブルシュート手順を整備する。


### PR DESCRIPTION
## Summary
- refresh the step summary layout note to reflect the shared helper and the new --from-envelope flow
- document the current implementation status and point to the Tempo/Grafana playbook
- revise the TODO list to focus on remaining action items (links, multi-domain support, troubleshooting)

## Testing
- not run (documentation only)
