### PR TITLE
Fix formal-aggregate workflow dispatch

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -11,9 +11,6 @@ on:
         description: "Pull request number to comment on"
         required: false
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        required: false
   workflow_dispatch:
     inputs:
       source_run_id:


### PR DESCRIPTION
## 概要
- formal-aggregate.yml の workflow_call で予約名 GITHUB_TOKEN を定義していたため、workflow_dispatch が失敗していた問題を修正（secrets 定義を削除）

## 影響
- Formal Verify を workflow_dispatch で起動可能になります

## 関連
- #1880
- #1881