### PR TITLE
chore(ci): split quality summary loader

### DIFF
--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -165,7 +165,7 @@ jobs:
               fs.writeFileSync('artifacts/quality/summary.prev.json', match[1]);
               console.log('Loaded previous quality summary');
             }
-            NODE
+          NODE
           fi
       - name: Render quality summary
         env:


### PR DESCRIPTION
## 何が
- quality-gates-centralized の long one-liner を here-doc に分割

## なぜ
- 長行/引用の複雑さを減らし、lint 誤検知のリスクを低減

## どう検証したか
- 未実施（CIで /verify-lite を実行）