### PR TITLE
fix(integration): add retry for optimization system tests

### DIFF
--- a/docs/notes/issue-1005-integration-test-inventory.md
+++ b/docs/notes/issue-1005-integration-test-inventory.md
@@ -11,7 +11,7 @@
 | tests/integration/system-validation.test.ts | yes | yes | yes | yes |
 | tests/integration/test-orchestrator.test.ts | yes | yes | yes | yes |
 | tests/integration/web-api/reservations.test.ts | no | yes | yes | yes |
-| tests/optimization/system-integration.test.ts | no | yes | no | yes |
+| tests/optimization/system-integration.test.ts | no | yes | yes | yes |
 
 ## Notes
 - This inventory is a baseline for flake investigation and cleanup planning.

--- a/tests/optimization/system-integration.test.ts
+++ b/tests/optimization/system-integration.test.ts
@@ -12,10 +12,15 @@ import {
   type SystemMetrics,
   type OptimizationDashboard 
 } from '../../src/optimization/index.js';
-import { registerIntegrationCleanup } from '../_helpers/integration-test-utils.js';
+import {
+  applyIntegrationRetry,
+  registerIntegrationCleanup,
+} from '../_helpers/integration-test-utils.js';
 
 // Import integration setup for resource leak detection
 import '../integration/setup';
+
+applyIntegrationRetry(it);
 
 describe('Complete Optimization System Integration', () => {
   let optimizationSystem: OptimizationSystem;


### PR DESCRIPTION
## 背景
Issue #1005 の integration inventory で retry 未対応だった optimization/system-integration テストを共通リトライ設定に揃えるため。

## 変更
- `tests/optimization/system-integration.test.ts` に `applyIntegrationRetry` を適用
- inventory を retry 対応済みに更新

## ログ
- `pnpm vitest run tests/optimization/system-integration.test.ts`
  - MaxListenersExceededWarning が出たがテストは成功

## テスト
- `pnpm vitest run tests/optimization/system-integration.test.ts`

## 影響
- integration retry の統一で flake 低減（仕様変更なし）

## ロールバック
- このPRを revert

## 関連Issue
- #1005
