### PR TITLE
chore(security): ensure npm >=10.5

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -12,8 +12,18 @@ runs:
     - run: |
         set -euo pipefail
         VERSION="${{ inputs.version }}"
-        node -e "const [major, minor] = process.versions.npm.split('.').map(Number); if (major < 10 || (major === 10 && minor < 5)) process.exit(1);" \
-          || npm install -g "npm@10.5.0"
+        MIN_NPM="10.5.0"
+        CURRENT_NPM="$(npm --version 2>/dev/null || true)"
+        if [ -z "$CURRENT_NPM" ]; then
+          echo "npm not found; installing npm@latest-10"
+          npm install -g "npm@latest-10"
+        else
+          LOWEST="$(printf '%s\n' "$MIN_NPM" "$CURRENT_NPM" | sort -V | head -n1)"
+          if [ "$LOWEST" != "$MIN_NPM" ]; then
+            echo "Detected npm version $CURRENT_NPM < $MIN_NPM; upgrading to npm@latest-10"
+            npm install -g "npm@latest-10"
+          fi
+        fi
         if command -v corepack >/dev/null 2>&1; then
           corepack enable > /dev/null 2>&1 || true
           corepack prepare "pnpm@${VERSION}" --activate


### PR DESCRIPTION
## 背景
- #1225 の npm 脆弱性（CVE-2025-64756: npm 10.4.5 -> 10.5.0）対策として、CI内のnpmを最低 10.5.0 に引き上げる

## 変更
- setup-pnpm composite action で npm バージョンをチェックし、10.5未満なら 10.5.0 をインストール

## ログ
- CI準備ステップのみの変更

## テスト
- 未実施（CIで確認）

## 影響
- CIで使用するnpmが脆弱バージョンに固定されるのを回避

## ロールバック
- このPRのコミットを revert

## 関連Issue
- #1225
