### PR TITLE
fix: remove TOCTOU checks in cegis cleanup

### DIFF
--- a/scripts/cegis-report-cleanup.mjs
+++ b/scripts/cegis-report-cleanup.mjs
@@ -19,15 +19,10 @@ class CEGISReportCleanup {
 
   async createArchiveDirectory() {
     console.log('📁 Creating archive directory...');
-    
-    if (!fs.existsSync('./temp-reports')) {
-      fs.mkdirSync('./temp-reports', { recursive: true });
-    }
-    
-    if (!fs.existsSync(this.archiveDir)) {
-      fs.mkdirSync(this.archiveDir, { recursive: true });
-    }
-    
+
+    await fsp.mkdir('./temp-reports', { recursive: true });
+    await fsp.mkdir(this.archiveDir, { recursive: true });
+
     console.log(`✅ Archive directory created: ${this.archiveDir}`);
   }
 
@@ -175,8 +170,10 @@ class CEGISReportCleanup {
     ];
     
     let gitignoreContent = '';
-    if (fs.existsSync(gitignorePath)) {
-      gitignoreContent = fs.readFileSync(gitignorePath, 'utf8');
+    try {
+      gitignoreContent = await fsp.readFile(gitignorePath, 'utf8');
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
     }
     
     let updated = false;


### PR DESCRIPTION
## 背景
#1004 の CodeQL 警告（`js/file-system-race`）を小粒で減らすため、`scripts/cegis-report-cleanup.mjs` のファイル存在チェックを整理する必要があるため。

## 変更
- `scripts/cegis-report-cleanup.mjs` で `existsSync` → `fsp.mkdir` / `fsp.readFile` に置換し、TOCTOU パターンを回避。

## ログ
- なし

## テスト
- 未実施（スクリプトのI/O整理のみ）

## 影響
- CEGIS レポート整理スクリプトのI/O挙動は同等

## ロールバック
- 該当コミットを revert

## 関連Issue
- #1004
