### PR TITLE
docs: refresh agent builder integration plan

### DIFF
--- a/docs/notes/issue-1047-plan.md
+++ b/docs/notes/issue-1047-plan.md
@@ -6,14 +6,14 @@
 
 ## 進行状況
 - ✅ 要件・ロードマップは #1047 / #1053 で定義済み。
-- ☐ Flow Schema / Envelope / Ajv CI などの実装は未着手。
-- ☐ Verify Lite からの変換ロジック・PoC も未着手。
+- ✅ Flow Schema / Envelope / Ajv CI などのベース実装は PR #1184/#1186/#1187 で整備済み。
+- ☐ Agent Builder Adapter / Verify Lite PoC は未着手（タスク分解済み）。
 
 ## 直近のアクション候補
-1. PR-1: Flow Schema v0.1 + Envelope v1.0 + Ajv CI。
-2. PR-2: Verify Lite → Envelope 変換の実装とテスト。
-3. PR-3: Agent Builder Adapter スケルトンの構築。
-4. PR-4: Intent→Formal→Code→Verify PoC。
+1. ✅ PR-1: Flow Schema v0.1 + Envelope v1.0 + Ajv CI（#1184/#1186/#1187）。
+2. ✅ PR-2: Verify Lite → Envelope 変換の実装とテスト（#1186）。
+3. 🔄 PR-3: Agent Builder Adapter スケルトン（flow JSON 取り込み・ノード実行モック・Envelope出力整合）。
+4. 🔄 PR-4: Intent→Formal→Code→Verify PoC（Adapter + Verify Lite + Formal ツール連携での e2e 実験）。
 
 ## リスク
 - スキーマ変更の影響 → semver 管理、スナップショットテスト。


### PR DESCRIPTION
## 背景
- フェーズDで進行中の Agent Builder 連携について、Flow/Envelope の整備が完了したため残タスクを再定義する。

## 変更
-  の進行状況を更新し、PR #1184/#1186/#1187 により完了した項目をチェック。
- Agent Builder Adapter PoC のサブタスク（flow JSON 取り込み、ノード実行モック、Envelope整合）を明記。
- Intent→Formal→Code→Verify PoC を次ステップとして整理。

## テスト
- ドキュメントのみの更新につき無し。

## 影響
- 計画ドキュメントの更新のみで実装への影響なし。

## ロールバック
-  でドキュメントの変更を戻せます。

## 関連Issue
- Refs #1160 #1047 #1053