### PR TITLE
test: prevent global stub leaks (Phase 3)

### DIFF
--- a/docs/testing/mock-fixture-strategy.md
+++ b/docs/testing/mock-fixture-strategy.md
@@ -23,6 +23,10 @@
 
 ## Recommended patterns
 
+### Globals (fetch, timers, etc)
+- Prefer `vi.stubGlobal(...)` over direct assignment (e.g. `globalThis.fetch = ...`).
+- Ensure globals are reverted via `vi.unstubAllGlobals()` (CI test setup does this in `tests/setup/ci-vitest.ts`).
+
 ### Time
 - Use `vi.useFakeTimers()` and `vi.setSystemTime(...)`.
 - Restore timers in `afterEach` to avoid cross-test leakage.

--- a/tests/_setup/afterEach.integration.ts
+++ b/tests/_setup/afterEach.integration.ts
@@ -82,6 +82,7 @@ afterEach(async () => {
 
   vi.restoreAllMocks();
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
   vi.useRealTimers();
 
   const afterHandles = (process as any)['_getActiveHandles']?.().length ?? 0

--- a/tests/integration/integration-cli.test.ts
+++ b/tests/integration/integration-cli.test.ts
@@ -326,9 +326,8 @@ describe('IntegrationTestingCli', () => {
 
     it('should handle watch mode setup', async () => {
       // Mock setInterval to prevent actual watching
-      const originalSetInterval = global.setInterval;
-      const mockSetInterval = vi.fn();
-      global.setInterval = mockSetInterval;
+      const mockSetInterval = vi.fn(() => 0 as any);
+      vi.stubGlobal('setInterval', mockSetInterval);
 
       const command = cli.createCommand();
       const args = ['node', 'cli', 'status', '--watch', '--refresh', '2'];
@@ -338,9 +337,6 @@ describe('IntegrationTestingCli', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Watching test execution status')
       );
-
-      // Restore original
-      global.setInterval = originalSetInterval;
     });
   });
 

--- a/tests/resilience/backoff-strategies.test.ts
+++ b/tests/resilience/backoff-strategies.test.ts
@@ -442,7 +442,7 @@ describe('ResilientHttpClient', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     mockFetch = vi.fn();
-    global.fetch = mockFetch;
+    vi.stubGlobal('fetch', mockFetch);
   });
 
   afterEach(() => {
@@ -662,7 +662,7 @@ describe('Integration Tests', () => {
     });
 
     const mockFetch = vi.fn();
-    global.fetch = mockFetch;
+    vi.stubGlobal('fetch', mockFetch);
 
     // Simulate initial failures followed by recovery
     mockFetch

--- a/tests/setup/ci-vitest.ts
+++ b/tests/setup/ci-vitest.ts
@@ -15,6 +15,11 @@ beforeAll(() => {
 
 afterEach(() => {
   try {
+    vi.unstubAllGlobals();
+  } catch {
+    // ignore: globals may already be real/unstubbed
+  }
+  try {
     vi.useRealTimers();
   } catch {
     // ignore: timers may already be real


### PR DESCRIPTION
背景
- #1005 Phase 3「Comprehensive mocking strategy」の一環として、テスト内でのグローバル差し替え（fetch/setInterval 等）の復元漏れがあると、並列実行時にテスト間干渉/フレーク要因になります。

変更
- `tests/setup/ci-vitest.ts`: `vi.unstubAllGlobals()` を追加し、`vi.stubGlobal(...)` の差し替えを afterEach で確実に復元
- `tests/resilience/backoff-strategies.test.ts`: `global.fetch = ...` を `vi.stubGlobal('fetch', ...)` に変更（復元漏れの解消）
- `tests/integration/integration-cli.test.ts`: `setInterval` 差し替えを `vi.stubGlobal('setInterval', ...)` に変更（手動復元の撤去）
- `tests/_setup/afterEach.integration.ts`: `vi.unstubAllGlobals()` を追加（integration setup 経由でも復元）
- `docs/testing/mock-fixture-strategy.md`: グローバルstubの推奨パターンを追記

ログ/テスト
- Node v22.19.0 / pnpm 10.0.0
- `pnpm vitest run tests/resilience/backoff-strategies.test.ts tests/integration/integration-cli.test.ts`

影響
- テストのグローバル差し替えがテスト間でリークしないことを保証（特に threads pool の並列実行時の干渉低減）

ロールバック
- このPRの変更を revert

関連Issue
- #1005
