### PR TITLE
fix(codeql): drop unused self-improve test imports

### DIFF
--- a/tests/resilience/backoff-strategies.test.ts
+++ b/tests/resilience/backoff-strategies.test.ts
@@ -9,9 +9,7 @@ import {
   CircuitState,
   TokenBucketRateLimiter,
   ResilientHttpClient,
-  RetryOptions,
   CircuitBreakerOptions,
-  RateLimiterOptions,
 } from '../../src/resilience/backoff-strategies.js';
 
 describe('BackoffStrategy', () => {

--- a/tests/self-improvement/setup-git-hooks.test.ts
+++ b/tests/self-improvement/setup-git-hooks.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { formatGWT } from '../utils/gwt-format';
 import { GitHooksSetup, createGitHooksSetup } from '../../src/self-improvement/setup-git-hooks.js';
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 
 // Mock fs module
 vi.mock('node:fs', () => ({

--- a/tests/self-improvement/tdd-setup.test.ts
+++ b/tests/self-improvement/tdd-setup.test.ts
@@ -9,7 +9,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { formatGWT } from '../utils/gwt-format';
 import { SelfImprovementTDDSetup, createSelfImprovementTDDSetup } from '../../src/self-improvement/tdd-setup.js';
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 
 // Mock dependencies at module level
 vi.mock('../../src/integration/hybrid-tdd-system.js', () => ({


### PR DESCRIPTION
## 背景
- CodeQLのunused local variable/import指摘を削減し、テストのノイズを低減するため。

## 変更
- `tests/self-improvement/tdd-setup.test.ts` の未使用path importを削除
- `tests/self-improvement/setup-git-hooks.test.ts` の未使用path importを削除
- `tests/resilience/backoff-strategies.test.ts` の未使用型import（RetryOptions/RateLimiterOptions）を削除

## ログ
- fix(codeql): drop unused self-improve test imports

## テスト
- 未実施（変更が未使用importの削除のみのため）

## 影響
- 動作への影響なし（テストのみの整理）
- CodeQLの未使用変数アラートを低減

## ロールバック
- 本PRをrevert

## 関連Issue
- #1004
