### PR TITLE
fix(mutation): Stryker v8 の configFile 引数に合わせて修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "bdd": "cucumber-js specs/bdd/features --import 'specs/bdd/steps/**/*.js'",
     "pbt": "vitest run -c tests/property/vitest.config.ts",
     "mbt": "node tests/mbt/run.js",
-    "mutation": "stryker run --config configs/stryker/stryker.conf.cjs",
+    "mutation": "stryker run configs/stryker/stryker.conf.cjs",
     "perf:budgets": "node scripts/performance-budget-validator.js",
     "perf:budgets:dev": "NODE_ENV=development node scripts/performance-budget-validator.js",
     "perf:budgets:prod": "NODE_ENV=production node scripts/performance-budget-validator.js",

--- a/scripts/mutation/run-scoped.sh
+++ b/scripts/mutation/run-scoped.sh
@@ -212,11 +212,12 @@ else
   TEMP_PATHS+=("$WORKSPACE_DIR")
   CMD+=("--tempDirName" "${WORKSPACE_DIR}")
 fi
-if [[ -n "$CONFIG_PATH" ]] ; then
-  CMD+=("--config" "$CONFIG_PATH")
-fi
 if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
   CMD+=("${EXTRA_ARGS[@]}")
+fi
+# StrykerJS v8 expects the config file as the final positional argument (not via --config).
+if [[ -n "$CONFIG_PATH" ]] ; then
+  CMD+=("$CONFIG_PATH")
 fi
 
 CMD_STATUS=0


### PR DESCRIPTION
Refs #1160

## 背景
- `scripts/mutation/run-scoped.sh` が `npx stryker run --config ...` を使用しており、StrykerJS CLI v8系では `--config` がサポートされないため `unknown option '--config'` で停止していました。
- `.github/workflows/mutation-quick.yml` も同スクリプト経由のため、Mutation Quick が実行不能になります。

## 変更内容
- `scripts/mutation/run-scoped.sh`: configFile を `stryker run` の最後の positional 引数として渡すよう変更
- `package.json`: `pnpm mutation` の `--config` を廃止

## ローカル確認
- `./scripts/mutation/run-scoped.sh --quick --mutate src/utils/enhanced-state-manager.ts -- --dryRunOnly` が `unknown option '--config'` で落ちないことを確認
