### PR TITLE
chore(ci): skip security jobs on fork PRs

### DIFF
--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   sbom-generation:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || contains(join(fromJSON(toJSON(github.event.pull_request.labels)).*.name, ','), 'run-security')
+    if: ${{ github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && contains(join(fromJSON(toJSON(github.event.pull_request.labels)).*.name, ','), 'run-security')) }}
     
     permissions:
       contents: read
@@ -162,7 +162,7 @@ jobs:
         
   security-analysis:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-security')
+    if: ${{ github.event_name != 'pull_request' || (!github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-security')) }}
     continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking') }}
     needs: sbom-generation
     

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,9 +33,11 @@ jobs:
         with:
           script: |
             const isPR = context.eventName === 'pull_request';
+            const isFork = isPR && context.payload.pull_request?.head?.repo?.fork;
             const labels = (context.payload.pull_request?.labels || []).map(l=>l.name);
-            const runSecurity = !isPR || labels.includes('run-security');
+            const runSecurity = !isPR || (!isFork && labels.includes('run-security'));
             core.setOutput('run_security', String(runSecurity));
+            core.setOutput('is_fork', String(Boolean(isFork)));
   security-scan:
     needs: gate
     if: ${{ needs.gate.outputs.run_security == 'true' }}


### PR DESCRIPTION
背景
- #1005 の「fork PR での security/audit/container ジョブ失敗」を抑制するため、fork 由来PRでは重いセキュリティ系ジョブを実行しない方針にします。

変更
- .github/workflows/security.yml: fork PR の場合は gate で run_security=false にして Security/CodeQL/Container 系ジョブをスキップ
- .github/workflows/sbom-generation.yml: fork PR の場合は SBOM/CodeQL 分析ジョブをスキップ

ログ
- fork PR の場合、run-security ラベルが付いていても Security/SBOM 系は走らない

テスト
- 未実施（ワークフロー変更）

影響
- fork PR ではセキュリティ系の重いスキャンが実行されず、CI失敗の原因を除去
- 必要時は本リポジトリ側ブランチ/手動実行で実施

ロールバック
- 本PRを revert

関連Issue
- #1005
- #1336
