### PR TITLE
feat(quality): add runner skeleton

### DIFF
--- a/scripts/quality/run.mjs
+++ b/scripts/quality/run.mjs
@@ -1,6 +1,30 @@
 #!/usr/bin/env node
+/**
+ * CLI entry point for running project quality profiles.
+ *
+ * This script resolves a named "quality profile" (e.g. `all`, `gates`, `policy`)
+ * to one or more underlying package scripts and executes them sequentially.
+ * It is intended to provide a single, consistent interface for running
+ * the repository's quality checks from the command line or CI.
+ *
+ * Usage:
+ *   node scripts/quality/run.mjs --profile <name> [--list] [--dry-run]
+ *
+ * Options:
+ *   -p, --profile <name>   Name of the quality profile to run.
+ *   --list                 Print all available profile names and exit.
+ *   --dry-run              Print the resolved commands instead of executing them.
+ *   -h, --help             Show this usage information and exit.
+ *
+ * Exit codes:
+ *   0  - Success (including help or list output).
+ *   2  - Unknown profile name.
+ *   3  - Invalid or missing arguments.
+ *   >0 - Non-zero exit code from a child quality command.
+ */
 import { spawnSync } from 'node:child_process';
-import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const PROFILE_COMMANDS = {
   all: [['pnpm', 'run', 'quality:run:all']],
@@ -13,22 +37,29 @@ export function listProfiles() {
 }
 
 export function resolveProfile(profile) {
-  return PROFILE_COMMANDS[profile] ?? null;
+  return Object.prototype.hasOwnProperty.call(PROFILE_COMMANDS, profile)
+    ? PROFILE_COMMANDS[profile]
+    : null;
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const options = {
     profile: null,
     list: false,
     dryRun: false,
     help: false,
+    profileError: false,
     unknown: [],
   };
 
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
     const next = argv[i + 1];
-    if ((arg === '--profile' || arg === '-p') && next) {
+    if (arg === '--profile' || arg === '-p') {
+      if (!next || next.startsWith('-')) {
+        options.profileError = true;
+        continue;
+      }
       options.profile = next;
       i += 1;
     } else if (arg === '--list') {
@@ -56,7 +87,7 @@ Options:
 `);
 }
 
-function runQuality(options) {
+export function runQuality(options) {
   if (options.help) {
     printHelp();
     return 0;
@@ -65,6 +96,11 @@ function runQuality(options) {
   if (options.list) {
     console.log(listProfiles().join('\n'));
     return 0;
+  }
+
+  if (options.profileError) {
+    console.error('[quality-runner] missing value for --profile');
+    return 3;
   }
 
   if (options.unknown.length > 0) {
@@ -95,6 +131,12 @@ function runQuality(options) {
       stdio: 'inherit',
       env: process.env,
     });
+    if (result.error) {
+      console.error(
+        `[quality-runner] failed to spawn command: ${command.join(' ')}: ${result.error.message ?? result.error}`
+      );
+      return result.error.code === 'ENOENT' ? 127 : 1;
+    }
     if (result.status !== 0) {
       return result.status ?? 1;
     }
@@ -102,8 +144,13 @@ function runQuality(options) {
   return 0;
 }
 
-function isCliInvocation(argv) {
-  return import.meta.url === pathToFileURL(argv[1]).href;
+export function isCliInvocation(argv) {
+  if (!argv[1]) return false;
+  try {
+    return fileURLToPath(import.meta.url) === path.resolve(argv[1]);
+  } catch {
+    return false;
+  }
 }
 
 if (isCliInvocation(process.argv)) {

--- a/tests/quality/quality-runner.test.ts
+++ b/tests/quality/quality-runner.test.ts
@@ -1,5 +1,30 @@
-import { describe, it, expect } from 'vitest';
-import { listProfiles, resolveProfile } from '../../scripts/quality/run.mjs';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+const spawnSyncMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawnSync: (...args) => spawnSyncMock(...args),
+}));
+
+let listProfiles;
+let resolveProfile;
+let parseArgs;
+let runQuality;
+let isCliInvocation;
+
+beforeAll(async () => {
+  ({
+    listProfiles,
+    resolveProfile,
+    parseArgs,
+    runQuality,
+    isCliInvocation,
+  } = await import('../../scripts/quality/run.mjs'));
+});
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+});
 
 describe('quality runner profiles', () => {
   it('lists supported profiles', () => {
@@ -12,5 +37,58 @@ describe('quality runner profiles', () => {
 
   it('returns null for unknown profiles', () => {
     expect(resolveProfile('unknown')).toBeNull();
+  });
+});
+
+describe('quality runner arg parsing', () => {
+  it('parses profile value', () => {
+    const options = parseArgs(['node', 'script', '--profile', 'all']);
+    expect(options.profile).toBe('all');
+    expect(options.profileError).toBe(false);
+  });
+
+  it('flags missing profile value', () => {
+    const options = parseArgs(['node', 'script', '--profile']);
+    expect(options.profileError).toBe(true);
+  });
+});
+
+describe('quality runner execution', () => {
+  it('returns 0 for list', () => {
+    const options = parseArgs(['node', 'script', '--list']);
+    expect(runQuality(options)).toBe(0);
+  });
+
+  it('returns 3 for unknown args', () => {
+    const options = parseArgs(['node', 'script', '--bogus']);
+    expect(runQuality(options)).toBe(3);
+  });
+
+  it('returns 3 for missing profile', () => {
+    const options = parseArgs(['node', 'script']);
+    expect(runQuality(options)).toBe(3);
+  });
+
+  it('returns 2 for unknown profile', () => {
+    const options = parseArgs(['node', 'script', '--profile', 'missing']);
+    expect(runQuality(options)).toBe(2);
+  });
+
+  it('returns 0 for dry-run', () => {
+    const options = parseArgs(['node', 'script', '--profile', 'gates', '--dry-run']);
+    expect(runQuality(options)).toBe(0);
+  });
+
+  it('handles spawn errors', () => {
+    spawnSyncMock.mockReturnValueOnce({
+      error: Object.assign(new Error('not found'), { code: 'ENOENT' }),
+      status: null,
+    });
+    const options = parseArgs(['node', 'script', '--profile', 'gates']);
+    expect(runQuality(options)).toBe(127);
+  });
+
+  it('detects non-cli invocation', () => {
+    expect(isCliInvocation(['node', '/tmp/unknown'])).toBe(false);
   });
 });


### PR DESCRIPTION
## 背景\n#1006 Phase1 の最小実装として、qualityカテゴリの統合 runner をスケルトンで追加します。\n\n## 変更\n- scripts/quality/run.mjs を追加（--profile/--list/--dry-run 対応）\n- runner のプロファイル解決をテストで保証\n\n## ログ\n- scripts/quality/run.mjs\n- tests/quality/quality-runner.test.ts\n\n## テスト\n- pnpm vitest run tests/quality/quality-runner.test.ts\n\n## 影響\n- 新規 runner 追加（既存コマンドの挙動は不変更）\n\n## ロールバック\n- このPRのrevertで戻せます\n\n## 関連Issue\n- #1006\n