### PR TITLE
feat(trace): surface artifacts and trace ids in summary

### DIFF
--- a/docs/notes/step-summary-layout.md
+++ b/docs/notes/step-summary-layout.md
@@ -21,6 +21,7 @@ Issue refs: #1097 / #1096 / #1038
 - **Spec セクション**: `verify:conformance` が TLC 実行時に `hermetic-reports/formal/tla-summary.json` のステータスを要約する（ツールが未導入の場合は `status: tool_not_available` を表示）。
 - **Verify Lite セクション**: `pipelines:full` で `reports/verify-lite/verify-lite-run-summary.json` を Envelope に詰めたうえで、lint / mutation quick / property の結果を `summary.steps.*` から抜粋する。
 - **Trace セクション**: `verify:conformance` または `verify:conformance --from-envelope` の `summary.trace` を描画し、Projection/Validation/TLC の結果と issues 数を列挙する。
+  - `traceIds` や `artifacts` 情報（projection/validation/state sequence/replay）を付与しておくと、Step Summary から GitHub Artifacts へジャンプできる。
 
 ## 実装メモ (2025-10-09)
 - `scripts/ci/step-summary.mjs` が `appendSection` などの共通ユーティリティを提供し、`verify-conformance`・`pipelines:trace`・CI スクリプトから同じ Markdown フォーマットで出力できる。

--- a/scripts/formal/verify-conformance.mjs
+++ b/scripts/formal/verify-conformance.mjs
@@ -280,6 +280,39 @@ function appendStepSummary(summary) {
     if (summary.trace.replay) {
       lines.push(`  - replay: ${summary.trace.replay.status}`);
     }
+    if (Array.isArray(summary.trace.traceIds) && summary.trace.traceIds.length > 0) {
+      lines.push(`  - trace ids: ${summary.trace.traceIds.join(', ')}`);
+    }
+
+    const artifactsUrl = (() => {
+      const server = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+      const repo = process.env.GITHUB_REPOSITORY;
+      const runId = process.env.GITHUB_RUN_ID;
+      if (!repo || !runId) return null;
+      return `${server}/${repo}/actions/runs/${runId}?check_suite_focus=true#artifacts`;
+    })();
+
+    const formatArtifact = (label, value) => {
+      if (!value) return null;
+      const display = `\`${value}\``;
+      if (artifactsUrl) {
+        return `    - ${label}: ${display} ([Artifacts](${artifactsUrl}))`;
+      }
+      return `    - ${label}: ${value}`;
+    };
+
+    const artifactLines = [];
+    const ndjsonPath = summary.trace.ndjson;
+    if (ndjsonPath) artifactLines.push(formatArtifact('ndjson', ndjsonPath));
+    if (summary.projection?.path) artifactLines.push(formatArtifact('projection', summary.projection.path));
+    if (summary.projection?.stateSequence) artifactLines.push(formatArtifact('state sequence', summary.projection.stateSequence));
+    if (summary.validation?.path) artifactLines.push(formatArtifact('validation', summary.validation.path));
+    if (summary.replay?.summaryPath) artifactLines.push(formatArtifact('replay summary', summary.replay.summaryPath));
+    const filtered = artifactLines.filter(Boolean);
+    if (filtered.length > 0) {
+      lines.push('  - artifacts:');
+      lines.push(...filtered);
+    }
   }
   appendSection('Verify Conformance', lines);
 }


### PR DESCRIPTION
## Summary
- enrich verify:conformance step summary with trace ids and artifact references derived from the NDJSON run
- link trace artifacts to GitHub Actions artifacts when available so investigations start from the Step Summary
- document the new behaviour in the step summary layout note for future reference

## Testing
- pnpm vitest run tests/unit/formal/verify-conformance.integration.test.ts tests/unit/trace/create-report-envelope.test.ts tests/unit/trace/build-kvonce-envelope-summary.test.ts
