### PR TITLE
feat(trace): auto-discover domain summaries

### DIFF
--- a/scripts/trace/build-kvonce-envelope-summary.mjs
+++ b/scripts/trace/build-kvonce-envelope-summary.mjs
@@ -149,6 +149,7 @@ function normalizeDomainSummary(summary, sourcePath) {
 
 const SUMMARY_FILENAME_PATTERN = /-domain-summary\.json$/i;
 const DIRECTORY_DENYLIST = new Set(['.git', 'node_modules', '.pnpm-store', '.cache', 'dist', 'tmp']);
+const MAX_DISCOVERY_DEPTH = 3;
 
 function addSearchRoot(roots, candidate) {
   if (!candidate) return;
@@ -180,7 +181,7 @@ function discoverDomainSummaryFiles({ traceDir, outputPath, summaryPath, explici
 
   const visit = (dir, depth = 0) => {
     const resolvedDir = path.resolve(dir);
-    if (visitedDirs.has(resolvedDir) || depth > 3) return;
+    if (visitedDirs.has(resolvedDir) || depth > MAX_DISCOVERY_DEPTH) return;
     visitedDirs.add(resolvedDir);
     let entries;
     try {
@@ -354,7 +355,7 @@ for (const descriptor of domainSummaryDescriptors) {
   const discoveryMode = descriptor.mode;
   const directPath = summaryPath;
   const rawInput = descriptor.raw;
-  const fallbackPath = rawInput ? path.resolve(traceDir, rawInput) : null;
+  const fallbackPath = rawInput && !path.isAbsolute(rawInput) ? path.resolve(traceDir, rawInput) : null;
   let resolved = null;
   if (fs.existsSync(directPath)) {
     resolved = directPath;


### PR DESCRIPTION
## 概要
- `build-kvonce-envelope-summary.mjs` に `--no-auto-domain-summaries` フラグと自動探索ロジックを追加し、`*-domain-summary.json` を自動的に取り込むようにしました
- domain summary 正規化を流用し、探索元や自動検出フラグをメタデータとして出力に含めるよう調整しました
- 探索対象ディレクトリを `traceDir`／`artifacts/trace` 周辺に限定し、重複取り込みを避けながら traceIds / tempoLinks 集計へ反映します

## テスト
- `node scripts/trace/run-inventory-conformance.sh --output-dir /tmp/inventory-run`
- `node scripts/trace/build-inventory-domain-summary.mjs --trace-dir /tmp/inventory-run --output artifacts/trace/inventory-domain-summary.json`
- `node scripts/trace/build-kvonce-envelope-summary.mjs --trace-dir /tmp/kvonce-run --output /tmp/kvonce-envelope.json`
  - 上記実行後、`/tmp/kvonce-envelope.json` に Inventory ドメインが自動的に取り込まれていることを確認
