### PR TITLE
docs: refresh issue-1006 workflow maps

### DIFF
--- a/docs/notes/issue-1006-workflow-inventory.md
+++ b/docs/notes/issue-1006-workflow-inventory.md
@@ -1,8 +1,8 @@
 # Issue 1006: Workflow Inventory (Phase 1)
 
 ## Snapshot
-- Commit: 61f30b60
-- .github/workflows/*.yml count: 45
+- Commit: 6f9fce7b
+- .github/workflows/*.yml count: 46
 
 ## Prefix counts (file name before first '-' or '.')
 - ci: 4
@@ -28,6 +28,7 @@
 - model: 1
 - minimal: 1
 - hermetic: 1
+- lean: 1
 - grafana: 1
 - fail: 1
 - docker: 1
@@ -39,7 +40,7 @@
 - auto: 1
 - ae: 1
 - adapter: 1
-- total: 45 (matches workflow count)
+- total: 46 (matches workflow count)
 
 ## Workflow files (sorted)
 - adapter-thresholds.yml
@@ -63,6 +64,7 @@
 - formal-verify.yml
 - grafana-dashboards.yml
 - hermetic-ci.yml
+- lean-proof.yml
 - minimal-pipeline.yml
 - model-checking-manual.yml
 - mutation-quick.yml

--- a/docs/notes/issue-1006-workflow-overlap-candidates.md
+++ b/docs/notes/issue-1006-workflow-overlap-candidates.md
@@ -1,7 +1,7 @@
 # Issue 1006: Workflow Overlap Candidates (Phase 1.5 draft)
 
 ## Snapshot
-- Commit: 61f30b60
+- Commit: 6f9fce7b
 - Source: docs/notes/issue-1006-workflow-inventory.md
 
 ## Required checks snapshot (main protection)
@@ -30,13 +30,14 @@
 - codegen-drift-check.yml: pull_request (all PRs to main; execution gated by label "run-drift") + push (main; paths: spec/**/*.md, .ae/ae-ir.json, src/codegen/**, templates/**, .github/workflows/codegen-drift-check.yml) + workflow_call
 
 ### Formal verification
-- formal-verify.yml / formal-aggregate.yml / model-checking-manual.yml
+- formal-verify.yml / formal-aggregate.yml / model-checking-manual.yml / lean-proof.yml
   - Candidate: define a single formal "entry" and document when manual vs automated runs apply.
 
 #### Trigger mapping (formal verification group)
 - formal-verify.yml: pull_request (types: opened, synchronize, reopened, ready_for_review, labeled; jobs gated by label "run-formal") + push (tags: v*) + workflow_dispatch (inputs.target)
 - formal-aggregate.yml: pull_request (types: opened, synchronize, reopened, labeled; job gated by label "run-formal") + workflow_dispatch
 - model-checking-manual.yml: workflow_dispatch (inputs.engine, spec_path)
+- lean-proof.yml: pull_request (paths: proofs/lean/**, .github/workflows/lean-proof.yml) + push (main; same paths)
 
 ### Flake and stability
 - flake-detect.yml / flake-maintenance.yml / nightly-monitoring.yml / parallel-test-execution.yml
@@ -54,7 +55,7 @@
 
 #### Trigger mapping (release group)
 - release.yml: push (tags: v*)
-- release-quality-artifacts.yml: release (published) + push (tags: v*) + workflow_dispatch
+- release-quality-artifacts.yml: release (published) + workflow_dispatch
 
 ### Agent automation
 - agent-commands.yml

--- a/docs/notes/issue-1006-workflow-trigger-profiles.md
+++ b/docs/notes/issue-1006-workflow-trigger-profiles.md
@@ -1,21 +1,20 @@
 # Issue 1006: Workflow Trigger Profiles (Phase 1.5 draft)
 
 ## Snapshot
-- Commit: 61f30b60
-- Total workflows: 45
+- Commit: 6f9fce7b
+- Total workflows: 46
 
 ## Trigger signatures
 
-### pull_request (6)
+### pull_request (4)
 - adapter-thresholds.yml
 - auto-labels.yml
-- copilot-review-gate.yml
 - phase6-validation.yml
 - pr-summary-comment.yml
-- validate-artifacts-ajv.yml
 
-### pull_request, push (6)
+### pull_request, push (7)
 - coverage-check.yml
+- lean-proof.yml
 - parallel-test-execution.yml
 - pr-verify.yml
 - testing-ddd-scripts.yml
@@ -43,7 +42,8 @@
 - quality-gates-centralized.yml
 - spec-validation.yml
 
-### pull_request, workflow_dispatch (3)
+### pull_request, workflow_dispatch (4)
+- copilot-review-gate.yml
 - formal-aggregate.yml
 - spec-check.yml
 - spec-generate-model.yml
@@ -82,6 +82,9 @@
 
 ### workflow_call (1)
 - ci-core.yml
+
+### workflow_call, workflow_dispatch (1)
+- validate-artifacts-ajv.yml
 
 ## Notes
 - Use this profile map to identify overused trigger combinations (e.g., pull_request+push) for consolidation.

--- a/docs/notes/issue-1006-workflow-triggers.md
+++ b/docs/notes/issue-1006-workflow-triggers.md
@@ -1,17 +1,17 @@
 # Issue 1006: Workflow Trigger Map (Phase 1.5 draft)
 
 ## Snapshot
-- Commit: 61f30b60
-- Total workflows: 45
+- Commit: 6f9fce7b
+- Total workflows: 46
 
 ## Trigger counts
 - issue_comment: 1
 - pull_request: 30
-- push: 23
+- push: 24
 - release: 1
 - schedule: 10
-- workflow_call: 6
-- workflow_dispatch: 26
+- workflow_call: 7
+- workflow_dispatch: 28
 
 ## Trigger → workflow files
 
@@ -33,6 +33,7 @@
 - formal-verify.yml
 - grafana-dashboards.yml
 - hermetic-ci.yml
+- lean-proof.yml
 - parallel-test-execution.yml
 - phase6-validation.yml
 - podman-smoke.yml
@@ -45,12 +46,11 @@
 - spec-generate-model.yml
 - spec-validation.yml
 - testing-ddd-scripts.yml
-- validate-artifacts-ajv.yml
 - verify-lite.yml
 - verify.yml
 - workflow-lint.yml
 
-### push (23)
+### push (24)
 - ae-ci.yml
 - cedar-quality-gates.yml
 - ci-extended.yml
@@ -61,6 +61,7 @@
 - fail-fast-spec-validation.yml
 - formal-verify.yml
 - hermetic-ci.yml
+- lean-proof.yml
 - parallel-test-execution.yml
 - podman-smoke.yml
 - pr-verify.yml
@@ -90,21 +91,23 @@
 - sbom-generation.yml
 - security.yml
 
-### workflow_call (6)
+### workflow_call (7)
 - ci-core.yml
 - ci-fast.yml
 - codegen-drift-check.yml
 - fail-fast-spec-validation.yml
 - quality-gates-centralized.yml
 - spec-validation.yml
+- validate-artifacts-ajv.yml
 
-### workflow_dispatch (26)
+### workflow_dispatch (28)
 - ae-ci.yml
 - branch-protection-apply.yml
 - cedar-quality-gates.yml
 - ci-extended.yml
 - ci-fast.yml
 - ci.yml
+- copilot-review-gate.yml
 - docker-tests.yml
 - flake-detect.yml
 - flake-maintenance.yml
@@ -123,6 +126,7 @@
 - security.yml
 - spec-check.yml
 - spec-generate-model.yml
+- validate-artifacts-ajv.yml
 - verify-lite.yml
 - webapi-sample-ci.yml
 


### PR DESCRIPTION
## 背景
- Issue #1006 のワークフローマップ/トリガー表が現状とズレていたため、最新状態に合わせて更新します。

## 変更
- `docs/notes/issue-1006-workflow-inventory.md` の件数/一覧を更新（lean-proof を追加）。
- `docs/notes/issue-1006-workflow-overlap-candidates.md` の formal/release トリガー記述を更新。
- `docs/notes/issue-1006-workflow-triggers.md` / `docs/notes/issue-1006-workflow-trigger-profiles.md` のカウントと一覧を最新化。

## ログ
- ローカルでトリガー一覧を再集計して差分を反映。

## テスト
- 未実施（ドキュメントのみ）。

## 影響
- ドキュメントのみ。

## ロールバック
- このPRのrevertで復旧可能。

## 関連Issue
- #1006
