### PR TITLE
docs: add Pack4/5 links to README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,10 @@ Comprehensive documentation for the AI‑Enhanced Development Framework.
 ### Quality / Verification
 - Formal Quality Gates (DoD v0.2): `quality/formal-gates.md`
 - Ownership DoD: `quality/ownership-dod.md`
+- LLM first-pass review checklist: `quality/llm-first-review-checklist.md`
+- Guarded automation template: `quality/guarded-automation-template.md`
+- Incident triage template: `quality/incident-triage-template.md`
+- Adoption sample flow: `quality/adoption-sample-flow.md`
 - Runbooks / Traceability / Runtime Contracts: see `docs/quality` and `docs/verify`
  - Coverage policy: `quality/coverage-policy.md`（しきい値の由来/Required化の運用）
  - Formal runbook: `quality/formal-runbook.md`（ラベル/dispatch/要約/環境変数）
@@ -115,6 +119,10 @@ Claude CodeやMCPとの統合
 
 - **[formal-gates.md](./quality/formal-gates.md)** ⭐ フォーマル品質ゲート（v0.2 DoD）
 - [ownership-dod.md](./quality/ownership-dod.md) - Ownership DoD（説明責任/運用/ロールバック）
+- [llm-first-review-checklist.md](./quality/llm-first-review-checklist.md) - LLM一次レビューの標準チェック
+- [guarded-automation-template.md](./quality/guarded-automation-template.md) - Guarded automation 運用テンプレ
+- [incident-triage-template.md](./quality/incident-triage-template.md) - インシデント一次切り分けテンプレ
+- [adoption-sample-flow.md](./quality/adoption-sample-flow.md) - 導入の最小フロー（エンドツーエンド）
 - [formal-runbook.md](./quality/formal-runbook.md) - 実行・運用手順（ラベルゲート/手動実行）
 - [formal-tools-setup.md](./quality/formal-tools-setup.md) - ローカル環境セットアップ（Apalache/TLC/Z3/cvc5）
  - [formal-mini-flow.md](./quality/formal-mini-flow.md) - 反例→失敗テスト→修正→緑の最小フロー


### PR DESCRIPTION
## 背景
#1436 Pack5（Ownership & Adoption）の成果物が増えたため、README からの導線を追加する。

## 変更
- `docs/README.md` に Pack4/5 のリンクを追加
  - LLM一次レビュー/Guarded automation/Incident triage/Adoption flow の導線

## テスト
- なし（ドキュメントのみ）

## 影響
- ドキュメント更新のみ

## ロールバック
- このPRをrevert

## 関連Issue
- #1436
