### PR TITLE
fix: ignore generated public types in CodeQL

### DIFF
--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -187,6 +187,10 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: javascript
+        config: |
+          paths-ignore:
+            - api/public-types.d.ts
+            - artifacts/public-types.current.d.ts
         
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -180,6 +180,10 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
+          config: |
+            paths-ignore:
+              - api/public-types.d.ts
+              - artifacts/public-types.current.d.ts
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3


### PR DESCRIPTION
## 背景\nCodeQLの js/assignment-to-constant が生成された .d.ts に対して誤検知しているため、生成成果物を解析対象から除外します。\n\n## 変更\n- CodeQL設定で以下の生成ファイルを除外\n  - api/public-types.d.ts\n  - artifacts/public-types.current.d.ts\n\n## ログ\n- なし\n\n## テスト\n- 未実施（CIで確認）\n\n## 影響\n- 生成成果物のCodeQL解析を除外（ランタイム影響なし）\n\n## ロールバック\n- このPRをrevert\n\n## 関連Issue\n- #1004\n