### PR TITLE
Add formal full-run usage documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -165,8 +165,8 @@ Claude CodeやMCPとの統合
 - [adoption-sample-flow.md](./quality/adoption-sample-flow.md) - 導入の最小フロー（エンドツーエンド）
 - [formal-runbook.md](./quality/formal-runbook.md) - 実行・運用手順（ラベルゲート/手動実行）
 - [formal-tools-setup.md](./quality/formal-tools-setup.md) - ローカル環境セットアップ（Apalache/TLC/Z3/cvc5）
- - [formal-full-run.md](./quality/formal-full-run.md) - 全ツールのスモークテスト手順（CI/ローカル）
- - [formal-mini-flow.md](./quality/formal-mini-flow.md) - 反例→失敗テスト→修正→緑の最小フロー
+- [formal-full-run.md](./quality/formal-full-run.md) - 全ツールのスモークテスト手順（CI/ローカル）
+- [formal-mini-flow.md](./quality/formal-mini-flow.md) - 反例→失敗テスト→修正→緑の最小フロー
 
 ### 📐 [spec/](./spec/) - 仕様レジストリ
 仕様の配置と規約

--- a/docs/quality/formal-full-run.md
+++ b/docs/quality/formal-full-run.md
@@ -77,7 +77,7 @@ node scripts/formal/verify-kani.mjs
 
 #### 6) Model check (TLC/Alloy scan)
 ```bash
-npm run verify:model
+pnpm run verify:model
 ```
 
 Outputs:
@@ -160,7 +160,7 @@ node scripts/formal/verify-kani.mjs
 
 #### 6) モデル検査（TLC/Alloy スキャン）
 ```bash
-npm run verify:model
+pnpm run verify:model
 ```
 
 成果物:

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -20,7 +20,7 @@
     - `engine`: tlc|apalache（tla用）
     - `solver`: z3|cvc5（smt用）
     - `alloyJar`: Alloy jar のパス（任意）
-  - `tlaToolsJar`: tla2tools.jar のパス（任意）
+    - `tlaToolsJar`: tla2tools.jar のパス（任意）
 Full smoke test instructions: `docs/quality/formal-full-run.md`.
 
 ### CLI Stubs (to be wired)


### PR DESCRIPTION
## Summary
- add a full-run smoke test guide for all formal tools (CI + local)
- link the guide from formal runbook and docs index

## Testing
- not run (docs only)