### PR TITLE
docs: add flaky test triage checklist

### DIFF
--- a/docs/testing/flaky-test-triage.md
+++ b/docs/testing/flaky-test-triage.md
@@ -12,7 +12,7 @@ Purpose: Provide a minimal, repeatable checklist to diagnose flaky tests without
   - `pnpm run test:ci:lite`
   - or the specific suite (unit/integration/property/mbt)
 - If Vitest stalls, try:
-  - `vitest --run --reporter=verbose --maxWorkers=50% --bail=1`
+  - `vitest --run --reporter=verbose --maxWorkers=50% --bail`
 
 ## 3) Isolate the test
 - Use a name or file filter to limit scope


### PR DESCRIPTION
## 背景
#1005（Test Stability Issues）のドキュメント更新として、フレイキーテストの最小トリアージ手順を追加する。

## 変更
- `docs/testing/flaky-test-triage.md` を追加
  - 収集→再現→切り分け→原因分類→緩和→記録のチェックリスト
  - Vitest 停滞時の再実行オプションを明記

## テスト
- なし（ドキュメントのみ）

## 影響
- ドキュメント追加のみ

## ロールバック
- このPRをrevert

## 関連Issue
- #1005
