### PR TITLE
chore: scope workflow-lint to workflow changes

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,8 +1,12 @@
 name: Workflow Lint
 on:
   pull_request:
+    paths:
+      - ".github/workflows/**"
   push:
     branches: [main, develop]
+    paths:
+      - ".github/workflows/**"
 permissions: read-all
 jobs:
   actionlint:

--- a/docs/notes/issue-1006-workflow-overlap-candidates.md
+++ b/docs/notes/issue-1006-workflow-overlap-candidates.md
@@ -78,7 +78,7 @@
   - Candidate: keep separate, but ensure they do not duplicate gating outputs.
 
 #### Trigger mapping (misc utilities group)
-- workflow-lint.yml: pull_request + push (branches: main, develop)
+- workflow-lint.yml: pull_request (paths: .github/workflows/**) + push (branches: main, develop; paths: .github/workflows/**)
 - branch-protection-apply.yml: workflow_dispatch (inputs: preset, branch)
 - auto-labels.yml: pull_request (types: opened, edited, synchronize, reopened)
 - pr-summary-comment.yml: pull_request (types: opened, synchronize, reopened)


### PR DESCRIPTION
## 背景
- Issue #1006 のCIコスト最適化観点で、workflow-lint が全PR/全pushで走っていたため不要な実行が発生していました。

## 変更
- `.github/workflows/workflow-lint.yml` を workflow ファイル変更時のみ実行するよう `paths` フィルタを追加。
- `docs/notes/issue-1006-workflow-overlap-candidates.md` のトリガー記述を更新。

## ログ
- 対象: workflow-lint の実行条件を限定。

## テスト
- 未実施（トリガー条件の変更のみ）。

## 影響
- workflow ファイル変更がないPR/Pushでは workflow-lint が走らなくなります。

## ロールバック
- このPRのrevertで復旧可能。

## 関連Issue
- #1006
