### PR TITLE
chore: narrow release-quality-artifacts trigger

### DIFF
--- a/.github/workflows/release-quality-artifacts.yml
+++ b/.github/workflows/release-quality-artifacts.yml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   release:
     types: [published]
-  push:
-    tags: ['v*']
 permissions:
   contents: write
 jobs:

--- a/docs/notes/issue-1006-workflow-overlap-candidates.md
+++ b/docs/notes/issue-1006-workflow-overlap-candidates.md
@@ -90,9 +90,8 @@
 These are proposals to reduce overlap without changing required checks or safety gates. Execute after confirming triggers and required status checks.
 
 1) Spec / artifact validation
-   - Treat `spec-validation.yml` as the canonical PR gate.
-   - Fold `validate-artifacts-ajv.yml` into `spec-validation.yml` or call it via a reusable workflow.
-   - Keep `fail-fast-spec-validation.yml` as an alias only if the PR gate cannot be updated safely.
+   - ✅ Completed: `spec-validation.yml` をPRゲートとして採用し、`validate-artifacts-ajv.yml` を workflow_call で呼び出す構成に統合済み。
+   - ✅ Completed: required checks への影響なしで統合を反映済み。
 
 2) Artifact preview vs generation
    - ✅ Completed: preview step/comment を `spec-generate-model.yml` に集約し、重複していた `generate-artifacts-preview.yml` を削除。

--- a/docs/notes/issue-1006-workflow-trigger-profiles.md
+++ b/docs/notes/issue-1006-workflow-trigger-profiles.md
@@ -71,7 +71,7 @@
 ### push (1)
 - release.yml
 
-### push, release, workflow_dispatch (1)
+### release, workflow_dispatch (1)
 - release-quality-artifacts.yml
 
 ### push, schedule, workflow_dispatch (1)

--- a/docs/notes/issue-1006-workflow-triggers.md
+++ b/docs/notes/issue-1006-workflow-triggers.md
@@ -7,7 +7,7 @@
 ## Trigger counts
 - issue_comment: 1
 - pull_request: 30
-- push: 24
+- push: 23
 - release: 1
 - schedule: 10
 - workflow_call: 6
@@ -50,7 +50,7 @@
 - verify.yml
 - workflow-lint.yml
 
-### push (24)
+### push (23)
 - ae-ci.yml
 - cedar-quality-gates.yml
 - ci-extended.yml
@@ -65,7 +65,6 @@
 - podman-smoke.yml
 - pr-verify.yml
 - quality-gates-centralized.yml
-- release-quality-artifacts.yml
 - release.yml
 - sbom-generation.yml
 - security.yml


### PR DESCRIPTION
## 背景
Issue #1006 の CI 重複整理の一環として、release-quality-artifacts が tag push と release の両方で走っており重複実行になっているため、低リスクでトリガーを整理する。

## 変更
- `release-quality-artifacts.yml` から `push: tags` を削除（release + workflow_dispatch のみに限定）
- workflow inventory/trigger マップの件数と一覧を更新
- overlap candidates の Spec/Artifact 統合/Artifact preview 統合を完了扱いで更新

## ログ
- 変更前: tag push と release published の両方で実行
- 変更後: release published または manual dispatch のみ

## テスト
- 未実施（GitHub Actions 実行で確認）

## 影響
- tag push での重複実行が解消される
- release published でのアセット添付は継続

## ロールバック
- このPRを revert し、`push` トリガーを復元する

## 関連Issue
- #1006
