### PR TITLE
chore(ci): add concurrency to pr-summary-comment

### DIFF
--- a/.github/workflows/pr-summary-comment.yml
+++ b/.github/workflows/pr-summary-comment.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - "docs/**"
       - "**/*.md"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## 背景\n- #1653 の concurrency 追加方針に従い、無駄な再実行を抑制する。\n\n## 変更\n- pr-summary-comment.yml に concurrency を追加。\n\n## ログ\n- .github/workflows/pr-summary-comment.yml\n\n## テスト\n- 未実行（CIで確認）\n\n## 影響\n- 同一PRの古い実行をキャンセルし待ち時間を削減。\n\n## ロールバック\n- このPRを revert。\n\n## 関連Issue\n- #1653\n