### PR TITLE
chore: drop ci tag trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,6 @@ on:
   schedule:
     - cron: '0 2 * * 0'  # 毎週日曜日 2:00 UTC
   workflow_dispatch:      # 手動実行
-  push:
-    tags: ['v*']          # リリースタグ時
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/docs/notes/issue-1006-workflow-trigger-profiles.md
+++ b/docs/notes/issue-1006-workflow-trigger-profiles.md
@@ -26,7 +26,8 @@
 - podman-smoke.yml
 - verify-lite.yml
 
-### schedule, workflow_dispatch (5)
+### schedule, workflow_dispatch (6)
+- ci.yml
 - docker-tests.yml
 - flake-detect.yml
 - flake-maintenance.yml
@@ -73,9 +74,6 @@
 
 ### release, workflow_dispatch (1)
 - release-quality-artifacts.yml
-
-### push, schedule, workflow_dispatch (1)
-- ci.yml
 
 ### workflow_call (1)
 - ci-core.yml

--- a/docs/notes/issue-1006-workflow-triggers.md
+++ b/docs/notes/issue-1006-workflow-triggers.md
@@ -7,7 +7,7 @@
 ## Trigger counts
 - issue_comment: 1
 - pull_request: 30
-- push: 23
+- push: 22
 - release: 1
 - schedule: 10
 - workflow_call: 7
@@ -50,11 +50,10 @@
 - verify.yml
 - workflow-lint.yml
 
-### push (23)
+### push (22)
 - ae-ci.yml
 - ci-extended.yml
 - ci-fast.yml
-- ci.yml
 - codegen-drift-check.yml
 - coverage-check.yml
 - fail-fast-spec-validation.yml

--- a/tests/ci/tag-trigger.test.ts
+++ b/tests/ci/tag-trigger.test.ts
@@ -37,7 +37,6 @@ describe('CI/CD Tag Trigger Configuration - Phase 1.3', () => {
   describe('Tag Trigger Consistency', () => {
     it('should limit tag triggers to approved workflows', () => {
       const allowedTagWorkflows = new Set([
-        'ci',
         'release',
         'verify'
       ]);


### PR DESCRIPTION
## 背景
タグpush時の重複実行を減らすため、フルCI（ci.yml）のタグトリガーを整理します。

## 変更
- ci.yml の tag push トリガーを削除（schedule / 手動実行は維持）
- tag trigger 許可リストから ci を削除
- trigger map / profile を更新

## ログ
- 変更ファイル: .github/workflows/ci.yml, tests/ci/tag-trigger.test.ts, docs/notes/issue-1006-workflow-trigger-profiles.md, docs/notes/issue-1006-workflow-triggers.md

## テスト
- 未実施（ワークフロー/テスト/ドキュメント変更）

## 影響
- タグpush時にフルCIが走らなくなります（release workflow の quality/ci-fast は維持）

## ロールバック
- ci.yml に tag push を復帰し、許可リスト/ドキュメントを戻す

## 関連Issue
- #1336
