### PR TITLE
docs: align flake retry note (EN)

### DIFF
--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -67,8 +67,8 @@ CI Extended restores cached heavy test artifacts (`.cache/test-results`) when re
     - `/formal-aggregate-dispatch` … Formal Reports Aggregate を実行（`run-formal` 併用時に集約コメントを生成）
     - `/run-flake-dispatch` … flake-detect を実行
     - `/spec-validation-dispatch` … spec-validation を実行
-  - 手動実行（Actions UI）
-    - `Flake Retry Dispatch (Phase 3)` は workflow_dispatch で `workflow_file` / `eligibility_artifact` / `eligibility_path` / `dry_run` を指定可能
+  - Manual run (Actions UI)
+    - `Flake Retry Dispatch (Phase 3)` supports workflow_dispatch inputs: `workflow_file` / `eligibility_artifact` / `eligibility_path` / `dry_run`
   - ラベル付与（Opt-in 実行/ポリシー切替）
     - `/run-qa` … `run-qa` を付与（ae-ci の QA 実行）
     - `/run-security` … `run-security` を付与（Security/SBOM 実行。PR要約も投稿）


### PR DESCRIPTION
## 背景
English セクションの手動実行メモが日本語のまま残っていたため、英語表記に揃えます。

## 変更
- Flake Retry Dispatch の手動実行メモを英語に統一

## ログ
- docs/ci-policy.md

## テスト
- なし（ドキュメント更新）

## 影響
- ドキュメント表記の統一のみ

## ロールバック
- 変更箇所を元に戻す

## 関連Issue
- #1005
