### PR TITLE
feat(ci): link verify lite artifacts in step summary

### DIFF
--- a/scripts/ci/lib/verify-lite-summary.mjs
+++ b/scripts/ci/lib/verify-lite-summary.mjs
@@ -1,4 +1,4 @@
-export const renderVerifyLiteSummary = (summary) => {
+export const renderVerifyLiteSummary = (summary, options = {}) => {
   if (!summary || typeof summary !== 'object') {
     throw new Error('Invalid summary payload');
   }
@@ -93,9 +93,24 @@ export const renderVerifyLiteSummary = (summary) => {
 
   const artifactLines = [];
   if (Object.keys(artifacts).length > 0) {
+    const { artifactsUrl } = options;
+    const formatArtifact = (value) => {
+      if (!value) return 'n/a';
+      if (/^https?:\/\//i.test(value)) {
+        return `[${value}](${value})`;
+      }
+      if (artifactsUrl) {
+        return `\`${value}\` ([Artifacts](${artifactsUrl}))`;
+      }
+      return value;
+    };
+
     artifactLines.push('\nArtifacts:');
     for (const [key, value] of Object.entries(artifacts)) {
-      artifactLines.push(`- ${key}: ${value ?? 'n/a'}`);
+      artifactLines.push(`- ${key}: ${formatArtifact(value)}`);
+    }
+    if (artifactsUrl) {
+      artifactLines.push(`- GitHub Artifacts: [Open](${artifactsUrl})`);
     }
   }
 

--- a/scripts/ci/render-verify-lite-summary.mjs
+++ b/scripts/ci/render-verify-lite-summary.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { renderVerifyLiteSummary } from './lib/verify-lite-summary.mjs';
 
 const summaryPath = process.argv[2] ?? 'verify-lite-run-summary.json';
 const resolved = path.resolve(summaryPath);
@@ -19,100 +20,10 @@ try {
   process.exit(1);
 }
 
-const { timestamp, flags = {}, steps = {}, artifacts = {} } = summary;
+const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+const repository = process.env.GITHUB_REPOSITORY;
+const runId = process.env.GITHUB_RUN_ID;
+const artifactsUrl = repository && runId ? `${serverUrl}/${repository}/actions/runs/${runId}?check_suite_focus=true#artifacts` : null;
 
-const yesNo = (value) => (value ? '✅' : '❌');
-const escapeHtml = (text) =>
-  String(text).replace(/[&<>'"]/g, (char) => {
-    switch (char) {
-      case '&':
-        return '&amp;';
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-      case '"':
-        return '&quot;';
-      case "'":
-        return '&#39;';
-      default:
-        return char;
-    }
-  });
-const formatStatus = (status) => {
-  if (!status) return 'n/a';
-  const normalized = String(status).toLowerCase();
-  if (normalized === 'success') return '✅ success';
-  if (normalized === 'failure') return '❌ failure';
-  if (normalized === 'skipped') return '⏭️ skipped';
-  if (normalized === 'pending') return '… pending';
-  return normalized;
-};
-
-const flagLines = [
-  `- install flags: \`${flags.install ?? ''}\``,
-  `- no frozen lockfile: ${yesNo(flags.noFrozen)}`,
-  `- keep lint log: ${yesNo(flags.keepLintLog)}`,
-  `- enforce lint: ${yesNo(flags.enforceLint)}`,
-  `- run mutation: ${yesNo(flags.runMutation)}`,
-];
-
-const stepEntries = Object.entries(steps);
-const orderedKeys = [
-  'install',
-  'specCompilerBuild',
-  'typeCheck',
-  'lint',
-  'build',
-  'bddLint',
-  'mutationQuick',
-];
-const seen = new Set();
-const orderedSteps = [];
-for (const key of orderedKeys) {
-  if (steps[key]) {
-    orderedSteps.push([key, steps[key]]);
-    seen.add(key);
-  }
-}
-for (const [key, value] of stepEntries) {
-  if (!seen.has(key)) {
-    orderedSteps.push([key, value]);
-  }
-}
-
-const titleCase = (name) =>
-  name
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, (ch) => ch.toUpperCase());
-
-const tableLines = [
-  '| Step | Status | Notes |',
-  '| --- | --- | --- |',
-];
-for (const [key, value] of orderedSteps) {
-  const status = formatStatus(value?.status);
-  const notes = value?.notes ? escapeHtml(value.notes).replace(/\n/g, '<br>') : '';
-  tableLines.push(`| ${titleCase(key)} | ${status} | ${notes} |`);
-}
-
-const artifactLines = [];
-if (Object.keys(artifacts).length > 0) {
-  artifactLines.push('\nArtifacts:');
-  for (const [key, value] of Object.entries(artifacts)) {
-    artifactLines.push(`- ${key}: ${value ?? 'n/a'}`);
-  }
-}
-
-const output = [
-  timestamp ? `Timestamp: ${timestamp}` : 'Timestamp: n/a',
-  `Schema Version: ${summary.schemaVersion ?? 'unknown'}`,
-  ...flagLines,
-  '',
-  ...tableLines,
-  '',
-  ...artifactLines,
-];
-
-console.log(output.join('\n'));
+const output = renderVerifyLiteSummary(summary, { artifactsUrl });
+console.log(output);

--- a/tests/unit/ci/__snapshots__/render-verify-lite-summary.test.ts.snap
+++ b/tests/unit/ci/__snapshots__/render-verify-lite-summary.test.ts.snap
@@ -41,8 +41,9 @@ Schema Version: 1.0.0
 
 
 Artifacts:
-- lintSummary: verify-lite-lint-summary.json
-- lintLog: verify-lite-lint.log
-- mutationSummary: mutation-summary.md
-- mutationSurvivors: reports/mutation/survivors.json"
+- lintSummary: \`verify-lite-lint-summary.json\` ([Artifacts](https://example.com/artifacts))
+- lintLog: \`verify-lite-lint.log\` ([Artifacts](https://example.com/artifacts))
+- mutationSummary: \`mutation-summary.md\` ([Artifacts](https://example.com/artifacts))
+- mutationSurvivors: \`reports/mutation/survivors.json\` ([Artifacts](https://example.com/artifacts))
+- GitHub Artifacts: [Open](https://example.com/artifacts)"
 `;

--- a/tests/unit/ci/render-verify-lite-summary.test.ts
+++ b/tests/unit/ci/render-verify-lite-summary.test.ts
@@ -28,7 +28,7 @@ describe('renderVerifyLiteSummary', () => {
   };
 
   it('renders markdown summary with schema version and flags', () => {
-    const result = renderVerifyLiteSummary(baseSummary);
+    const result = renderVerifyLiteSummary(baseSummary, { artifactsUrl: 'https://example.com/artifacts' });
     expect(result).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Summary
- route verify-lite summary rendering through the shared helper and surface GitHub artifacts links when available
- format artifact paths as markdown links (falling back to plain paths for local runs)
- update tests and snapshots to cover the new formatting logic

## Testing
- pnpm vitest run tests/unit/ci/render-verify-lite-summary.test.ts
