### PR TITLE
chore(ci): align concurrency audit + add concurrency

### DIFF
--- a/.github/workflows/auto-merge-eligible.yml
+++ b/.github/workflows/auto-merge-eligible.yml
@@ -12,7 +12,7 @@ on:
         default: "false"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.pr_number || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## 背景\nworkflow_callのみのWFはconcurrency対象外の方針だが、auditがそれを未対応扱いにしていた。加えてauto-merge-eligibleはconcurrency未設定だった。\n\n## 変更\n- concurrency-auditがworkflow_callのみのWFをスキップするように判定ロジックを追加\n- auto-merge-eligible workflowにconcurrencyを追加\n\n## ログ\n- concurrency-audit: workflow_call-onlyを除外、missing一覧の精度向上\n- auto-merge-eligible: concurrency group/cancel-in-progress追加\n\n## テスト\n- Workflows missing concurrency:
- pr-ci-status-comment.yml
Skipped workflow_call-only workflows:
- ci-core.yml
- flake-stability.yml\n\n## 影響\n- audit結果の正確性向上\n- 手動dispatchの重複実行を抑制\n\n## ロールバック\n- 変更2ファイルを戻す\n\n## 関連Issue\n- #1336\n- #1653