### PR TITLE
feat(trace): add grafana dashboard export script

### DIFF
--- a/docs/trace/grafana/tempo-dashboard.md
+++ b/docs/trace/grafana/tempo-dashboard.md
@@ -43,3 +43,4 @@ Issue refs: #1036 / #1038 / #1011
 - [ ] Verify Lite Envelope を同じダッシュボードに統合し、Mutation/Lint 指標も可視化する。
 - [ ] `pipelines:trace` 実行時に Grafana Link パネル向け URL を Envelope の `notes` に追記する。
 - [ ] ダッシュボードの export/import スクリプトを `scripts/trace/` 配下に追加し、自動化する。
+- ダッシュボードの JSON は `scripts/trace/export-dashboard.mjs --uid <UID>` を使って取得し、`docs/trace/grafana/tempo-dashboard.json` に保存できる。GitHub Actions から自動取得する場合は `GRAFANA_HOST` / `GRAFANA_API_TOKEN` を環境変数で渡す。

--- a/scripts/trace/export-dashboard.mjs
+++ b/scripts/trace/export-dashboard.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const options = {
+    host: process.env.GRAFANA_HOST ?? 'http://localhost:3000',
+    uid: process.env.GRAFANA_DASHBOARD_UID ?? null,
+    token: process.env.GRAFANA_API_TOKEN ?? null,
+    output: 'docs/trace/grafana/tempo-dashboard.json',
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if ((arg === '--host' || arg === '-h') && next) {
+      options.host = next;
+      i += 1;
+    } else if ((arg === '--uid' || arg === '-u') && next) {
+      options.uid = next;
+      i += 1;
+    } else if ((arg === '--token' || arg === '-t') && next) {
+      options.token = next;
+      i += 1;
+    } else if ((arg === '--output' || arg === '-o') && next) {
+      options.output = next;
+      i += 1;
+    } else if (arg === '--help') {
+      console.log(`Usage: node scripts/trace/export-dashboard.mjs [options]
+
+Options:
+  -h, --host <url>     Grafana base URL (default: http://localhost:3000)
+  -u, --uid <uid>      Dashboard UID to export (required)
+  -t, --token <token>  Grafana API token with dashboard:read scope
+  -o, --output <file>  Output JSON path (default: docs/trace/grafana/tempo-dashboard.json)
+      --help           Show this message
+`);
+      process.exit(0);
+    }
+  }
+
+  if (!options.uid) {
+    console.error('[export-dashboard] missing required --uid');
+    process.exit(1);
+  }
+
+  return options;
+}
+
+async function exportDashboard({ host, uid, token, output }) {
+  const url = new URL(`/api/dashboards/uid/${encodeURIComponent(uid)}`, host).toString();
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to fetch dashboard (${response.status}): ${body}`);
+  }
+
+  const data = await response.json();
+  const destPath = path.resolve(output);
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  fs.writeFileSync(destPath, JSON.stringify(data, null, 2));
+  console.log(`[export-dashboard] wrote dashboard to ${destPath}`);
+}
+
+async function main() {
+  const options = parseArgs(process.argv);
+  try {
+    await exportDashboard(options);
+  } catch (error) {
+    console.error('[export-dashboard] error:', error.message);
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests/unit/trace/export-dashboard.test.ts
+++ b/tests/unit/trace/export-dashboard.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const scriptPath = join(process.cwd(), 'scripts/trace/export-dashboard.mjs');
+
+describe('export-dashboard CLI', () => {
+  it('shows help message', () => {
+    const result = spawnSync(process.execPath, [scriptPath, '--help'], { encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Usage:');
+  });
+
+  it('fails when uid is missing', () => {
+    const result = spawnSync(process.execPath, [scriptPath], { encoding: 'utf8' });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('missing required --uid');
+  });
+});


### PR DESCRIPTION
## Summary
- add a small CLI () to export Grafana dashboards via the API
- support configuration via CLI flags or environment variables and document the workflow in the Tempo playbook
- cover the help/error behaviour with a vitest unit test

## Testing
- pnpm vitest run tests/unit/trace/export-dashboard.test.ts
