### PR TITLE
chore(codeql): drop unused test imports

### DIFF
--- a/tests/unit/utils/enhanced-state-manager.survivors.test.ts
+++ b/tests/unit/utils/enhanced-state-manager.survivors.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { createHash } from 'node:crypto';
-import { EnhancedStateManager } from '../../../src/utils/enhanced-state-manager.js';
-import type { StateEntry, AEIR } from '../../../src/utils/enhanced-state-manager.js';
 import { asInternal, createManager as createTestManager, createTempProjectRoot, cleanupProjectRoot } from '../../_helpers/enhanced-state-manager.js';
 
 const defaultOptions = {

--- a/tests/unit/utils/enhanced-state-manager.test.ts
+++ b/tests/unit/utils/enhanced-state-manager.test.ts
@@ -1,12 +1,12 @@
 import { afterAll, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, mkdir, rm, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { gzipSync } from 'node:zlib';
 import { createHash } from 'node:crypto';
 import { EnhancedStateManager } from '../../../src/utils/enhanced-state-manager.js';
 import type { StateEntry } from '../../../src/utils/enhanced-state-manager.js';
-import { asInternal, getStorage, getTransactions, getOptions, getKeyIndex, getVersionIndex, buildExportedState, buildStateEntry } from '../../_helpers/enhanced-state-manager.js';
+import { asInternal, getStorage, getOptions, getKeyIndex, getVersionIndex, buildExportedState, buildStateEntry } from '../../_helpers/enhanced-state-manager.js';
 
 const tempRoots: string[] = [];
 


### PR DESCRIPTION
## 背景
CodeQL の unused-import 警告がテストに残っているため、ノイズ低減を図ります。

## 変更
- 未使用の import（mkdir/getTransactions/EnhancedStateManager/StateEntry/AEIR）を削除

## ログ
- テストのロジック変更なし、警告低減のみ

## テスト
- 未実施（import整理のみ）

## 影響
- なし（挙動変更なし）

## ロールバック
- このPRをrevert

## 関連Issue
- なし
