### PR TITLE
fix: remove unused api server bindings

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,6 +1,5 @@
 import Fastify from "fastify";
 import type { FastifyInstance } from "fastify";
-import { Reservation } from "../domain/contracts.js";
 import { securityHeadersPlugin, getSecurityConfiguration } from "./middleware/security-headers.js";
 import { runtimeGuard, CommonSchemas, ViolationSeverity } from "../telemetry/runtime-guards.js";
 import { enhancedTelemetry, TELEMETRY_ATTRIBUTES } from "../telemetry/enhanced-telemetry.js";
@@ -110,7 +109,7 @@ export async function createServer(): Promise<FastifyInstance> {
         // Still return the data in case of validation error to maintain availability
       }
 
-      const duration = timer.end({
+      timer.end({
         endpoint: '/health',
         validation_result: validation.valid ? 'success' : 'failure',
       });
@@ -203,7 +202,7 @@ export async function createServer(): Promise<FastifyInstance> {
         console.error('Reservation response validation failed:', responseValidation.violations);
       }
 
-      const duration = timer.end({
+      timer.end({
         endpoint: '/reservations',
         result: 'success',
         validation_result: responseValidation.valid ? 'success' : 'failure',


### PR DESCRIPTION
## 背景\nCodeQLのunused-local-variableアラート（src/api/server.ts）解消の小粒対応です。\n\n## 変更\n- 使っていないReservationのimportを削除\n- timer.endの戻り値を未使用のまま代入していた箇所を整理\n\n## ログ\n- lint: pnpm exec eslint --no-ignore src/api/server.ts（warningのみ、既存の警告）\n\n## テスト\n- 上記lintのみ（テストはCIで実施）\n\n## 影響\n- APIレスポンス/メトリクスの挙動変更なし（未使用変数の削除のみ）\n\n## ロールバック\n- このPRのrevertで元に戻せます\n\n## 関連Issue\n- #1004