### PR TITLE
fix(ci): ensure pnpm after setup-node

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -17,6 +17,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: ./.github/actions/setup-pnpm
+      with:
+        version: ${{ inputs.pnpm-version }}
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
## 背景
- setup-node-pnpm を使用するワークフローで、setup-node後にpnpmが見つからない可能性が指摘された

## 変更
- setup-node-pnpm の実行順を `setup-node` → `setup-pnpm` に変更

## ログ
- なし

## テスト
- 未実行（CIに委譲）

## 影響
- Node切替後の pnpm 利用を安定化

## ロールバック
- このPRを revert

## 関連Issue
- #1627
