### PR TITLE
formal: tighten Apalache error keyword boundaries

### DIFF
--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -29,21 +29,21 @@ const ERROR_LINE_CLAMP = Number(process.env.APALACHE_ERROR_LINE_CLAMP || '200');
 const SNIPPET_BEFORE = Number(process.env.APALACHE_SNIPPET_BEFORE || '2');
 const SNIPPET_AFTER = Number(process.env.APALACHE_SNIPPET_AFTER || '2');
 const OUTPUT_CLAMP = Number(process.env.APALACHE_OUTPUT_CLAMP || '4000');
-const ERROR_KEY = /\b(?:error|errors?|fail(?:ed|ure|ures)?|violat(?:e|ed|ion|ions)?|unsat|unsatisfied|unsatisfiable|counter-?examples?|dead[-\s]*lock|dead[-\s]*end)\b/i;
+const ERROR_KEY = /\b(?:error|errors?|fail(?:ed|ure|ures)?|violat(?:e|ed|ion|ions)|unsat|unsatisfied|unsatisfiable|counter-?examples?|dead[-\s]*lock|dead[-\s]*end)\b/i;
 
-function extractErrors(out){
+export function extractErrors(out){
   const lines = (out || '').split(/\r?\n/);
   const picked = [];
   for (const l of lines) { if (ERROR_KEY.test(l)) picked.push(l.trim()); if (picked.length>=ERRORS_LIMIT) break; }
   // Trim very long lines for readability in aggregate comments
   return picked.map(l => l.length > ERROR_LINE_CLAMP ? (l.slice(0, ERROR_LINE_CLAMP) + '…') : l);
 }
-function countErrors(out){
+export function countErrors(out){
   const lines = (out || '').split(/\r?\n/);
   let n = 0; for (const l of lines) if (ERROR_KEY.test(l)) n++;
   return n;
 }
-function extractErrorSnippet(out, before=SNIPPET_BEFORE, after=SNIPPET_AFTER){
+export function extractErrorSnippet(out, before=SNIPPET_BEFORE, after=SNIPPET_AFTER){
   const lines = (out || '').split(/\r?\n/);
   for (let i=0;i<lines.length;i++){
     if (ERROR_KEY.test(lines[i])){

--- a/tests/formal/verify-apalache.error-extraction.test.ts
+++ b/tests/formal/verify-apalache.error-extraction.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { extractErrors, countErrors, extractErrorSnippet } from '../../scripts/formal/verify-apalache.mjs';
+
+describe('verify-apalache error extraction', () => {
+  it('matches full keywords and ignores partial stems', () => {
+    const output = [
+      'Info: ok',
+      'violat',
+      'violation detected',
+      'unsatisfied constraint',
+      'dead end reached',
+      'counter-example found',
+      'error: failure'
+    ].join('\n');
+
+    const errors = extractErrors(output);
+    expect(errors).not.toContain('violat');
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        'violation detected',
+        'unsatisfied constraint',
+        'dead end reached',
+        'counter-example found',
+        'error: failure'
+      ])
+    );
+    expect(countErrors(output)).toBe(5);
+  });
+
+  it('returns a snippet around the first matched line', () => {
+    const output = [
+      'line 1',
+      'line 2',
+      'unsat result',
+      'line 4',
+      'line 5'
+    ].join('\n');
+    const snippet = extractErrorSnippet(output);
+    expect(snippet).not.toBeNull();
+    expect(snippet?.lines).toContain('unsat result');
+  });
+});


### PR DESCRIPTION
## 概要\n- Apalache のエラー抽出語彙を境界付きに調整し、抽出の誤検知を抑制\n\n## 変更点\n- scripts/formal/verify-apalache.mjs の ERROR_KEY 正規表現を境界付きに整理\n\n## 検証\n- 未実施（正規表現の範囲調整のみ）\n\nRefs: #937