### PR TITLE
chore(ci): use setup-node-pnpm in docker-tests

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -29,8 +29,24 @@ jobs:
         with:
           ref: ${{ env.TARGET_SHA }}
 
+      - name: Detect local setup-node-pnpm
+        id: setup-node-pnpm
+        run: |
+          if [ -d ".github/actions/setup-node-pnpm" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Node + pnpm
+        if: steps.setup-node-pnpm.outputs.available == 'true'
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: '20'
+
+      - name: Setup Node (fallback)
+        if: steps.setup-node-pnpm.outputs.available != 'true'
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
 


### PR DESCRIPTION
## 背景\nsetup-node-pnpm の適用範囲を拡大し、Node バージョンを統一する。\n\n## 変更\n- docker-tests.yml に setup-node-pnpm を追加\n\n## テスト\n- なし（workflow定義のみ）\n\n## 影響\n- Node バージョンを固定化（pnpm setup は将来拡張用）\n\n## ロールバック\n- 追加したステップを削除\n\n## 関連Issue\n- #1627\n- #1336