### PR TITLE
chore: drop pr-verify tag trigger

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -6,8 +6,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
-  push:
-    tags: ['v*']
 
 concurrency:
   group: pr-verify-${{ github.ref }}

--- a/docs/notes/issue-1006-workflow-trigger-profiles.md
+++ b/docs/notes/issue-1006-workflow-trigger-profiles.md
@@ -12,11 +12,10 @@
 - phase6-validation.yml
 - pr-summary-comment.yml
 
-### pull_request, push (7)
+### pull_request, push (6)
 - coverage-check.yml
 - lean-proof.yml
 - parallel-test-execution.yml
-- pr-verify.yml
 - testing-ddd-scripts.yml
 - verify.yml
 - workflow-lint.yml

--- a/docs/notes/issue-1006-workflow-triggers.md
+++ b/docs/notes/issue-1006-workflow-triggers.md
@@ -7,7 +7,7 @@
 ## Trigger counts
 - issue_comment: 1
 - pull_request: 30
-- push: 24
+- push: 23
 - release: 1
 - schedule: 10
 - workflow_call: 7
@@ -50,7 +50,7 @@
 - verify.yml
 - workflow-lint.yml
 
-### push (24)
+### push (23)
 - ae-ci.yml
 - ci-extended.yml
 - ci-fast.yml
@@ -63,7 +63,6 @@
 - lean-proof.yml
 - parallel-test-execution.yml
 - podman-smoke.yml
-- pr-verify.yml
 - quality-gates-centralized.yml
 - release.yml
 - sbom-generation.yml


### PR DESCRIPTION
## 背景\nタグpush時の重複CIを減らすため、PR専用ワークフローのタグトリガーを整理します。\n\n## 変更\n- pr-verify の tag push トリガーを削除（PR実行のみ）\n- workflow trigger のマップ/プロファイルを更新\n\n## ログ\n- 変更ファイル: .github/workflows/pr-verify.yml, docs/notes/issue-1006-workflow-trigger-profiles.md, docs/notes/issue-1006-workflow-triggers.md\n\n## テスト\n- 未実施（ワークフロー/ドキュメント変更）\n\n## 影響\n- タグpush時に pr-verify が走らなくなります（release 側は workflow_call により ci-fast / quality-gates のみ実行）\n\n## ロールバック\n- pr-verify.yml の tag push を復帰し、トリガー表記を戻す\n\n## 関連Issue\n- #1336