### PR TITLE
docs: add CodeQL warning hotspots (#1004)

### DIFF
--- a/docs/notes/issue-1004-codeql-targets.md
+++ b/docs/notes/issue-1004-codeql-targets.md
@@ -33,6 +33,8 @@ This note captures the current open CodeQL alerts related to Issue #1004 so fixe
 - `src/cli/quality-cli.ts`: 1
 - `src/commands/ci/scaffold.ts`: 1
 - `src/integration/hybrid-intent-system.ts`: 1
+- `src/providers/recorder.ts`: 1
+- `src/self-improvement/setup-git-hooks.ts`: 1
 
 ### Warning hotspots: `js/shell-command-injection-from-environment` (top paths)
 


### PR DESCRIPTION
## 背景
#1004 の warning 対応を小粒PRで進めるため、ホットスポット（該当ファイル）を可視化したい。

## 変更
- `docs/notes/issue-1004-codeql-targets.md` に `js/file-system-race` / `js/shell-command-injection-from-environment` の上位パス一覧を追記。

## ログ
- 取得コマンド: `gh api --paginate /repos/itdojp/ae-framework/code-scanning/alerts?state=open`

## テスト
- 未実施（ドキュメント追加のみ）

## 影響
- ドキュメントのみ

## ロールバック
- 追記したセクションを削除

## 関連Issue
- #1004
