### PR TITLE
feat: add formal plan schema scaffold

### DIFF
--- a/docs/guides/FORMAL-PLAN-SCHEMA.md
+++ b/docs/guides/FORMAL-PLAN-SCHEMA.md
@@ -1,0 +1,66 @@
+# Formal Plan Schema (formal.yaml)
+
+This document defines the `formal.yaml` contract exchanged between the **Planning** and **Coding** stages of `ae formal:auto`.
+The YAML format is equivalent to the JSON schema at `schema/formal-plan.schema.json`.
+
+## Purpose
+
+`formal.yaml` captures the planner's structured understanding of the problem:
+- state variables and constants
+- action definitions (Init/Next candidates)
+- invariants and liveness goals
+- assumptions and requirements
+
+The coder uses this contract to emit a TLA+ module skeleton.
+
+## Schema
+
+- **Schema file**: `schema/formal-plan.schema.json`
+- **Fixture**: `fixtures/formal-plan/sample.formal-plan.json`
+
+### Required fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `schemaVersion` | string | Semantic version for the schema (e.g., `0.1.0`). |
+| `metadata` | object | Source and timestamp information. |
+| `variables` | array | State variables with their types. |
+| `actions` | array | Action candidates with TLA+ fragments. |
+| `invariants` | array | Safety properties to enforce. |
+
+### Optional fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `requirements` | array | Natural-language requirements the planner extracted. |
+| `constants` | array | Constants and domain annotations. |
+| `liveness` | array | Liveness properties (`<>`, `[]<>`). |
+| `assumptions` | array | Environmental assumptions and constraints. |
+
+## Example
+
+```json
+{
+  "schemaVersion": "0.1.0",
+  "metadata": {
+    "source": "formalize-planner",
+    "generatedAt": "2026-01-01T00:00:00Z"
+  },
+  "variables": [
+    {"name": "tokens", "type": "Int"},
+    {"name": "capacity", "type": "Int"}
+  ],
+  "actions": [
+    {"name": "Init", "tla": "tokens = 0 /\\ capacity \\in Nat"},
+    {"name": "Refill", "tla": "tokens' = Min(capacity, tokens + 1)"}
+  ],
+  "invariants": [
+    {"name": "CapInvariant", "tla": "tokens <= capacity"}
+  ]
+}
+```
+
+## Validation
+
+The fixture is validated in CI via `scripts/ci/validate-json.mjs`.
+If you edit the schema, update the fixture accordingly.

--- a/fixtures/formal-plan/sample.formal-plan.json
+++ b/fixtures/formal-plan/sample.formal-plan.json
@@ -1,0 +1,66 @@
+{
+  "schemaVersion": "0.1.0",
+  "metadata": {
+    "source": "formalize-planner",
+    "generatedAt": "2026-01-01T00:00:00Z",
+    "model": {
+      "name": "token-bucket",
+      "version": "v0"
+    }
+  },
+  "requirements": [
+    {
+      "id": "REQ-1",
+      "text": "The bucket never exceeds its capacity."
+    }
+  ],
+  "variables": [
+    {
+      "name": "tokens",
+      "type": "Int",
+      "description": "Current token count"
+    },
+    {
+      "name": "capacity",
+      "type": "Int",
+      "description": "Maximum allowed tokens"
+    }
+  ],
+  "constants": [
+    {
+      "name": "MaxCapacity",
+      "type": "Int",
+      "description": "Upper bound for capacity"
+    }
+  ],
+  "actions": [
+    {
+      "name": "Init",
+      "tla": "tokens = 0 /\\ capacity \\in Nat",
+      "description": "Initialize state"
+    },
+    {
+      "name": "Refill",
+      "tla": "tokens' = Min(capacity, tokens + 1)",
+      "description": "Add a token"
+    }
+  ],
+  "invariants": [
+    {
+      "name": "CapInvariant",
+      "tla": "tokens <= capacity"
+    }
+  ],
+  "liveness": [
+    {
+      "name": "EventuallyRefill",
+      "tla": "<> (tokens > 0)"
+    }
+  ],
+  "assumptions": [
+    {
+      "name": "CapacityNonNeg",
+      "tla": "capacity \\in Nat"
+    }
+  ]
+}

--- a/schema/formal-plan.schema.json
+++ b/schema/formal-plan.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/formal-plan.schema.json",
+  "title": "ae-formal-plan",
+  "type": "object",
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+    },
+    "namedFormula": {
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/$defs/identifier" },
+        "tla": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" }
+      },
+      "required": ["name", "tla"],
+      "additionalProperties": true
+    },
+    "variable": {
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/$defs/identifier" },
+        "type": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "domain": { "type": "string" }
+      },
+      "required": ["name", "type"],
+      "additionalProperties": true
+    },
+    "constant": {
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/$defs/identifier" },
+        "type": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "value": { "type": "string" }
+      },
+      "required": ["name", "type"],
+      "additionalProperties": true
+    },
+    "action": {
+      "type": "object",
+      "properties": {
+        "name": { "$ref": "#/$defs/identifier" },
+        "tla": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "preconditions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "effects": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["name", "tla"],
+      "additionalProperties": true
+    },
+    "requirement": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "text": { "type": "string", "minLength": 1 }
+      },
+      "required": ["id", "text"],
+      "additionalProperties": true
+    }
+  },
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "source": { "type": "string" },
+        "generatedAt": { "type": "string", "format": "date-time" },
+        "model": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "version": { "type": "string" }
+          },
+          "required": ["name"],
+          "additionalProperties": true
+        }
+      },
+      "required": ["source", "generatedAt"],
+      "additionalProperties": true
+    },
+    "requirements": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/requirement" }
+    },
+    "variables": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/variable" },
+      "minItems": 1
+    },
+    "constants": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/constant" }
+    },
+    "actions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/action" },
+      "minItems": 1
+    },
+    "invariants": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/namedFormula" },
+      "minItems": 1
+    },
+    "liveness": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/namedFormula" }
+    },
+    "assumptions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/namedFormula" }
+    }
+  },
+  "required": ["schemaVersion", "metadata", "variables", "actions", "invariants"],
+  "additionalProperties": true
+}

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -60,6 +60,11 @@ const checks = [
     schema: 'schema/agentic-metrics.schema.json',
     fixtures: ['fixtures/agentic-metrics/sample.agentic-metrics.json'],
     label: 'Agentic metrics schema validation'
+  },
+  {
+    schema: 'schema/formal-plan.schema.json',
+    fixtures: ['fixtures/formal-plan/sample.formal-plan.json'],
+    label: 'Formal plan schema validation'
   }
 ];
 


### PR DESCRIPTION
背景
- #1066 Autoformalize-TLA+ の最初のタスク（formal.yaml I/O 契約）を前進させるため、スキーマと fixture を追加します。

変更
- `schema/formal-plan.schema.json` を追加（formal.yaml の JSON Schema）
- `fixtures/formal-plan/sample.formal-plan.json` を追加
- `docs/guides/FORMAL-PLAN-SCHEMA.md` を追加
- `scripts/ci/validate-json.mjs` に formal plan の検証を追加

テスト
- `node scripts/ci/validate-json.mjs`

影響
- planner/coder の I/O 仕様を先行で固定。実装は後続 PR で追加予定。

ロールバック
- 本PRのコミットを revert。

関連
- #1066
