### PR TITLE
fix: avoid chokidar type resolution

### DIFF
--- a/src/cli/codegen-cli.ts
+++ b/src/cli/codegen-cli.ts
@@ -158,9 +158,11 @@ export function createCodegenCommand(): Command {
           on(event: 'add' | 'change', handler: () => void): Watcher;
           close(): Promise<void> | void;
         };
+        const moduleName: string = 'chokidar';
         let watchFn!: (paths: string | readonly string[], options?: { ignoreInitial?: boolean }) => Watcher;
         try {
-          ({ watch: watchFn } = await import('chokidar'));
+          const mod = await import(moduleName);
+          watchFn = mod.watch;
         } catch (error: unknown) {
           console.log(chalk.yellow('Watch mode not available - chokidar not installed'));
           console.log('Install with: npm install chokidar');


### PR DESCRIPTION
## 背景\n- watchモードの`import('chokidar')`が型解決され、依存未導入時に`TS2307`でビルドが失敗しうるため。\n\n## 変更\n- 文字列リテラルではなく変数経由の動的importに変更し、型解決エラーを回避。\n\n## ログ\n- fix: avoid chokidar type resolution\n\n## テスト\n- pnpm -w tsc -p tsconfig.build.json\n\n## 影響\n- 依存未導入でもビルドが失敗しにくくなり、watchモードの挙動は維持。\n\n## ロールバック\n- 本PRのコミットをrevert。\n\n## 関連Issue\n- なし\n