### PR TITLE
chore: skip formal workflows on docs-only changes

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**/*.md'
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**/*.md'
   push:
     tags: ['v*']
   workflow_dispatch:

--- a/docs/notes/issue-1006-workflow-overlap-candidates.md
+++ b/docs/notes/issue-1006-workflow-overlap-candidates.md
@@ -34,8 +34,8 @@
   - Candidate: define a single formal "entry" and document when manual vs automated runs apply.
 
 #### Trigger mapping (formal verification group)
-- formal-verify.yml: pull_request (types: opened, synchronize, reopened, ready_for_review, labeled; paths-ignore: docs/**, *.md; jobs gated by label "run-formal") + push (tags: v*) + workflow_dispatch (inputs.target)
-- formal-aggregate.yml: pull_request (types: opened, synchronize, reopened, labeled; paths-ignore: docs/**, *.md; job gated by label "run-formal") + workflow_dispatch
+- formal-verify.yml: pull_request (types: opened, synchronize, reopened, ready_for_review, labeled; paths-ignore: docs/**, **/*.md; jobs gated by label "run-formal") + push (tags: v*) + workflow_dispatch (inputs.target)
+- formal-aggregate.yml: pull_request (types: opened, synchronize, reopened, labeled; paths-ignore: docs/**, **/*.md; job gated by label "run-formal") + workflow_dispatch
 - model-checking-manual.yml: workflow_dispatch (inputs.engine, spec_path)
 - lean-proof.yml: pull_request (paths: proofs/lean/**, .github/workflows/lean-proof.yml) + push (main; same paths)
 


### PR DESCRIPTION
## 背景
- Issue #1006 のCIコスト最適化の一環として、formal系ワークフローがドキュメントのみの変更でも起動していました。

## 変更
- `formal-verify.yml` と `formal-aggregate.yml` に `paths-ignore` を追加し、`docs/**` と `*.md` のみの変更では起動しないようにしました。
- トリガー記述（Issue #1006 のドキュメント）を更新しました。

## ログ
- 対象: formal系ワークフローのドキュメント変更時の起動抑制。

## テスト
- 未実施（トリガー条件の変更のみ）。

## 影響
- ドキュメントのみの変更では formal系が自動起動しません。必要時は `workflow_dispatch` で手動実行できます。

## ロールバック
- このPRのrevertで復旧可能。

## 関連Issue
- #1006
