### PR TITLE
Add multi-domain support to trace envelopes

### DIFF
--- a/docs/trace/multi-domain-samples/envelope-with-domains.json
+++ b/docs/trace/multi-domain-samples/envelope-with-domains.json
@@ -1,0 +1,76 @@
+{
+  "schemaVersion": "1.0.0",
+  "source": "multi-domain-trace",
+  "generatedAt": "2025-10-09T00:00:00Z",
+  "correlation": {
+    "runId": "12345",
+    "workflow": "trace-ci",
+    "branch": "feature/multi-domain",
+    "commit": "abcdef0",
+    "traceIds": ["inventory-trace-1", "reservation-trace-8"]
+  },
+  "summary": {
+    "trace": {
+      "status": "invalid",
+      "domains": [
+        {
+          "key": "inventory",
+          "label": "Inventory",
+          "status": "valid",
+          "issues": 0,
+          "traceIds": ["inventory-trace-1"],
+          "tempoLinks": [
+            "https://tempo.example.com/explore?traceId=inventory-trace-1"
+          ],
+          "artifacts": {
+            "validationPath": "hermetic-reports/trace/inventory/validation.json",
+            "projectionPath": "hermetic-reports/trace/inventory/projection.json",
+            "stateSequencePath": "hermetic-reports/trace/inventory/state-sequence.json"
+          },
+          "metrics": {
+            "eventCount": 32,
+            "replayStatus": "skipped"
+          }
+        },
+        {
+          "key": "reservation",
+          "label": "Reservation",
+          "status": "invalid",
+          "issues": 2,
+          "traceIds": ["reservation-trace-8"],
+          "tempoLinks": [
+            "https://tempo.example.com/explore?traceId=reservation-trace-8"
+          ],
+          "artifacts": {
+            "validationPath": "hermetic-reports/trace/reservation/validation.json",
+            "projectionPath": "hermetic-reports/trace/reservation/projection.json"
+          },
+          "metrics": {
+            "eventCount": 21,
+            "replayStatus": "ran"
+          }
+        }
+      ],
+      "aggregate": {
+        "traceIds": ["inventory-trace-1", "reservation-trace-8"],
+        "tempoLinks": [
+          "https://tempo.example.com/explore?traceId=inventory-trace-1",
+          "https://tempo.example.com/explore?traceId=reservation-trace-8"
+        ],
+        "issues": 2
+      }
+    }
+  },
+  "artifacts": [
+    {
+      "type": "application/json",
+      "path": "hermetic-reports/trace/inventory/validation.json",
+      "checksum": "sha256:deadbeef"
+    },
+    {
+      "type": "application/json",
+      "path": "hermetic-reports/trace/reservation/validation.json",
+      "checksum": "sha256:feedface"
+    }
+  ]
+}

--- a/docs/trace/multi-domain-samples/inventory-domain-summary.json
+++ b/docs/trace/multi-domain-samples/inventory-domain-summary.json
@@ -1,0 +1,17 @@
+{
+  "key": "inventory",
+  "label": "Inventory",
+  "status": "valid",
+  "issues": 0,
+  "traceIds": ["inventory-trace-1"],
+  "tempoLinks": ["https://tempo.example.com/explore?traceId=inventory-trace-1"],
+  "artifacts": {
+    "validationPath": "hermetic-reports/trace/inventory/validation.json",
+    "projectionPath": "hermetic-reports/trace/inventory/projection.json",
+    "stateSequencePath": "hermetic-reports/trace/inventory/state-sequence.json"
+  },
+  "metrics": {
+    "eventCount": 32,
+    "replayStatus": "skipped"
+  }
+}

--- a/docs/trace/multi-domain-samples/reservation-domain-summary.json
+++ b/docs/trace/multi-domain-samples/reservation-domain-summary.json
@@ -1,0 +1,16 @@
+{
+  "key": "reservation",
+  "label": "Reservation",
+  "status": "invalid",
+  "issues": 2,
+  "traceIds": ["reservation-trace-8"],
+  "tempoLinks": ["https://tempo.example.com/explore?traceId=reservation-trace-8"],
+  "artifacts": {
+    "validationPath": "hermetic-reports/trace/reservation/validation.json",
+    "projectionPath": "hermetic-reports/trace/reservation/projection.json"
+  },
+  "metrics": {
+    "eventCount": 21,
+    "replayStatus": "ran"
+  }
+}

--- a/docs/trace/multi-domain-trace-schema.md
+++ b/docs/trace/multi-domain-trace-schema.md
@@ -71,9 +71,19 @@ summary.trace = {
 - `scripts/trace/generate-grafana-variables.mjs` を拡張し、`variables.domains` として `{ value: "inventory", text: "Inventory" }` を出力。テンプレート変数でドメイン切り替えが可能になる。
 - Tempo 側 span 属性に `trace.domain=inventory` を付与し、Grafana ダッシュボードで `kvonce_domain` などのタグを使ってフィルタリング。
 
+## サンプル
+
+`docs/trace/multi-domain-samples/` には envelope とドメインサマリの例が含まれる。
+
+- `envelope-with-domains.json`: `summary.trace.domains[]` を含むサンプル envelope。
+- `inventory-domain-summary.json`: Inventory ドメインのドメインサマリ例。
+- `reservation-domain-summary.json`: Reservation ドメインのドメインサマリ例。
+
+実装やテストで multi-domain 構造を扱う際のリファレンスとして利用できる。
+
 ## TODO
 
 - [ ] Inventory サンプル NDJSON を用意し、`pipelines:trace` で `summary.trace.domains[]` に追加するスクリプトを実装。
-- [ ] `scripts/formal/verify-conformance.mjs` の Step Summary 出力を multi-domain 対応させる。
+- [x] `scripts/formal/verify-conformance.mjs` の Step Summary 出力を multi-domain 対応させる。
 - [ ] Grafana ダッシュボード JSON をドメイン別にエクスポートし、テンプレート変数から切り替えられるようにする。
-- [ ] GitHub コメント CLI (`post-envelope-comment.mjs`) で `### Trace Cases` セクションにドメイン名を含める。
+- [x] GitHub コメント CLI (`post-envelope-comment.mjs`) で `### Trace Cases` セクションにドメイン名を含める。

--- a/scripts/trace/post-envelope-comment.mjs
+++ b/scripts/trace/post-envelope-comment.mjs
@@ -115,6 +115,19 @@ function formatTempoLinks(envelope) {
   return ['### Tempo Links', ...items].join('\n');
 }
 
+function formatDomains(envelope) {
+  const domains = Array.isArray(envelope?.summary?.trace?.domains) ? envelope.summary.trace.domains : [];
+  if (domains.length === 0) return null;
+  const items = domains.map((domain) => {
+    const label = domain?.label ?? domain?.key ?? 'unknown';
+    const status = domain?.status ?? 'unknown';
+    const issues = domain?.issues ?? 0;
+    const traceIds = Array.isArray(domain?.traceIds) && domain.traceIds.length > 0 ? ` traceIds=${domain.traceIds.join(', ')}` : '';
+    return `- **${label}**: status=${status} issues=${issues}${traceIds}`;
+  });
+  return ['### Trace Domains', ...items].join('\n');
+}
+
 function getCaseValidity(value) {
   if (value === true) return 'valid';
   if (value === false) return 'invalid';
@@ -155,6 +168,7 @@ function buildComment(envelope) {
     header,
     formatTraceIds(envelope),
     formatTempoLinks(envelope),
+    formatDomains(envelope),
     formatArtifacts(envelope),
     formatCases(envelope),
   ].filter(Boolean);

--- a/tests/unit/formal/verify-conformance.integration.test.ts
+++ b/tests/unit/formal/verify-conformance.integration.test.ts
@@ -70,6 +70,8 @@ describe('verify-conformance --from-envelope', () => {
       expect(summary.trace?.status).toBeDefined();
       expect(summary.trace?.traceIds ?? summary.traceIds).toEqual(['trace-1']);
       expect(summary.trace?.tempoLinks ?? summary.tempoLinks).toEqual(['https://tempo.example.com/explore?traceId=trace-1']);
+      expect(summary.trace?.domains?.[0]?.key).toBe('kvonce');
+      expect(summary.trace?.domains?.[0]?.traceIds).toEqual(['trace-1']);
 
       const envelopePath = join(dir, 'envelope.json');
       const envelope = {
@@ -106,6 +108,8 @@ describe('verify-conformance --from-envelope', () => {
       expect(replaySummary.trace?.status).toBe(summary.trace?.status);
       expect(replaySummary.trace?.traceIds ?? replaySummary.traceIds).toEqual(['trace-1']);
       expect(replaySummary.trace?.tempoLinks ?? replaySummary.tempoLinks).toEqual(['https://tempo.example.com/explore?traceId=trace-1']);
+      expect(replaySummary.trace?.domains?.[0]?.key).toBe('kvonce');
+      expect(replaySummary.trace?.domains?.[0]?.traceIds).toEqual(['trace-1']);
     });
   });
 });

--- a/tests/unit/trace/build-kvonce-envelope-summary.test.ts
+++ b/tests/unit/trace/build-kvonce-envelope-summary.test.ts
@@ -97,6 +97,15 @@ describe('build-kvonce-envelope-summary.mjs', () => {
       expect(summary.traceIds).toEqual(['trace-xyz']);
       expect(summary.tempoLinks).toContain('https://tempo.example.com/explore?traceId=trace-xyz');
       expect(summary.conformance?.trace?.traceIds).toEqual(['trace-xyz']);
+      expect(summary.trace?.traceIds).toEqual(['trace-xyz']);
+      expect(summary.trace?.tempoLinks).toEqual(['https://tempo.example.com/explore?traceId=trace-xyz']);
+      const domain = summary.trace?.domains?.find((entry: { key: string }) => entry.key === 'current');
+      expect(domain).toBeDefined();
+      expect(domain?.status).toBe('valid');
+      expect(domain?.traceIds).toEqual(['trace-xyz']);
+      expect(summary.trace?.aggregate?.traceIds).toEqual(['trace-xyz']);
+      expect(summary.trace?.aggregate?.tempoLinks).toEqual(['https://tempo.example.com/explore?traceId=trace-xyz']);
+      expect(summary.trace?.aggregate?.issues).toBe(0);
     });
   });
 });

--- a/tests/unit/trace/post-envelope-comment.test.ts
+++ b/tests/unit/trace/post-envelope-comment.test.ts
@@ -32,6 +32,16 @@ describe('post-envelope-comment CLI', () => {
         trace: {
           status: 'valid',
           traceIds: ['trace-b'],
+          domains: [
+            {
+              key: 'inventory',
+              label: 'Inventory',
+              status: 'valid',
+              issues: 0,
+              traceIds: ['trace-b'],
+              tempoLinks: ['https://tempo.example.com/explore?traceId=trace-b'],
+            },
+          ],
         },
         cases: [
           { format: 'current', label: 'Current', valid: true, traceIds: ['trace-b'] },
@@ -54,6 +64,7 @@ describe('post-envelope-comment CLI', () => {
     expect(result.stdout).toContain('Tempo Links');
     expect(result.stdout).toContain('Trace IDs');
     expect(result.stdout).toContain('Trace Cases');
+    expect(result.stdout).toContain('Trace Domains');
   });
 
   it('writes output file when --output is specified', () => {


### PR DESCRIPTION
## Summary
- extend build-kvonce-envelope-summary to emit summary.trace.domains entries and aggregate trace metadata
- ensure create-report-envelope and verify-conformance consume domain trace IDs/links and expose them in step summaries and comments
- add sample JSON fixtures, tests, and documentation for multi-domain envelope structures