### PR TITLE
docs(issue-1006): update config move status

### DIFF
--- a/docs/notes/issue-1006-config-inventory.md
+++ b/docs/notes/issue-1006-config-inventory.md
@@ -19,7 +19,7 @@
 | `sample-config.json` | Sample config | Candidate | CLI sample outputs now default to `configs/samples` (PR #1535).
 | `tsconfig.json` | TS base config | Keep | Tooling expects root.
 | `tsconfig.build.json` | TS build config | Moved | Relocated to `configs/tsconfig/tsconfig.build.json` (PR #1544).
-| `tsconfig.types.json` | TS types config | In review | Moving to `configs/tsconfig/tsconfig.types.json` (PR #1545).
+| `tsconfig.types.json` | TS types config | Moved | Relocated to `configs/tsconfig/tsconfig.types.json` (PR #1545).
 | `tsconfig.verify.json` | TS verify config | Candidate | Same as above.
 | `vitest.config.ts` | Vitest root config | Keep (short-term) | Default lookup expects root.
 

--- a/docs/notes/issue-1006-config-move-plan.md
+++ b/docs/notes/issue-1006-config-move-plan.md
@@ -43,7 +43,7 @@ configs/
 | sample-config.json | configs/samples/sample-config.json | Update references | Could also move to `samples/`. | Done (PR #1535)
 | stryker.conf.cjs | configs/stryker/stryker.conf.cjs | Update stryker command | Already have configs/stryker*.js; consolidate. | Done (PR #1537)
 | tsconfig.build.json | configs/tsconfig/tsconfig.build.json | Update build scripts | Keep tsconfig.json at root. | Done (PR #1544)
-| tsconfig.types.json | configs/tsconfig/tsconfig.types.json | Update scripts | Keep tsconfig.json at root. | In review (PR #1545)
+| tsconfig.types.json | configs/tsconfig/tsconfig.types.json | Update scripts | Keep tsconfig.json at root. | Done (PR #1545)
 | tsconfig.verify.json | configs/tsconfig/tsconfig.verify.json | Update scripts | Keep tsconfig.json at root. | Planned
 | vitest.workspace.ts | configs/vitest/vitest.workspace.ts | Update test scripts | Vitest defaults to root; must pass config explicitly. | Done (PR #1538)
 

--- a/docs/notes/issue-1006-config-reference-map.md
+++ b/docs/notes/issue-1006-config-reference-map.md
@@ -43,7 +43,7 @@ Track where candidate config files are referenced so relocation can update both 
 - `docs/reference/CLI-COMMANDS-REFERENCE.md`
 - `artifacts/recovery-verify.md`
 
-### tsconfig.types.json (in review: PR #1545)
+### tsconfig.types.json (moved in PR #1545)
 - `package.json` (`api:emit`, type extraction)
 - `scripts/api/check-types.mjs`
 - `artifacts/types-hardening-validation.md`


### PR DESCRIPTION
## 背景
Issue #1006 の設定移動の進捗が散在していたため、状況を整理して参照可能にする。

## 変更
- `docs/notes/issue-1006-config-move-plan.md` のステータス更新（tsconfig.build: 完了、tsconfig.types: PR中）
- `docs/notes/issue-1006-config-reference-map.md` の注記更新
- `docs/notes/issue-1006-config-inventory.md` の移動状況を更新

## ログ
- 変更対象: docs/notes の3ファイルのみ

## テスト
- 未実施（ドキュメント更新のみ）

## 影響
- 実装には影響なし（記録の整合性向上のみ）

## ロールバック
- 当PRのrevertで復旧可能

## 関連Issue
- #1006
