### PR TITLE
chore: skip security scans on markdown-only pushes

### DIFF
--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main, develop ]
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**/*.md'
   pull_request:
     branches: [ main ]
     # Run SBOM only when dependency or code manifests change

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main, develop ]
     paths-ignore:
       - 'docs/**'
-      - '*.md'
+      - '**/*.md'
   pull_request:
     branches: [ main ]
     # Avoid running heavy scans for docs-only changes

--- a/docs/notes/issue-1006-workflow-overlap-candidates.md
+++ b/docs/notes/issue-1006-workflow-overlap-candidates.md
@@ -69,8 +69,8 @@
   - Candidate: map which are required for PR gating vs nightly audit.
 
 #### Trigger mapping (security/compliance group)
-- security.yml: pull_request (branches: main; paths-ignore: docs/**, **/*.md; jobs gated by label "run-security") + push (branches: main, develop; paths-ignore: docs/**, *.md; jobs run unconditionally) + schedule (cron: 20 5 * * 1 UTC) + workflow_dispatch
-- sbom-generation.yml: pull_request (branches: main; paths: package.json, pnpm-lock.yaml, packages/**, apps/**, src/**; job gated by label "run-security") + push (branches: main, develop; paths-ignore: docs/**, *.md; job runs unconditionally) + schedule (cron: 40 5 * * 1 UTC) + workflow_dispatch (input: include_vulnerabilities)
+- security.yml: pull_request (branches: main; paths-ignore: docs/**, **/*.md; jobs gated by label "run-security") + push (branches: main, develop; paths-ignore: docs/**, **/*.md; jobs run unconditionally) + schedule (cron: 20 5 * * 1 UTC) + workflow_dispatch
+- sbom-generation.yml: pull_request (branches: main; paths: package.json, pnpm-lock.yaml, packages/**, apps/**, src/**; job gated by label "run-security") + push (branches: main, develop; paths-ignore: docs/**, **/*.md; job runs unconditionally) + schedule (cron: 40 5 * * 1 UTC) + workflow_dispatch (input: include_vulnerabilities)
 - cedar-quality-gates.yml: pull_request (job gated by labels "run-security" or "run-cedar"; enforce with "enforce-security") + push (branch: main; tags: v*) + workflow_dispatch (note: job is effectively skipped on push/dispatch because it depends on PR labels)
 
 ### Misc utilities


### PR DESCRIPTION
## 背景
Issue #1006 のCIコスト低減の一環として、pushイベントでのdocs/Markdownのみ変更時の不要実行を減らす。

## 変更
- `security.yml` と `sbom-generation.yml` の push `paths-ignore` を `**/*.md` に拡張
- `docs/notes/issue-1006-workflow-overlap-candidates.md` のトリガ記述を更新

## ログ
- 変更ファイル: `.github/workflows/security.yml`, `.github/workflows/sbom-generation.yml`, `docs/notes/issue-1006-workflow-overlap-candidates.md`

## テスト
- 未実施（CIで確認）

## 影響
- main/develop への push で Markdown のみ変更時に Security/SBOM が実行されない

## ロールバック
- `paths-ignore` を `*.md` に戻す

## 関連Issue
- #1006
