### PR TITLE
docs: add pr-verify retry examples

### DIFF
--- a/docs/ci/flake-retry-dispatch.md
+++ b/docs/ci/flake-retry-dispatch.md
@@ -13,12 +13,12 @@ flake-detect で検知したフレークのうち、**再試行可否が true** 
 Actions から `Flake Retry Dispatch (Phase 3)` を起動し、必要に応じて以下を指定する。
 
 - `workflow_file`  
-  既定: `flake-detect.yml`（例: verify-lite の場合は `verify-lite.yml`）
+  既定: `flake-detect.yml`（例: verify-lite は `verify-lite.yml` / pr-verify は `pr-verify.yml`）
 - `eligibility_artifact`  
-  既定: `flake-detection-report`（例: verify-lite の場合は `verify-lite-report`）
+  既定: `flake-detection-report`（例: verify-lite は `verify-lite-report` / pr-verify は `ae-artifacts`）
 - `eligibility_path`  
   既定: `reports/flake-retry-eligibility.json`  
-  例: verify-lite の場合は `artifacts/verify-lite/verify-lite-retry-eligibility.json`
+  例: verify-lite は `artifacts/verify-lite/verify-lite-retry-eligibility.json` / pr-verify は `artifacts/pr-verify/pr-verify-retry-eligibility.json`
 - `dry_run`  
   既定: `false`（true の場合は rerun-failed-jobs を実行しない）
 

--- a/docs/notes/issue-1005-flake-recovery-draft.md
+++ b/docs/notes/issue-1005-flake-recovery-draft.md
@@ -37,5 +37,7 @@ Define a minimal, safe automation loop that retries flaky CI jobs once, records 
 - Validate behavior on a dry-run schedule.
 
 ## Status update (2026-01)
-- Flake Stability: retry eligibility artifact (`reports/flake-retry-eligibility.json`) を追加済み。残りは verify-lite / pr-verify への適用と、dispatcher の試作。
-- Dispatcher: flake-detect 失敗ランの eligibility を確認し、条件一致時に rerun-failed-jobs を実行する最小ワークフローを追加（PR#1722）。
+- Flake Stability: retry eligibility artifact (`reports/flake-retry-eligibility.json`) を追加済み。
+- Verify-lite: eligibility artifact を追加済み。
+- pr-verify: `ae-artifacts` に eligibility JSON を同梱（`artifacts/pr-verify/pr-verify-retry-eligibility.json`）。
+- Dispatcher: flake-detect 失敗ランの eligibility を確認し、条件一致時に rerun-failed-jobs を実行する最小ワークフローを追加（PR#1722）。`eligibility_path` 入力で verify-lite / pr-verify を切替可能。


### PR DESCRIPTION
## 背景
flake retry dispatcher の運用例に pr-verify が含まれておらず、verify-lite と同様に inputs を揃える必要がありました。

## 変更
- flake-retry-dispatch の手動入力例に pr-verify の workflow/artifact/path を追記
- issue-1005 のフレーク復旧ドラフトに現状の適用範囲を追記

## ログ
- docs/ci/flake-retry-dispatch.md
- docs/notes/issue-1005-flake-recovery-draft.md

## テスト
- なし（ドキュメント更新）

## 影響
- 運用手順の明確化のみ。実行ロジックは変更なし。

## ロールバック
- 当該ドキュメントの追記を削除

## 関連Issue
- #1005
