### PR TITLE
chore(ci): skip adapter thresholds on fork PRs

### DIFF
--- a/.github/workflows/adapter-thresholds.yml
+++ b/.github/workflows/adapter-thresholds.yml
@@ -10,7 +10,7 @@ permissions: read-all
 
 jobs:
   summarize-a11y:
-    if: !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-adapters')
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'run-adapters')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -95,7 +95,7 @@ jobs:
           path: reports/a11y-results.json
 
   summarize-perf:
-    if: !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-adapters')
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'run-adapters')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -180,7 +180,7 @@ jobs:
           fi
 
   summarize-lh:
-    if: !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-adapters')
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && contains(github.event.pull_request.labels.*.name, 'run-adapters')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
背景
- fork PR では `GITHUB_TOKEN` が read-only のため、adapter-thresholds のPRコメント投稿が失敗しやすい。
- #1005 のCI安定化（fork PRでの失敗抑制）として、fork PR では adapter-thresholds をスキップする。

変更
- .github/workflows/adapter-thresholds.yml: fork PR の場合は各 summarize ジョブをスキップ

ログ
- fork PR では adapter-thresholds が実行されない

テスト
- 未実施（ワークフロー変更）

影響
- fork PR でのコメント投稿失敗による赤CIを回避
- 本リポジトリ内PRでは従来どおり adapter-thresholds が実行される

ロールバック
- 本PRを revert

関連Issue
- #1005
- #1336
