### PR TITLE
ci(formal): consolidate formal aggregate entry

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           path: artifacts_dl
           run-id: ${{ inputs.source_run_id != '' && inputs.source_run_id || github.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN || github.token }}
       - name: Aggregate formal reports
         id: agg
         run: |
@@ -291,7 +291,7 @@ jobs:
         run: |
           node scripts/formal/validate-conformance-summary.mjs || true
       - name: Comment on PR (upsert)
-        if: github.event_name == 'workflow_call' && inputs.pr_number != ''
+        if: (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && inputs.pr_number != ''
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -230,7 +230,7 @@ jobs:
       - verify-smt
       - verify-apalache
       - verify-kani
-    if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || github.event_name == 'workflow_dispatch'
+    if: always() && ((github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/formal-aggregate.yml
     permissions:
       contents: read


### PR DESCRIPTION
## Summary\n- make formal-aggregate reusable and route PR aggregation through formal-verify\n- pass source run id + PR number for artifact download and comment upsert\n- keep manual dispatch by allowing run id input\n\n## Testing\n- not run (workflow change)