### PR TITLE
chore(ci): auto update behind PR branches

### DIFF
--- a/.github/workflows/pr-auto-update-branch.yml
+++ b/.github/workflows/pr-auto-update-branch.yml
@@ -28,10 +28,10 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const inputNumber = core.getInput('pr_number');
+            const inputNumber = context.payload.inputs?.pr_number ?? core.getInput('pr_number');
             const parsedInput = inputNumber ? Number(inputNumber) : null;
             const prNumber = context.payload.pull_request?.number ?? parsedInput;
-            if (!prNumber || Number.isNaN(prNumber)) {
+            if (!Number.isFinite(prNumber)) {
               core.notice('No PR number provided; skipping.');
               return;
             }
@@ -41,6 +41,42 @@ jobs:
             const waitMs = 10000;
             let mergeableState = 'unknown';
             let pr = null;
+            const marker = '<!-- AE-PR-AUTO-UPDATE -->';
+            const upsertComment = async (content) => {
+              const body = [marker, content].join('\n\n');
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: prNumber,
+                per_page: 100
+              });
+              const existing = comments.find((comment) =>
+                typeof comment.body === 'string' && comment.body.includes(marker)
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body
+                });
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body
+              });
+            };
+            const safeComment = async (content, contextLabel) => {
+              try {
+                await upsertComment(content);
+              } catch (error) {
+                const message = error?.message ?? String(error);
+                core.warning(`Failed to post update comment (${contextLabel}) on PR #${prNumber}: ${message}`);
+              }
+            };
 
             for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
               const { data } = await github.rest.pulls.get({
@@ -58,8 +94,14 @@ jobs:
                 break;
               }
               if (attempt < maxAttempts) {
+                core.info(`Attempt ${attempt}/${maxAttempts}: mergeable_state still unknown, waiting ${waitMs / 1000}s before retry...`);
                 await sleep(waitMs);
               }
+            }
+
+            if (mergeableState === 'unknown') {
+              core.warning(`PR #${prNumber} mergeable_state remains unknown after ${maxAttempts} attempts; skipping auto-update.`);
+              return;
             }
 
             if (mergeableState !== 'behind') {
@@ -74,25 +116,27 @@ jobs:
                 pull_number: prNumber
               });
             } catch (error) {
-              const message = error && error.message ? error.message : String(error);
+              const message = error?.message ?? String(error);
+              const status = error?.status ?? error?.response?.status;
+              const looksLikeConflict = status === 409 || /conflict/i.test(message);
+              if (looksLikeConflict) {
+                const content = [
+                  '### Auto Update Branch',
+                  `PR #${prNumber} could not be auto-updated due to conflicts.`,
+                  `Details: ${message}`,
+                  'Please resolve conflicts manually.'
+                ].join('\n');
+                await safeComment(content, 'conflict');
+                core.notice(`Auto-update skipped for PR #${prNumber} due to conflicts.`);
+                return;
+              }
               core.setFailed(`Failed to update branch for PR #${prNumber}: ${message}`);
               return;
             }
 
-            const body = [
+            const content = [
               '### Auto Update Branch',
               `PR #${prNumber} was behind base; triggered branch update.`,
               'If conflicts remain, manual resolution is required.'
             ].join('\n');
-
-            try {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: prNumber,
-                body
-              });
-            } catch (error) {
-              const message = error && error.message ? error.message : String(error);
-              core.warning(`Failed to post update comment on PR #${prNumber}: ${message}`);
-            }
+            await safeComment(content, 'updated');


### PR DESCRIPTION
## 背景\nPRがbaseから遅れている場合の更新は手動対応が多く、レビュー待ちのボトルネックになっていました。\n\n## 変更\n- PRがbehindの場合に自動でupdate-branchを実行\n- draft PRはスキップ\n- update後にPRへ通知コメントを投稿\n- workflow_dispatch での手動実行にも対応\n\n## ログ\n- なし\n\n## テスト\n- 未実行（CIで確認）\n\n## 影響\n- behind状態のPRが自動で更新され、手動更新を削減\n\n## ロールバック\n- 本PRをrevert\n\n## 関連Issue\n- #1005\n- #1336\n