### PR TITLE
ci: ignore doc-only pushes for core workflows

### DIFF
--- a/.github/workflows/ae-ci.yml
+++ b/.github/workflows/ae-ci.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [ main ]
     tags: ['v*']
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   schedule:
     - cron: '30 6 * * *'
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:      # 手動実行
   push:
     tags: ['v*']          # リリースタグ時
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -6,6 +6,9 @@ on:
       - '*.md'
   push:
     branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -12,6 +12,9 @@ on:
       - 'types/**'
   push:
     tags: ['v*']
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   workflow_call:
     # Allow reuse from other workflows (e.g., release)
     inputs:

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [main]
     tags: ['v*'] # Verify traceability on releases
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## 背景
- docs/ や *.md のみの変更でも複数の CI ワークフローが走り、不要な実行コストが発生している。

## 変更
- 以下のワークフローに push 時の doc-only 変更を除外する paths-ignore を追加。
  - ae-ci.yml
  - coverage-check.yml
  - verify.yml
  - verify-lite.yml
  - ci.yml
  - ci-extended.yml
  - quality-gates-centralized.yml
- 既存の pull_request 側の除外設定は維持。

## テスト
- 設定のみの変更のためローカル実行なし。CIの actionlint にて確認予定。
