### PR TITLE
feat(trace): derive trace ids for envelopes

### DIFF
--- a/scripts/formal/verify-conformance.mjs
+++ b/scripts/formal/verify-conformance.mjs
@@ -257,6 +257,26 @@ async function runTracePipeline({ tracePath, format, outputDir, skipReplay }) {
     } else {
       summary.replay = { status: 'skipped' };
     }
+
+    const traceIdSet = new Set();
+    try {
+      const ndjsonContent = fs.readFileSync(ensured.ndjsonPath, 'utf8');
+      for (const line of ndjsonContent.split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        try {
+          const event = JSON.parse(line);
+          const value = event && typeof event.traceId === 'string' ? event.traceId.trim() : '';
+          if (value) traceIdSet.add(value);
+        } catch (parseError) {
+          // ignore malformed lines
+        }
+      }
+    } catch (readError) {
+      summary.traceReadError = readError.message;
+    }
+    if (traceIdSet.size > 0) {
+      summary.traceIds = Array.from(traceIdSet);
+    }
   } catch (error) {
     summary.status = 'error';
     summary.error = error.message;

--- a/scripts/trace/build-kvonce-envelope-summary.mjs
+++ b/scripts/trace/build-kvonce-envelope-summary.mjs
@@ -2,72 +2,193 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const outputPath = process.argv[2] ?? 'artifacts/kvonce-trace-summary.json';
-const baseDir = path.join('hermetic-reports', 'trace');
-const cases = [
-  { key: 'otlp', label: 'OTLP payload', dir: path.join(baseDir, 'otlp') },
-  { key: 'ndjson', label: 'NDJSON sample', dir: path.join(baseDir, 'ndjson') }
+function parseArgs(argv) {
+  const options = {
+    output: 'artifacts/kvonce-trace-summary.json',
+    traceDir: path.join('hermetic-reports', 'trace'),
+    summary: null,
+    cases: null,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if ((arg === '--output' || arg === '-o') && next) {
+      options.output = next;
+      i += 1;
+    } else if ((arg === '--trace-dir' || arg === '-d') && next) {
+      options.traceDir = next;
+      i += 1;
+    } else if ((arg === '--summary' || arg === '-s') && next) {
+      options.summary = next;
+      i += 1;
+    } else if (arg === '--cases' && next) {
+      options.cases = next;
+      i += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: node scripts/trace/build-kvonce-envelope-summary.mjs [options]
+
+Options:
+  -o, --output <file>      Output JSON path (default: artifacts/kvonce-trace-summary.json)
+  -d, --trace-dir <dir>    Base directory containing trace artifacts (default: hermetic-reports/trace)
+  -s, --summary <file>     Conformance summary JSON (default: <trace-dir>/kvonce-conformance-summary.json)
+      --cases <list>       Comma-separated case descriptors key[:label[:subdir]]
+  -h, --help               Show this message
+`);
+      process.exit(0);
+    }
+  }
+  return options;
+}
+
+const options = parseArgs(process.argv);
+const outputPath = path.resolve(options.output);
+const traceDir = path.resolve(options.traceDir);
+
+const defaultCases = [
+  { key: 'current', label: 'Current run', dir: traceDir },
+  { key: 'otlp', label: 'OTLP payload', dir: path.join(traceDir, 'otlp') },
+  { key: 'ndjson', label: 'NDJSON sample', dir: path.join(traceDir, 'ndjson') },
 ];
 
-const readJsonSafe = (file) => {
+const parseCases = () => {
+  if (!options.cases) return defaultCases;
+  const entries = [];
+  for (const chunk of options.cases.split(',')) {
+    const trimmed = chunk.trim();
+    if (!trimmed) continue;
+    const [key, label, subdir] = trimmed.split(':');
+    if (!key) continue;
+    const dir = subdir ? path.join(traceDir, subdir) : (key === 'current' ? traceDir : path.join(traceDir, key));
+    entries.push({ key, label: label ?? key, dir });
+  }
+  return entries.length > 0 ? entries : defaultCases;
+};
+
+const cases = parseCases();
+
+const readJsonSafe = (filePath) => {
   try {
-    return JSON.parse(fs.readFileSync(file, 'utf8'));
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
   } catch (error) {
     return null;
   }
 };
 
-const metadata = readJsonSafe(path.join(baseDir, 'kvonce-payload-metadata.json')) ?? {};
+const collectTraceIds = (ndjsonPath) => {
+  if (!fs.existsSync(ndjsonPath)) return [];
+  const ids = new Set();
+  const content = fs.readFileSync(ndjsonPath, 'utf8');
+  for (const line of content.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line);
+      const value = event && typeof event.traceId === 'string' ? event.traceId.trim() : '';
+      if (value) ids.add(value);
+    } catch (error) {
+      // ignore malformed line
+    }
+  }
+  return Array.from(ids);
+};
+
+const metadata = readJsonSafe(path.join(traceDir, 'kvonce-payload-metadata.json')) ?? {};
 const casesSummary = [];
+const aggregateTraceIds = new Set();
 
 for (const item of cases) {
+  if (!item?.dir) continue;
   const reportPath = path.join(item.dir, 'kvonce-validation.json');
   const projectionPath = path.join(item.dir, 'kvonce-projection.json');
+  const stateSequencePath = path.join(item.dir, 'projected', 'kvonce-state-sequence.json');
+  const ndjsonPath = path.join(item.dir, 'kvonce-events.ndjson');
+
   const validation = readJsonSafe(reportPath);
   const projection = readJsonSafe(projectionPath);
+
   if (!validation) {
-    casesSummary.push({
+    const entry = {
       format: item.key,
+      label: item.label ?? item.key,
       status: 'missing',
       issues: [],
-      note: 'validation file missing'
-    });
+      note: 'validation file missing',
+    };
+    casesSummary.push(entry);
     continue;
   }
+
   const issues = Array.isArray(validation.issues) ? validation.issues : [];
   const trimmedIssues = issues.slice(0, 10).map((issue) => ({
     type: issue.type ?? 'unknown',
     key: issue.key ?? 'unknown',
-    message: issue.message ?? ''
+    message: issue.message ?? '',
   }));
   const projectionStats = projection?.stats ?? undefined;
-  const stateSequencePath = projection?.outputs?.stateSequence ?? undefined;
-  casesSummary.push({
+  const traceIds = collectTraceIds(ndjsonPath);
+  traceIds.forEach((value) => aggregateTraceIds.add(value));
+
+  const entry = {
     format: item.key,
+    label: item.label ?? item.key,
     valid: Boolean(validation.valid),
     issueCount: issues.length,
     issues: trimmedIssues,
     projectionStats,
-    ...(stateSequencePath ? { stateSequencePath } : {})
-  });
+  };
+
+  if (fs.existsSync(reportPath)) {
+    entry.validationPath = path.relative(process.cwd(), reportPath);
+  }
+  if (fs.existsSync(projectionPath)) {
+    entry.projectionPath = path.relative(process.cwd(), projectionPath);
+  }
+  if (fs.existsSync(stateSequencePath)) {
+    entry.stateSequencePath = path.relative(process.cwd(), stateSequencePath);
+  }
+  if (traceIds.length > 0) {
+    entry.traceIds = traceIds;
+  }
+
+  casesSummary.push(entry);
 }
 
-const summary = {
+const summaryPath = options.summary
+  ? path.resolve(options.summary)
+  : path.join(traceDir, 'kvonce-conformance-summary.json');
+
+const conformanceSummary = fs.existsSync(summaryPath) ? readJsonSafe(summaryPath) : null;
+if (Array.isArray(conformanceSummary?.trace?.traceIds)) {
+  for (const value of conformanceSummary.trace.traceIds) {
+    if (typeof value === 'string' && value.trim()) {
+      aggregateTraceIds.add(value.trim());
+    }
+  }
+}
+
+const output = {
   schemaVersion: '1.0.0',
   generatedAt: new Date().toISOString(),
+  traceDir: path.relative(process.cwd(), traceDir),
   payloadMetadata: {
     sourceType: metadata.sourceType ?? null,
     sourceDetail: metadata.sourceDetail ?? null,
     sha256: metadata.sha256 ?? null,
-    sizeBytes: metadata.sizeBytes ?? null
+    sizeBytes: metadata.sizeBytes ?? null,
   },
-  cases: casesSummary
+  cases: casesSummary,
 };
+
+if (conformanceSummary) {
+  output.conformance = conformanceSummary;
+}
+if (aggregateTraceIds.size > 0) {
+  output.traceIds = Array.from(aggregateTraceIds);
+}
 
 const destDir = path.dirname(outputPath);
 if (!fs.existsSync(destDir)) {
   fs.mkdirSync(destDir, { recursive: true });
 }
 
-fs.writeFileSync(outputPath, JSON.stringify(summary, null, 2));
+fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
 console.log(`[trace] wrote kvonce summary to ${outputPath}`);

--- a/scripts/trace/create-report-envelope.mjs
+++ b/scripts/trace/create-report-envelope.mjs
@@ -6,7 +6,6 @@ import crypto from 'node:crypto';
 const summaryPath = process.argv[2] ?? process.env.REPORT_ENVELOPE_SUMMARY ?? 'artifacts/verify-lite/verify-lite-run-summary.json';
 const outputPath = process.argv[3] ?? process.env.REPORT_ENVELOPE_OUTPUT ?? 'artifacts/report-envelope.json';
 const source = process.env.REPORT_ENVELOPE_SOURCE ?? 'verify-lite';
-const traceIdsEnv = process.env.REPORT_ENVELOPE_TRACE_IDS ?? '';
 const noteEnv = process.env.REPORT_ENVELOPE_NOTES ?? '';
 
 const ensureFile = (filePath) => {
@@ -72,10 +71,17 @@ const branch = process.env.GITHUB_REF ?? 'local';
 const runId = process.env.GITHUB_RUN_ID ?? `local-${Date.now()}`;
 const commit = process.env.GITHUB_SHA ?? '0000000';
 
-const traceIds = traceIdsEnv
-  .split(',')
-  .map((value) => value.trim())
-  .filter(Boolean);
+const derivedTraceIds = Array.isArray(summary?.trace?.traceIds)
+  ? summary.trace.traceIds.map((value) => (typeof value === 'string' ? value.trim() : '')).filter(Boolean)
+  : [];
+
+const traceIdSet = new Set(derivedTraceIds);
+const traceIdsEnv = process.env.REPORT_ENVELOPE_TRACE_IDS ?? '';
+for (const raw of traceIdsEnv.split(',')) {
+  const value = raw.trim();
+  if (value) traceIdSet.add(value);
+}
+const traceIds = Array.from(traceIdSet);
 
 const notes = noteEnv
   .split(/\r?\n/)

--- a/tests/unit/formal/verify-conformance.integration.test.ts
+++ b/tests/unit/formal/verify-conformance.integration.test.ts
@@ -36,6 +36,8 @@ describe('verify-conformance --from-envelope', () => {
         },
       ];
       await writeFile(eventsPath, JSON.stringify(events), 'utf8');
+      const tracePath = join(dir, 'trace.ndjson');
+      await writeFile(tracePath, events.map((item) => JSON.stringify(item)).join('\n'), 'utf8');
 
       await execFileAsync(nodePath, [
         scriptPath,
@@ -46,7 +48,7 @@ describe('verify-conformance --from-envelope', () => {
         '--out',
         summaryPath,
         '--trace',
-        'samples/trace/kvonce-sample.ndjson',
+        tracePath,
         '--trace-format',
         'ndjson',
         '--trace-output',
@@ -57,6 +59,7 @@ describe('verify-conformance --from-envelope', () => {
       const summary = JSON.parse(await readFile(summaryPath, 'utf8'));
       expect(summary.events).toBe(1);
       expect(summary.trace?.status).toBeDefined();
+      expect(summary.trace?.traceIds).toEqual(['trace-1']);
 
       const envelopePath = join(dir, 'envelope.json');
       const envelope = {
@@ -82,6 +85,7 @@ describe('verify-conformance --from-envelope', () => {
       expect(replaySummary.schemaErrors).toBe(summary.schemaErrors);
       expect(replaySummary.envelopePath).toBeDefined();
       expect(replaySummary.trace?.status).toBe(summary.trace?.status);
+      expect(replaySummary.trace?.traceIds).toEqual(['trace-1']);
     });
   });
 });

--- a/tests/unit/trace/build-kvonce-envelope-summary.test.ts
+++ b/tests/unit/trace/build-kvonce-envelope-summary.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+
+const execFileAsync = promisify(execFile);
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
+  const dir = await mkdtemp(join(tmpdir(), 'kvonce-summary-'));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('build-kvonce-envelope-summary.mjs', () => {
+  it('collects trace ids and conformance summary', async () => {
+    await withTempDir(async (dir) => {
+      const nodePath = process.execPath;
+      const projectorScript = resolve('scripts/trace/projector-kvonce.mjs');
+      const validatorScript = resolve('scripts/trace/validate-kvonce.mjs');
+      const summaryScript = resolve('scripts/trace/build-kvonce-envelope-summary.mjs');
+
+      const traceDir = join(dir, 'trace');
+      await mkdir(join(traceDir, 'projected'), { recursive: true });
+
+      const ndjsonPath = join(dir, 'input.ndjson');
+      const events = [
+        { traceId: 'trace-123', timestamp: '2025-10-08T10:00:00.000Z', type: 'success', key: 'alpha', value: 'v1' },
+        { traceId: 'trace-123', timestamp: '2025-10-08T10:01:00.000Z', type: 'retry', key: 'alpha', context: { attempts: 1 } },
+      ]
+        .map((event) => JSON.stringify(event))
+        .join('\n');
+      await writeFile(ndjsonPath, events, 'utf8');
+      await writeFile(join(traceDir, 'kvonce-events.ndjson'), events, 'utf8');
+
+      const projectionPath = join(traceDir, 'kvonce-projection.json');
+      const stateSequencePath = join(traceDir, 'projected', 'kvonce-state-sequence.json');
+      await execFileAsync(nodePath, [
+        projectorScript,
+        '--input',
+        ndjsonPath,
+        '--output',
+        projectionPath,
+        '--state-output',
+        stateSequencePath,
+      ]);
+
+      const validationPath = join(traceDir, 'kvonce-validation.json');
+      await execFileAsync(nodePath, [
+        validatorScript,
+        '--input',
+        projectionPath,
+        '--output',
+        validationPath,
+      ]);
+
+      const conformanceSummaryPath = join(traceDir, 'kvonce-conformance-summary.json');
+      const conformanceSummary = {
+        trace: {
+          status: 'valid',
+          traceIds: ['trace-123'],
+        },
+      };
+      await writeFile(conformanceSummaryPath, JSON.stringify(conformanceSummary, null, 2));
+
+      const outputPath = join(dir, 'kvonce-trace-summary.json');
+      await execFileAsync(nodePath, [
+        summaryScript,
+        '--trace-dir',
+        traceDir,
+        '--summary',
+        conformanceSummaryPath,
+        '--output',
+        outputPath,
+      ]);
+
+      const summary = JSON.parse(await readFile(outputPath, 'utf8'));
+      expect(summary.traceIds).toEqual(['trace-123']);
+      const currentCase = summary.cases.find((entry) => entry.format === 'current');
+      expect(currentCase?.traceIds).toEqual(['trace-123']);
+      expect(currentCase?.projectionPath).toBeDefined();
+      expect(summary.conformance.trace.traceIds).toEqual(['trace-123']);
+    });
+  });
+});

--- a/tests/unit/trace/create-report-envelope.test.ts
+++ b/tests/unit/trace/create-report-envelope.test.ts
@@ -92,4 +92,37 @@ describe('create-report-envelope CLI', () => {
     });
     expect(envelope.notes).toEqual(['note-one', 'note-two']);
   });
+
+  it('derives trace ids from the summary when env is not provided', async () => {
+    const summaryPath = join(workdir, 'summary.json');
+    const outputPath = join(workdir, 'envelope.json');
+
+    const summary = {
+      schemaVersion: '1.0.0',
+      trace: {
+        status: 'valid',
+        traceIds: ['trace-a', 'trace-b']
+      }
+    };
+
+    await writeFile(summaryPath, JSON.stringify(summary));
+
+    const result = spawnSync(process.execPath, [scriptPath, summaryPath, outputPath], {
+      cwd: workdir,
+      env: {
+        ...process.env,
+        REPORT_ENVELOPE_SOURCE: 'trace-replay',
+        GITHUB_RUN_ID: '123',
+        GITHUB_WORKFLOW: 'trace-workflow',
+        GITHUB_SHA: 'abcdef0',
+        GITHUB_REF: 'refs/heads/test-branch',
+      }
+    });
+
+    expect(result.status).toBe(0);
+
+    const envelope = JSON.parse(await readFile(outputPath, 'utf8'));
+    expect(envelope.correlation.traceIds).toEqual(['trace-a', 'trace-b']);
+    expect(envelope.summary.trace.traceIds).toEqual(['trace-a', 'trace-b']);
+  });
 });


### PR DESCRIPTION
## Summary
- parse NDJSON traces to gather trace ids inside verify:conformance and expose them in the summary
- fall back to summary-derived trace ids when generating report envelopes and trace summaries
- extend build-kvonce-envelope-summary with CLI options, trace id aggregation, and new vitest coverage

## Testing
- pnpm vitest run tests/unit/formal/verify-conformance.integration.test.ts tests/unit/pipelines/run-trace-conformance.integration.test.ts tests/unit/trace/create-report-envelope.test.ts tests/unit/trace/build-kvonce-envelope-summary.test.ts tests/unit/trace/projector-kvonce.test.ts
