### PR TITLE
docs(ci): add opt-in controls catalog

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -156,7 +156,7 @@ Claude CodeやMCPとの統合
 - [guarded-automation-template.md](./quality/guarded-automation-template.md) - Guarded automation 運用テンプレ
 - [incident-triage-template.md](./quality/incident-triage-template.md) - インシデント一次切り分けテンプレ
 - [adoption-sample-flow.md](./quality/adoption-sample-flow.md) - 導入の最小フロー（エンドツーエンド）
-- [../ci/OPT-IN-CONTROLS.md](../ci/OPT-IN-CONTROLS.md) - opt-in ラベル/Slash のカタログ
+- [./ci/OPT-IN-CONTROLS.md](./ci/OPT-IN-CONTROLS.md) - opt-in ラベル/Slash のカタログ
 - [formal-runbook.md](./quality/formal-runbook.md) - 実行・運用手順（ラベルゲート/手動実行）
 - [formal-tools-setup.md](./quality/formal-tools-setup.md) - ローカル環境セットアップ（Apalache/TLC/Z3/cvc5）
  - [formal-mini-flow.md](./quality/formal-mini-flow.md) - 反例→失敗テスト→修正→緑の最小フロー

--- a/docs/ci/OPT-IN-CONTROLS.md
+++ b/docs/ci/OPT-IN-CONTROLS.md
@@ -43,7 +43,7 @@ PRやIssueで **必要な検証だけを opt-in で起動** し、CIコストと
 ## 4. PR向け Slash コマンド（PRコメント）
 
 > 入口: `.github/workflows/agent-commands.yml`  
-> 権限: PRコメントの `author_association` が trusted の場合に動作
+> 権限: 多くのコマンドは `author_association` 制限なし（ラベル付与型）。`/review` のみ trusted 必須（`MEMBER/OWNER/COLLABORATOR`）。
 
 ### 4.1 主要コマンド
 - `/verify-lite`  
@@ -51,7 +51,7 @@ PRやIssueで **必要な検証だけを opt-in で起動** し、CIコストと
 - `/review [strict]`  
   - verify-lite + ci-fast を dispatch
   - `strict` なら coverage-check を追加 + `enforce-coverage` を付与
-- `/run-qa` / `/run-security` / `/run-cedar` / `/run-resilience` / `/run-spec` / `/run-drift` / `/run-hermetic`  
+- `/run-qa` / `/run-security` / `/run-cedar` / `/run-resilience` / `/run-spec` / `/run-drift` / `/run-hermetic` / `/run-formal`  
   - 対応ラベルを付与し、ラベル条件で各WFを起動
 - `/non-blocking` / `/blocking`  
   - `ci-non-blocking` の付与/解除
@@ -72,13 +72,14 @@ PRやIssueで **必要な検証だけを opt-in で起動** し、CIコストと
 - `/formal-apalache-dispatch`
 - `/run-flake-dispatch`
 - `/spec-validation-dispatch`
+- `/run-cedar-dispatch`
 - `/formal-aggregate-dispatch`
 
 ## 5. Issue向け Slash コマンド（Issueコメント）
 
-> 入口: `.github/workflows/slash-commands.yml`  
-> 権限: `MEMBER/OWNER/COLLABORATOR` のみ  
-> 変数: `AE_SLASH_COMMANDS_ISSUE=1` の場合のみ有効
+> 入口（2系統）:  
+> - `.github/workflows/agent-commands.yml`（常時有効 / `author_association` 制限なし）  
+> - `.github/workflows/slash-commands.yml`（`AE_SLASH_COMMANDS_ISSUE=1` かつ `MEMBER/OWNER/COLLABORATOR` のみ）
 
 - `/start` → `status:in-progress` 付与（commenter をアサイン）
 - `/plan` → Planテンプレコメント


### PR DESCRIPTION
## Summary
- add opt-in controls catalog for PR labels and slash commands
- link the catalog from docs/README.md (EN/JA sections)

## Testing
- not run (docs only)