### PR TITLE
chore(container): apply container helper to podman scripts

### DIFF
--- a/scripts/docker/run-unit.sh
+++ b/scripts/docker/run-unit.sh
@@ -58,29 +58,27 @@ if ! container::select_engine; then
   fallback_local "no supported container engine found"
 fi
 
-ENGINE_BIN="$CONTAINER_ENGINE_BIN"
-
-if ! timeout 30s "$ENGINE_BIN" ps >/dev/null 2>&1; then
-  fallback_local "$ENGINE_BIN ps failed (check rootless runtime)"
+if ! timeout 30s "$CONTAINER_ENGINE_BIN" ps >/dev/null 2>&1; then
+  fallback_local "$CONTAINER_ENGINE_BIN ps failed (check rootless runtime)"
 fi
 
-if ! timeout 30s "$ENGINE_BIN" system info >/dev/null 2>&1; then
-  fallback_local "$ENGINE_BIN system info failed"
+if ! timeout 30s "$CONTAINER_ENGINE_BIN" system info >/dev/null 2>&1; then
+  fallback_local "$CONTAINER_ENGINE_BIN system info failed"
 fi
 
 select_compose() {
   local preference="${1:-}"
   if [[ -n "$preference" ]]; then
-    if container::select_compose_command "$ENGINE_BIN" "$preference"; then
+    if container::select_compose_command "$CONTAINER_ENGINE_BIN" "$preference"; then
       return 0
     fi
     echo "[run-unit] provider=$preference unavailable; attempting auto-detect" >&2
   fi
-  container::select_compose_command "$ENGINE_BIN"
+  container::select_compose_command "$CONTAINER_ENGINE_BIN"
 }
 
 if ! select_compose "$PODMAN_COMPOSE_PROVIDER"; then
-  fallback_local "compose command not available for $ENGINE_BIN"
+  fallback_local "compose command not available for $CONTAINER_ENGINE_BIN"
 fi
 
 STORE_DIR="${AE_HOST_STORE:-$PROJECT_DIR/.pnpm-store}"

--- a/scripts/podman/smoke-test.sh
+++ b/scripts/podman/smoke-test.sh
@@ -107,8 +107,6 @@ if ! container::select_compose_command "$CONTAINER_ENGINE_BIN"; then
   fail "Compose support not available for '$CONTAINER_ENGINE_BIN'"
 fi
 
-ENGINE_BIN="$CONTAINER_ENGINE_BIN"
-
 compose_run() {
   container::compose "$@"
 }
@@ -125,25 +123,25 @@ cleanup() {
   fi
 
   if [[ "$KEEP_IMAGES" == false ]]; then
-    "$ENGINE_BIN" image rm -f "$RUNTIME_TAG" >/dev/null 2>&1 || true
-    "$ENGINE_BIN" image rm -f "$TEST_TAG" >/dev/null 2>&1 || true
+    "$CONTAINER_ENGINE_BIN" image rm -f "$RUNTIME_TAG" >/dev/null 2>&1 || true
+    "$CONTAINER_ENGINE_BIN" image rm -f "$TEST_TAG" >/dev/null 2>&1 || true
   fi
   return $status
 }
 trap cleanup EXIT
 
-log "using engine: $ENGINE_BIN"
-"$ENGINE_BIN" version || warn "Failed to retrieve engine version information; continuing"
+log "using engine: $CONTAINER_ENGINE_BIN"
+"$CONTAINER_ENGINE_BIN" version || warn "Failed to retrieve engine version information; continuing"
 
 if [[ "$SKIP_BUILD" == false ]]; then
   log "building runtime image ($RUNTIME_TAG)"
-  "$ENGINE_BIN" build \
+  "$CONTAINER_ENGINE_BIN" build \
     --file podman/Dockerfile \
     --tag "$RUNTIME_TAG" \
     podman/.. || fail "Runtime image build failed"
 
   log "building test image ($TEST_TAG)"
-  "$ENGINE_BIN" build \
+  "$CONTAINER_ENGINE_BIN" build \
     --file podman/Dockerfile.test \
     --target test-base \
     --tag "$TEST_TAG" \


### PR DESCRIPTION
## Summary
- scripts/podman/smoke-test.sh で container.sh を利用してエンジン／compose コマンドの検出を共通化
- scripts/docker/run-unit.sh でも同じヘルパーを使い、Podman/Docker 双方の compose 実行とローカルフォールバック処理を整理
- cleanup 時にも選択済み compose コマンドを利用することで重複実装を排除

## Testing
- bash scripts/podman/smoke-test.sh --skip-build --skip-compose
- timeout 60 bash scripts/docker/run-unit.sh（手元 Podman に compose プラグインがないためローカル vitest フォールバック経路で成功を確認）

Refs: #1132