### PR TITLE
fix: remove unused test imports (runtime/property)

### DIFF
--- a/tests/api/runtime-guard.reservations.test.ts
+++ b/tests/api/runtime-guard.reservations.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { SpyInstance } from 'vitest';
 import { FastifyInstance } from 'fastify';
-import { trace } from '@opentelemetry/api';
 import { formatGWT } from '../utils/gwt-format';
-import * as SecurityHeaders from '../../src/api/middleware/security-headers.js';
 import getServer, { createServer } from '../../src/api/server.js';
 
 const {

--- a/tests/property/reservation.pbt.test.ts
+++ b/tests/property/reservation.pbt.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fc from "fast-check";
 import { AEIR } from '@ae-framework/spec-compiler';
 import { DeterministicCodeGenerator } from '../../src/codegen/deterministic-generator';
-import { writeFileSync, readFileSync, unlinkSync, existsSync, mkdirSync, rmSync } from 'fs';
+import { writeFileSync, readFileSync, existsSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { createHash } from 'crypto';
 


### PR DESCRIPTION
## 背景\nCodeQL の未使用import 指摘（テスト）が残っており、スキャンノイズ削減が必要でした。\n\n## 変更\n- 未使用importを削除\n\n## ログ\n- tests/api/runtime-guard.reservations.test.ts: 未使用 trace / SecurityHeaders を削除\n- tests/property/reservation.pbt.test.ts: 未使用 unlinkSync を削除\n\n## テスト\n- 未実施（ローカル変更のみ）\n\n## 影響\n- テストのみ。実行時挙動に影響なし\n\n## ロールバック\n- このPRのコミットをrevert\n\n## 関連Issue\n- #1004\n