### PR TITLE
fix(tests): anchor docker alpine regex

### DIFF
--- a/tests/docker/optimization.test.ts
+++ b/tests/docker/optimization.test.ts
@@ -80,7 +80,7 @@ describe('Docker Production Optimization - Phase 1.4', () => {
       () => {
       const content = readFileSync(dockerfile, 'utf8');
       
-      expect(content, 'Should use Alpine images').toMatch(/docker\.io\/node:.*-alpine/);
+      expect(content, 'Should use Alpine images').toMatch(/^ARG\s+NODE_IMAGE=docker\.io\/node:[^\s]+-alpine$/m);
     });
   });
 


### PR DESCRIPTION
## 背景
#1004 の Code Scanning アラート #969（missing regexp anchor）を解消するため、Dockerfile の alpine 参照確認をアンカー付きに調整します。

## 変更
- `tests/docker/optimization.test.ts` の正規表現をアンカー付きに変更（ARG NODE_IMAGE を検証）

## テスト
- `pnpm exec vitest --run tests/docker/optimization.test.ts`

## 影響
- テスト条件が実際の Dockerfile 仕様（ARG NODE_IMAGE）に一致するようになり、誤検知を回避

## ロールバック
- 本PRのコミットを revert

## 関連Issue
- #1004
