### PR TITLE
Add MTTR tracking to MetricsCollector

### DIFF
--- a/src/cli/metrics/MetricsCollector.ts
+++ b/src/cli/metrics/MetricsCollector.ts
@@ -219,9 +219,9 @@ export class MetricsCollector {
     const incident: MTTRIncident = {
       id: this.generateSessionId(),
       detectedAt: new Date(),
-      source,
-      message: details.message,
-      severity: details.severity,
+      ...(source ? { source } : {}),
+      ...(details.message ? { message: details.message } : {}),
+      ...(details.severity ? { severity: details.severity } : {}),
     };
 
     this.projectMetrics.incidents.push(incident);


### PR DESCRIPTION
Closes #922

## Summary
- add incident tracking for failure/recovery timestamps
- compute MTTR overall + weekly aggregation in metrics report
- resolve incidents on phase end and on error violations

## Testing
- not run (metrics collector changes only)