### PR TITLE
ci: fix hermetic deployment artifact download

### DIFF
--- a/.github/workflows/hermetic-ci.yml
+++ b/.github/workflows/hermetic-ci.yml
@@ -426,7 +426,9 @@ jobs:
           set -euo pipefail
 
           # Expect at least one build artifact directory like hermetic-build/hermetic-build-20/.
-          BUILD_DIR="$(find hermetic-build -maxdepth 1 -mindepth 1 -type d -name 'hermetic-build-*' -print 2>/dev/null | sort | head -n 1 || true)"
+          # If multiple artifacts exist (e.g. when the deterministic build matrix expands),
+          # pick the highest version directory to avoid lexicographic mis-selection.
+          BUILD_DIR="$(find hermetic-build -maxdepth 1 -mindepth 1 -type d -name 'hermetic-build-*' -print 2>/dev/null | sort -V | tail -n 1 || true)"
           if [ -z "${BUILD_DIR:-}" ]; then
             printf "%s\n" "❌ No hermetic-build-* artifact found"
             ls -la hermetic-build || true


### PR DESCRIPTION
## 背景
- main の "Hermetic CI/CD Pipeline" が `Hermetic Deployment Validation` で恒常的に失敗していました（artifact `hermetic-build-18` が存在せず）。
- `Deterministic Build Verification` 側の artifact 名は `hermetic-build-${node-version}` で、現状 Node 20 のため `hermetic-build-20` が生成されます。

## 変更
- `Hermetic Deployment Validation` の artifact 取得を `pattern: hermetic-build-*` に変更し、固定値依存を排除。
- 取得した artifact ディレクトリ（例: `hermetic-build/hermetic-build-20`）を解決して、検証処理が参照するように修正。
- 自動実行は main のみに限定しつつ、`workflow_dispatch` ではブランチ上でも `Hermetic Deployment Validation` を実行できるように調整（事前検証用途）。

## テスト
- workflow_dispatch: 21287940489 (success)

## 影響
- main push 時の hermetic-deployment ジョブが artifact 名の不整合で落ちる問題を解消。

## ロールバック
- 本PRを revert。

## 関連
- #1005
