### PR TITLE
docs: add research survey summary for #1062

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -13,3 +13,4 @@ ae-framework に関連する理論調査・実証研究・サーベイを集約�
 ## 目次
 
 - [ae-framework-foundation-survey.md](./ae-framework-foundation-survey.md) — AE Framework 基礎調査（Formal Methods × AI）
+- [issue-1062-research-survey.md](./issue-1062-research-survey.md) — 研究サーベイ（Issue #1062 要約）

--- a/docs/research/issue-1062-research-survey.md
+++ b/docs/research/issue-1062-research-survey.md
@@ -2,7 +2,7 @@
 
 ## Snapshot
 - Date: 2026-01-24
-- Source: GitHub Issue #1062
+- Source: [GitHub Issue #1062](https://github.com/itdojp/ae-framework/issues/1062)
 
 ## Goal
 Provide a concise map of relevant research to ae-framework phases and highlight
@@ -12,7 +12,7 @@ adoption or design-modification opportunities.
 
 | Paper | Year/Venue | Phases | Adoption idea | Notes |
 | --- | --- | --- | --- | --- |
-| PAT-Agent | ASE 2025 | Formal, Verify | Planning→Coding→MC→Repair loop | PAT-centric; needs verifier adapter |
+| PAT-Agent | ASE 2025 | Formal, Verify | Planning→Coding→ModelCheck→Repair loop | PAT-centric; needs verifier adapter |
 | TiCoder | FSE 2022 | Intent, Tests, Code | Tests-first intent formalization | Tests alone insufficient |
 | Agentic Programming Survey | 2024 | All | Define metrics: cost/tokens/memory/turns | High-level taxonomy |
 | FormalCoder | 2024 | Formal, Code, Verify | NL→Spec→MC→Code chain | Alloy bias |
@@ -39,11 +39,11 @@ adoption or design-modification opportunities.
 - Unified Verify stage (tests + formal + runtime)
 - Formal plan contract (`formal.yaml`) between Planning/Coding
 
-## Follow-up checklist (from Issue 1062)
+## Follow-up checklist (from Issue 1062, proposed)
 - Docs: phase alignment in README + docs/phases
 - Verifier adapter: TLC/Apalache + unified counterexample JSON
-- Autoformalize: `ae formal:auto`
-- Tests-first default: `ae tests:suggest` + `ae code:rank-by-tests`
-- Autoverify: `ae code:autoverify`
-- Runtime: `verify:conformance` + `ae operate:monitor`
+- Autoformalize (planned CLI): `ae formal:auto`
+- Tests-first default (planned CLI): `ae tests:suggest` + `ae code:rank-by-tests`
+- Autoverify (planned CLI): `ae code:autoverify`
+- Runtime (planned CLI): `verify:conformance` + `ae operate:monitor`
 - Benchmark: req2run metrics extension


### PR DESCRIPTION
## 背景\n#1062 の研究サーベイ内容をリポジトリ内に整理して残す。\n\n## 変更\n- docs/research/issue-1062-research-survey.md を追加\n\n## ログ\n- なし（ドキュメント追加のみ）\n\n## テスト\n- 未実施（ドキュメント追加のみ）\n\n## 影響\n- 実装変更なし。サーベイの要約のみ。\n\n## ロールバック\n- 本PRのコミットをrevert。\n\n## 関連Issue\n- #1062\n- #1160\n