### PR TITLE
chore(ci): note stable flake runs

### DIFF
--- a/.github/workflows/flake-detect.yml
+++ b/.github/workflows/flake-detect.yml
@@ -397,6 +397,7 @@ jobs:
             const failureRate = '${{ env.FAILURE_RATE }}';
             const totalRuns = '${{ env.TOTAL_RUNS }}';
             const failures = '${{ env.FAILS }}';
+            const timestamp = new Date().toISOString();
             const envSection = `### 🧪 Environment\n- Node: ${process.env.NODE_VERSION || 'unknown'}\n- pnpm: ${process.env.PNPM_VERSION || 'unknown'}\n- Vitest: ${process.env.VITEST_VERSION || 'unknown'}\n- Run: ${process.env.RUN_URL || 'unknown'}\n`;
 
             const existingIssues = await github.rest.issues.listForRepo({
@@ -416,7 +417,7 @@ jobs:
               return;
             }
 
-            const body = `✅ **Stable run** - ${failureRate}% failure rate (${failures}/${totalRuns})\\n\\n${envSection}`;
+            const body = `✅ **Stable run** - ${failureRate}% failure rate (${failures}/${totalRuns})\n\n**Timestamp:** ${timestamp}\n\n${envSection}`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## 背景
- flake-detect が安定している場合の記録が Issue に残らず、復帰確認がしづらいため。

## 変更
- flake-detect が安定時に、既存の flaky issue へ安定コメントを追加

## ログ
- .github/workflows/flake-detect.yml

## テスト
- 未実行（ワークフロー更新のみ）

## 影響
- flake issue に復帰状況が記録される

## ロールバック
- このPRをrevert

## 関連Issue
- #1000
- #1005
