### PR TITLE
chore: skip PR summary on docs-only changes

### DIFF
--- a/.github/workflows/pr-summary-comment.yml
+++ b/.github/workflows/pr-summary-comment.yml
@@ -2,6 +2,9 @@ name: pr-summary-comment
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
 permissions:
   contents: read
   pull-requests: write

--- a/docs/notes/issue-1006-workflow-overlap-candidates.md
+++ b/docs/notes/issue-1006-workflow-overlap-candidates.md
@@ -81,7 +81,7 @@
 - workflow-lint.yml: pull_request (paths: .github/workflows/**) + push (branches: main, develop; paths: .github/workflows/**)
 - branch-protection-apply.yml: workflow_dispatch (inputs: preset, branch)
 - auto-labels.yml: pull_request (types: opened, edited, synchronize, reopened)
-- pr-summary-comment.yml: pull_request (types: opened, synchronize, reopened)
+- pr-summary-comment.yml: pull_request (types: opened, synchronize, reopened; paths-ignore: docs/**, **/*.md)
 
 ## Next steps
 - Map each candidate group to its actual trigger (PR gate, label-gate, nightly, manual).


### PR DESCRIPTION
## 背景
- Issue #1006 のCIコスト最適化の一環として、`pr-summary-comment.yml` がドキュメントのみの変更でも実行されていました。

## 変更
- `pr-summary-comment.yml` に `paths-ignore` を追加し、`docs/**` と `**/*.md` のみ変更時は実行しないようにしました。
- ドキュメントのトリガー記述を更新しました。

## ログ
- 対象: PRサマリコメントの実行条件を限定。

## テスト
- 未実施（トリガー条件の変更のみ）。

## 影響
- ドキュメントのみの変更ではPRサマリコメントが生成されなくなります。

## ロールバック
- このPRのrevertで復旧可能。

## 関連Issue
- #1006
