### PR TITLE
fix: update npm in container images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY package*.json ./
 COPY pnpm-lock.yaml* ./
 
 # Install all dependencies first (needed for building)
-RUN corepack enable pnpm && \
+RUN npm install -g npm@11.7.0 && corepack enable pnpm && \
     pnpm install --frozen-lockfile
 
 # Stage 2: Build the application
@@ -26,6 +26,9 @@ RUN pnpm prune --prod
 # Stage 3: Production runtime with minimal dependencies
 FROM docker.io/node:22-alpine AS runtime
 WORKDIR /app
+
+# Update npm to remove vulnerable glob from the base image
+RUN npm install -g npm@11.7.0
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \

--- a/podman/Dockerfile
+++ b/podman/Dockerfile
@@ -11,7 +11,7 @@ COPY package*.json pnpm-lock.yaml* ./
 COPY pnpm-workspace.yaml ./
 COPY tsconfig*.json ./
 COPY packages ./packages
-RUN corepack enable pnpm && pnpm install --frozen-lockfile
+RUN npm install -g npm@11.7.0 && corepack enable pnpm && pnpm install --frozen-lockfile
 
 FROM deps AS build
 WORKDIR /app
@@ -28,6 +28,9 @@ RUN pnpm run build && pnpm prune --prod
 
 FROM ${NODE_IMAGE} AS runtime
 WORKDIR /app
+
+# Update npm to remove vulnerable glob from the base image
+RUN npm install -g npm@11.7.0
 
 # Rootless user (matches tests期待)
 RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001


### PR DESCRIPTION
## 背景
Trivy Code Scanning で npm 同梱の glob が CVE-2025-64756 (HIGH) として検出されているため、コンテナ内の npm を更新します。

## 変更
- `podman/Dockerfile` と `docker/Dockerfile` で npm@11.7.0 を導入
- ベースイメージ由来の glob@10.4.5 を更新（npm同梱）

## ログ
- `podman build -f podman/Dockerfile --target deps -t ae-framework:deps .`

## テスト
- `podman build -f podman/Dockerfile --target deps -t ae-framework:deps .`

## 影響
- コンテナビルド時に npm を更新（ビルド時間に数秒追加）

## ロールバック
- 本PRのコミットを revert し、npm更新を削除

## 関連Issue
- Code Scanning alert #1012
