### PR TITLE
chore: make mutation timeout optional

### DIFF
--- a/scripts/mutation/run-scoped.sh
+++ b/scripts/mutation/run-scoped.sh
@@ -186,7 +186,7 @@ if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
   CMD+=("${EXTRA_ARGS[@]}")
 fi
 
-if command -v timeout >/dev/null 2>&1; then
+if command -v timeout >/dev/null 2>&1 && [[ -n "${TIME_LIMIT}" && "${TIME_LIMIT}" != "0" ]]; then
   timeout --foreground "${TIME_LIMIT}"s "${CMD[@]}"
 else
   "${CMD[@]}"


### PR DESCRIPTION
## Summary
- Skip wrapping Stryker invocation with `timeout` when `STRYKER_TIME_LIMIT=0`
- Allows `pnpm pipelines:full` to finish with exit code 0 after long mutation runs

## Testing
- STRYKER_TIME_LIMIT=0 pnpm pipelines:full (locally, mutation quick 100% kill)