### PR TITLE
fix: ship state-machine schema with package

### DIFF
--- a/package.json
+++ b/package.json
@@ -419,6 +419,7 @@
     "dist/**",
     "templates/**",
     "docs/**",
+    "schema/**",
     "types/**",
     "packages/**",
     "ae.config.ts",

--- a/src/state-machine/validator.ts
+++ b/src/state-machine/validator.ts
@@ -78,7 +78,11 @@ function resolveSchemaPath() {
     path.dirname(fileURLToPath(import.meta.url)),
     '../../schema/state-machine.schema.json'
   );
-  const candidates = [cwdPath, modulePath];
+  const packageRootPath = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../../../schema/state-machine.schema.json'
+  );
+  const candidates = [cwdPath, modulePath, packageRootPath];
   const resolved = candidates.find((candidate) => existsSync(candidate));
   if (!resolved) {
     throw new Error(


### PR DESCRIPTION
## 背景
- state-machine validator が参照する `schema/state-machine.schema.json` が配布物に含まれず、インストール環境で `ae sm validate` が失敗しうる。

## 変更
- package 配布対象に `schema/**` を追加
- validator がパッケージ配下の `schema/` を参照できるよう解決パスを拡張

## テスト
- なし（コード変更のみ、挙動はパス解決）

## 影響
- CLI 実行時のスキーマ解決が安定

## ロールバック
- 本PRをrevert

## 関連Issue
- #1512
