### PR TITLE
chore: fix CI tag trigger coverage

### DIFF
--- a/.github/workflows/webapi-sample-ci.yml
+++ b/.github/workflows/webapi-sample-ci.yml
@@ -2,6 +2,9 @@ name: Web API Sample CI (manual)
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read


### PR DESCRIPTION
## 背景
- main の qa-bench (test:fast) で CI タグトリガーテストが 2 件失敗していた（webapi-sample-ci に push tag トリガーなし、endsWith マッチで ci.yml 判定にも影響）。

## 変更
- webapi-sample-ci.yml に `push.tags: ['v*']` を追加し、タグ配布/テスト期待を満たす。

## テスト
- pnpm vitest run tests/ci/tag-trigger.test.ts --reporter=dot
