### PR TITLE
ci: fix hermetic pipeline lockfile install

### DIFF
--- a/.github/workflows/hermetic-ci.yml
+++ b/.github/workflows/hermetic-ci.yml
@@ -23,6 +23,9 @@ env:
   NODE_ENV: ci
   CI: true
   DETERMINISTIC_BUILD: true
+  # pnpm lockfile must be enabled for hermetic verification (some runners set these to false).
+  NPM_CONFIG_LOCKFILE: true
+  NPM_CONFIG_USE_LOCKFILE: true
   # Disable analytics and telemetry
   NEXT_TELEMETRY_DISABLED: 1
   NETLIFY_TELEMETRY_DISABLED: 1
@@ -100,7 +103,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [20]
         
     steps:
       - name: Checkout code
@@ -196,7 +199,7 @@ jobs:
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '18'
+          node-version: '20'
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline || pnpm install --no-frozen-lockfile --prefer-offline
@@ -261,7 +264,7 @@ jobs:
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '18'
+          node-version: '20'
           
       - name: Analyze dependency hermeticity
         run: |
@@ -330,7 +333,7 @@ jobs:
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
-          node-version: '18'
+          node-version: '20'
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
背景
- main push の `Hermetic CI/CD Pipeline` が継続的に failure（例: run 21287015576）
- 失敗点: `Dependency Hermetic Analysis` の `pnpm install --frozen-lockfile` が `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` で終了（ログ上 `current configuration prohibits to read or write a lockfile`）

変更
- `.github/workflows/hermetic-ci.yml`
  - Node.js を 18 → 20 に更新（`package.json` engines: `>=20.11 <23` と整合）
  - `NPM_CONFIG_LOCKFILE=true` / `NPM_CONFIG_USE_LOCKFILE=true` を workflow env に追加し、runner 側の設定で lockfile が無効化されても `--frozen-lockfile` が成立するように固定

テスト
- ローカル: `pnpm install --frozen-lockfile --prefer-offline`
- CI: `Hermetic CI/CD Pipeline`（push / PR）で `Dependency Hermetic Analysis` が pass すること

影響
- Hermetic workflow の実行環境が Node 20 ベースになります（既存の `engines` と同一方針）。

ロールバック
- 本PRの revert で戻せます。

関連Issue
- #1005
- #1160
