### PR TITLE
chore(ci): add auto-merge eligibility check

### DIFF
--- a/.github/workflows/auto-merge-eligible.yml
+++ b/.github/workflows/auto-merge-eligible.yml
@@ -26,6 +26,7 @@ jobs:
           node-version: "20"
       - name: Evaluate auto-merge eligibility
         env:
+          # Prefer github.token; GH_TOKEN allows an explicit PAT when org policies require it.
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           ENABLE_AUTO_MERGE: ${{ inputs.enable_auto_merge }}

--- a/scripts/ci/auto-merge-eligible.mjs
+++ b/scripts/ci/auto-merge-eligible.mjs
@@ -17,40 +17,93 @@ if (!prNumber) {
   console.error('[auto-merge] PR_NUMBER is required.');
   process.exit(1);
 }
+if (!/^[1-9][0-9]*$/.test(String(prNumber))) {
+  console.error('[auto-merge] PR_NUMBER must be a positive integer.');
+  process.exit(1);
+}
 
 const execJson = (args) => {
-  const output = execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
-  return JSON.parse(output);
+  try {
+    const output = execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return JSON.parse(output);
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    console.error('[auto-merge] gh failed:', message);
+    throw error;
+  }
 };
 
-const summarizeChecks = (rollup = []) => {
-  const counts = { success: 0, failure: 0, pending: 0 };
+const fetchRequiredContexts = (repoName, baseRefName) => {
+  try {
+    const contexts = execJson([
+      'api',
+      `repos/${repoName}/branches/${baseRefName}/protection/required_status_checks/contexts`,
+    ]);
+    return Array.isArray(contexts) ? contexts : [];
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    if (message.includes('Not Found') || message.includes('404')) {
+      return [];
+    }
+    console.error('[auto-merge] Failed to fetch required status checks:', message);
+    return null;
+  }
+};
+
+const summarizeChecks = (rollup = [], requiredContexts = []) => {
+  const counts = { success: 0, failure: 0, pending: 0, skipped: 0, neutral: 0 };
   const failed = [];
+  const requiredSet = new Set(requiredContexts);
   for (const item of rollup) {
     if (item.__typename === 'CheckRun') {
+      if (requiredSet.size > 0 && !requiredSet.has(item.name)) {
+        continue;
+      }
       if (item.status !== 'COMPLETED') {
         counts.pending += 1;
         continue;
       }
-      if (item.conclusion === 'SUCCESS' || item.conclusion === 'SKIPPED') {
-        counts.success += 1;
-        continue;
+      switch (item.conclusion) {
+        case 'SUCCESS':
+          counts.success += 1;
+          break;
+        case 'FAILURE':
+        case 'CANCELLED':
+        case 'TIMED_OUT':
+        case 'ACTION_REQUIRED':
+        case 'STALE':
+          counts.failure += 1;
+          failed.push(item.name);
+          break;
+        case 'SKIPPED':
+          counts.skipped += 1;
+          break;
+        default:
+          counts.neutral += 1;
+          break;
       }
-      counts.failure += 1;
-      failed.push(item.name);
       continue;
     }
     if (item.__typename === 'StatusContext') {
-      if (item.state === 'SUCCESS') {
-        counts.success += 1;
+      if (requiredSet.size > 0 && !requiredSet.has(item.context)) {
         continue;
       }
-      if (item.state === 'PENDING') {
-        counts.pending += 1;
-        continue;
+      switch (item.state) {
+        case 'SUCCESS':
+          counts.success += 1;
+          break;
+        case 'PENDING':
+          counts.pending += 1;
+          break;
+        case 'FAILURE':
+        case 'ERROR':
+          counts.failure += 1;
+          failed.push(item.context);
+          break;
+        default:
+          counts.neutral += 1;
+          break;
       }
-      counts.failure += 1;
-      failed.push(item.context);
     }
   }
   return { counts, failed };
@@ -60,11 +113,18 @@ const pr = execJson([
   'pr',
   'view',
   String(prNumber),
+  '--repo',
+  repo,
   '--json',
-  'number,title,mergeable,reviewDecision,statusCheckRollup',
+  'number,title,mergeable,reviewDecision,statusCheckRollup,baseRefName',
 ]);
 
-const { counts, failed } = summarizeChecks(pr.statusCheckRollup || []);
+const requiredContexts = fetchRequiredContexts(repo, pr.baseRefName);
+if (requiredContexts === null) {
+  console.log('[auto-merge] Not eligible (required status checks unavailable).');
+  process.exit(0);
+}
+const { counts, failed } = summarizeChecks(pr.statusCheckRollup || [], requiredContexts);
 const eligible =
   pr.mergeable === 'MERGEABLE' &&
   pr.reviewDecision === 'APPROVED' &&
@@ -73,7 +133,9 @@ const eligible =
 
 console.log(`[auto-merge] PR #${pr.number}: ${pr.title}`);
 console.log(`[auto-merge] mergeable=${pr.mergeable} review=${pr.reviewDecision}`);
-console.log(`[auto-merge] checks: success=${counts.success} failure=${counts.failure} pending=${counts.pending}`);
+console.log(
+  `[auto-merge] required checks: ${requiredContexts.length || 'none'} | success=${counts.success} failure=${counts.failure} pending=${counts.pending}`
+);
 if (failed.length > 0) {
   console.log(`[auto-merge] failed: ${failed.slice(0, 10).join(', ')}`);
 }
@@ -88,6 +150,6 @@ if (!enable) {
   process.exit(0);
 }
 
-execFileSync('gh', ['pr', 'merge', String(prNumber), '--auto', '--squash'], {
+execFileSync('gh', ['pr', 'merge', String(prNumber), '--repo', repo, '--auto', '--squash'], {
   stdio: 'inherit',
 });


### PR DESCRIPTION
## 背景\nAuto-mergeの適用条件確認と手動操作の負荷を低減するため、適用可否の判定を自動化したい。\n\n## 変更\n- auto-merge適用可否を判定するスクリプトを追加\n- workflow_dispatchでPR番号を入力し、適用可否を出力（オプションでauto-merge有効化）\n\n## ログ\n- なし\n\n## テスト\n- 未実施（workflow/スクリプト追加のみ）\n\n## 影響\n- 手動運用の補助（auto-mergeは明示有効化時のみ）\n\n## ロールバック\n- 本PRをrevert\n\n## 関連Issue\n- #1694\n