### PR TITLE
chore(ci): add dry-run to retry dispatcher

### DIFF
--- a/.github/workflows/flake-retry-dispatch.yml
+++ b/.github/workflows/flake-retry-dispatch.yml
@@ -13,8 +13,9 @@ on:
         default: flake-detection-report
       dry_run:
         description: Skip rerun and only report decision (true/false)
+        type: boolean
         required: false
-        default: "false"
+        default: false
   schedule:
     - cron: '0 22 * * *' # JST 07:00 (after flake-detect)
 


### PR DESCRIPTION
## 背景
#1005 Phase 3 の dispatcher を安全に検証するため、dry-run を追加する。

## 変更
- workflow_dispatch 入力に `dry_run` を追加
- dry_run=true の場合は rerun-failed-jobs を実行せず、Summary に出力

## ログ
- なし

## テスト
- なし（CIワークフロー変更）

## 影響
- 手動実行時に再実行せず判定のみ行える

## ロールバック
- dry_run 入力/分岐の削除

## 関連Issue
- #1005
