### PR TITLE
docs(ci): add flake retry dispatch guide

### DIFF
--- a/docs/ci/flake-retry-dispatch.md
+++ b/docs/ci/flake-retry-dispatch.md
@@ -28,4 +28,5 @@ Step Summary に以下が出力される。
 ## 失敗時の代表的な原因
 - eligibility アーティファクトが存在しない（`reason=no_artifact`）
 - zip 展開に失敗（`reason=unzip_failed`）
+- eligibility JSON ファイルが存在するが中身が空（`reason=missing_file`）
 - `retriable=false` のため再試行を実施しない


### PR DESCRIPTION
## 背景
#1005 Phase 3 の retry dispatcher 運用を文書化する。

## 変更
- `docs/ci/flake-retry-dispatch.md` を追加

## ログ
- なし

## テスト
- なし（ドキュメントのみ）

## 影響
- なし

## ロールバック
- 追加ファイルの削除

## 関連Issue
- #1005
