### PR TITLE
chore(ci): verify-lite emits Formal Summary v1

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -160,7 +160,13 @@ jobs:
           node scripts/formal/verify-kani.mjs || true
           node scripts/formal/presets-apply.mjs || true
           node scripts/formal/aggregate-formal.mjs || true
+          node scripts/formal/generate-formal-summary-v1.mjs --layout hermetic --in artifacts/hermetic-reports --out artifacts/formal/formal-summary-v1.json || true
           node scripts/formal/print-summary.mjs || true
+      - name: Validate formal summary v1 schema (non-blocking)
+        if: ${{ steps.docs-only.outputs.docs_only != 'true' && always() }}
+        continue-on-error: true
+        run: |
+          node scripts/ci/validate-formal-summary-v1.mjs
       - name: Aggregate adapters/formal/properties (non-blocking)
         if: ${{ steps.docs-only.outputs.docs_only != 'true' }}
         continue-on-error: true
@@ -207,7 +213,7 @@ jobs:
         if: ${{ steps.docs-only.outputs.docs_only != 'true' && always() }}
         continue-on-error: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-run-manifest')) }}
         env:
-          RUN_MANIFEST_REQUIRE_FRESH: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-formal')) && 'verifyLite,reportEnvelope,formal' || 'verifyLite,reportEnvelope' }}
+          RUN_MANIFEST_REQUIRE_FRESH: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-formal')) && 'verifyLite,reportEnvelope,formal,formalSummaryV1' || 'verifyLite,reportEnvelope' }}
         run: |
           node scripts/ci/check-run-manifest.mjs \
             --manifest artifacts/run-manifest.json \

--- a/docs/quality/ARTIFACTS-CONTRACT.md
+++ b/docs/quality/ARTIFACTS-CONTRACT.md
@@ -36,7 +36,7 @@ CIが生成する成果物（artifacts/reports）について **最低限の契�
 | --- | --- | --- |
 | `artifacts/hermetic-reports/conformance/summary.json` | conformance 検証を実行した場合 | `verify-conformance.mjs` の出力 |
 | `artifacts/hermetic-reports/formal/summary.json` | formal aggregate を実行した場合 | `aggregate-formal.mjs` の出力 |
-| `artifacts/formal/formal-summary-v1.json` | formal aggregate を実行した場合 | Formal Summary v1（normalized、スキーマ: `schema/formal-summary-v1.schema.json`） |
+| `artifacts/formal/formal-summary-v1.json` | formal aggregate または verify-lite（`run-formal`）を実行した場合 | Formal Summary v1（normalized、スキーマ: `schema/formal-summary-v1.schema.json`） |
 
 ## 4. 検証スクリプト
 

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -86,7 +86,7 @@ Aggregate JSON の軽量検証（非ブロッキング）
 - ローカル確認: `node scripts/formal/validate-aggregate-json.mjs`（存在時に検証、欠損/不正は `::warning::` 出力）
 
 Formal Summary v1（Normalized / 段階導入）
-- 集約ワークフローは `artifacts/formal/formal-summary-v1.json` も出力します（スキーマ: `schema/formal-summary-v1.schema.json`）。
+- 集約ワークフロー（および verify-lite の `run-formal` 実行）は `artifacts/formal/formal-summary-v1.json` を出力します（スキーマ: `schema/formal-summary-v1.schema.json`）。
 - ローカル確認: `node scripts/ci/validate-formal-summary-v1.mjs artifacts/formal/formal-summary-v1.json schema/formal-summary-v1.schema.json`
 - strict（欠損/不正で失敗）: PRラベル `enforce-formal` が付与されている場合、Formal Reports Aggregate 内で v1 を必須検証します。
 - 1行サマリを表示する簡易CLI（ローカル）:

--- a/docs/quality/run-manifest-freshness-contract.md
+++ b/docs/quality/run-manifest-freshness-contract.md
@@ -31,7 +31,7 @@ node scripts/ci/generate-run-manifest.mjs \
 ```bash
 node scripts/ci/check-run-manifest.mjs \
   --manifest artifacts/run-manifest.json \
-  --require-fresh verifyLite,reportEnvelope,formal \
+  --require-fresh verifyLite,reportEnvelope,formal,formalSummaryV1 \
   --result artifacts/run-manifest-check.json
 ```
 
@@ -51,4 +51,3 @@ node scripts/ci/check-run-manifest.mjs \
 - `schema/run-manifest.schema.json`
 - `scripts/ci/generate-run-manifest.mjs`
 - `scripts/ci/check-run-manifest.mjs`
-

--- a/scripts/ci/generate-run-manifest.mjs
+++ b/scripts/ci/generate-run-manifest.mjs
@@ -170,6 +170,7 @@ export function main(argv = process.argv) {
     { name: 'verifyLite', relPath: path.join('artifacts', 'verify-lite', 'verify-lite-run-summary.json') },
     { name: 'reportEnvelope', relPath: path.join('artifacts', 'report-envelope.json') },
     { name: 'formal', relPath: path.join('artifacts', 'hermetic-reports', 'formal', 'summary.json') },
+    { name: 'formalSummaryV1', relPath: path.join('artifacts', 'formal', 'formal-summary-v1.json') },
     { name: 'conformance', relPath: path.join('artifacts', 'hermetic-reports', 'conformance', 'summary.json') },
     { name: 'progress', relPath: path.join('artifacts', 'progress', 'summary.json') },
   ];

--- a/tests/unit/ci/run-manifest.test.ts
+++ b/tests/unit/ci/run-manifest.test.ts
@@ -28,9 +28,11 @@ describe('run-manifest (generate + check)', () => {
 
       const verifyLitePath = join(dir, 'artifacts', 'verify-lite', 'verify-lite-run-summary.json');
       const envelopePath = join(dir, 'artifacts', 'report-envelope.json');
+      const formalSummaryV1Path = join(dir, 'artifacts', 'formal', 'formal-summary-v1.json');
 
       writeJson(verifyLitePath, { metadata: { gitCommit: commit } });
       writeJson(envelopePath, { correlation: { commit } });
+      writeJson(formalSummaryV1Path, { metadata: { gitCommit: commit } });
 
       const gen = runNode(
         dir,
@@ -51,7 +53,7 @@ describe('run-manifest (generate + check)', () => {
       const check = runNode(
         dir,
         checkScript,
-        ['--manifest', 'artifacts/run-manifest.json', '--require-fresh', 'verifyLite,reportEnvelope', '--result', 'artifacts/run-manifest-check.json'],
+        ['--manifest', 'artifacts/run-manifest.json', '--require-fresh', 'verifyLite,reportEnvelope,formalSummaryV1', '--result', 'artifacts/run-manifest-check.json'],
         {},
       );
       expect(check.status).toBe(0);

--- a/tests/unit/formal/generate-formal-summary-v1.test.ts
+++ b/tests/unit/formal/generate-formal-summary-v1.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+const generatorScript = resolve('scripts/formal/generate-formal-summary-v1.mjs');
+
+function writeJson(p: string, data: unknown) {
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, JSON.stringify(data, null, 2), 'utf8');
+}
+
+function runNode(cwd: string, args: string[], env: Record<string, string>) {
+  return spawnSync('node', [generatorScript, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+describe('formal-summary/v1 generator', () => {
+  it('supports hermetic layout inputs', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'formal-summary-v1-'));
+    try {
+      const commit = '0123456789abcdef0123456789abcdef01234567';
+
+      writeJson(join(dir, 'input', 'formal', 'tla-summary.json'), { ran: true, status: 'ran' });
+      writeJson(join(dir, 'input', 'formal', 'alloy-summary.json'), { ok: true, exitCode: 0, timeMs: 10 });
+      writeJson(join(dir, 'input', 'conformance', 'summary.json'), { ok: true, exitCode: 0, timeMs: 5 });
+
+      const out = join(dir, 'out', 'formal-summary-v1.json');
+      const result = runNode(dir, ['--layout', 'hermetic', '--in', 'input', '--out', out], { GIT_COMMIT: commit });
+      expect(result.status).toBe(0);
+
+      const payload = JSON.parse(readFileSync(out, 'utf8'));
+      expect(payload.schemaVersion).toBe('formal-summary/v1');
+      expect(payload.tool).toBe('aggregate');
+      expect(payload.metadata.gitCommit).toBe(commit);
+
+      const names = payload.results.map((r: any) => r.name);
+      expect(names).toEqual(['tla', 'alloy', 'smt', 'apalache', 'conformance', 'kani', 'spin', 'csp', 'lean']);
+
+      const byName = Object.fromEntries(payload.results.map((r: any) => [r.name, r]));
+      expect(byName.alloy.status).toBe('ok');
+      expect(byName.alloy.code).toBe(0);
+      expect(byName.alloy.durationMs).toBe(10);
+
+      expect(byName.conformance.status).toBe('ok');
+      expect(byName.conformance.code).toBe(0);
+      expect(byName.conformance.durationMs).toBe(5);
+
+      // ran without ok flag is normalized to unknown (fact-only)
+      expect(byName.tla.status).toBe('unknown');
+      expect(byName.tla.reason).toBe('ran_without_ok');
+
+      // missing inputs still get an explicit result entry
+      expect(byName.smt.status).toBe('missing');
+      expect(byName.apalache.status).toBe('missing');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+


### PR DESCRIPTION
verify-lite の `run-formal` 実行で Formal Summary v1 を生成し、run-manifest で追跡できるようにします。

- verify-lite(`run-formal`) で `artifacts/hermetic-reports` から `artifacts/formal/formal-summary-v1.json` を生成（`--layout hermetic`）
- run-manifest に `formalSummaryV1` を追加し、`run-formal` 時の freshness 要件に含める
- 関連ドキュメントを更新（Artifacts contract / formal runbook / run-manifest freshness contract）
- unit test 追加（hermetic layout の v1 生成）と run-manifest test 更新
