### PR TITLE
fix(codeql): clean up compare-test-trends

### DIFF
--- a/scripts/pipelines/compare-test-trends.mjs
+++ b/scripts/pipelines/compare-test-trends.mjs
@@ -9,7 +9,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..', '..');
 
-const CACHE_ROOT = path.join(repoRoot, '.cache', 'test-results');
 const BASELINE_ROOT = path.join(repoRoot, '.cache', 'test-results-baseline');
 
 const TARGETS = [
@@ -130,8 +129,8 @@ function diffMetrics(baseline, current) {
     );
   }
   const keys = new Set([
-    ...Object.keys(baseline ?? {}),
-    ...Object.keys(current ?? {}),
+    ...Object.keys(baseline),
+    ...Object.keys(current),
   ]);
   const result = {};
   for (const key of keys) {


### PR DESCRIPTION
## 背景\nCodeQL の trivial-conditional / unused-variable 警告が compare-test-trends に残っていたため整理します。\n\n## 変更\n- 未使用の CACHE_ROOT 定義を削除\n- baseline/current が必ず存在する経路では nullish-coalescing を外し警告を回避\n\n## ログ\n- CodeQL の警告低減（js/trivial-conditional, js/unused-local-variable 対応）\n\n## テスト\n- 未実施（静的なリファクタのみのため）\n\n## 影響\n- なし（ロジック変更なしの整理）\n\n## ロールバック\n- このPRをrevert\n\n## 関連Issue\n- なし\n