### PR TITLE
test: harden EnhancedStateManager import versionIndex

### DIFF
--- a/src/utils/enhanced-state-manager.ts
+++ b/src/utils/enhanced-state-manager.ts
@@ -1036,7 +1036,7 @@ export class EnhancedStateManager extends EventEmitter {
 
   private findLatestKey(logicalKey: string): string | null {
     const keys = this.keyIndex.get(logicalKey);
-    if (!keys || keys.size === 0) {
+    if (!keys) {
       return null;
     }
 
@@ -1044,7 +1044,7 @@ export class EnhancedStateManager extends EventEmitter {
     let latestKey: string | null = null;
     let latestVersion = -1;
 
-    for (const key of Array.from(keys)) {
+    for (const key of keys) {
       const entry = this.storage.get(key);
       if (entry && entry.version > latestVersion) {
         latestVersion = entry.version;


### PR DESCRIPTION
背景\n- #1080 の survivor 対応（importState の versionIndex 算出／findLatestKey 空集合パス）を補強します。\n\n変更\n- importState: exported indices の versionIndex が欠落/先行しているケースを unit test で固定。\n- findLatestKey: 空集合ガード（keys.size===0）を削除し、equivalent mutant を除去。\n- docs: mutation-coverage-plan の #1080 更新（2026-01-23 の測定値を追記）。\n\nログ\n- Mutation Quick（EnhancedStateManager / command runner）\n  - 変更前: score 64.60%（killed 465 / survived 257 / timeout 4 / total 726）\n  - 変更後: score 65.01%（killed 466 / survived 253 / timeout 4 / total 723）\n\nテスト\n- pnpm vitest run tests/unit/utils/enhanced-state-manager.test.ts --reporter dot\n- pnpm vitest run tests/utils/enhanced-state-manager-import-bytes.test.ts --reporter dot\n- STRYKER_TIME_LIMIT=1800 ./scripts/mutation/run-scoped.sh --quick --mutate src/utils/enhanced-state-manager.ts -c configs/stryker.enhanced.config.js -- --force\n\n影響\n- 実行時挙動の変更は意図していません（findLatestKey の早期 return 削除のみ）。\n\nロールバック\n- 本PRの revert で戻せます。\n\n関連Issue\n- #1080