### PR TITLE
chore: include env details in flake detection reports

### DIFF
--- a/.github/workflows/flake-detect.yml
+++ b/.github/workflows/flake-detect.yml
@@ -27,19 +27,20 @@ jobs:
           NODE_VERSION="$(node -v)"
           PNPM_VERSION="$(pnpm -v)"
           VITEST_VERSION="$(pnpm exec vitest --version || printf '%s\n' 'unknown')"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           {
             printf "%s\n" "NODE_VERSION=$NODE_VERSION"
             printf "%s\n" "PNPM_VERSION=$PNPM_VERSION"
             printf "%s\n" "VITEST_VERSION=$VITEST_VERSION"
+            printf "%s\n" "RUN_URL=$RUN_URL"
           } >> "$GITHUB_ENV"
-          cat > reports/flake-detection-env.json <<EOF
-          {
-            "node": "$NODE_VERSION",
-            "pnpm": "$PNPM_VERSION",
-            "vitest": "$VITEST_VERSION",
-            "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          }
-          EOF
+          jq -n \
+            --arg node "$NODE_VERSION" \
+            --arg pnpm "$PNPM_VERSION" \
+            --arg vitest "$VITEST_VERSION" \
+            --arg url "$RUN_URL" \
+            '{node: $node, pnpm: $pnpm, vitest: $vitest, runUrl: $url}' \
+            > reports/flake-detection-env.json
       
       - name: Run tests multiple times
         id: flake-test
@@ -47,7 +48,6 @@ jobs:
           set -e
           fails=0
           total_runs=3
-          mkdir -p reports/flake-detection
           
           printf "%s\n" "🔍 Starting flake detection with $total_runs runs"
           
@@ -210,6 +210,7 @@ jobs:
             reports/flake-detection-report.json
             reports/flake-detection-failures.json
             reports/flake-detection-failures.md
+            reports/flake-detection-env.json
             reports/flake-detection/run-*.json
           retention-days: 30
       
@@ -231,7 +232,7 @@ jobs:
             const failureSection = failureSummary
               ? `### ❗ Failing tests (latest runs)\n${failureSummary}\n`
               : '### ❗ Failing tests (latest runs)\n- Summary not available. See flake-detection-report artifacts.\n';
-            const envSection = `### 🧪 Environment\n- Node: ${process.env.NODE_VERSION || 'unknown'}\n- pnpm: ${process.env.PNPM_VERSION || 'unknown'}\n- Vitest: ${process.env.VITEST_VERSION || 'unknown'}\n- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n`;
+            const envSection = `### 🧪 Environment\n- Node: ${process.env.NODE_VERSION || 'unknown'}\n- pnpm: ${process.env.PNPM_VERSION || 'unknown'}\n- Vitest: ${process.env.VITEST_VERSION || 'unknown'}\n- Run: ${process.env.RUN_URL || 'unknown'}\n`;
             const reproSection = `### ▶️ Reproduction command\n\`pnpm exec vitest run --workspace vitest.workspace.ts --project integration --reporter=json\`\n`;
             
             const title = `🔍 Flaky Test Detected - Integration Tests (${failureRate}% failure rate)`;


### PR DESCRIPTION
## 背景
#1000/#1005 の再現条件記録を強化し、flake検出Issueに環境情報と再現コマンドを付与する。

## 変更
- flake-detect ワークフローで Node/pnpm/Vitest のバージョンと実行URLを収集
- Issue本文に環境情報/再現コマンドを追加
- 失敗テストの要約が取得できない場合のフォールバック文言を追加

## ログ
- 変更ファイル: `.github/workflows/flake-detect.yml`

## テスト
- 未実施（CIで確認）

## 影響
- Flake検出Issueの再現性とトリアージ効率が向上

## ロールバック
- 追加セクションを削除

## 関連Issue
- #1000
- #1005
