### PR TITLE
docs(issue-1006): update verify move status

### DIFF
--- a/docs/notes/issue-1006-config-inventory.md
+++ b/docs/notes/issue-1006-config-inventory.md
@@ -20,7 +20,7 @@
 | `tsconfig.json` | TS base config | Keep | Tooling expects root.
 | `tsconfig.build.json` | TS build config | Moved | Relocated to `configs/tsconfig/tsconfig.build.json` (PR #1544).
 | `tsconfig.types.json` | TS types config | Moved | Relocated to `configs/tsconfig/tsconfig.types.json` (PR #1545).
-| `tsconfig.verify.json` | TS verify config | Candidate | Same as above.
+| `tsconfig.verify.json` | TS verify config | Moved | Relocated to `configs/tsconfig/tsconfig.verify.json` (PR #1547).
 | `vitest.config.ts` | Vitest root config | Keep (short-term) | Default lookup expects root.
 
 ## Notes
@@ -35,6 +35,8 @@
 - `configs/vitest/vitest.workspace.ts` (PR #1538)
 - `configs/mcp-config.json` (PR #1543)
 - `configs/tsconfig/tsconfig.build.json` (PR #1544)
+- `configs/tsconfig/tsconfig.types.json` (PR #1545)
+- `configs/tsconfig/tsconfig.verify.json` (PR #1547)
 
 ## Next (Phase 2)
 - Confirm actual lookup paths from scripts/CI before moving.

--- a/docs/notes/issue-1006-config-move-plan.md
+++ b/docs/notes/issue-1006-config-move-plan.md
@@ -42,9 +42,9 @@ configs/
 | mcp-config.json | configs/mcp-config.json | Update runtime lookup | Confirm where MCP server reads config. | Done (PR #1543)
 | sample-config.json | configs/samples/sample-config.json | Update references | Could also move to `samples/`. | Done (PR #1535)
 | stryker.conf.cjs | configs/stryker/stryker.conf.cjs | Update stryker command | Already have configs/stryker*.js; consolidate. | Done (PR #1537)
-| tsconfig.build.json | configs/tsconfig/tsconfig.build.json | Update build scripts | Keep tsconfig.json at root. | Done (PR #1544)
-| tsconfig.types.json | configs/tsconfig/tsconfig.types.json | Update scripts | Keep tsconfig.json at root. | Done (PR #1545)
-| tsconfig.verify.json | configs/tsconfig/tsconfig.verify.json | Update scripts | Keep tsconfig.json at root. | Planned
+| tsconfig.build.json | configs/tsconfig/tsconfig.build.json | Update build scripts | Keep tsconfig.json at root. | Planned
+| tsconfig.types.json | configs/tsconfig/tsconfig.types.json | Update scripts | Keep tsconfig.json at root. | Planned
+| tsconfig.verify.json | configs/tsconfig/tsconfig.verify.json | Update scripts | Keep tsconfig.json at root. | Done (PR #1547)
 | vitest.workspace.ts | configs/vitest/vitest.workspace.ts | Update test scripts | Vitest defaults to root; must pass config explicitly. | Done (PR #1538)
 
 ## Files to keep at root (for now)

--- a/docs/notes/issue-1006-config-reference-map.md
+++ b/docs/notes/issue-1006-config-reference-map.md
@@ -48,7 +48,7 @@ Track where candidate config files are referenced so relocation can update both 
 - `scripts/api/check-types.mjs`
 - `artifacts/types-hardening-validation.md`
 
-### tsconfig.verify.json
+### tsconfig.verify.json (moved in PR #1547)
 - `package.json` (`types:check`, type-coverage)
 - `src/commands/verify/run.ts` (primary verify path)
 - `docs/quality/type-coverage-policy.md`


### PR DESCRIPTION
## 背景
Issue #1006 のconfig移動進捗を最新化する（tsconfig.verifyの移動が完了）。

## 変更
- `docs/notes/issue-1006-config-move-plan.md` の tsconfig.verify ステータス更新
- `docs/notes/issue-1006-config-reference-map.md` の注記更新
- `docs/notes/issue-1006-config-inventory.md` の移動状況とMoved一覧更新

## テスト
- 未実施（ドキュメント更新のみ）

## 影響
- 記録の整合性のみ

## ロールバック
- 当PRのrevertで復旧可能

## 関連Issue
- #1006
- #1547
