### PR TITLE
docs: update config reference notes (#1006)

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -475,6 +475,8 @@ graph TD
     style P33 fill:#fff8e1
 ```
 
+注記: `tsconfig.json` と `eslint.config.js` は互換用のシムで、実体は `configs/tsconfig/tsconfig.root.json` と `configs/eslint.config.js` に集約済み（PR #1757/#1756）。
+
 ## ファイル・ドキュメント関係図
 
 ```mermaid

--- a/docs/notes/issue-1006-config-inventory.md
+++ b/docs/notes/issue-1006-config-inventory.md
@@ -12,12 +12,12 @@
 | `ae-framework.yml` | Project config (pipeline/runtime) | Keep | Referenced from root by scripts/tools.
 | `ae-framework-v2.yml` | Project config v2 | Keep | Same as above.
 | `ae.config.ts` | AE core config | Keep | Root entry is conventional.
-| `eslint.config.js` | ESLint root config | Keep (short-term) | Already have `configs/eslint.config.js`; consolidate later.
+| `eslint.config.js` | ESLint root config (shim) | Keep (shim) | Canonical config is `configs/eslint.config.js` (PR #1756); root file is compatibility shim.
 | `issues.yaml` | Issue templates/data | Keep | GitHub expects root.
 | `pnpm-lock.yaml` | pnpm lockfile | Keep | Tooling expects root.
 | `pnpm-workspace.yaml` | workspace config | Keep | Tooling expects root.
 | `sample-config.json` | Sample config | Moved | Relocated to `configs/samples/sample-config.json` (PR #1551).
-| `tsconfig.json` | TS base config | Keep | Tooling expects root.
+| `tsconfig.json` | TS base config (shim) | Keep (shim) | Root extends `configs/tsconfig/tsconfig.root.json` (PR #1757) for tooling defaults.
 | `tsconfig.build.json` | TS build config | Moved | Relocated to `configs/tsconfig/tsconfig.build.json` (PR #1544).
 | `tsconfig.types.json` | TS types config | Moved | Relocated to `configs/tsconfig/tsconfig.types.json` (PR #1545).
 | `tsconfig.verify.json` | TS verify config | Moved | Relocated to `configs/tsconfig/tsconfig.verify.json` (PR #1547).

--- a/docs/notes/issue-1006-config-move-plan.md
+++ b/docs/notes/issue-1006-config-move-plan.md
@@ -20,6 +20,7 @@
 configs/
   api-extractor.json
   benchmark-config.json
+  eslint.config.js
   mcp-config.json
   samples/
     sample-config.json
@@ -29,6 +30,7 @@ configs/
   stryker/
     stryker.conf.cjs
   tsconfig/
+    tsconfig.root.json
     tsconfig.build.json
     tsconfig.types.json
     tsconfig.verify.json
@@ -42,6 +44,7 @@ configs/
 | --- | --- | --- | --- | --- |
 | api-extractor.json | configs/api-extractor.json | Update API Extractor invocation | Default path is root; must update scripts. | Done (PR #1534)
 | benchmark-config.json | configs/benchmark-config.json | Update benchmark scripts | Ensure benchmark runner reads new path. | Done (PR #1533)
+| eslint.config.js | configs/eslint.config.js | Consolidate ESLint config | Keep root shim for compatibility. | Done (PR #1756)
 | mcp-config.json | configs/mcp-config.json | Update runtime lookup | Confirm where MCP server reads config. | Done (PR #1543)
 | sample-config.json | configs/samples/sample-config.json | Update references | Defaults updated in PR #1535; file moved in PR #1551. | Done (PR #1551)
 | sample-context.json | configs/samples/sample-context.json | Update references | Defaults updated in PR #1535; file moved in PR #1551. | Done (PR #1551)
@@ -57,9 +60,9 @@ configs/
 - .editorconfig
 - pnpm-lock.yaml
 - pnpm-workspace.yaml
-- tsconfig.json (base)
+- tsconfig.json (shim -> configs/tsconfig/tsconfig.root.json, PR #1757)
 - vitest.config.ts (default lookup)
-- eslint.config.js (until ESLint config consolidation)
+- eslint.config.js (shim -> configs/eslint.config.js, PR #1756)
 - ae-framework.yml / ae-framework-v2.yml / ae.config.ts
 
 ## Migration steps (staged)


### PR DESCRIPTION
## 背景
#1006 の設定ファイル集約（PR #1756/#1757）に合わせて、ドキュメント内の参照を最新化します。

## 変更
- docs/notes/issue-1006-config-inventory.md の ESLint/tsconfig 行を shim 前提に更新
- docs/notes/issue-1006-config-move-plan.md の configs レイアウトと候補移動表を更新
- docs/architecture/ARCHITECTURE.md に tsconfig/eslint の shim 注記を追加

## ログ
- なし

## テスト
- 未実施（ドキュメント更新のみ）

## 影響
- 実行時挙動への影響なし

## ロールバック
- 本 PR のコミットをリバート

## 関連Issue
- #1006