### PR TITLE
Add envelope GitHub comment helper

### DIFF
--- a/docs/trace/REPORT_ENVELOPE.md
+++ b/docs/trace/REPORT_ENVELOPE.md
@@ -135,6 +135,12 @@ Issue: #1011 / #1012 / #1036 / #1038
    - Envelope が揃っている場合は `pnpm verify:conformance --from-envelope artifacts/report-envelope.json` でトレースサマリを再掲でき、CI なしの環境でも Step Summary を再利用できる。
 2. Envelope の生成時に `GITHUB_RUN_ID` / `GITHUB_WORKFLOW` / `GITHUB_SHA` / `GITHUB_REF` を自動埋め込み、他の CI でも環境変数から補完できるようにする。
 3. `REPORT_ENVELOPE_TEMPO_LINK_TEMPLATE` を設定すると `tempoLinks[]` に Tempo Explore への URL が追加され、Step Summary やダッシュボードから対象 trace をすぐ開ける（例: `https://tempo.example.com/explore?traceId={traceId}`）。
+
+### GitHub へのコメント展開
+- `scripts/trace/post-envelope-comment.mjs` を使うと、Envelope の内容を GitHub Issue / Pull Request コメントとして展開できる。
+  - `node scripts/trace/post-envelope-comment.mjs --envelope artifacts/trace/report-envelope.json --dry-run` で出力を確認。
+  - 実際に投稿する場合は `--repo <owner/repo>` と `--issue`（または `--pr`）を指定し、`gh` CLI が利用可能な環境で実行する。
+  - コメントには Trace IDs、Tempo Links、Artifacts、Cases などが Markdown で整形され、Slack や GitHub 上での共有を容易にする。
 4. Trace 系ジョブでは、Collector から取得した payload のメタデータ (`kvonce-payload-metadata.json`) を artifacts 配列に追加し、`scripts/trace/build-kvonce-envelope-summary.mjs` で集計したサマリを `scripts/trace/create-report-envelope.mjs` でラップする。
 5. Dashboard / Tempo 連携は Envelope を単位としてインジェストし、必要に応じて `traceIds` から関連 span を引き直す。
 6. S3 などに Envelope を保存する場合は `scripts/trace/upload-envelope.mjs`（AWS CLI 要）を利用し、`REPORT_ENVELOPE_OUTPUT` を指すファイルを `REPORT_ENVELOPE_S3_BUCKET` / `REPORT_ENVELOPE_S3_KEY` でアップロードする。

--- a/scripts/trace/post-envelope-comment.mjs
+++ b/scripts/trace/post-envelope-comment.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+function parseArgs(argv) {
+  const options = {
+    envelope: process.env.ENVELOPE_COMMENT_SOURCE ?? 'artifacts/trace/report-envelope.json',
+    issue: null,
+    pr: null,
+    repo: process.env.GITHUB_REPOSITORY ?? null,
+    dryRun: false,
+    output: null,
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if ((arg === '--envelope' || arg === '-e') && next) {
+      options.envelope = next;
+      i += 1;
+    } else if ((arg === '--issue' || arg === '-i') && next) {
+      const parsed = Number(next);
+      options.issue = Number.isNaN(parsed) ? null : parsed;
+      i += 1;
+    } else if (arg === '--pr' && next) {
+      const parsed = Number(next);
+      options.pr = Number.isNaN(parsed) ? null : parsed;
+      i += 1;
+    } else if ((arg === '--repo' || arg === '-r') && next) {
+      options.repo = next;
+      i += 1;
+    } else if (arg === '--output' && next) {
+      options.output = next;
+      i += 1;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: node scripts/trace/post-envelope-comment.mjs [options]
+
+Options:
+  -e, --envelope <file>    Envelope JSON path (default: artifacts/trace/report-envelope.json)
+  -i, --issue <number>     Issue number to comment on
+      --pr <number>        Pull request number to comment on
+  -r, --repo <owner/repo>  Repository (default: $GITHUB_REPOSITORY)
+      --output <file>      Write the generated comment Markdown to a file
+      --dry-run            Print the comment and skip posting to GitHub
+  -h, --help               Show this message
+`);
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+function readEnvelope(filePath) {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    console.error(`[envelope-comment] envelope not found: ${resolved}`);
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(resolved, 'utf8'));
+  } catch (error) {
+    console.error(`[envelope-comment] failed to parse envelope: ${resolved}`);
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+const inlineCode = (value) => `\`${value}\``;
+
+function formatArtifacts(envelope) {
+  const records = Array.isArray(envelope?.artifacts) ? envelope.artifacts : [];
+  const items = records
+    .filter((item) => typeof item?.path === 'string' && item.path.trim())
+    .map((item) => {
+      const label = item.description ? `${item.description}` : 'artifact';
+      return `- ${label}: ${inlineCode(item.path)}`;
+    });
+  if (items.length === 0) return null;
+  return ['### Artifacts', ...items].join('\n');
+}
+
+function collectStringValues(...maybeArrays) {
+  const values = new Set();
+  for (const candidate of maybeArrays) {
+    if (!Array.isArray(candidate)) continue;
+    for (const value of candidate) {
+      if (typeof value === 'string' && value.trim()) {
+        values.add(value.trim());
+      }
+    }
+  }
+  return Array.from(values);
+}
+
+function formatTraceIds(envelope) {
+  const traceIds = collectStringValues(
+    envelope?.summary?.trace?.traceIds,
+    envelope?.summary?.traceIds,
+    envelope?.correlation?.traceIds,
+  );
+  if (traceIds.length === 0) return null;
+  const lines = traceIds.sort().map((id) => `- ${inlineCode(id)}`);
+  return ['### Trace IDs', ...lines].join('\n');
+}
+
+function formatTempoLinks(envelope) {
+  const tempoLinks = collectStringValues(envelope?.tempoLinks, envelope?.summary?.tempoLinks);
+  if (tempoLinks.length === 0) return null;
+  const items = tempoLinks.sort().map((link) => `- ${link}`);
+  return ['### Tempo Links', ...items].join('\n');
+}
+
+function getCaseValidity(value) {
+  if (value === true) return 'valid';
+  if (value === false) return 'invalid';
+  return 'unknown';
+}
+
+function formatCases(envelope) {
+  const cases = Array.isArray(envelope?.summary?.cases) ? envelope.summary.cases : [];
+  if (cases.length === 0) return null;
+  const items = cases.map((entry) => {
+    const label = entry.label ?? entry.format ?? entry.key ?? 'unknown';
+    const valid = getCaseValidity(entry.valid);
+    const traceIds = Array.isArray(entry.traceIds) ? entry.traceIds.filter((id) => typeof id === 'string' && id.trim()) : [];
+    const suffix = traceIds.length > 0 ? ` traceIds=${traceIds.join(', ')}` : '';
+    return `- **${label}**: status=${valid}${suffix}`;
+  });
+  return ['### Trace Cases', ...items].join('\n');
+}
+
+function buildComment(envelope) {
+  const meta = envelope?.correlation ?? {};
+  const source = envelope?.source ?? 'unknown';
+  const runId = meta.runId ?? '(unknown run)';
+  const branch = meta.branch ?? '(unknown branch)';
+  const status = envelope?.summary?.trace?.status ?? envelope?.summary?.status ?? 'unknown';
+  const workflow = meta.workflow ?? null;
+
+  const header = [
+    '## Trace Envelope Summary',
+    `- Source: ${inlineCode(source)}`,
+    `- Status: ${inlineCode(status)}`,
+    `- Run: ${inlineCode(runId)}`,
+    `- Branch: ${inlineCode(branch)}`,
+    workflow ? `- Workflow: ${inlineCode(workflow)}` : null,
+  ].filter(Boolean).join('\n');
+
+  const sections = [
+    header,
+    formatTraceIds(envelope),
+    formatTempoLinks(envelope),
+    formatArtifacts(envelope),
+    formatCases(envelope),
+  ].filter(Boolean);
+
+  return sections.join('\n\n');
+}
+
+function writeOutput(outputPath, content) {
+  if (!outputPath) return;
+  const resolved = path.resolve(outputPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, `${content}\n`);
+  console.log(`[envelope-comment] wrote comment body to ${resolved}`);
+}
+
+function postToGithub({ repo, issueNumber, body }) {
+  if (!repo) {
+    console.error('[envelope-comment] repository not specified (use --repo or set GITHUB_REPOSITORY)');
+    process.exit(1);
+  }
+  if (!issueNumber) {
+    console.error('[envelope-comment] issue or PR number is required');
+    process.exit(1);
+  }
+  const payload = JSON.stringify({ body });
+  const args = [
+    'api',
+    `repos/${repo}/issues/${issueNumber}/comments`,
+    '--method',
+    'POST',
+    '-H',
+    'Content-Type: application/json',
+    '--input',
+    '-',
+  ];
+  const result = spawnSync('gh', args, { stdio: ['pipe', 'inherit', 'inherit'], input: payload });
+  if (result.status !== 0) {
+    console.error('[envelope-comment] failed to post comment with gh');
+    process.exit(result.status ?? 1);
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv);
+  const envelope = readEnvelope(options.envelope);
+  const body = buildComment(envelope);
+  if (!body) {
+    console.error('[envelope-comment] failed to build comment body');
+    process.exit(1);
+  }
+  if (options.output) {
+    writeOutput(options.output, body);
+  }
+  console.log(body);
+  if (options.dryRun) {
+    return;
+  }
+  const issueNumber = options.pr ?? options.issue;
+  postToGithub({ repo: options.repo, issueNumber, body });
+}
+
+const isDirectExecution = (() => {
+  const invoked = process.argv[1] ? path.resolve(process.argv[1]) : null;
+  const current = fileURLToPath(import.meta.url);
+  return invoked && current === invoked;
+})();
+
+if (isDirectExecution) {
+  main();
+}

--- a/tests/unit/trace/post-envelope-comment.test.ts
+++ b/tests/unit/trace/post-envelope-comment.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import os from 'node:os';
+
+const scriptPath = join(process.cwd(), 'scripts/trace/post-envelope-comment.mjs');
+
+describe('post-envelope-comment CLI', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(os.tmpdir(), 'envelope-comment-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('prints comment in dry-run mode', () => {
+    const envelopePath = join(tempDir, 'envelope.json');
+    writeFileSync(envelopePath, JSON.stringify({
+      source: 'verify-lite',
+      correlation: {
+        runId: '123',
+        branch: 'feature/x',
+        workflow: 'CI',
+        traceIds: ['trace-a'],
+      },
+      summary: {
+        status: 'valid',
+        trace: {
+          status: 'valid',
+          traceIds: ['trace-b'],
+        },
+        cases: [
+          { format: 'current', label: 'Current', valid: true, traceIds: ['trace-b'] },
+        ],
+        tempoLinks: ['https://tempo.example.com/explore?traceId=trace-a'],
+      },
+      artifacts: [
+        { description: 'Validation', path: 'hermetic-reports/trace/kvonce-validation.json' },
+      ],
+    }, null, 2));
+
+    const result = spawnSync(process.execPath, [
+      scriptPath,
+      '--envelope', envelopePath,
+      '--dry-run',
+    ], { encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('## Trace Envelope Summary');
+    expect(result.stdout).toContain('Tempo Links');
+    expect(result.stdout).toContain('Trace IDs');
+    expect(result.stdout).toContain('Trace Cases');
+  });
+
+  it('writes output file when --output is specified', () => {
+    const envelopePath = join(tempDir, 'envelope.json');
+    const outputPath = join(tempDir, 'comment.md');
+    writeFileSync(envelopePath, JSON.stringify({ summary: {} }));
+
+    const result = spawnSync(process.execPath, [
+      scriptPath,
+      '--envelope', envelopePath,
+      '--dry-run',
+      '--output', outputPath,
+    ], { encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+    expect(readFileSync(outputPath, 'utf8')).toContain('Trace Envelope Summary');
+  });
+});


### PR DESCRIPTION
## Summary
- add a CLI that renders envelope metadata as Markdown for GitHub issue/PR comments
- support dry-run output and optional posting via gh api with repository/issue inputs
- document the workflow in REPORT_ENVELOPE.md and cover behaviour with Vitest