### PR TITLE
Add Kiro spec export command

### DIFF
--- a/src/cli/spec-cli.ts
+++ b/src/cli/spec-cli.ts
@@ -199,7 +199,7 @@ export function createSpecCommand(): Command {
         const result = exportKiroSpec({
           inputPath: resolve(options.input),
           format: options.format,
-          outputDir: options.out,
+          outputDir: options.out ? resolve(options.out) : options.out,
           specId: options.specId,
         });
         console.log(chalk.green('✅ Spec export completed'));

--- a/src/cli/spec-exporter.ts
+++ b/src/cli/spec-exporter.ts
@@ -17,13 +17,6 @@ const sanitizeId = (value: string): string =>
     .replace(/^-+|-+$/g, '')
     .slice(0, 64) || 'spec';
 
-const renderList = (items: string[], emptyLabel: string): string[] => {
-  if (!items.length) {
-    return [`- ${emptyLabel}`];
-  }
-  return items.map((item) => `- ${item}`);
-};
-
 const renderUsecases = (usecases?: AEIR['usecases']): string[] => {
   if (!usecases?.length) return ['- (no use cases defined)'];
   return usecases.map((usecase) => {
@@ -47,11 +40,11 @@ const renderApi = (api?: AEIR['api']): string[] => {
 };
 
 const renderDomain = (domain: AEIR['domain']): string[] => {
-  if (!domain?.length) return ['- (no domain entities defined)'];
+  if (!domain.length) return ['- (no domain entities defined)'];
   return domain.map((entity) => {
     const fields = entity.fields.map((field) => `${field.name}:${field.type}`).join(', ');
     const desc = entity.description ? ` - ${entity.description}` : '';
-    return `- ${entity.name}${desc}${fields ? ` (fields: ${fields})` : ''}`;
+    return `- ${entity.name}${fields ? ` (fields: ${fields})` : ''}${desc}`;
   });
 };
 
@@ -139,6 +132,10 @@ const renderTasks = (ir: AEIR): string[] => {
   return lines;
 };
 
+/**
+ * Export AE-IR JSON into Kiro-compatible spec artifacts.
+ * Produces requirements.md, design.md, tasks.md under .kiro/specs/<specId>/ by default.
+ */
 export function exportKiroSpec(options: ExportOptions): { outputDir: string; specId: string; files: string[] } {
   const { inputPath, format, outputDir, specId } = options;
   if (format !== 'kiro') {
@@ -153,7 +150,14 @@ export function exportKiroSpec(options: ExportOptions): { outputDir: string; spe
     throw new Error(`Failed to read AE-IR: ${toMessage(error)}`);
   }
 
-  const derivedId = specId ? sanitizeId(specId) : sanitizeId(ir.metadata?.name ?? 'spec');
+  if (!ir?.metadata?.name) {
+    throw new Error('AE-IR metadata.name is required for export');
+  }
+  if (!Array.isArray(ir.domain)) {
+    throw new Error('AE-IR domain must be an array');
+  }
+
+  const derivedId = specId ? sanitizeId(specId) : sanitizeId(ir.metadata.name);
   const targetDir = outputDir ? outputDir : path.join('.kiro', 'specs', derivedId);
   const now = new Date().toISOString();
 
@@ -163,15 +167,15 @@ export function exportKiroSpec(options: ExportOptions): { outputDir: string; spe
   const requirements = [
     '---',
     `specId: ${derivedId}`,
-    `version: ${ir.metadata?.version ?? '1.0.0'}`,
+    `version: ${ir.metadata.version ?? '1.0.0'}`,
     `generatedAt: ${now}`,
     '---',
     '',
     '# Requirements',
     '',
     '## Overview',
-    `- Name: ${ir.metadata?.name ?? 'unknown'}`,
-    `- Description: ${ir.metadata?.description ?? 'n/a'}`,
+    `- Name: ${ir.metadata.name}`,
+    `- Description: ${ir.metadata.description ?? 'n/a'}`,
     '',
     '## Use Cases',
     ...renderUsecases(ir.usecases),
@@ -211,7 +215,7 @@ export function exportKiroSpec(options: ExportOptions): { outputDir: string; spe
   ];
 
   for (const file of files) {
-    fs.writeFileSync(path.join(targetDir, file.name), file.contents);
+    fs.writeFileSync(path.join(targetDir, file.name), file.contents, 'utf-8');
   }
 
   return { outputDir: targetDir, specId: derivedId, files: files.map((file) => file.name) };


### PR DESCRIPTION
## Summary\n- add Kiro format exporter from AE-IR to requirements/design/tasks\n- add  command with format/out/spec-id options\n- generate .kiro/specs/<spec-id>/ with assets placeholder\n\n## Testing\n- Not run (not requested)\n\nCloses #983