### PR TITLE
fix: align CodeQL suppression comments

### DIFF
--- a/scripts/coverage/pr-coverage-summary.mjs
+++ b/scripts/coverage/pr-coverage-summary.mjs
@@ -236,7 +236,8 @@ const base = `https://api.github.com/repos/${owner}/${repo}`;
 const headers = { 'authorization': `Bearer ${token}`, 'accept': 'application/vnd.github+json' };
 
 try {
-  const list = await fetch(`${base}/issues/${number}/comments?per_page=100`, { headers }); // lgtm [js/file-access-to-http] CI posts a coverage summary to GitHub by design.
+  // codeql [js/file-access-to-http] CI posts a coverage summary to GitHub by design.
+  const list = await fetch(`${base}/issues/${number}/comments?per_page=100`, { headers });
   if (!list.ok) {
     console.error('Non-fatal: failed to list comments', list.status, await list.text());
     process.exit(0);
@@ -244,14 +245,16 @@ try {
   const comments = await list.json();
   const mine = comments.find(c => typeof c.body === 'string' && c.body.startsWith(HEADER));
   if (mine) {
-    const res = await fetch(`${base}/issues/comments/${mine.id}`, { method: 'PATCH', headers: { ...headers, 'content-type': 'application/json' }, body: JSON.stringify({ body }) }); // lgtm [js/file-access-to-http] CI updates the coverage summary comment intentionally.
+    // codeql [js/file-access-to-http] CI updates the coverage summary comment intentionally.
+    const res = await fetch(`${base}/issues/comments/${mine.id}`, { method: 'PATCH', headers: { ...headers, 'content-type': 'application/json' }, body: JSON.stringify({ body }) });
     if (!res.ok) {
       console.error('Non-fatal: failed to update comment', res.status, await res.text());
       process.exit(0);
     }
     console.log('Updated AE-COVERAGE-SUMMARY');
   } else {
-    const res = await fetch(`${base}/issues/${number}/comments`, { method: 'POST', headers: { ...headers, 'content-type': 'application/json' }, body: JSON.stringify({ body }) }); // lgtm [js/file-access-to-http] CI creates the coverage summary comment intentionally.
+    // codeql [js/file-access-to-http] CI creates the coverage summary comment intentionally.
+    const res = await fetch(`${base}/issues/${number}/comments`, { method: 'POST', headers: { ...headers, 'content-type': 'application/json' }, body: JSON.stringify({ body }) });
     if (!res.ok) {
       console.error('Non-fatal: failed to create comment', res.status, await res.text());
       process.exit(0);

--- a/scripts/trace/export-dashboard.mjs
+++ b/scripts/trace/export-dashboard.mjs
@@ -102,7 +102,8 @@ async function exportDashboard({ host, uid, token, output, dryRun }) {
   const data = await response.json();
   const destPath = path.resolve(output);
   fs.mkdirSync(path.dirname(destPath), { recursive: true });
-  fs.writeFileSync(destPath, JSON.stringify(data, null, 2)); // lgtm [js/http-to-file-access] Exporting dashboards to disk is an explicit CLI action.
+  // codeql [js/http-to-file-access] Exporting dashboards to disk is an explicit CLI action.
+  fs.writeFileSync(destPath, JSON.stringify(data, null, 2));
   const suffix = dryRun ? ' (dry-run)' : '';
   console.log(`[export-dashboard] dashboard export completed${suffix}`);
 }

--- a/scripts/trace/fetch-otlp-payload.mjs
+++ b/scripts/trace/fetch-otlp-payload.mjs
@@ -108,7 +108,8 @@ const copyFile = async (source, fallbackType) => {
 };
 
 const writeBuffer = async (buffer, fallbackType, fallbackDetail) => {
-  await fsp.writeFile(targetPath, buffer); // lgtm [js/http-to-file-access] Persisting fetched payloads is an explicit CLI action.
+  // codeql [js/http-to-file-access] Persisting fetched payloads is an explicit CLI action.
+  await fsp.writeFile(targetPath, buffer);
   setSource(fallbackType, fallbackDetail);
 };
 

--- a/scripts/trace/import-dashboard.mjs
+++ b/scripts/trace/import-dashboard.mjs
@@ -90,7 +90,8 @@ async function importDashboard({ host, token, folderId, overwrite, input }) {
     overwrite,
   };
 
-  const response = await fetch(new URL('/api/dashboards/db', host), { // lgtm [js/file-access-to-http] Uploading dashboards is an explicit CLI action.
+  // codeql [js/file-access-to-http] Uploading dashboards is an explicit CLI action.
+  const response = await fetch(new URL('/api/dashboards/db', host), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## 背景\nCodeQL の抑止コメントが従来形式（lgtm）になっており、警告が解消されない状態でした。\n\n## 変更\n- CodeQLの推奨フォーマット（codeql）にコメントを更新\n\n## ログ\n- scripts/trace/export-dashboard.mjs: http→fileの抑止コメントを更新\n- scripts/trace/fetch-otlp-payload.mjs: http→fileの抑止コメントを更新\n- scripts/trace/import-dashboard.mjs: file→httpの抑止コメントを更新\n- scripts/coverage/pr-coverage-summary.mjs: file→httpの抑止コメントを更新\n\n## テスト\n- 未実施（コメントのみ変更）\n\n## 影響\n- 実行挙動の変更なし（抑止コメントのみ）\n\n## ロールバック\n- このPRのコミットをrevert\n\n## 関連Issue\n- #1004\n