### PR TITLE
docs: add Issue 1006 config reference map

### DIFF
--- a/docs/notes/issue-1006-config-reference-map.md
+++ b/docs/notes/issue-1006-config-reference-map.md
@@ -25,6 +25,7 @@ Track where candidate config files are referenced so relocation can update both 
 
 ### sample-config.json
 - `src/cli/conformance-cli.ts` (default `sample-config.json`)
+- `package.json` (`conformance:sample` uses `samples/conformance/sample-config.json`)
 - `docs/getting-started/SETUP.md`
 - `docs/guides/USAGE.md`
 - `docs/reference/CLI-COMMANDS-REFERENCE.md`


### PR DESCRIPTION
## 背景
#1006 Phase 2 のconfig移動を進めるため、参照箇所の洗い出しが必要なため。

## 変更
- ルート設定ファイルの参照箇所を docs/notes/issue-1006-config-reference-map.md に整理。

## ログ
- コード/ドキュメントの参照先をまとめ、移動時の更新ポイントを明確化。

## テスト
- 未実行（ドキュメントのみ）

## 影響
- なし（ドキュメントのみ）

## ロールバック
- PR を revert すれば元に戻せます。

## 関連Issue
- #1006
