### PR TITLE
docs(ci): note dry_run input

### DIFF
--- a/docs/ci/flake-retry-dispatch.md
+++ b/docs/ci/flake-retry-dispatch.md
@@ -16,6 +16,8 @@ Actions から `Flake Retry Dispatch (Phase 3)` を起動し、必要に応じ�
   既定: `flake-detect.yml`
 - `eligibility_artifact`  
   既定: `flake-detection-report`
+- `dry_run`  
+  既定: `false`（true の場合は rerun-failed-jobs を実行しない）
 
 ## 出力
 Step Summary に以下が出力される。


### PR DESCRIPTION
## 背景
Flake Retry Dispatch に追加した dry_run 入力を運用ガイドへ反映する。

## 変更
- `docs/ci/flake-retry-dispatch.md` に dry_run 入力を追記

## ログ
- なし

## テスト
- なし（ドキュメントのみ）

## 影響
- なし

## ロールバック
- 追記行の削除

## 関連Issue
- #1005
