### PR TITLE
docs: add CI environment setup notes

### DIFF
--- a/docs/ci/ci-environment-setup.md
+++ b/docs/ci/ci-environment-setup.md
@@ -1,0 +1,25 @@
+# CI Environment Setup (Quick)
+
+Purpose: Minimal environment notes to reproduce CI locally without heavy suites.
+
+## Prerequisites
+- Node.js (v22.x)
+- pnpm via corepack (`corepack enable`)
+- Container runtime: Podman or Docker
+
+## Recommended defaults
+- pnpm store: `.pnpm-store` in repo root
+- Use Verify Lite for baseline: `pnpm run verify:lite`
+- Use CI-lite test suite: `pnpm run test:ci:lite`
+
+## Container runtime notes
+- Podman setup: `docs/infra/podman-shared-runner.md`
+- Container runtime basics: `docs/infra/container-runtime.md`
+
+## CI gating notes
+- Heavy suites are label-gated (`docs/ci/label-gating.md`)
+- Stable profile for baseline signal (`docs/ci/stable-profile.md`)
+
+## Troubleshooting
+- CI failures: `docs/ci/ci-troubleshooting-guide.md`
+- Flaky tests: `docs/testing/flaky-test-triage.md`


### PR DESCRIPTION
## 背景
#1005（Test Stability Issues）のドキュメント更新として、CIの最小環境セットアップ手順を追加する。

## 変更
- `docs/ci/ci-environment-setup.md` を追加
  - Node/pnpm/コンテナ実行の最小要件
  - Verify Lite / test:ci:lite の基準
  - 既存ドキュメントへの導線

## テスト
- なし（ドキュメントのみ）

## 影響
- ドキュメント追加のみ

## ロールバック
- このPRをrevert

## 関連Issue
- #1005
