### PR TITLE
fix: simplify repro-writer test assertion

### DIFF
--- a/tests/unit/testing/repro-writer.test.ts
+++ b/tests/unit/testing/repro-writer.test.ts
@@ -37,10 +37,16 @@ describe('writeRepro', () => {
     expect(writeFile).toHaveBeenCalledWith(expectedPath, expect.any(String));
 
     const body = writeFile.mock.calls[0]?.[1] ?? '';
-    expect(body).toContain(`JSON.parse(${JSON.stringify(JSON.stringify(data))})`);
-    expect(body).toContain('test(');
-    expect(body).toContain('process.env.AE_SEED=');
-    expect(body).toContain('JSON.parse(');
+    const testNameMatch = body.match(/test\(("(?:[^"\\]|\\.)*")/);
+    const seedMatch = body.match(/process\.env\.AE_SEED=("(?:[^"\\]|\\.)*")/);
+    const dataMatch = body.match(/JSON\.parse\(("(?:[^"\\]|\\.)*")\)/);
+
+    expect(testNameMatch).not.toBeNull();
+    expect(seedMatch).not.toBeNull();
+    expect(dataMatch).not.toBeNull();
+    expect(JSON.parse(testNameMatch?.[1] ?? '""')).toBe(`${name} repro`);
+    expect(JSON.parse(seedMatch?.[1] ?? '""')).toBe(String(seed));
+    expect(JSON.parse(dataMatch?.[1] ?? '""')).toBe(JSON.stringify(data));
     expect(body.endsWith(');')).toBe(true);
   });
 
@@ -64,9 +70,11 @@ describe('writeRepro', () => {
     const safeName = sanitizeFilename(name);
     const expectedPath = `artifacts/repros/${safeName}.repro.ts`;
 
-    expect(writeFile).toHaveBeenCalledWith(
-      expectedPath,
-      expect.stringContaining(JSON.stringify(`${name} repro`))
-    );
+    const body = writeFile.mock.calls[0]?.[1] ?? '';
+    const testNameMatch = body.match(/test\(("(?:[^"\\]|\\.)*")/);
+
+    expect(writeFile).toHaveBeenCalledWith(expectedPath, expect.any(String));
+    expect(testNameMatch).not.toBeNull();
+    expect(JSON.parse(testNameMatch?.[1] ?? '""')).toBe(`${name} repro`);
   });
 });


### PR DESCRIPTION
## 背景
Code Scanning の js/bad-code-sanitization (#1029) がテストコードで検出されているため、テストの検証方法を調整します。

## 変更
- `tests/unit/testing/repro-writer.test.ts` の文字列生成テストを簡素化し、コード文字列への直接埋め込みを避ける

## ログ
- `pnpm -w vitest run tests/unit/testing/repro-writer.test.ts`

## テスト
- `pnpm -w vitest run tests/unit/testing/repro-writer.test.ts`

## 影響
- テストの期待値のみ変更（プロダクションコード変更なし）

## ロールバック
- 本PRのコミットを revert し、テスト期待値を戻す

## 関連Issue
- Code Scanning alert #1029
