### PR TITLE
chore(ci): add pr-verify retry eligibility signal

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -123,16 +123,16 @@ jobs:
         run: |
           mkdir -p artifacts/pr-verify
           cat > artifacts/pr-verify/pr-verify-retry-eligibility.json <<EOF
-{
-  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "workflow": "pr-verify",
-  "runId": "${{ github.run_id }}",
-  "sha": "${{ github.sha }}",
-  "required": false,
-  "retriable": false,
-  "reason": "not_evaluated"
-}
-EOF
+          {
+            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "workflow": "pr-verify",
+            "runId": "${{ github.run_id }}",
+            "sha": "${{ github.sha }}",
+            "required": false,
+            "retriable": false,
+            "reason": "not_evaluated"
+          }
+          EOF
 
       - name: Comment summary on PR
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork


### PR DESCRIPTION
## 背景
#1005 Phase 3 の自動フレーク回復に向け、pr-verify 実行の再試行可否シグナルを成果物として残す。

## 変更
- pr-verify で `artifacts/pr-verify/pr-verify-retry-eligibility.json` を生成

## ログ
- なし（生成物はワークフロー実行時）

## テスト
- なし（CIワークフロー変更）

## 影響
- pr-verify の成果物に retry eligibility が追加される

## ロールバック
- 追加ステップを削除

## 関連Issue
- #1005
