### PR TITLE
fix(codeql): drop unused afterEach in tests

### DIFF
--- a/tests/resilience/integration.test.ts
+++ b/tests/resilience/integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for the complete resilience system
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   BackoffStrategy,
   CircuitBreaker,

--- a/tests/resilience/simple-resilience.test.ts
+++ b/tests/resilience/simple-resilience.test.ts
@@ -2,7 +2,7 @@
  * Simple tests to verify core resilience functionality
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   BackoffStrategy,
   CircuitBreaker,

--- a/tests/security/sbom-generator.test.ts
+++ b/tests/security/sbom-generator.test.ts
@@ -2,7 +2,7 @@
  * Tests for SBOM Generator
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SBOMGenerator, type SBOMGeneratorOptions, type SBOM } from '../../src/security/sbom-generator.js';
 import * as fs from 'fs/promises';
 


### PR DESCRIPTION
## 背景
- CodeQLのunused local variable指摘を削減し、テストのノイズを低減するため。

## 変更
- `tests/security/sbom-generator.test.ts` の未使用`afterEach` importを削除
- `tests/resilience/integration.test.ts` の未使用`afterEach` importを削除
- `tests/resilience/simple-resilience.test.ts` の未使用`afterEach` importを削除

## ログ
- fix(codeql): drop unused afterEach in tests

## テスト
- 未実施（変更が未使用importの削除のみのため）

## 影響
- 動作への影響なし（テストのみの整理）
- CodeQLの未使用変数アラートを低減

## ロールバック
- 本PRをrevert

## 関連Issue
- #1004
