### PR TITLE
docs: link spec kit activation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ node scripts/pipelines/compare-test-trends.mjs --json-output reports/heavy-test-
 - CI/quality gates: `docs/ci/phase2-ci-hardening-outline.md`, `docs/ci/label-gating.md`
 - Heavy test observability: `docs/ci/heavy-test-trend-archive.md`, `docs/ci/heavy-test-alerts.md`, `docs/ci/heavy-test-album.md`
 - Specification & verification: `docs/quality/`, `docs/ci-policy.md`, `docs/testing/integration-runtime-helpers.md`
-- Spec & Verification Kit (minimal activation): `docs/reference/SPEC-VERIFICATION-KIT-MIN.md`
+- Spec & Verification Kit (minimal activation guide): `docs/reference/SPEC-VERIFICATION-KIT-MIN.md`
 - Connectors & agent workflows: `docs/integrations/CLAUDE-CODE-TASK-TOOL-INTEGRATION.md`, `docs/integrations/CODEX-INTEGRATION.md`
 
 ---
@@ -93,7 +93,7 @@ node scripts/pipelines/compare-test-trends.mjs --json-output reports/heavy-test-
 - CI/品質ゲート: `docs/ci/phase2-ci-hardening-outline.md`, `docs/ci/label-gating.md`
 - ヘビーテスト観測: `docs/ci/heavy-test-trend-archive.md`, `docs/ci/heavy-test-alerts.md`, `docs/ci/heavy-test-album.md`
 - 仕様と検証: `docs/ci-policy.md`, `docs/testing/integration-runtime-helpers.md`, `docs/quality/`
-- Spec & Verification Kit 最小パッケージ（有効化手順）: `docs/reference/SPEC-VERIFICATION-KIT-MIN.md`
+- Spec & Verification Kit（最小パッケージ・有効化手順）: `docs/reference/SPEC-VERIFICATION-KIT-MIN.md`
 - エージェント統合: `docs/integrations/CLAUDE-CODE-TASK-TOOL-INTEGRATION.md`, `docs/integrations/CODEX-INTEGRATION.md`
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ Comprehensive documentation for the AI‑Enhanced Development Framework.
 ### Reference
 - CLI Commands: `reference/CLI-COMMANDS-REFERENCE.md`
 - API Reference: `reference/API.md`
-- Spec & Verification Kit (minimal): `reference/SPEC-VERIFICATION-KIT-MIN.md`
+- Spec & Verification Kit (minimal activation guide): `reference/SPEC-VERIFICATION-KIT-MIN.md`
 - Legacy ExecPlan (6-phase, deprecated): `../plans/archive/legacy-6-phase.md`
 
 ### Architecture
@@ -108,7 +108,7 @@ Claude CodeやMCPとの統合
 
 - **[CLI-COMMANDS-REFERENCE.md](./reference/CLI-COMMANDS-REFERENCE.md)** ⭐ **重要** - 全CLIコマンドリファレンス
 - [API.md](./reference/API.md) - API仕様
-- [SPEC-VERIFICATION-KIT-MIN.md](./reference/SPEC-VERIFICATION-KIT-MIN.md) - Spec & Verification Kit（最小パッケージ）
+- [SPEC-VERIFICATION-KIT-MIN.md](./reference/SPEC-VERIFICATION-KIT-MIN.md) - Spec & Verification Kit（最小パッケージ・有効化手順）
 - [legacy-6-phase.md](../plans/archive/legacy-6-phase.md) - 旧6フェーズExecPlan（非推奨）
 
 ### 🏗️ [architecture/](./architecture/) - アーキテクチャ・設計


### PR DESCRIPTION
## 背景
Spec & Verification Kit の有効化手順を README / docs から辿れるようにし、#1196 の残タスクを進めます。

## 変更
- README のドキュメント導線に Spec Kit 有効化ガイドを追加
- docs/README の Reference に Spec Kit 最小パッケージを追記

## ログ
- なし（ドキュメントのみ）

## テスト
- 未実施（ドキュメントのみ）

## 影響
- ドキュメントのみ

## ロールバック
- このPRを revert

## 関連Issue
- #1196
