### PR TITLE
chore(ci): drop cedar gates push trigger

### DIFF
--- a/.github/workflows/cedar-quality-gates.yml
+++ b/.github/workflows/cedar-quality-gates.yml
@@ -5,12 +5,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
-  push:
-    branches: [main]
-    tags: ['v*']
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
## 背景
- Issue #1006 のCIコスト削減（Cedar Quality Gates はPRラベル前提のため push では常にスキップ）

## 変更
- `cedar-quality-gates.yml` の push トリガーを削除（PR/手動のみ）

## ログ
- なし

## テスト
- 未実施（workflow設定のみ）

## 影響
- push イベントでは Cedar Quality Gates が起動しなくなる（従来は常にskip）
- PRラベル/手動実行は維持

## ロールバック
- push トリガーを復活

## 関連Issue
- #1006
- #1336