### PR TITLE
fix(codeql): trim env logging and unused assignments

### DIFF
--- a/scripts/trace/export-dashboard.mjs
+++ b/scripts/trace/export-dashboard.mjs
@@ -105,7 +105,7 @@ async function exportDashboard({ host, uid, token, output, dryRun }) {
   // codeql[js/http-to-file-access] Exporting dashboards to disk is an explicit CLI action.
   fs.writeFileSync(destPath, JSON.stringify(data, null, 2));
   const suffix = dryRun ? ' (dry-run)' : '';
-  console.log(`[export-dashboard] dashboard export completed for uid=${uid} -> ${destPath}${suffix}`);
+  console.log(`[export-dashboard] dashboard export completed${suffix}`);
 }
 
 async function main() {

--- a/src/utils/token-optimizer.ts
+++ b/src/utils/token-optimizer.ts
@@ -137,7 +137,6 @@ export class TokenOptimizer {
       const sourceTokens = this.estimateTokens(trimmedSource);
       if (processedTokens > sourceTokens) {
         processedContent = trimmedSource;
-        processedTokens = sourceTokens;
       }
 
       // Remove dangling commas or semicolons that often appear in loose notes

--- a/tests/quality/policy-loader.test.ts
+++ b/tests/quality/policy-loader.test.ts
@@ -3,7 +3,7 @@
  * Tests for centralized quality policy management
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs';
 import { createTempDir, writeTempJson, rmrf } from '../_helpers/tmpfs.js';
 import { QualityPolicyLoader, QualityGateResult } from '../../src/quality/policy-loader.js';


### PR DESCRIPTION
## 背景
- #1004 の CodeQL 指摘（clear-text logging / unused import / useless assignment）の小粒対応。

## 変更
- scripts/trace/export-dashboard.mjs の完了ログから UID/パスを削除（環境値由来のログを抑制）。
- src/utils/token-optimizer.ts の不要な processedTokens 代入を削除。
- tests/quality/policy-loader.test.ts の未使用 import を削除。

## ログ
- CodeQL 3件（#1025/#1026/#944）を対象。

## テスト
- pnpm exec vitest run tests/quality/policy-loader.test.ts
- pnpm exec eslint scripts/trace/export-dashboard.mjs src/utils/token-optimizer.ts tests/quality/policy-loader.test.ts（警告: ignore対象ファイル/既存warningあり）

## 影響
- ログ文言のみ（内容の秘匿化）、処理ロジックは維持。

## ロールバック
- このPRのコミットをリバート。

## 関連Issue
- #1004
- #1160