### PR TITLE
fix: remove unused dependency value

### DIFF
--- a/src/inference/core/solution-composer.ts
+++ b/src/inference/core/solution-composer.ts
@@ -504,7 +504,7 @@ export class SolutionComposer {
   private resolveSubSolutionDependencies(solution: SubSolution, allSolutions: SubSolution[]): Record<string, any> {
     const resolved: Record<string, any> = {};
     
-    for (const [depId, depValue] of Object.entries(solution.dependencies)) {
+    for (const depId of Object.keys(solution.dependencies)) {
       const depSolution = allSolutions.find(s => s.subProblemId === depId);
       if (depSolution && depSolution.success) {
         resolved[depId] = depSolution.result;


### PR DESCRIPTION
## 背景
Code Scanning の js/unused-loop-variable (#401) が `src/inference/core/solution-composer.ts` で検出されているため、ループ変数の扱いを見直します。

## 変更
- `solution.dependencies` の走査を `Object.entries` から `Object.keys` に変更し、未使用の `depValue` を排除

## ログ
- `pnpm -w eslint src/inference/core/solution-composer.ts`
- `pnpm -w vitest run tests/unit`

## テスト
- `pnpm -w eslint src/inference/core/solution-composer.ts`（警告のみ）
- `pnpm -w vitest run tests/unit`

## 影響
- 依存関係の解決ロジックは同一（走査方法のみ変更）

## ロールバック
- 本PRのコミットを revert

## 関連Issue
- Code Scanning alert #401
- #1004
