### PR TITLE
docs: Verify Lite lint backlog plan (#1019)

### DIFF
--- a/docs/quality/verify-lite-lint-backlog.md
+++ b/docs/quality/verify-lite-lint-backlog.md
@@ -11,13 +11,15 @@
 - 🛠 `--fix` で自動修正可能な指摘は 46 件（主に `no-unnecessary-type-assertion`）
 
 ### ファイル別インパクト（抜粋）
-| 主要ファイル | 代表的なルール | 指摘件数 |
+| 主要ファイル | 代表的なルール | 指摘件数<sup>*</sup> |
 | --- | --- | --- |
-| `src/runtime/runtime-middleware.ts` | no-explicit-any / no-unsafe-* | 146 |
-| `src/inference/core/solution-composer.ts` | no-unused-vars / require-await / no-explicit-any | 78 |
-| `src/inference/strategies/sequential-strategy.ts` | no-explicit-any / no-unsafe-* | 95 |
-| `src/integration/runners/e2e-runner.ts` | require-await / no-unsafe-* | 78 |
-| `src/runtime/conformance-guards.ts` | no-explicit-any / no-unsafe-* | 86 |
+| `src/runtime/runtime-middleware.ts` | no-explicit-any / no-unsafe-* | 154 |
+| `src/inference/core/solution-composer.ts` | no-unused-vars / require-await / no-explicit-any | 81 |
+| `src/inference/strategies/sequential-strategy.ts` | no-explicit-any / no-unsafe-* | 98 |
+| `src/integration/runners/e2e-runner.ts` | require-await / no-unsafe-* | 79 |
+| `src/runtime/conformance-guards.ts` | no-explicit-any / no-unsafe-* | 89 |
+
+<sup>*</sup> 指摘件数は `reports/lint/verify-lite-lint-summary.json` の該当ファイル・ルールの合計値。
 
 > English TL;DR: Unsafe typed interactions dominate (52%), followed by `any` usage (23%). Five files (`runtime-middleware`, `solution-composer`, `sequential-strategy`, `e2e-runner`, `conformance-guards`) account for ~20% of the backlog and should anchor the first remediation sprint.
 

--- a/reports/lint/verify-lite-lint-summary.json
+++ b/reports/lint/verify-lite-lint-summary.json
@@ -1,4 +1,11 @@
 {
+  "schemaVersion": "1.0.0",
+  "generator": {
+    "name": "verify-lite-lint-summary-manual",
+    "version": "0.1.0",
+    "eslintVersion": "9.8.0",
+    "configHash": "manual-baseline-20251014"
+  },
   "generatedAt": "2025-10-14T23:07:32.778Z",
   "totals": {
     "totalIssues": 2668,
@@ -407,8 +414,9 @@
         "count": 2
       },
       {
-        "rule": "unknown",
-        "count": 1
+        "rule": null,
+        "count": 1,
+        "notes": "Rule ID unavailable; could not be determined."
       }
     ],
     "byFile": [


### PR DESCRIPTION
Summary
- Documented Verify Lite lint backlog with rule/file checklists and staged remediation plan (ISSUE#1019)
- Added generated summary JSON for lint distribution to support tracking against Stage 0 baseline

Risk/impact
- Low: docs + static report only

Checklist
- [ ] Verify Lite passes locally (`pnpm types:check && pnpm lint && pnpm build`)
- [ ] test:fast passes (`pnpm run test:fast`)
- [x] Docs updated if behavior changes (see `docs/ci-policy.md`)
