### PR TITLE
chore: scope fail-fast spec validation push

### DIFF
--- a/.github/workflows/fail-fast-spec-validation.yml
+++ b/.github/workflows/fail-fast-spec-validation.yml
@@ -14,6 +14,10 @@ on:
       - 'schema/**'
       - 'docs/schemas/**'
       - 'specs/formal/**'
+      - 'packages/spec-compiler/**'
+      - 'src/cli/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
       - '.github/workflows/fail-fast-spec-validation.yml'
   workflow_call:
     # Allow this workflow to be called by other workflows

--- a/docs/notes/issue-1006-workflow-overlap-candidates.md
+++ b/docs/notes/issue-1006-workflow-overlap-candidates.md
@@ -24,7 +24,7 @@
 #### Trigger mapping (spec/artifact validation group)
 - spec-check.yml: pull_request (paths: specs/formal/**, scripts/formal/verify-tla.mjs, package.json, .github/workflows/spec-check.yml) + workflow_dispatch
 - spec-validation.yml: pull_request (paths: spec/**, .ae/**, artifacts/**, schema/**, docs/schemas/**, specs/formal/**, .github/workflows/spec-validation.yml, .github/workflows/validate-artifacts-ajv.yml) + push (main, develop; same paths) + workflow_call
-- fail-fast-spec-validation.yml: pull_request (paths: spec/**, .ae/**) + push (main; spec/ae/artifacts/schema/specs/formal/docs/schemas + workflow file) + workflow_call
+- fail-fast-spec-validation.yml: pull_request (paths: spec/**, .ae/**) + push (main; paths: spec/**, .ae/**, artifacts/**, schema/**, specs/formal/**, docs/schemas/**, packages/spec-compiler/**, src/cli/**, package.json, pnpm-lock.yaml, .github/workflows/fail-fast-spec-validation.yml) + workflow_call
 - validate-artifacts-ajv.yml: workflow_call (invoked from spec-validation on PRs) + workflow_dispatch
 - spec-generate-model.yml: pull_request (paths: specs/**, templates/**, scripts/**, tests/**, artifacts/**, .github/workflows/spec-generate-model.yml) + workflow_dispatch
 - codegen-drift-check.yml: pull_request (all PRs to main; types: opened, synchronize, reopened, labeled; paths-ignore: docs/**, **/*.md; execution gated by label "run-drift") + push (main; paths: spec/**/*.md, .ae/ae-ir.json, src/codegen/**, templates/**, .github/workflows/codegen-drift-check.yml) + workflow_call


### PR DESCRIPTION
背景:
- #1006 のCIコスト低減として、Fail-Fast Spec Validation のpush実行を spec/関連変更に限定する。

変更:
- fail-fast-spec-validation.yml の push トリガーに paths を追加（spec/.ae/artifacts/schema/specs/formal/docs/schemas + workflow自身）。
- overlap候補ドキュメントのトリガー説明を更新。

ログ:
- 変更点: .github/workflows/fail-fast-spec-validation.yml, docs/notes/issue-1006-workflow-overlap-candidates.md

テスト:
- 未実施（トリガー条件とドキュメントのみ変更）。

影響:
- main へのpushでも spec/関連パス外の変更では fail-fast-spec-validation が起動しません。

ロールバック:
- fail-fast-spec-validation.yml の push paths を削除し、ドキュメント記述を元に戻す。

関連Issue:
- #1006
- #1336
