### PR TITLE
fix(codeql): drop unused benchmark path

### DIFF
--- a/src/self-improvement/phase3-typescript-fixes.ts
+++ b/src/self-improvement/phase3-typescript-fixes.ts
@@ -135,8 +135,6 @@ export class Phase3TypeScriptFixer {
    * Fix Benchmark Runner type mismatch
    */
   private async fixBenchmarkRunnerTypeMismatch(): Promise<void> {
-    const filePath = path.join(process.cwd(), 'src/benchmark/req2run/runners/BenchmarkRunner.ts');
-    
     try {
       // This is a more complex fix that would require understanding the type mismatch
       // For now, we'll document it for later resolution


### PR DESCRIPTION
## 背景
CodeQL の unused-local-variable 指摘（phase3-typescript-fixes）を解消します。

## 変更
- `src/self-improvement/phase3-typescript-fixes.ts` の未使用変数 `filePath` を削除

## ログ
- テスト/ lint は未実施（node_modules 未導入）

## テスト
- 未実施（node_modules 未導入のため）

## 影響
- 未使用変数整理のみ（挙動変更なし）

## ロールバック
- このPRのコミットを revert

## 関連Issue
- #1004
