### PR TITLE
fix: clean up unused test code (a11y/sbom/email)

### DIFF
--- a/tests/a11y/setup.js
+++ b/tests/a11y/setup.js
@@ -46,16 +46,6 @@ const ensureExpectExtended = () => {
   }
 };
 
-const getExpect = () => {
-  const instance = tryResolveExpect();
-  if (typeof instance !== 'function') {
-    throw new Error('Global expect is not available; ensure the test runner provides it');
-  }
-  registerMatcher(instance);
-  cachedExpect = instance;
-  return instance;
-};
-
 /**
  * Accessibility test setup for Phase 6 Quality Gates
  * Simplified version for Node.js environment

--- a/tests/property/email.normalize.idempotent.pbt.test.ts
+++ b/tests/property/email.normalize.idempotent.pbt.test.ts
@@ -29,17 +29,14 @@ describe('PBT: Email normalization is idempotent and case/space-insensitive', ()
           casing
         }),
         async ({ email, leading, trailing, casing }) => {
-          let mixedCase = email;
-          if (casing === 'upper') {
-            mixedCase = email.toUpperCase();
-          } else if (casing === 'lower') {
-            mixedCase = email.toLowerCase();
-          } else {
-            mixedCase = email
-              .split('')
-              .map((char, idx) => (idx % 2 === 0 ? char.toUpperCase() : char.toLowerCase()))
-              .join('');
-          }
+          const mixedCase = casing === 'upper'
+            ? email.toUpperCase()
+            : (casing === 'lower'
+              ? email.toLowerCase()
+              : email
+                .split('')
+                .map((char, idx) => (idx % 2 === 0 ? char.toUpperCase() : char.toLowerCase()))
+                .join(''));
           const raw = `${leading}${mixedCase}${trailing}`;
           const e1 = makeEmail(raw) as unknown as string;
           const e2 = makeEmail(e1) as unknown as string;

--- a/tests/security/sbom-generator.test.ts
+++ b/tests/security/sbom-generator.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SBOMGenerator, type SBOMGeneratorOptions, type SBOM } from '../../src/security/sbom-generator.js';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 
 // Mock fs module
 vi.mock('fs/promises');


### PR DESCRIPTION
## 背景\nCodeQL の未使用変数/未使用import（テスト）が残っており、スキャンノイズ削減が必要でした。\n\n## 変更\n- 未使用変数/未使用importを削除\n\n## ログ\n- tests/property/email.normalize.idempotent.pbt.test.ts: 無駄な初期代入を整理\n- tests/security/sbom-generator.test.ts: 未使用 path import を削除\n- tests/a11y/setup.js: 未使用 getExpect を削除\n\n## テスト\n- 未実施（ローカル変更のみ）\n\n## 影響\n- テストのみ。実行時挙動に影響なし\n\n## ロールバック\n- このPRのコミットをrevert\n\n## 関連Issue\n- #1004\n