### PR TITLE
fix: avoid unused override value

### DIFF
--- a/scripts/validate-quality-policy.cjs
+++ b/scripts/validate-quality-policy.cjs
@@ -121,7 +121,7 @@ function validateQualityPolicy() {
         
         // Validate override paths
         if (env.overrides) {
-          for (const [overridePath, value] of Object.entries(env.overrides)) {
+          for (const overridePath of Object.keys(env.overrides)) {
             const pathParts = overridePath.split('.');
             
             if (pathParts.length < 2) {


### PR DESCRIPTION
## 背景
Code Scanning の js/unused-loop-variable (#400) が `scripts/validate-quality-policy.cjs` で検出されているため、ループ変数の扱いを見直します。

## 変更
- `env.overrides` の走査を `Object.entries` から `Object.keys` に変更し、未使用の値を排除

## ログ
- `node scripts/validate-quality-policy.cjs`

## テスト
- `node scripts/validate-quality-policy.cjs`

## 影響
- ループの読み取り方法のみ変更（検証ロジックは同一）

## ロールバック
- 本PRのコミットを revert

## 関連Issue
- Code Scanning alert #400
- #1004