### PR TITLE
docs: add agent guides and manual model checking workflow

### DIFF
--- a/.github/workflows/model-checking-manual.yml
+++ b/.github/workflows/model-checking-manual.yml
@@ -40,4 +40,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: model-check-logs
-          path: artifacts/**
+          path: hermetic-reports/formal/**

--- a/docs/integrations/ANTIGRAVITY-GUIDE.md
+++ b/docs/integrations/ANTIGRAVITY-GUIDE.md
@@ -5,21 +5,21 @@
 - 入出力は Markdown/JSON に限定し、AJV/Schema で検証可能な形に固定する。
 
 ## 前提
-- リポ構成: `spec/`, `tests/`, `plans/common/*` もしくは `plans/web-api/*`
+- リポ構成: `spec/`, `tests/`, `plans/web-api/*`（共通テンプレは今後 `plans/common/*` に追加予定）
 - Antigravity 側で repo をチェックアウト済み、コマンド実行が可能
 
 ## 実行フロー（例）
 1. 仕様生成
-   - `plans/common/01-spec.md` をプロンプトとして渡し、OpenAPI/BDD/Property を生成
+   - `plans/web-api/01-spec.md` をプロンプトとして渡し、OpenAPI/BDD/Property を生成
    - 生成先は必ずファイルパスで指定（例: `spec/api/openapi.yml`）
 2. テスト骨子
-   - `plans/common/02-tests.md` を渡し、テストスケルトンを生成（必要に応じて skip）
+   - `plans/web-api/02-tests.md` を渡し、テストスケルトンを生成（必要に応じて skip）
 3. 実装
-   - `plans/common/03-impl.md` を渡し、handler/service/repo を生成
+   - `plans/web-api/03-impl.md` を渡し、handler/service/repo を生成
 4. 検証
-   - `plans/common/04-verify.md` のコマンドをシェルで実行（lint/type/unit/integration/property）
+   - `plans/web-api/04-verify.md` のコマンドをシェルで実行（lint/type/unit/integration/property）
 5. PR 仕上げ
-   - `plans/common/05-pr.md` をもとに PR 本文を作成
+   - `plans/web-api/05-pr.md` をもとに PR 本文を作成
 
 ## 成果物検証
 - Schema/JSON: `pnpm lint` / `pnpm spec:validate` が通ること

--- a/docs/integrations/GEMINI-GUIDE.md
+++ b/docs/integrations/GEMINI-GUIDE.md
@@ -5,15 +5,15 @@
 - Markdown/JSON 入出力を徹底し、AJV/Schema で検証可能な形に固定する。
 
 ## 前提
-- リポ構成: `spec/`, `tests/`, `plans/common/*` (またはドメイン別 ExecPlan)
+- リポ構成: `spec/`, `tests/`, `plans/web-api/*`（`plans/common/*` は今後追加予定、現時点では `plans/web-api/` をテンプレとして利用）
 - Gemini からシェルコマンド実行/ファイル編集が可能
 
 ## 実行フロー（例）
-1. 仕様生成: `plans/common/01-spec.md` を入力し、OpenAPI/BDD/Property を生成
-2. テスト骨子: `plans/common/02-tests.md` を入力し、テストスケルトンを生成（skip許容）
-3. 実装: `plans/common/03-impl.md` を入力し、実装を生成
-4. 検証: `plans/common/04-verify.md` のコマンドを実行
-5. PR: `plans/common/05-pr.md` をもとに PR 本文を作成
+1. 仕様生成: `plans/web-api/01-spec.md` を入力し、OpenAPI/BDD/Property を生成
+2. テスト骨子: `plans/web-api/02-tests.md` を入力し、テストスケルトンを生成（skip許容）
+3. 実装: `plans/web-api/03-impl.md` を入力し、実装を生成
+4. 検証: `plans/web-api/04-verify.md` のコマンドを実行
+5. PR: `plans/web-api/05-pr.md` をもとに PR 本文を作成
 
 ## 検証コマンド例
 - `pnpm run lint`


### PR DESCRIPTION
背景
- #1198 に基づき、他エージェント向けガイドと高度検証入口（model checking手動実行）を追加。

変更
- Antigravity向けガイド: `docs/integrations/ANTIGRAVITY-GUIDE.md`
- Gemini向けガイド: `docs/integrations/GEMINI-GUIDE.md`
- 手動 model checking workflow_dispatch テンプレ: `.github/workflows/model-checking-manual.yml`（TLA+ tlc/apalache、Alloyはstub）

ログ
- なし

テスト
- なし（ドキュメントと手動トリガ workflow のみ）

影響
- 他エージェント導入時の手順が明文化され、手動の model checking 実行テンプレを提供。既存CIには影響なし（手動起動のみ）。

ロールバック
- 追加ファイル削除

関連Issue
- #1193
- #1198
