### PR TITLE
ci: add docker test workflow

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -79,22 +79,7 @@ jobs:
             node scripts/generate-test-report.cjs || true
           fi
           if [ -f reports/consolidated-test-report.json ]; then
-            node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
-            const fs = require('fs');
-            const path = 'reports/consolidated-test-report.json';
-            try {
-              const { suites = {} } = JSON.parse(fs.readFileSync(path, 'utf8'));
-              const lines = Object.entries(suites).map(([name, info]) => `- ${name}: ${(info && info.status) || 'unknown'}`);
-              if (lines.length === 0) {
-                lines.push('- no suites reported');
-              }
-              console.log('## Docker test suites');
-              console.log(lines.join('\n'));
-            } catch (error) {
-              console.log('## Docker test suites');
-              console.log(`- failed to summarize report: ${error.message}`);
-            }
-NODE
+            node -e "const fs=require('fs');const path='reports/consolidated-test-report.json';try{const data=JSON.parse(fs.readFileSync(path,'utf8'));const suites=data.suites||{};const lines=Object.entries(suites).map(([name,info])=>'- '+name+': '+((info&&info.status)||'unknown'));const body=['## Docker test suites'].concat(lines.length?lines:['- no suites reported']).join('\n');console.log(body);}catch(error){console.log('## Docker test suites\n- failed to summarize report: '+error.message);}}" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload artifacts


### PR DESCRIPTION
## 背景
- ISSUE #1003 の残タスクとして、`make test-docker-all` を GitHub Actions 上で再実行できるようにする手順を整備する必要があった。
- 既存のテストワークフローは Verify Lite / Mutation Quick などに分散しており、Docker Compose ベースの統合テストは手動手順のままだった。

## 変更内容
- `.github/workflows/docker-tests.yml` を追加し、`workflow_dispatch` と平日深夜スケジュールで `docker/docker-compose.test.yml` を起動できるようにした。
  - 事前に `reports/` / `logs/` の作成と権限調整、pnpm キャッシュ復元を行う。
  - `service_filter` 入力が指定された場合は個別サービスを `docker compose run --rm` で実行、未指定時は `up --abort-on-container-exit` で全体を実施。
  - ログを `docker-compose.log` に集約し、テスト終了後に `down -v --remove-orphans` を必ず実行。
  - `scripts/generate-test-report.cjs` が存在する場合はレポートをまとめ、Step Summary に各スイートのステータスを表示。
  - 成果物として `reports/**`, `logs/**`, `docker-compose.log`, `mutation-summary.txt` をアップロード。

## ログ
- なし（CI ワークフロー定義のみ）

## テスト
- ローカルでは実行していません（GitHub Actions 上での動作確認が前提）

## 影響範囲
- 新規ワークフロー追加による CI 実行負荷増加（手動 / スケジュール起動を想定）
- 本番ブランチへの影響は無し（既存ワークフロー未変更）

## ロールバック手順
1. `git revert <commit>` で当該コミットを取り消す
2. `origin/chore/docker-tests-workflow` ブランチを削除

## 関連Issue
- refs #1003
