### PR TITLE
docs: add CodeQL warning distribution (#1004)

### DIFF
--- a/docs/notes/issue-1004-codeql-targets.md
+++ b/docs/notes/issue-1004-codeql-targets.md
@@ -6,7 +6,7 @@ This note captures the current open CodeQL alerts related to Issue #1004 so fixe
 
 ### Severity distribution
 
-- Open alerts are currently **note** and **warning** only (no error/critical in the CodeQL list).
+- Open **CodeQL code scanning alerts** are currently **note** and **warning** only (no error/critical severities in the CodeQL list). This statement applies only to CodeQL alerts and does **not** include dependency vulnerability alerts (e.g., CVEs), which are tracked separately in Issue #1004 and may still include HIGH/CRITICAL severities.
 
 ### Warning rules (open counts)
 


### PR DESCRIPTION
## 背景
#1004 の優先度付けを進めるため、現時点の CodeQL 警告の分布を明文化する必要があるため。

## 変更
- `docs/notes/issue-1004-codeql-targets.md` に警告ルールの分布と現状の severity（note/warningのみ）を追記。

## ログ
- 取得コマンド: `gh api --paginate /repos/itdojp/ae-framework/code-scanning/alerts?state=open`

## テスト
- 未実施（ドキュメント追加のみ）

## 影響
- ドキュメントのみ

## ロールバック
- 追記したセクションを削除

## 関連Issue
- #1004
