### PR TITLE
fix: drop unused performance thresholds

### DIFF
--- a/src/inference/core/validation-orchestrator.ts
+++ b/src/inference/core/validation-orchestrator.ts
@@ -697,8 +697,6 @@ export class ValidationOrchestrator extends EventEmitter {
     context: ValidationContext,
     config: ValidatorConfig
   ): Promise<ValidationResult> {
-    const thresholds = config.parameters['performanceThresholds'] || {};
-    
     return {
       criterion: 'performance_metrics',
       passed: true,


### PR DESCRIPTION
## 背景\nCodeQL の js/unused-local-variable で指摘された未使用変数（performanceThresholds）を解消します。\n\n## 変更\n- performanceThresholds の未使用変数を削除\n\n## ログ\n- なし\n\n## テスト\n- 未実施（CIで確認）\n\n## 影響\n- なし（振る舞い変更なし）\n\n## ロールバック\n- このPRをrevert\n\n## 関連Issue\n- #1004\n