### PR TITLE
docs: snapshot open code scanning alerts (#1225)

### DIFF
--- a/docs/notes/issue-1225-codeql-open-alerts.md
+++ b/docs/notes/issue-1225-codeql-open-alerts.md
@@ -35,9 +35,23 @@ This note captures the current GitHub code-scanning open alerts so we can triage
 | `artifacts/` | 2 |
 | `packages/` | 1 |
 
+## Warning-level hotspots (top 12 paths)
+
+- `src/agents/rust-verification-agent.ts`: 6
+- `scripts/coverage/pr-coverage-summary.mjs`: 5
+- `scripts/accessibility-analyzer.js`: 4
+- `scripts/security-analyzer.js`: 3
+- `scripts/cegis-report-cleanup.mjs`: 2
+- `scripts/codex/quickstart.mjs`: 2
+- `scripts/doctest.ts`: 2
+- `src/commands/adapt/jest.ts`: 2
+- `src/commands/adapt/vitest.ts`: 2
+- `scripts/admin/apply-branch-protection.mjs`: 1
+- `scripts/check-a11y-threshold.cjs`: 1
+- `scripts/check-opa-compliance.cjs`: 1
+
 ## Suggested triage focus
 
 1. **Warnings first**: resolve or justify the 49 warning-level alerts.
 2. **Separate generated or sample code**: determine if `js/unused-local-variable` in `examples/` or generated assets should be excluded or fixed.
 3. **Narrow scope**: prioritize `src/` and `scripts/` where runtime risk is higher.
-


### PR DESCRIPTION
## 背景
#1225 の対応に向け、現時点の Code Scanning オープンアラートを可視化する必要があるため。

## 変更
- `docs/notes/issue-1225-codeql-open-alerts.md` に 2026-01-03 時点のスナップショットを追加（総数/ルール別/パス別）。

## ログ
- 取得コマンド: `gh api --paginate /repos/itdojp/ae-framework/code-scanning/alerts?state=open`

## テスト
- 未実施（ドキュメント追加のみ）

## 影響
- ドキュメントのみ

## ロールバック
- 追加した note を削除

## 関連Issue
- #1225
