### PR TITLE
chore(ci): add flake retry dispatcher

### DIFF
--- a/.github/workflows/flake-retry-dispatch.yml
+++ b/.github/workflows/flake-retry-dispatch.yml
@@ -76,7 +76,9 @@ jobs:
       - name: Summary
         if: always()
         run: |
-          printf '%s\n' "## Flake Retry Dispatch" >> "$GITHUB_STEP_SUMMARY"
-          printf '%s\n' "- run_id: ${{ steps.select.outputs.run_id != '' && steps.select.outputs.run_id || 'none' }}" >> "$GITHUB_STEP_SUMMARY"
-          printf '%s\n' "- retriable: ${{ steps.eligibility.outputs.retriable || 'n/a' }}" >> "$GITHUB_STEP_SUMMARY"
-          printf '%s\n' "- reason: ${{ steps.eligibility.outputs.reason || 'n/a' }}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            printf '%s\n' "## Flake Retry Dispatch"
+            printf '%s\n' "- run_id: ${{ steps.select.outputs.run_id != '' && steps.select.outputs.run_id || 'none' }}"
+            printf '%s\n' "- retriable: ${{ steps.eligibility.outputs.retriable || 'n/a' }}"
+            printf '%s\n' "- reason: ${{ steps.eligibility.outputs.reason || 'n/a' }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 背景
#1005 Phase 3 の自動フレーク回復の最小実装として、フレーク検知ワークフローの失敗時に再実行を試みるディスパッチャを追加する。

## 変更
- flake-detect の最新失敗ランを確認し、retry eligibility が true の場合のみ rerun-failed-jobs を実行
- 1回目の実行のみ対象（run_attempt==1）
- 実行結果を Step Summary に記録

## ログ
- なし（workflow実行ログのみ）

## テスト
- なし（CIワークフロー変更）

## 影響
- 定期実行/手動実行で失敗ランの再実行を試行

## ロールバック
- 追加ワークフローを削除

## 関連Issue
- #1005
