### PR TITLE
fix: align CodeQL suppressions for trace/admin CLI writes

### DIFF
--- a/scripts/admin/apply-branch-protection.mjs
+++ b/scripts/admin/apply-branch-protection.mjs
@@ -30,7 +30,7 @@ async function main() {
   const file = path.resolve(process.cwd(), presetPath);
   const body = await fs.readFile(file, 'utf8');
 
-  const res = await fetch(api, { // codeql[js/file-access-to-http] Applying branch protection is an explicit admin CLI action.
+  const res = await fetch(api, { // lgtm[js/file-access-to-http] Applying branch protection is an explicit admin CLI action.
     method: 'PUT',
     headers: {
       'Authorization': `token ${token}`,

--- a/scripts/trace/export-dashboard.mjs
+++ b/scripts/trace/export-dashboard.mjs
@@ -102,7 +102,7 @@ async function exportDashboard({ host, uid, token, output, dryRun }) {
   const data = await response.json();
   const destPath = path.resolve(output);
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.writeFileSync(destPath, JSON.stringify(data, null, 2)); // codeql[js/http-to-file-access] Exporting dashboards to disk is an explicit CLI action.
+  fs.writeFileSync(destPath, JSON.stringify(data, null, 2)); // lgtm[js/http-to-file-access] Exporting dashboards to disk is an explicit CLI action.
   const suffix = dryRun ? ' (dry-run)' : '';
   console.log(`[export-dashboard] dashboard export completed${suffix}`);
 }

--- a/scripts/trace/fetch-otlp-payload.mjs
+++ b/scripts/trace/fetch-otlp-payload.mjs
@@ -108,7 +108,7 @@ const copyFile = async (source, fallbackType) => {
 };
 
 const writeBuffer = async (buffer, fallbackType, fallbackDetail) => {
-  await fsp.writeFile(targetPath, buffer); // codeql[js/http-to-file-access] Persisting fetched payloads is an explicit CLI action.
+  await fsp.writeFile(targetPath, buffer); // lgtm[js/http-to-file-access] Persisting fetched payloads is an explicit CLI action.
   setSource(fallbackType, fallbackDetail);
 };
 

--- a/scripts/trace/import-dashboard.mjs
+++ b/scripts/trace/import-dashboard.mjs
@@ -90,7 +90,7 @@ async function importDashboard({ host, token, folderId, overwrite, input }) {
     overwrite,
   };
 
-  const response = await fetch(new URL('/api/dashboards/db', host), { // codeql[js/file-access-to-http] Uploading dashboards is an explicit CLI action.
+  const response = await fetch(new URL('/api/dashboards/db', host), { // lgtm[js/file-access-to-http] Uploading dashboards is an explicit CLI action.
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
背景\n- CodeQL の http-to-file / file-access-to-http 警告が、"codeql[]" コメントでは抑制されていなかったため、CLI用途で明示的な抑制に統一する\n\n変更\n- CLIスクリプトの抑制コメントを lgtm 形式に統一\n  - scripts/trace/export-dashboard.mjs\n  - scripts/trace/fetch-otlp-payload.mjs\n  - scripts/trace/import-dashboard.mjs\n  - scripts/admin/apply-branch-protection.mjs\n\nログ\n- CodeQL: js/http-to-file-access, js/file-access-to-http の抑制コメント整備\n\nテスト\n- 未実施（コメントのみ変更）\n\n影響\n- 動作変更なし（コメントのみ）\n\nロールバック\n- このPRのコミットをrevert\n\n関連Issue\n- #1160