### PR TITLE
chore: drop hermetic-ci tag trigger

### DIFF
--- a/.github/workflows/hermetic-ci.yml
+++ b/.github/workflows/hermetic-ci.yml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
-    tags: ['v*']
   pull_request:
     branches: [ main ]
     paths-ignore:

--- a/tests/ci/tag-trigger.test.ts
+++ b/tests/ci/tag-trigger.test.ts
@@ -39,7 +39,6 @@ describe('CI/CD Tag Trigger Configuration - Phase 1.3', () => {
       const allowedTagWorkflows = new Set([
         'ae-ci',
         'ci',
-        'hermetic-ci',
         'release',
         'verify'
       ]);


### PR DESCRIPTION
## 背景\nタグpush時の重複実行を減らすため、hermetic-ci のタグトリガーを整理します。\n\n## 変更\n- hermetic-ci の tag push を削除（main/develop push・PR・手動実行は維持）\n- tag trigger 許可リストから hermetic-ci を削除\n\n## ログ\n- 変更ファイル: .github/workflows/hermetic-ci.yml, tests/ci/tag-trigger.test.ts\n\n## テスト\n- 未実施（ワークフロー/テスト更新）\n\n## 影響\n- タグpush時に hermetic-ci が走らなくなります（main/develop push は維持）\n\n## ロールバック\n- hermetic-ci.yml に tags を復帰し、許可リストを戻す\n\n## 関連Issue\n- #1336