### PR TITLE
Add publish-envelope CLI for S3 automation

### DIFF
--- a/docs/trace/REPORT_ENVELOPE.md
+++ b/docs/trace/REPORT_ENVELOPE.md
@@ -144,6 +144,7 @@ Issue: #1011 / #1012 / #1036 / #1038
 4. Trace 系ジョブでは、Collector から取得した payload のメタデータ (`kvonce-payload-metadata.json`) を artifacts 配列に追加し、`scripts/trace/build-kvonce-envelope-summary.mjs` で集計したサマリを `scripts/trace/create-report-envelope.mjs` でラップする。
 5. Dashboard / Tempo 連携は Envelope を単位としてインジェストし、必要に応じて `traceIds` から関連 span を引き直す。
 6. S3 などに Envelope を保存する場合は `scripts/trace/upload-envelope.mjs`（AWS CLI 要）を利用し、`REPORT_ENVELOPE_OUTPUT` を指すファイルを `REPORT_ENVELOPE_S3_BUCKET` / `REPORT_ENVELOPE_S3_KEY` でアップロードする。
+7. presigned URL や Slack 通知が必要な場合は `scripts/trace/publish-envelope.mjs` を利用する。`--dry-run` でプレビュー後、`--bucket` 等を指定して `upload-envelope` → `aws s3 presign` → Slack 通知までを一括で実行できる。
 
 ## OTLP Attribute Mapping
 | Envelope Field | OTLP Span Attribute | 説明 |

--- a/docs/trace/envelope-s3-automation.md
+++ b/docs/trace/envelope-s3-automation.md
@@ -1,0 +1,39 @@
+# Envelope S3 Automation Plan
+
+Issue refs: #1038 / #1042
+
+## 目的
+- Verify Lite / Trace pipeline で生成される Envelope を S3 にアップロードし、presigned URL を生成して Slack に通知する。
+- CLI 化し、GitHub Actions とローカル環境の両方で再利用できるよう整備する。
+
+## 要求仕様
+1. `scripts/trace/upload-envelope.mjs` を利用して S3 にアップロードしたファイルに対して presigned URL を生成する。
+2. presigned URL と GitHub Actions のメタデータを Slack Webhook に送信できる（dry-run では標準出力のみ）。
+3. 生成したメタデータを JSON (`artifacts/trace/publish-envelope.json`) に保存し、後続の Step Summary や GitHub コメントで参照可能にする。
+4. CLI は AWS 認証情報がない場合には早期にエラーを出し、dry-run で挙動を確認できる。
+
+## CLI: `scripts/trace/publish-envelope.mjs`
+```
+Usage: node scripts/trace/publish-envelope.mjs [options]
+  -e, --envelope <file>       Envelope JSON (default: artifacts/report-envelope.json)
+  -b, --bucket <name>         S3 bucket (required)
+  -k, --key <key>             S3 key (default: envelopes/<runId>/<filename>)
+      --expires <seconds>     Presigned URL expiration (default: 604800)
+      --slack-webhook <url>   Slack Incoming Webhook URL (optional)
+      --slack-channel <name>  Slack channel label (optional)
+      --output <file>         Metadata JSON path (default: artifacts/trace/publish-envelope.json)
+      --dry-run               Upload/presign/slack を行わずプレビューのみ
+      --help
+```
+
+## 実行フロー
+1. Envelope JSON を読み込み、`correlation.runId` などを取り出す。
+2. dry-run でなければ `upload-envelope.mjs` を呼び出し S3 へアップロード。
+3. `aws s3 presign` で presigned URL を生成。
+4. Slack Webhook が設定されている場合は通知文を組み立て送信（dry-run 時は標準出力にプレビュー）。
+5. `artifacts/trace/publish-envelope.json` に実行結果（bucket/key/presignedUrl/dryRun 等）を書き出す。
+
+## 後続 TODO
+- GitHub Actions ワークフローから `publish-envelope.mjs` を呼び出し、Step Summary へ presigned URL を追記する。
+- `post-envelope-comment.mjs` の `### Trace Domains` に加えて `### Presigned URL` を追加し、Slack 同等の情報をコメントにも展開する。
+- 環境ごとに bucket/key を切り替えるための設定ファイル (`envelope.publish.config.json` など) を導入する。

--- a/scripts/trace/publish-envelope.mjs
+++ b/scripts/trace/publish-envelope.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import https from 'node:https';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function parseArgs(argv) {
+  const options = {
+    envelope: process.env.ENVELOPE_PUBLISH_SOURCE ?? 'artifacts/report-envelope.json',
+    bucket: process.env.ENVELOPE_PUBLISH_BUCKET ?? null,
+    key: process.env.ENVELOPE_PUBLISH_KEY ?? null,
+    expires: Number.parseInt(process.env.ENVELOPE_PUBLISH_EXPIRES ?? '604800', 10),
+    slackWebhook: process.env.ENVELOPE_PUBLISH_SLACK_WEBHOOK ?? null,
+    slackChannel: process.env.ENVELOPE_PUBLISH_SLACK_CHANNEL ?? null,
+    output: process.env.ENVELOPE_PUBLISH_OUTPUT ?? 'artifacts/trace/publish-envelope.json',
+    dryRun: false,
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if ((arg === '--envelope' || arg === '-e') && next) {
+      options.envelope = next;
+      i += 1;
+    } else if ((arg === '--bucket' || arg === '-b') && next) {
+      options.bucket = next;
+      i += 1;
+    } else if ((arg === '--key' || arg === '-k') && next) {
+      options.key = next;
+      i += 1;
+    } else if (arg === '--expires' && next) {
+      options.expires = Number.parseInt(next, 10);
+      i += 1;
+    } else if (arg === '--slack-webhook' && next) {
+      options.slackWebhook = next;
+      i += 1;
+    } else if (arg === '--slack-channel' && next) {
+      options.slackChannel = next;
+      i += 1;
+    } else if ((arg === '--output' || arg === '-o') && next) {
+      options.output = next;
+      i += 1;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: node scripts/trace/publish-envelope.mjs [options]
+Options:
+  -e, --envelope <file>       Envelope JSON (default: artifacts/report-envelope.json)
+  -b, --bucket <name>         S3 bucket (required)
+  -k, --key <key>             S3 key (default: envelopes/<runId>/<filename>)
+      --expires <seconds>     Presigned URL expiration in seconds (default: 604800)
+      --slack-webhook <url>   Slack Incoming Webhook URL (optional)
+      --slack-channel <name>  Slack channel or conversation label
+      --output <file>         Output metadata JSON (default: artifacts/trace/publish-envelope.json)
+      --dry-run               Skip upload/presign/slack, emit summary only
+      --help                  Show this message
+`);
+      process.exit(0);
+    }
+  }
+  return options;
+}
+
+function readEnvelope(resolvedPath) {
+  if (!fs.existsSync(resolvedPath)) {
+    console.error(`[publish-envelope] envelope not found: ${resolvedPath}`);
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+  } catch (error) {
+    console.error(`[publish-envelope] failed to parse envelope: ${resolvedPath}`);
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+function runUpload(envelopePath, bucket, key) {
+  const uploadScript = path.resolve(repoRoot, 'scripts', 'trace', 'upload-envelope.mjs');
+  const result = spawnSync(process.execPath, [uploadScript, '--file', envelopePath, '--bucket', bucket, '--key', key], {
+    stdio: 'inherit',
+    cwd: repoRoot,
+  });
+  if (result.status !== 0) {
+    console.error(`[publish-envelope] upload failed with status ${result.status}`);
+    process.exit(result.status ?? 1);
+  }
+}
+
+function runPresign(bucket, key, expires) {
+  const s3Path = `s3://${bucket}/${key}`;
+  const result = spawnSync('aws', ['s3', 'presign', s3Path, '--expires', String(expires)], {
+    encoding: 'utf8',
+    cwd: repoRoot,
+  });
+  if (result.status !== 0) {
+    console.error('[publish-envelope] aws s3 presign failed');
+    if (result.stderr) console.error(result.stderr.trim());
+    process.exit(result.status ?? 1);
+  }
+  return result.stdout.trim();
+}
+
+function postSlack(webhookUrl, payload) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(webhookUrl);
+    const request = https.request({
+      hostname: url.hostname,
+      path: `${url.pathname}${url.search}`,
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }, (res) => {
+      if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+        resolve();
+      } else {
+        reject(new Error(`Slack webhook failed with status ${res.statusCode}`));
+      }
+    });
+    request.on('error', reject);
+    request.write(JSON.stringify(payload));
+    request.end();
+  });
+}
+
+function ensureOutputDir(filePath) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv);
+  if (!options.bucket) {
+    console.error('[publish-envelope] missing required bucket (--bucket)');
+    process.exit(1);
+  }
+
+  const envelopePath = path.resolve(options.envelope);
+  const envelope = readEnvelope(envelopePath);
+  const defaultKey = () => {
+    const runId = envelope?.correlation?.runId ?? `run-${Date.now()}`;
+    return `envelopes/${runId}/${path.basename(envelopePath)}`;
+  };
+  const key = options.key ?? defaultKey();
+
+  console.log(`[publish-envelope] envelope=${path.relative(repoRoot, envelopePath)}`);
+  console.log(`[publish-envelope] bucket=${options.bucket} key=${key}`);
+
+  let presignedUrl = null;
+  const dryRun = Boolean(options.dryRun);
+
+  if (!dryRun) {
+    runUpload(path.relative(process.cwd(), envelopePath), options.bucket, key);
+    presignedUrl = runPresign(options.bucket, key, options.expires);
+    console.log(`[publish-envelope] presigned URL: ${presignedUrl}`);
+  } else {
+    console.log('[publish-envelope] dry-run mode, skipping upload/presign');
+  }
+
+  const tempoLinks = Array.isArray(envelope?.tempoLinks)
+    ? envelope.tempoLinks.slice(0, 3)
+    : Array.isArray(envelope?.summary?.tempoLinks)
+      ? envelope.summary.tempoLinks.slice(0, 3)
+      : [];
+
+  const slackPayload = {
+    text: 'Envelope uploaded ✅',
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `Envelope uploaded ✅\n- workflow: *${envelope?.correlation?.workflow ?? 'n/a'}*\n- branch: *${envelope?.correlation?.branch ?? 'n/a'}*\n- presigned: ${presignedUrl ?? '(dry-run)'}\n- tempo links: ${tempoLinks.length > 0 ? tempoLinks.join(', ') : 'n/a'}`,
+        },
+      },
+    ],
+  };
+
+  if (!dryRun && options.slackWebhook) {
+    try {
+      await postSlack(options.slackWebhook, {
+        ...slackPayload,
+        ...(options.slackChannel ? { channel: options.slackChannel } : {}),
+      });
+      console.log('[publish-envelope] posted Slack notification');
+    } catch (error) {
+      console.error('[publish-envelope] Slack notification failed:', error.message);
+      process.exit(1);
+    }
+  } else if (options.slackWebhook && dryRun) {
+    console.log('[publish-envelope] dry-run: Slack payload preview');
+    console.log(JSON.stringify(slackPayload, null, 2));
+  }
+
+  const metadata = {
+    bucket: options.bucket,
+    key,
+    presignedUrl,
+    expires: options.expires,
+    slackWebhook: options.slackWebhook ? 'configured' : null,
+    slackChannel: options.slackChannel ?? null,
+    notified: Boolean(options.slackWebhook && !dryRun),
+    dryRun,
+    generatedAt: new Date().toISOString(),
+  };
+
+  const outputPath = path.resolve(options.output);
+  ensureOutputDir(outputPath);
+  fs.writeFileSync(outputPath, JSON.stringify(metadata, null, 2));
+  console.log(`[publish-envelope] metadata written to ${outputPath}`);
+}
+
+main().catch((error) => {
+  console.error('[publish-envelope] unexpected error', error);
+  process.exit(1);
+});

--- a/tests/unit/trace/publish-envelope.test.ts
+++ b/tests/unit/trace/publish-envelope.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import os from 'node:os';
+
+const scriptPath = join(process.cwd(), 'scripts/trace/publish-envelope.mjs');
+
+describe('publish-envelope CLI', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(os.tmpdir(), 'publish-envelope-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('outputs metadata in dry-run mode without calling AWS', () => {
+    const envelopePath = join(tempDir, 'envelope.json');
+    const outputPath = join(tempDir, 'publish.json');
+
+    writeFileSync(envelopePath, JSON.stringify({
+      correlation: {
+        workflow: 'trace-ci',
+        branch: 'feature/sample',
+        runId: '123',
+      },
+      tempoLinks: ['https://tempo.example.com/explore?traceId=abc'],
+    }, null, 2));
+
+    const result = spawnSync(process.execPath, [
+      scriptPath,
+      '--envelope', envelopePath,
+      '--bucket', 'example-bucket',
+      '--key', 'envelopes/sample/envelope.json',
+      '--output', outputPath,
+      '--slack-webhook', 'https://example.com/webhook',
+      '--dry-run',
+    ], { encoding: 'utf8' });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+    const metadata = JSON.parse(readFileSync(outputPath, 'utf8'));
+    expect(metadata.dryRun).toBe(true);
+    expect(metadata.presignedUrl).toBeNull();
+    expect(metadata.bucket).toBe('example-bucket');
+    expect(metadata.key).toBe('envelopes/sample/envelope.json');
+    expect(metadata.notified).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a publish-envelope CLI that wraps upload, presign, and Slack notification with dry-run support
- document the S3 automation plan and reference the new CLI from REPORT_ENVELOPE.md
- cover dry-run behaviour with a Vitest and write metadata artifacts for follow-up tooling