### PR TITLE
docs: outline minimal spec & verification kit

### DIFF
--- a/docs/reference/SPEC-VERIFICATION-KIT-MIN.md
+++ b/docs/reference/SPEC-VERIFICATION-KIT-MIN.md
@@ -1,0 +1,39 @@
+# Spec & Verification Kit (最小実用パッケージ) 草案
+
+## 目的
+- TypeScript を主軸に、仕様→テスト→検証を一括で有効化できる最小セットを定義する。
+- もう1言語（例: Go）を追加できる拡張ポイントを明示する。
+
+## 対象言語（初期）
+- TypeScript (Node 20, pnpm)
+- Go (オプション、fast-check 相当は `gopter` を候補)
+
+## 含める要素（TS）
+- BDD: `spec/bdd/*.md` を `.feature` に昇格可能な雛形 + step スケルトン (CucumberJS)
+- Property: `spec/properties/*.md` → `tests/property/**/*.test.ts` に写経可能なテンプレ + fast-check 設定
+- Lint/Static/Type: `pnpm lint`, `pnpm types:check`, `pnpm run test:fast`
+- CLI: `pnpm run test:property -- --runInBand --maxWorkers=50%`
+- CI: workflow テンプレートで lint/type/unit/property を一括実行（workflow_dispatch または再利用可能 action）
+
+## 有効化フロー（TS）
+1. `pnpm install` 後、下記を実行できる状態にする:
+   - `pnpm lint`
+   - `pnpm types:check`
+   - `pnpm run test:fast`
+   - `pnpm run test:property -- --runInBand --maxWorkers=50%`
+2. `spec/bdd/template.feature` と `spec/properties/template.ts` をコピーして編集
+3. `pnpm run test:property` が green になるようジェネレータ/不変条件を埋める
+4. CI (workflow_dispatch テンプレ) で lint/type/unit/property を確認
+
+## Go 追加時の拡張ポイント（メモ）
+- テスト: `go test ./...`
+- Property: `gopter` もしくは `rapid` を検討
+- Lint: `golangci-lint run`
+- Makefile/Taskfile で TS/Go の二言語をまとめて実行
+
+## TODO（実装タスク）
+- [ ] `spec/bdd/template.feature` と step スケルトンの追加（実行されない doc テンプレ）
+- [ ] `spec/properties/template.md` + fast-check boilerplate（ジェネレータ/不変条件入り）
+- [ ] `package.json` に `types:check`, `test:property` の標準スクリプトを確認・不足なら追加
+- [ ] CI テンプレ（workflow_dispatch）で lint/type/unit/property を並列 or 直列実行
+- [ ] README/Docs に「有効化手順」を追記


### PR DESCRIPTION
背景
- #1193/#1196 のタスクとして、Spec & Verification Kit の最小実用パッケージ方針を整理。

変更
- `docs/reference/SPEC-VERIFICATION-KIT-MIN.md` に対象言語、含める要素、実装タスクを記載（TS中心、Go拡張メモ付き）

ログ
- なし（ドキュメントのみ）

テスト
- なし（ドキュメントのみ）

影響
- 最小キットのスコープと残タスクが明文化され、次の実装ブランチの着手が容易になる

ロールバック
- 新規ファイルを削除

関連Issue
- #1193
- #1196
