### PR TITLE
feat: add bdd steps and property harness templates

### DIFF
--- a/spec/bdd/steps/template.steps.ts
+++ b/spec/bdd/steps/template.steps.ts
@@ -1,0 +1,23 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+
+// NOTE: テンプレート。実装時に適宜置き換えてください。
+
+Given('サービスが起動している', async function () {
+  // TODO: app 起動 or ヘルスチェック
+});
+
+Given('商品 {string} の在庫が {int} である', async function (sku: string, stock: number) {
+  // TODO: テスト用の在庫初期化
+});
+
+When('ユーザー {string} が {string} を {int} 個予約する', async function (userId: string, sku: string, qty: number) {
+  // TODO: POST /reservations を呼ぶ
+});
+
+Then('レスポンスは {int} で予約IDを返す', async function (status: number) {
+  // TODO: ステータスとレスポンスボディを検証
+});
+
+Then('在庫は {int} になる', async function (expected: number) {
+  // TODO: DB もしくは in-memory state を確認
+});

--- a/spec/properties/template.md
+++ b/spec/properties/template.md
@@ -7,7 +7,7 @@
 
 ## ジェネレータ方針
 - requestId: fc.uuid()
-- quantity: fc.integer({ min: 0, max: 5 })
+- quantity: fc.integer({ min: 1, max: 5 })
 - users: fc.constantFrom('u1','u2','u3')
 - inventory seed: fc.array(fc.record({ sku: fc.string(), stock: fc.integer({min:0, max:10}) }), {minLength:1, maxLength:3})
 

--- a/tests/property/web-api/fast-check.config.ts
+++ b/tests/property/web-api/fast-check.config.ts
@@ -1,0 +1,18 @@
+import fc from 'fast-check';
+
+export const defaultRuns = 20;
+
+export const reservationArb = fc.record({
+  requestId: fc.uuid(),
+  sku: fc.string({ minLength: 3, maxLength: 12 }),
+  quantity: fc.integer({ min: 1, max: 5 }),
+  userId: fc.constantFrom('u1', 'u2', 'u3'),
+});
+
+export const inventorySeedArb = fc.array(
+  fc.record({
+    sku: fc.string({ minLength: 3, maxLength: 12 }),
+    stock: fc.integer({ min: 0, max: 10 }),
+  }),
+  { minLength: 1, maxLength: 3 },
+);

--- a/tests/property/web-api/sample.spec.ts
+++ b/tests/property/web-api/sample.spec.ts
@@ -1,17 +1,18 @@
 import fc from 'fast-check';
+import { reservationArb, defaultRuns } from './fast-check.config';
 
-// NOTE: ドキュメント用サンプル。実行環境が整うまで skip。
+// NOTE: 足場用。実装前なので skip。
 describe.skip('property: web api reservation', () => {
   it('idempotent request does not double-book', async () => {
     await fc.assert(
-      fc.asyncProperty(
-        fc.uuid(),
-        fc.integer({ min: 1, max: 3 }),
-        async (requestId, qty) => {
-          // arrange/act/assert: 実装後に埋める
-        },
-      ),
-      { numRuns: 10 },
+      fc.asyncProperty(reservationArb, async ({ requestId, sku, quantity, userId }) => {
+        // arrange/act/assert: 実装後に埋める
+        void requestId;
+        void sku;
+        void quantity;
+        void userId;
+      }),
+      { numRuns: defaultRuns },
     );
   });
 });


### PR DESCRIPTION
背景
- #1196 に基づき、Spec & Verification Kit 最小パッケージの実装準備として BDD steps テンプレと property harness を追加。

変更
- BDDステップ雛形: `spec/bdd/steps/template.steps.ts`
- Propertyテスト用 fast-check 設定: `tests/property/web-api/fast-check.config.ts`
- Propertyサンプルを設定利用に差し替え（skipのまま）: `tests/property/web-api/sample.spec.ts`
- Propertyテンプレ quantity 最小値を1に修正: `spec/properties/template.md`

ログ
- なし

テスト
- なし（テンプレ/足場のみ、skip状態）

影響
- 最小キットの具体化が進み、実装時にそのまま利用できる雛形を提供。既存CIへの影響なし。

ロールバック
- 追加ファイル削除とテンプレ修正前の状態へ戻す

関連Issue
- #1193
- #1196
