### PR TITLE
fix: inline CodeQL suppression for branch protection

### DIFF
--- a/scripts/admin/apply-branch-protection.mjs
+++ b/scripts/admin/apply-branch-protection.mjs
@@ -30,7 +30,7 @@ async function main() {
   const file = path.resolve(process.cwd(), presetPath);
   const body = await fs.readFile(file, 'utf8');
 
-  const res = await fetch(api, {
+  const res = await fetch(api, { // codeql[js/file-access-to-http] Applying branch protection is an explicit admin CLI action.
     method: 'PUT',
     headers: {
       'Authorization': `token ${token}`,
@@ -55,4 +55,3 @@ main().catch((e) => {
   console.error(e);
   process.exit(1);
 });
-


### PR DESCRIPTION
## 背景\n- CodeQLのfile-access-to-http警告(#899)が`scripts/admin/apply-branch-protection.mjs`に残っているため。\n\n## 変更\n- fetch行にCodeQL抑制コメントをインライン化。\n\n## ログ\n- fix: inline codeql suppression for branch protection\n\n## テスト\n- なし（コメント位置の調整のみ）\n\n## 影響\n- 挙動は同一。CodeQL警告の解消が目的。\n\n## ロールバック\n- 本PRのコミットをrevert。\n\n## 関連Issue\n- #1004\n