### PR TITLE
docs: add auto-update token hint

### DIFF
--- a/docs/ci/ci-troubleshooting-guide.md
+++ b/docs/ci/ci-troubleshooting-guide.md
@@ -24,7 +24,7 @@ Purpose: Provide a short, deterministic path to diagnose common CI failures.
 ## 5) Automation notes
 - Failed job は `ci-auto-rerun-failed` が **1回だけ**自動再実行します（再実行ログを確認）。
 - `pr-auto-update-branch` が behind の PR を自動更新します。競合時は手動解決が必要です。
-- `gateExpected` / `verify-liteExpected` が "Waiting for status to be reported" の場合、auto update で作られたマージコミットにチェックが載っていない可能性があります。対処: PRブランチに空コミットを追加してPRイベントを再発火、またはPR画面から再実行します。
+- `gateExpected` / `verify-liteExpected` が "Waiting for status to be reported" の場合、auto update で作られたマージコミットにチェックが載っていない可能性があります。対処: PRブランチに空コミットを追加してPRイベントを再発火、またはPR画面から再実行します。恒久策として `AE_AUTO_UPDATE_TOKEN` をSecretsに設定し、auto update の更新コミットから required checks が走るようにします。
 
 ## References
 - `docs/ci/ci-baseline-checklist.md`


### PR DESCRIPTION
## 背景
- auto update 由来のマージコミットで required checks が pending になる事象の恒久対策を追記するため。

## 変更
- CI troubleshooting guide に `AE_AUTO_UPDATE_TOKEN` 設定の恒久策を追記。

## ログ
- ドキュメントのみ。

## テスト
- 未実施（ドキュメントのみ）。

## 影響
- 運用メモの更新のみ。

## ロールバック
- 本PRをrevert。

## 関連Issue
- #1005
