### PR TITLE
test: cover provider-utils and normalizeError

### DIFF
--- a/src/providers/provider-utils.ts
+++ b/src/providers/provider-utils.ts
@@ -1,3 +1,6 @@
+/**
+ * Convert unknown values to a string for logging/debugging.
+ */
 export const stringifyUnknown = (value: unknown, fallback = '[unserializable]'): string => {
   if (value == null) return '';
   if (typeof value === 'string') return value;
@@ -19,6 +22,9 @@ const hasTextField = (value: unknown): value is { text: string } => {
   return typeof text === 'string';
 };
 
+/**
+ * Extract the first available text from Anthropic response content.
+ */
 export const extractAnthropicText = (content: unknown): string => {
   if (Array.isArray(content)) {
     for (const entry of content) {
@@ -45,6 +51,9 @@ const hasTextMethod = (value: unknown): value is { text: () => string } => {
 
 const isUnknownArray = (value: unknown): value is unknown[] => Array.isArray(value);
 
+/**
+ * Extract text from Gemini SDK response shapes.
+ */
 export const extractGeminiText = (response: unknown): string => {
   if (hasTextMethod(response)) {
     const text = response.text();
@@ -72,6 +81,9 @@ export const extractGeminiText = (response: unknown): string => {
   return '';
 };
 
+/**
+ * Type guard for modules exposing a constructor under the given key.
+ */
 export const hasConstructorProperty = <TKey extends string>(
   value: unknown,
   key: TKey

--- a/src/resilience/error-utils.ts
+++ b/src/resilience/error-utils.ts
@@ -1,3 +1,6 @@
+/**
+ * Normalize unknown error values into an Error instance with preserved metadata.
+ */
 export const normalizeError = (error: unknown, fallbackMessage: string): Error => {
   if (error instanceof Error) return error;
   if (typeof error === 'string') return new Error(error);

--- a/tests/providers/provider-utils.test.ts
+++ b/tests/providers/provider-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest';
+import {
+  stringifyUnknown,
+  extractAnthropicText,
+  extractGeminiText,
+  hasConstructorProperty,
+} from '../../src/providers/provider-utils.js';
+
+describe('provider-utils', () => {
+  describe('stringifyUnknown', () => {
+    test('returns empty string for nullish values', () => {
+      expect(stringifyUnknown(null)).toBe('');
+      expect(stringifyUnknown(undefined)).toBe('');
+    });
+
+    test('returns string values as-is', () => {
+      expect(stringifyUnknown('hello')).toBe('hello');
+    });
+
+    test('stringifies numbers and booleans', () => {
+      expect(stringifyUnknown(42)).toBe('42');
+      expect(stringifyUnknown(true)).toBe('true');
+    });
+
+    test('extracts message from Error instances', () => {
+      expect(stringifyUnknown(new Error('boom'))).toBe('boom');
+    });
+
+    test('serializes objects when possible', () => {
+      expect(stringifyUnknown({ ok: true })).toBe('{"ok":true}');
+    });
+
+    test('uses fallback when serialization fails', () => {
+      const circular: { self?: unknown } = {};
+      circular.self = circular;
+      expect(stringifyUnknown(circular, 'fallback')).toBe('fallback');
+    });
+  });
+
+  describe('extractAnthropicText', () => {
+    test('returns text from a string response', () => {
+      expect(extractAnthropicText('hi')).toBe('hi');
+    });
+
+    test('returns text from an object with text field', () => {
+      expect(extractAnthropicText({ text: 'from field' })).toBe('from field');
+    });
+
+    test('returns first non-empty entry from arrays', () => {
+      const content = [{ text: '' }, { text: 'first' }, { text: 'second' }];
+      expect(extractAnthropicText(content)).toBe('first');
+    });
+
+    test('returns empty string when no text is found', () => {
+      expect(extractAnthropicText({})).toBe('');
+    });
+  });
+
+  describe('extractGeminiText', () => {
+    test('uses text() method when present', () => {
+      const response = { text: () => 'from method' };
+      expect(extractGeminiText(response)).toBe('from method');
+    });
+
+    test('stringifies non-string text() values', () => {
+      const response = { text: () => 123 };
+      expect(extractGeminiText(response)).toBe('123');
+    });
+
+    test('extracts from candidates/parts shape', () => {
+      const response = {
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'from parts' }],
+            },
+          },
+        ],
+      };
+      expect(extractGeminiText(response)).toBe('from parts');
+    });
+
+    test('returns empty string when no text is available', () => {
+      expect(extractGeminiText({})).toBe('');
+    });
+  });
+
+  describe('hasConstructorProperty', () => {
+    test('returns true for constructor functions', () => {
+      const mod = { default: class Example {} };
+      expect(hasConstructorProperty(mod, 'default')).toBe(true);
+    });
+
+    test('returns false for non-function values', () => {
+      const mod = { default: 'not a constructor' };
+      expect(hasConstructorProperty(mod, 'default')).toBe(false);
+    });
+
+    test('returns false for non-object inputs', () => {
+      expect(hasConstructorProperty(null, 'default')).toBe(false);
+    });
+  });
+});

--- a/tests/resilience/error-utils.test.ts
+++ b/tests/resilience/error-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest';
+import { normalizeError } from '../../src/resilience/error-utils.js';
+
+describe('normalizeError', () => {
+  test('returns Error instances unchanged', () => {
+    const error = new Error('boom');
+    expect(normalizeError(error, 'fallback')).toBe(error);
+  });
+
+  test('wraps string errors', () => {
+    const normalized = normalizeError('oops', 'fallback');
+    expect(normalized).toBeInstanceOf(Error);
+    expect(normalized.message).toBe('oops');
+  });
+
+  test('preserves message, name, and metadata from objects', () => {
+    const normalized = normalizeError(
+      { message: 'nope', name: 'RetryableError', status: 503, code: 'E_TEST' },
+      'fallback'
+    );
+    expect(normalized.message).toBe('nope');
+    expect(normalized.name).toBe('RetryableError');
+    expect((normalized as { status?: number }).status).toBe(503);
+    expect((normalized as { code?: string }).code).toBe('E_TEST');
+  });
+
+  test('falls back to JSON string when message is missing', () => {
+    const normalized = normalizeError({ detail: 'missing' }, 'fallback');
+    expect(normalized.message).toContain('"detail":"missing"');
+  });
+
+  test('uses fallback when JSON serialization fails', () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    const normalized = normalizeError(circular, 'fallback');
+    expect(normalized.message).toBe('fallback');
+  });
+});


### PR DESCRIPTION
背景\n- Issue #1391 で指摘された provider-utils / normalizeError のテストと最小JSDocを追加します。\n\n変更\n- provider-utils / normalizeError に短いJSDocを追加\n- provider-utils と normalizeError のユニットテストを追加\n\nログ\n- なし\n\nテスト\n- 未実施（CIで確認予定）\n\n影響\n- 仕様変更なし（テストとドキュメントのみ）\n\nロールバック\n- このPRのrevert\n\n関連Issue\n- #1391