### PR TITLE
docs: add CLI entry migration guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ Comprehensive documentation for the AI‑Enhanced Development Framework.
 - Phase 2 Advanced Features (2.1–2.3): `guides/PHASE-2-ADVANCED-FEATURES-GUIDE.md`
 - Advanced Troubleshooting: `guides/ADVANCED-TROUBLESHOOTING-GUIDE.md`
 - General Usage: `guides/USAGE.md`
+- CLI Entry Migration: `guides/CLI-MIGRATION.md`
 - ExecPlan JSON schema: `guides/EXECPLAN-SCHEMA.md`
 
 ### Phases
@@ -93,6 +94,7 @@ ae-frameworkは、AI-Powered TDDによる6フェーズでソフトウェア開�
 - **🆕 [PHASE-2-ADVANCED-FEATURES-GUIDE.md](./guides/PHASE-2-ADVANCED-FEATURES-GUIDE.md)** ⭐ **NEW** - Phase 2.1-2.3統合ガイド
 - **🆕 [ADVANCED-TROUBLESHOOTING-GUIDE.md](./guides/ADVANCED-TROUBLESHOOTING-GUIDE.md)** ⭐ **NEW** - 高度な機能のトラブルシューティング
 - [USAGE.md](./guides/USAGE.md) - 一般的な使い方ガイド
+- [CLI-MIGRATION.md](./guides/CLI-MIGRATION.md) - CLI entry 移行ガイド
 - [test-generation-guide.md](./guides/test-generation-guide.md) - テスト生成ガイド
 - [EXECPLAN-SCHEMA.md](./guides/EXECPLAN-SCHEMA.md) - ExecPlan JSONスキーマ
 

--- a/docs/guides/CLI-MIGRATION.md
+++ b/docs/guides/CLI-MIGRATION.md
@@ -1,0 +1,62 @@
+# CLI Entry Migration Guide (Issue #1006)
+
+This guide documents the migration from legacy `pnpm run` scripts to the consolidated runner entry points and the `ae entry` command.
+
+## Summary
+- Consolidated runners live under `scripts/<category>/run.mjs`.
+- The `ae entry <category>` command routes to those runners.
+- Legacy scripts remain available via alias mapping and emit deprecation warnings.
+
+## What changed
+### New entry runners
+Each category has a unified entry script with a consistent interface:
+
+```
+node scripts/<category>/run.mjs --profile <name> [--list] [--dry-run]
+```
+
+### New CLI routing
+Run the same entry from the CLI without knowing the script path:
+
+```
+ae entry <category> --profile <name> [--list] [--dry-run] [--root <path>]
+```
+
+Use `--root` when invoking from outside the repository. The command switches its working directory to the given root before executing the runner.
+
+### Legacy aliases (still supported)
+Legacy scripts are wired through `scripts/admin/run-script-alias.mjs` and configured in:
+
+- `scripts/admin/script-alias-map.json`
+
+The policy is to keep legacy names for two releases while emitting warnings.
+
+## Quick mapping (legacy -> entry)
+| Legacy script | Replacement |
+| --- | --- |
+| `test:ci` | `ae entry test --profile ci` |
+| `test:ci:lite` | `ae entry test --profile ci-lite` |
+| `test:ci:extended` | `ae entry test --profile ci-extended` |
+| `quality:run:all` | `ae entry quality --profile all` |
+| `quality:gates` | `ae entry quality --profile gates` |
+| `verify:lite` | `ae entry verify --profile lite` |
+| `verify:conformance` | `ae entry verify --profile conformance` |
+| `flake:detect` | `ae entry flake --profile detect` |
+| `flake:detect:quick` | `ae entry flake --profile quick` |
+| `security:integrated:quick` | `ae entry security --profile quick` |
+
+## Examples
+```bash
+# List profiles for a category
+$ ae entry test --list
+
+# Dry-run to see the resolved commands
+$ ae entry verify --dry-run --profile lite
+
+# Run from another directory
+$ ae entry test --profile ci-lite --root /path/to/repo
+```
+
+## Troubleshooting
+- If you see `[script-alias]` warnings, switch to the `ae entry` command shown in the mapping table.
+- If a runner script is missing, confirm you are running from the repository root or pass `--root`.

--- a/docs/guides/USAGE.md
+++ b/docs/guides/USAGE.md
@@ -24,6 +24,10 @@ AE Framework supports software development through the following 6 phases:
 
 Default after intent: run `ae tests:suggest` to generate tests-first prompts before proceeding to later phases.
 
+### CLI Reference
+- Canonical command list: `docs/reference/CLI-COMMANDS-REFERENCE.md`
+- Entry migration guide: `docs/guides/CLI-MIGRATION.md`
+
 ### 🔄 Basic Development Flow
 
 #### Complete Project Example
@@ -405,6 +409,10 @@ console.log('Test results:', executionResult.summary);
 ---
 
 ## Japanese
+
+### CLI リファレンス
+- コマンド一覧: `docs/reference/CLI-COMMANDS-REFERENCE.md`
+- 統一 entry の移行ガイド: `docs/guides/CLI-MIGRATION.md`
 
 **ae-frameworkの全6フェーズエージェントの使用方法と実践例を詳しく説明します**
 

--- a/docs/notes/issue-1006-dx-roadmap.md
+++ b/docs/notes/issue-1006-dx-roadmap.md
@@ -50,7 +50,7 @@
 - [x] alias map を参照し legacy 実行時に警告 + 転送
 - [x] `pnpm run help` のカテゴリ/推奨エントリ表示（既存）
 - [x] 統一 CLI 入口から entry runner へルーティング（`ae entry <category>` で接続）
-- [ ] docs の統一/移行ガイド整備
+- [x] docs の統一/移行ガイド整備（USAGE/CLI reference/CLI-MIGRATION）
 
 ## リスクと対策
 - 互換性: alias による後方互換 + 段階的削除

--- a/docs/reference/CLI-COMMANDS-REFERENCE.md
+++ b/docs/reference/CLI-COMMANDS-REFERENCE.md
@@ -12,6 +12,10 @@
 
 The ae-framework CLI commands support the complete 6-phase software development workflow. Alongside Claude Code Task Tool integration, it provides a command-line environment for developers.
 
+See also:
+- Workflow guide: `docs/guides/USAGE.md`
+- Entry migration guide: `docs/guides/CLI-MIGRATION.md`
+
 ### Basic Syntax
 
 ```bash
@@ -36,6 +40,30 @@ ae-framework <command> [options] [flags]
 --output <file>     # Output file specification
 --no-color          # Disable color output
 ```
+
+## Consolidated Runner Entry (entry)
+Route to the consolidated runner entry points for test/quality/verify/flake/security.
+
+```bash
+# Basic usage
+ae entry <category> --profile <name>
+
+# List available profiles
+ae entry test --list
+
+# Dry-run
+ae entry verify --dry-run --profile lite
+
+# Run from another directory
+ae entry test --profile ci-lite --root /path/to/repo
+```
+
+**Options:**
+- `<category>`: test | quality | verify | flake | security
+- `--profile <name>`: runner profile to execute
+- `--list`: list available profiles
+- `--dry-run`: print resolved commands without executing
+- `--root <path>`: project root (changes working directory)
 
 ## Phase 1: Intent Analysis
 
@@ -154,10 +182,15 @@ ae-framework sbom compare base.json head.json --verbose
 ### 基本構文
 `ae-framework <command> [options] [flags]`
 
+参照:
+- ワークフローガイド: `docs/guides/USAGE.md`
+- 統一 entry 移行ガイド: `docs/guides/CLI-MIGRATION.md`
+
 ### 共通オプション（抜粋）
 `--help/-h`, `--version/-v`, `--config <path>`, `--verbose`, `--quiet`, `--format <json|yaml|table|markdown>`, `--output <file>`
 
 ### フェーズ別コマンド（要点）
+- entry: 統一 runner へのルーティング（test/quality/verify/flake/security）
 - Phase 1: `intent` — 要件/意図分析（`--analyze`, `--validate`, `--sources`）
 - 推奨（Intent直後）: `tests:suggest` — tests-first プロンプト生成（`--template`, `--intent`, `--input`, `--output`）
 - Phase 2: `natural-language` — NL 要件の構造化/検証（`--extract-entities`, `--resolve-ambiguity` など）


### PR DESCRIPTION
## Summary
- add CLI entry migration guide for consolidated runners
- cross-link USAGE/CLI reference and document `ae entry`
- update DX roadmap progress for docs consolidation

## Testing
- not run (docs only)

## Related
- #1006
