### PR TITLE
docs: clarify integration cleanup coverage

### DIFF
--- a/docs/notes/issue-1005-integration-test-inventory.md
+++ b/docs/notes/issue-1005-integration-test-inventory.md
@@ -7,7 +7,7 @@
 ## Files and helper usage
 | file | temp dir | cleanup | retry | integration setup |
 | --- | --- | --- | --- | --- |
-| tests/integration/integration-cli.test.ts | yes | no | yes | no |
+| tests/integration/integration-cli.test.ts | yes | yes (temp dir) | yes | no |
 | tests/integration/system-validation.test.ts | yes | yes | yes | no |
 | tests/integration/test-orchestrator.test.ts | yes | yes | yes | no |
 | tests/integration/web-api/reservations.test.ts | no | no | yes | no |
@@ -15,4 +15,5 @@
 
 ## Notes
 - This inventory is a baseline for flake investigation and cleanup planning.
+- `createIntegrationTempDir` registers cleanup automatically; the cleanup column treats that as covered.
 - If a file shows "no" across cleanup helpers, review its teardown behavior first.


### PR DESCRIPTION
## 背景\n- #1005 の inventory で cleanup 表記が誤解を招きやすいため補足する\n\n## 変更\n- integration-cli の cleanup を temp dir 経由として明記\n- createIntegrationTempDir の自動 cleanup 登録を notes に追記\n\n## ログ\n- なし\n\n## テスト\n- なし\n\n## 影響\n- ドキュメント修正のみ\n\n## ロールバック\n- git revert 29887a71\n\n## 関連Issue\n- #1005\n- #1336