### PR TITLE
chore(ci): limit ci-fast/extended to workflow_call

### DIFF
--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -1,5 +1,6 @@
 name: CI Fast
 on:
+  workflow_dispatch:
   workflow_call:
     # Allow release workflow to reuse this fast CI
     inputs:


### PR DESCRIPTION
## Summary
- remove workflow_dispatch from ci-fast.yml and ci-extended.yml
- keep these workflows reusable only, entry remains in ci.yml

## Testing
- not run (workflow change)

## Related
- Issue #1006
- Issue #1160