### PR TITLE
docs(ci): include formal logs in verify-lite-report

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -252,6 +252,10 @@ jobs:
             artifacts/verify-lite/verify-lite-run-summary.json
             artifacts/verify-lite/verify-lite-retry-eligibility.json
             artifacts/report-envelope.json
+            artifacts/formal/formal-summary-v1.json
+            artifacts/hermetic-reports/conformance/summary.json
+            artifacts/hermetic-reports/formal/*.json
+            artifacts/hermetic-reports/formal/*.txt
             artifacts/run-manifest.json
             artifacts/run-manifest-check.json
             verify-lite-run-summary.json

--- a/docs/quality/ARTIFACTS-CONTRACT.md
+++ b/docs/quality/ARTIFACTS-CONTRACT.md
@@ -36,6 +36,7 @@ CIが生成する成果物（artifacts/reports）について **最低限の契�
 | --- | --- | --- |
 | `artifacts/hermetic-reports/conformance/summary.json` | conformance 検証を実行した場合 | `verify-conformance.mjs` の出力 |
 | `artifacts/hermetic-reports/formal/summary.json` | formal aggregate を実行した場合 | `aggregate-formal.mjs` の出力 |
+| `artifacts/hermetic-reports/formal/*-output.txt` | formal verifier を実行した場合 | 各ツールの実行ログ（全文）。Formal Summary v1 の `results[].logPath` から参照される場合があります |
 | `artifacts/formal/formal-summary-v1.json` | formal aggregate または verify-lite（`run-formal`）を実行した場合 | Formal Summary v1（normalized、スキーマ: `schema/formal-summary-v1.schema.json`） |
 
 ## 4. 検証スクリプト

--- a/docs/quality/formal-full-run.md
+++ b/docs/quality/formal-full-run.md
@@ -25,13 +25,13 @@ This guide shows how to run **all formal verification tools** end-to-end for a s
 - `formal-reports` artifact (folder): `artifacts/hermetic-reports/formal/*`
 - `formal-reports-conformance`: `conformance-summary.json`
 - `formal-reports-apalache`: `apalache-summary.json`, `apalache-output.txt`
-- `formal-reports-smt`: `smt-summary.json`
-- `formal-reports-alloy`: `alloy-summary.json`
-- `formal-reports-tla`: `tla-summary.json`
+- `formal-reports-smt`: `smt-summary.json`, `smt-output.txt`
+- `formal-reports-alloy`: `alloy-summary.json`, `alloy-output.txt`
+- `formal-reports-tla`: `tla-summary.json`, `tla-output.txt`
 - `formal-reports-kani`: `kani-summary.json`
-- `formal-reports-spin`: `spin-summary.json`
-- `formal-reports-csp`: `csp-summary.json`, `cspx-result.json`
-- `formal-reports-lean`: `lean-summary.json`
+- `formal-reports-spin`: `spin-summary.json`, `spin-output.txt`
+- `formal-reports-csp`: `csp-summary.json`, `csp-output.txt`, `cspx-result.json`
+- `formal-reports-lean`: `lean-summary.json`, `lean-output.txt`
 - `formal-summary-v1`: `artifacts/formal/formal-summary-v1.json` (normalized)
 
 ### Local (when you want a quick smoke test)

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -74,7 +74,8 @@ Timeout（任意）
 ### Troubleshooting（よくある確認ポイント）
 - PATH: `apalache` または `apalache-mc` が見つからない場合は `node scripts/formal/check-apalache.mjs` で存在/バージョンを確認
 - Timeout: 長時間のログが出続ける場合は `--timeout` を設定し、aggregate コメントの `status: "timeout"` を目安に切り上げ
-- Logs: 生ログは `artifacts/hermetic-reports/formal/apalache-output.txt` に保存（aggregate コメントは長行をトリム/折返し）
+- Logs: 生ログは `artifacts/hermetic-reports/formal/<tool>-output.txt` に保存（例: `apalache-output.txt`, `tla-output.txt`, `smt-output.txt`, `alloy-output.txt`, `spin-output.txt`, `csp-output.txt`, `lean-output.txt`）
+  - Formal Summary v1（`artifacts/formal/formal-summary-v1.json`）の `results[].logPath` は、ログが存在する場合にそのパス（repo-relative）を設定します
 
 Advanced toggles（運用向け）
 - Aggregate wrap 幅: `FORMAL_AGG_WRAP_WIDTH`（0=無効、推奨 80–100）


### PR DESCRIPTION
変更点\n- verify-lite の artifact(verify-lite-report) に formal 成果物を含める: `artifacts/formal/formal-summary-v1.json` / `artifacts/hermetic-reports/formal/*.{json,txt}` / `artifacts/hermetic-reports/conformance/summary.json`（run-formal 実行時のみ生成される想定。欠損は ignore）\n- docs を現状に追随: formal のログ保存先（`<tool>-output.txt`）と Formal Summary v1 の `results[].logPath` を明記\n\n狙い\n- verify-lite で run-formal を回した際、Formal Summary v1 からログへ辿れるようにし、再現/原因調査を容易にする\n\n補足\n- YAML構文は node で parse して確認（actionlintは ghcr.io pull が403で実行不可でした）。