### PR TITLE
chore: run verify in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,15 @@ jobs:
     name: CI Check  
     uses: ./.github/workflows/ci-fast.yml
 
+  # Verify traceability artifacts
+  verify-check:
+    name: Verify Traceability
+    uses: ./.github/workflows/verify.yml
+
   # Main release job - only runs if quality and CI checks pass
   release:
     runs-on: ubuntu-latest
-    needs: [quality-check, ci-check]
+    needs: [quality-check, ci-check, verify-check]
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,7 +2,6 @@ name: Verify Traceability
 on:
   push:
     branches: [main]
-    tags: ['v*'] # Verify traceability on releases
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
@@ -11,6 +10,7 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
+  workflow_call:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/tests/ci/tag-trigger.test.ts
+++ b/tests/ci/tag-trigger.test.ts
@@ -37,8 +37,7 @@ describe('CI/CD Tag Trigger Configuration - Phase 1.3', () => {
   describe('Tag Trigger Consistency', () => {
     it('should limit tag triggers to approved workflows', () => {
       const allowedTagWorkflows = new Set([
-        'release',
-        'verify'
+        'release'
       ]);
 
       const workflowsWithTags: string[] = [];


### PR DESCRIPTION
## 背景
タグpush時の重複実行を減らしつつ、リリース時のトレーサビリティ検証を確実に行うための整理です。

## 変更
- verify.yml に workflow_call を追加し、タグpushを削除
- release.yml から verify.yml を呼び出すジョブを追加
- tag trigger 許可リストから verify を除外（ci は残す）

## ログ
- 変更ファイル: .github/workflows/verify.yml, .github/workflows/release.yml, tests/ci/tag-trigger.test.ts

## テスト
- 未実施（ワークフロー/テスト更新）

## 影響
- タグpush時の verify ワークフロー単体実行は停止し、release ワークフロー内で実行されます

## ロールバック
- verify.yml の tag push を復帰し、release.yml の verify 呼び出しを削除する

## 関連Issue
- #1336
