### PR TITLE
fix(security): unblock container scan and SBOM signing

### DIFF
--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -491,7 +491,7 @@ jobs:
       env:
         COSIGN_EXPERIMENTAL: 1
       run: |
-        cosign sign-blob sbom.json --output-signature sbom.json.sig --output-certificate sbom.json.crt
+        cosign sign-blob --yes sbom.json --output-signature sbom.json.sig --output-certificate sbom.json.crt
         
     - name: Upload signed SBOM
       uses: actions/upload-artifact@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -66,7 +66,7 @@ jobs:
         run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
 
       - name: Run security analyzer
-        run: pnpm run security:scan
+        run: pnpm run security:analyze
         env:
           NODE_ENV: test
 
@@ -259,6 +259,8 @@ jobs:
   container-security:
     name: Container Security
     runs-on: ubuntu-latest
+    needs: gate
+    if: ${{ needs.gate.outputs.run_security == 'true' }}
     
     steps:
       - name: Checkout code

--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 
 COPY package*.json pnpm-lock.yaml* ./
 COPY pnpm-workspace.yaml ./
+COPY tsconfig*.json ./
 COPY packages ./packages
 RUN corepack enable pnpm && pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## 背景
スキャン実行後も Code Scanning アラートが旧コミットのまま残っており、原因を確認すると以下が発生していました。

- `Security Analysis` の `Container Security` が `podman/Dockerfile` 内の `pnpm install` で失敗（`/app/tsconfig.json` が無く `packages/spec-compiler` の `tsc` が落ちる）→ SARIF が生成されずアラート更新/クローズが進まない
- `Security Scanning` が `pnpm run security:scan`（URL必須）を引数無しで呼び出して失敗
- `SBOM Generation` の compliance で cosign が対話プロンプトで失敗

## 変更
- `podman/Dockerfile`: `tsconfig*.json` を deps ステージで COPY し、`pnpm install` が落ちないように修正
- `.github/workflows/security.yml`: `security:scan` → `security:analyze` に変更（`security-reports/` を生成/アップロード可能に）
- `.github/workflows/security.yml`: `container-security` を gate 経由にして PR では `run-security` 時のみ実行（push/schedule は従来通り）
- `.github/workflows/sbom-generation.yml`: `cosign sign-blob --yes` で非対話化

## テスト
- actionlint（ローカルDL版）: OK

## 影響
- Container Security が再び SARIF を生成できるようになり、依存アップデート後の脆弱性解消が Code Scanning 側へ反映されやすくなります。

## ロールバック
- このPRを revert

## 関連
- #1225 / #1004