### PR TITLE
feat: add mermaid rendering for state machines

### DIFF
--- a/src/state-machine/types.ts
+++ b/src/state-machine/types.ts
@@ -1,0 +1,29 @@
+export interface StateMachineState {
+  name: string;
+  description?: string;
+  entry?: string[];
+  exit?: string[];
+  meta?: Record<string, unknown>;
+}
+
+export interface StateMachineTransition {
+  from: string;
+  to: string;
+  event: string;
+  guard?: string;
+  actions?: string[];
+  meta?: Record<string, unknown>;
+}
+
+export interface StateMachineDefinition {
+  schemaVersion: string;
+  id?: string;
+  name?: string;
+  description?: string;
+  initial: string;
+  states: StateMachineState[];
+  events: string[];
+  transitions: StateMachineTransition[];
+  metadata?: Record<string, unknown>;
+  correlation?: Record<string, unknown>;
+}

--- a/src/state-machine/validator.ts
+++ b/src/state-machine/validator.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Ajv2020, type ErrorObject, type ValidateFunction } from 'ajv/dist/2020.js';
+import type { StateMachineDefinition } from './types.js';
 
 export type StateMachineIssueSeverity = 'error' | 'warn';
 
@@ -22,36 +23,6 @@ export interface StateMachineValidationResult {
   ok: boolean;
   issues: StateMachineIssue[];
   summary: StateMachineSummary;
-}
-
-interface StateMachineState {
-  name: string;
-  description?: string;
-  entry?: string[];
-  exit?: string[];
-  meta?: Record<string, unknown>;
-}
-
-interface StateMachineTransition {
-  from: string;
-  to: string;
-  event: string;
-  guard?: string;
-  actions?: string[];
-  meta?: Record<string, unknown>;
-}
-
-interface StateMachineDefinition {
-  schemaVersion: string;
-  id?: string;
-  name?: string;
-  description?: string;
-  initial: string;
-  states: StateMachineState[];
-  events: string[];
-  transitions: StateMachineTransition[];
-  metadata?: Record<string, unknown>;
-  correlation?: Record<string, unknown>;
 }
 
 const ajv = new Ajv2020({ allErrors: true, strict: false });

--- a/tests/unit/state-machine/render.test.ts
+++ b/tests/unit/state-machine/render.test.ts
@@ -27,4 +27,29 @@ describe('renderMermaidStateMachine', () => {
     expect(output).toContain('[*] --> Start_State');
     expect(output).toContain('Start_State --> End_State: GO [ready] / notify');
   });
+
+  it('escapes labels and ensures unique IDs', () => {
+    const output = renderMermaidStateMachine({
+      schemaVersion: '1.0.0',
+      id: 'edge-cases',
+      initial: 'Quote "State"\n',
+      states: [
+        { name: 'Quote "State"\n' },
+        { name: 'A-B' },
+        { name: 'A B' },
+        { name: '!!!' },
+      ],
+      events: ['GO'],
+      transitions: [
+        { from: 'Quote "State"\n', event: 'GO', to: 'A-B' },
+        { from: 'A-B', event: 'GO', to: 'A B' },
+        { from: 'A B', event: 'GO', to: '!!!' },
+      ],
+    });
+
+    expect(output).toContain('state "Quote \'State\'" as Quote_State');
+    expect(output).toContain('state "A-B" as A_B');
+    expect(output).toContain('state "A B" as A_B_1');
+    expect(output).toContain('state "!!!" as state');
+  });
 });


### PR DESCRIPTION
## 背景
- #1487 v1（Mermaid 生成 + --check）に向けた実装

## 変更
- `sm render` サブコマンドを追加（Mermaid 出力）
- 出力先/--check/形式チェックを実装
- Mermaid 生成ロジックと単体テストを追加

## ログ
- `pnpm -s vitest --run tests/unit/state-machine/render.test.ts`

## テスト
- `pnpm -s vitest --run tests/unit/state-machine/render.test.ts`

## 影響
- `node dist/cli.js sm render ...` が使用可能になる

## ロールバック
- `src/cli/state-machine-cli.ts` と `src/state-machine/render.ts` を元に戻す

## 関連Issue
- #1487
