### PR TITLE
chore(ci): extract formal-aggregate inline script

### DIFF
--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -59,8 +59,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN || github.token }}
       - name: Aggregate formal reports
         id: agg
+        # Requires actions/checkout: runs a repository script.
         run: |
-          node scripts/formal/aggregate-formal-reports.cjs
+          node scripts/formal/aggregate-formal-reports.mjs
       - name: Generate Formal Summary v1 (non-blocking)
         if: always()
         continue-on-error: ${{ inputs.strict_formal_summary_v1 != true }}


### PR DESCRIPTION
`.github/workflows/formal-aggregate.yml` の巨大な inline `node <<'JS'` を、リポジトリ内スクリプトに移動します。

- 変更点: `scripts/formal/aggregate-formal-reports.cjs` を新設し、workflow はそれを呼び出す
- 目的: 保守性/再利用性/差分レビュー性の向上（挙動は維持）
