### PR TITLE
chore(ci): fix flake-detect workspace path

### DIFF
--- a/.github/workflows/flake-detect.yml
+++ b/.github/workflows/flake-detect.yml
@@ -54,7 +54,7 @@ jobs:
           for ((i=1; i<=total_runs; i++)); do
             printf "%s\n" "📊 Run #$i of $total_runs"
             report_file="reports/flake-detection/run-$i.json"
-            if pnpm exec vitest run --workspace vitest.workspace.ts --project integration --reporter=json --outputFile "$report_file"; then
+            if pnpm exec vitest run --workspace configs/vitest/vitest.workspace.ts --project integration --reporter=json --outputFile "$report_file"; then
               printf "%s\n" "✅ Run #$i passed"
             else
               printf "%s\n" "❌ Run #$i failed"
@@ -296,7 +296,7 @@ jobs:
               ? `### ❗ Failing tests (latest runs)\n${failureSummary}\n`
               : '### ❗ Failing tests (latest runs)\n- Summary not available. See flake-detection-report artifacts.\n';
             const envSection = `### 🧪 Environment\n- Node: ${process.env.NODE_VERSION || 'unknown'}\n- pnpm: ${process.env.PNPM_VERSION || 'unknown'}\n- Vitest: ${process.env.VITEST_VERSION || 'unknown'}\n- Run: ${process.env.RUN_URL || 'unknown'}\n`;
-            const reproSection = `### ▶️ Reproduction command\n\`pnpm exec vitest run --workspace vitest.workspace.ts --project integration --reporter=json\`\n`;
+            const reproSection = `### ▶️ Reproduction command\n\`pnpm exec vitest run --workspace configs/vitest/vitest.workspace.ts --project integration --reporter=json\`\n`;
             
             const title = `🔍 Flaky Test Detected - Integration Tests (${failureRate}% failure rate)`;
             


### PR DESCRIPTION
## 背景
- flake-detect の実行ログで `vitest.workspace.ts` が見つからず、run-*.json が生成されないため失敗要約が空でした。

## 変更
- flake-detect の実行コマンドを `configs/vitest/vitest.workspace.ts` に修正
- Issue に出力する再現コマンドも同パスに合わせて更新

## ログ
- .github/workflows/flake-detect.yml

## テスト
- 未実行（ワークフロー更新のみ）

## 影響
- flake-detect が正しい workspace を参照し、run-*.json が生成される

## ロールバック
- このPRをrevert

## 関連Issue
- #1000
- #1005
