### PR TITLE
chore(ci): add verify-lite retry eligibility signal

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -206,7 +206,7 @@ jobs:
           }
           EOF
       - name: Upload verify-lite report
-        if: ${{ steps.docs-only.outputs.docs_only != 'true' && always() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: verify-lite-report


### PR DESCRIPTION
## 背景
#1005 Phase 3 の自動フレーク回復に向け、verify-lite 実行の再試行可否シグナルを成果物として残す。

## 変更
- verify-lite で `artifacts/verify-lite/verify-lite-retry-eligibility.json` を生成
- verify-lite レポートのアーティファクトに同ファイルを追加

## ログ
- なし（生成物はワークフロー実行時）

## テスト
- なし（CIワークフロー変更）

## 影響
- verify-lite の成果物に retry eligibility が追加される

## ロールバック
- 追加ステップとアーティファクト項目を削除

## 関連Issue
- #1005
