### PR TITLE
chore(ci): trigger copilot gate on review events

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   pull_request_review:
     types: [submitted]
-  pull_request_review_thread:
-    types: [resolved]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## 背景\nCopilot Review Gate は review 提出や thread 解決時に自動再評価されず、手動再実行が必要でした。\n\n## 変更\n- pull_request_review (submitted) でゲートを起動\n- pull_request_review_thread (resolved) でゲートを起動\n\n## ログ\n- なし\n\n## テスト\n- 未実行（CIで確認）\n\n## 影響\n- Review 提出/解決に連動してゲート再評価される\n\n## ロールバック\n- 本PRをrevert\n\n## 関連Issue\n- #1336\n