### PR TITLE
ci(auto-merge): branch protection aware + per-repo mode

### DIFF
--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -367,4 +367,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
           PR_NUMBER: ${{ inputs.pr_number }}
           ENABLE_AUTO_MERGE: ${{ inputs.enable_auto_merge }}
+          AE_AUTO_MERGE_MODE: ${{ vars.AE_AUTO_MERGE_MODE || 'all' }}
+          AE_AUTO_MERGE_LABEL: ${{ vars.AE_AUTO_MERGE_LABEL || '' }}
         run: node scripts/ci/auto-merge-eligible.mjs


### PR DESCRIPTION
ISSUE #1913 のA( auto-merge 即時化/条件修正 ) の一部を実装。

- ブランチ保護の required PR review を参照し、承認が必須な場合のみ `reviewDecision=APPROVED` を要求
- `AE_AUTO_MERGE_MODE=all|label` と `AE_AUTO_MERGE_LABEL` により全PR対象/ラベルopt-inを選択可能
- `PR_NUMBER` 指定で単一PRのみ評価可能（pull_requestイベントでの負荷削減）
- `.github/workflows/pr-ci-status-comment.yml` の enable-auto-merge を pull_request イベントでも実行（`vars.AE_AUTO_MERGE=1` でガード、forkは除外）
