### PR TITLE
Add data links to verify lite summary

### DIFF
--- a/docs/notes/step-summary-layout.md
+++ b/docs/notes/step-summary-layout.md
@@ -20,6 +20,7 @@ Issue refs: #1097 / #1096 / #1038
 
 - **Spec セクション**: `verify:conformance` が TLC 実行時に `hermetic-reports/formal/tla-summary.json` のステータスを要約する（ツールが未導入の場合は `status: tool_not_available` を表示）。
 - **Verify Lite セクション**: `pipelines:full` で `reports/verify-lite/verify-lite-run-summary.json` を Envelope に詰めたうえで、lint / mutation quick / property の結果を `summary.steps.*` から抜粋する。
+  - Lint Baseline Diff や Mutation HTML レポートは Step Summary の “Artifacts” セクションに `Lint Baseline Diff` / `Mutation HTML Report` として表示し、GitHub Artifacts への Data Link を添付する。
 - **Trace セクション**: `verify:conformance` または `verify:conformance --from-envelope` の `summary.trace` を描画し、Projection/Validation/TLC の結果と issues 数を列挙する。`REPORT_ENVELOPE_TEMPO_LINK_TEMPLATE` を設定しておくと Tempo Explore へのリンクも自動生成できる。
   - `traceIds` や `artifacts` 情報（projection/validation/state sequence/replay）を付与しておくと、Step Summary から GitHub Artifacts へジャンプできる。
 
@@ -31,7 +32,7 @@ Issue refs: #1097 / #1096 / #1038
 - Tempo / Grafana へリンクを貼る場合は `docs/trace/grafana/tempo-dashboard.md` のプレイブックに沿って Data Link を設定する。
 
 ## TODO
-- [ ] Verify Lite ワークフローの Step Summary に mutation report / lint baseline diff へのリンクを追加する。
+- [x] Verify Lite ワークフローの Step Summary に mutation report / lint baseline diff へのリンクを追加する。
 - [ ] Trace Envelope の `artifacts[]` から Tempo / S3 への Data Link を生成し、Step Summary から直接遷移できるようにする。
 - [ ] Multi-domain Trace が実装されたら `summary.trace.domains[]` をサポートする。
 - [ ] Step Summary 再利用手順（`--from-envelope`）を CI ガイドラインに反映し、手動トラブルシュート手順を整備する。

--- a/scripts/ci/lib/verify-lite-summary.mjs
+++ b/scripts/ci/lib/verify-lite-summary.mjs
@@ -94,19 +94,33 @@ export const renderVerifyLiteSummary = (summary, options = {}) => {
   const artifactLines = [];
   if (Object.keys(artifacts).length > 0) {
     const { artifactsUrl } = options;
+    const labelMap = {
+      lintSummary: 'Lint Baseline Diff',
+      lintLog: 'Lint Log',
+      mutationSummary: 'Mutation HTML Report',
+      mutationSurvivors: 'Mutation Survivors JSON',
+    };
     const formatArtifact = (value) => {
       if (!value) return 'n/a';
       if (/^https?:\/\//i.test(value)) {
-        return `[${value}](${value})`;
+        return `[Data Link](${value})`;
       }
       if (artifactsUrl) {
-        return `\`${value}\` ([Artifacts](${artifactsUrl}))`;
+        return `\`${value}\` ([Data Link](${artifactsUrl}))`;
       }
-      return value;
+      return `\`${value}\``;
     };
 
     artifactLines.push('\nArtifacts:');
+    const preferredOrder = ['lintSummary', 'lintLog', 'mutationSummary', 'mutationSurvivors'];
+    const handled = new Set();
+    for (const key of preferredOrder) {
+      if (!Object.prototype.hasOwnProperty.call(artifacts, key)) continue;
+      handled.add(key);
+      artifactLines.push(`- ${labelMap[key] ?? key}: ${formatArtifact(artifacts[key])}`);
+    }
     for (const [key, value] of Object.entries(artifacts)) {
+      if (handled.has(key)) continue;
       artifactLines.push(`- ${key}: ${formatArtifact(value)}`);
     }
     if (artifactsUrl) {

--- a/tests/unit/ci/__snapshots__/render-verify-lite-summary.test.ts.snap
+++ b/tests/unit/ci/__snapshots__/render-verify-lite-summary.test.ts.snap
@@ -16,10 +16,10 @@ Schema Version: 1.0.0
 
 
 Artifacts:
-- lintSummary: n/a
-- lintLog: n/a
-- mutationSummary: n/a
-- mutationSurvivors: n/a"
+- Lint Baseline Diff: n/a
+- Lint Log: n/a
+- Mutation HTML Report: n/a
+- Mutation Survivors JSON: n/a"
 `;
 
 exports[`renderVerifyLiteSummary > renders markdown summary with schema version and flags 1`] = `
@@ -41,9 +41,9 @@ Schema Version: 1.0.0
 
 
 Artifacts:
-- lintSummary: \`verify-lite-lint-summary.json\` ([Artifacts](https://example.com/artifacts))
-- lintLog: \`verify-lite-lint.log\` ([Artifacts](https://example.com/artifacts))
-- mutationSummary: \`mutation-summary.md\` ([Artifacts](https://example.com/artifacts))
-- mutationSurvivors: \`reports/mutation/survivors.json\` ([Artifacts](https://example.com/artifacts))
+- Lint Baseline Diff: \`verify-lite-lint-summary.json\` ([Data Link](https://example.com/artifacts))
+- Lint Log: \`verify-lite-lint.log\` ([Data Link](https://example.com/artifacts))
+- Mutation HTML Report: \`mutation-summary.md\` ([Data Link](https://example.com/artifacts))
+- Mutation Survivors JSON: \`reports/mutation/survivors.json\` ([Data Link](https://example.com/artifacts))
 - GitHub Artifacts: [Open](https://example.com/artifacts)"
 `;


### PR DESCRIPTION
## Summary
- enhance the verify-lite step summary renderer to label artifacts and provide explicit Data Link entries
- surface lint baseline diff and mutation HTML report links in GitHub step summaries via updated formatting and snapshots
- document the change in the step summary layout note