### PR TITLE
docs: add draft script alias map json

### DIFF
--- a/docs/notes/issue-1006-script-alias-map.md
+++ b/docs/notes/issue-1006-script-alias-map.md
@@ -5,6 +5,7 @@
 - Provide a reference for which legacy scripts should point to the new entry points.
 
 ## Draft aliases (Phase 1)
+Note: the JSON source of truth is `scripts/admin/script-alias-map.json`. This document summarizes it for review.
 | Legacy script | Proposed alias target | Rationale |
 | --- | --- | --- |
 | `test:ci` | `scripts/test/run.mjs --profile=ci` | Preserve CI entry while moving to unified test entry point. |

--- a/scripts/admin/script-alias-map.json
+++ b/scripts/admin/script-alias-map.json
@@ -1,0 +1,56 @@
+{
+  "phase": "1",
+  "note": "Draft alias map for script consolidation. No runtime wiring yet.",
+  "aliases": [
+    {
+      "legacy": "test:ci",
+      "target": "scripts/test/run.mjs --profile=ci",
+      "rationale": "Preserve CI entry while moving to unified test entry point."
+    },
+    {
+      "legacy": "test:ci:lite",
+      "target": "scripts/test/run.mjs --profile=ci-lite",
+      "rationale": "Keep Verify Lite split intact."
+    },
+    {
+      "legacy": "test:ci:extended",
+      "target": "scripts/test/run.mjs --profile=ci-extended",
+      "rationale": "Heavy suite remains opt-in via profile."
+    },
+    {
+      "legacy": "quality:run:all",
+      "target": "scripts/quality/run.mjs --profile=all",
+      "rationale": "Keep existing aggregation behavior."
+    },
+    {
+      "legacy": "quality:gates",
+      "target": "scripts/quality/run.mjs --profile=gates",
+      "rationale": "CI still calls gates; alias keeps the entry stable."
+    },
+    {
+      "legacy": "verify:lite",
+      "target": "scripts/verify/run.mjs --profile=lite",
+      "rationale": "Map to Verify Lite default profile."
+    },
+    {
+      "legacy": "verify:conformance",
+      "target": "scripts/verify/run.mjs --profile=conformance",
+      "rationale": "Maintain conformance as a named profile."
+    },
+    {
+      "legacy": "flake:detect",
+      "target": "scripts/flake/run.mjs --profile=detect",
+      "rationale": "Align detect with unified flake entry."
+    },
+    {
+      "legacy": "flake:detect:quick",
+      "target": "scripts/flake/run.mjs --profile=quick",
+      "rationale": "Keep quick as profile flag."
+    },
+    {
+      "legacy": "security:integrated:quick",
+      "target": "scripts/security/run.mjs --profile=quick",
+      "rationale": "Default quick path for PR gating."
+    }
+  ]
+}


### PR DESCRIPTION
## 背景\n#1006 Phase1 の移行準備として、暫定エイリアス表を JSON でも管理できるようにしました。\n\n## 変更\n- scripts/admin/script-alias-map.json を追加\n- docs/notes/issue-1006-script-alias-map.md にJSON参照を追記\n\n## ログ\n- scripts/admin/script-alias-map.json\n- docs/notes/issue-1006-script-alias-map.md\n\n## テスト\n- 未実施（ドキュメント/JSON追加のみ）\n\n## 影響\n- 仕様メモのみ（挙動変更なし）\n\n## ロールバック\n- このPRのrevertで戻せます\n\n## 関連Issue\n- #1006\n