### PR TITLE
ci: add property/pact smoke to verify-lite (#1003)

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -197,7 +197,13 @@ jobs:
         run: |
           if [ -f artifacts/properties/summary.json ]; then
             echo '## Property Harness' >> "$GITHUB_STEP_SUMMARY"
-            node -e $'const fs = require("fs");\ntry {\n  const data = JSON.parse(fs.readFileSync("artifacts/properties/summary.json", "utf8"));\n  console.log(`Trace ID: ${data.traceId}`);\n  console.log(`Seed: ${data.seed}`);\n  console.log(`Runs: ${data.runs}`);\n  console.log(`Passed: ${data.passed}`);\n  if (data.note) console.log(`Note: ${data.note}`);\n} catch (err) {\n  console.log("Failed to parse property summary: " + err.message);\n}' >> "$GITHUB_STEP_SUMMARY"
+            jq -r '
+              "Trace ID: \(.traceId)",
+              "Seed: \(.seed)",
+              "Runs: \(.runs)",
+              "Passed: \(.passed)",
+              (if .note then "Note: \(.note)" else empty end)
+            ' artifacts/properties/summary.json >> "$GITHUB_STEP_SUMMARY" || echo 'Failed to parse property summary.' >> "$GITHUB_STEP_SUMMARY"
           else
             echo 'Property harness summary not generated.' >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
Summary
- extend verify-lite workflow to run property harness and pact contract smoke tests after the main pipeline
- surface property harness results in the workflow step summary for quick inspection

Risk/impact
- Low: CI workflow adjustments only; property/pact commands validated locally

Checklist
- [ ] Verify Lite passes locally (`pnpm types:check && pnpm lint && pnpm build`)
- [x] test:fast passes (`pnpm test:property`)
- [x] Additional validation (`pnpm pipelines:pact`)
