### PR TITLE
chore: drop tag trigger from quality gates

### DIFF
--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -11,6 +11,8 @@ on:
       - 'scripts/**'
       - 'types/**'
   push:
+    branches:
+      - main
     paths:
       - 'src/**'
       - 'packages/**'

--- a/docs/notes/issue-1006-workflow-trigger-profiles.md
+++ b/docs/notes/issue-1006-workflow-trigger-profiles.md
@@ -35,12 +35,10 @@
 - nightly-monitoring.yml
 - nightly.yml
 
-### pull_request, push, workflow_call (3)
+### pull_request, push, workflow_call (4)
 - codegen-drift-check.yml
 - fail-fast-spec-validation.yml
 - spec-validation.yml
-
-### pull_request, workflow_call (1)
 - quality-gates-centralized.yml
 
 ### pull_request, workflow_dispatch (5)

--- a/docs/notes/issue-1006-workflow-triggers.md
+++ b/docs/notes/issue-1006-workflow-triggers.md
@@ -7,7 +7,7 @@
 ## Trigger counts
 - issue_comment: 1
 - pull_request: 30
-- push: 23
+- push: 24
 - release: 1
 - schedule: 10
 - workflow_call: 7
@@ -50,7 +50,7 @@
 - verify.yml
 - workflow-lint.yml
 
-### push (23)
+### push (24)
 - ae-ci.yml
 - ci-extended.yml
 - ci-fast.yml
@@ -64,6 +64,7 @@
 - parallel-test-execution.yml
 - podman-smoke.yml
 - pr-verify.yml
+- quality-gates-centralized.yml
 - release.yml
 - sbom-generation.yml
 - security.yml


### PR DESCRIPTION
背景:
- #1006 のCIコスト低減。タグpush時は release.yml が quality-gates-centralized を workflow_call で実行しており、quality-gates の tag push トリガーが重複実行になっている。

変更:
- quality-gates-centralized.yml の push タグトリガーを削除。
- トリガー表/プロファイル表を更新。

ログ:
- 変更点: .github/workflows/quality-gates-centralized.yml, docs/notes/issue-1006-workflow-triggers.md, docs/notes/issue-1006-workflow-trigger-profiles.md

テスト:
- 未実施（トリガー定義とドキュメントのみ変更）。

影響:
- vタグpush時の quality-gates-centralized 単独起動がなくなり、release.yml の workflow_call のみが実行されます。

ロールバック:
- quality-gates-centralized.yml の push tags を復元し、ドキュメントを元に戻す。

関連Issue:
- #1006
- #1336
