### PR TITLE
docs(formal): add cspx unsupported troubleshooting

### DIFF
--- a/docs/quality/formal-csp.md
+++ b/docs/quality/formal-csp.md
@@ -47,9 +47,9 @@ Notes:
 
 ### Troubleshooting
 
-- If `csp-summary.json` reports `status: "unsupported"` and `csp-output.txt` mentions `unexpected argument '--summary-json'`, your `cspx` is too old (upgrade per `docs/quality/formal-tools-setup.md`, or set `CSP_RUN_CMD`).
+- If `csp-summary.json` reports `status: "unsupported"` and `artifacts/hermetic-reports/formal/csp-output.txt` (or the path in `outputFile`) shows a CLI error about `--summary-json` (for example, messages containing `unexpected argument`, `unknown argument`, or `wasn't expected`), your `cspx` is too old (upgrade per `docs/quality/formal-tools-setup.md`, or set `CSP_RUN_CMD`).
 - If it reports `schema_version mismatch: expected 0.1`, check `cspx-result.json` and align `cspx` to the current contract (`schema_version=0.1`).
-- If `detailsFile` is `null`, `cspx` did not produce a details JSON; inspect `csp-output.txt` for the underlying CLI error.
+- If `detailsFile` is `null`, first verify that `backend` in `csp-summary.json` is `cspx:*`. If `backend` is `cspx:*` and `detailsFile` is `null`, `cspx` did not produce a details JSON; inspect `artifacts/hermetic-reports/formal/csp-output.txt` (or the path in `outputFile`) for the underlying CLI error. For `CSP_RUN_CMD` / `refines` / `cspmchecker` backends, `detailsFile: null` is expected.
 
 ### Run
 
@@ -189,9 +189,9 @@ cspx typecheck --help | grep -- --summary-json
 
 ### トラブルシューティング
 
-- `csp-summary.json` が `status: "unsupported"` かつ `csp-output.txt` に `unexpected argument '--summary-json'` が出る場合、`cspx` が古く互換性がありません（`docs/quality/formal-tools-setup.md` の手順で更新、または `CSP_RUN_CMD` を設定）。
+- `csp-summary.json` の `status` が `"unsupported"` で、`artifacts/hermetic-reports/formal/csp-output.txt`（または `csp-summary.json` の `outputFile`）に `--summary-json` に関する CLI エラー（例: `unexpected argument`, `unknown argument`, `wasn't expected` など）が出る場合、`cspx` が古く互換性がありません（`docs/quality/formal-tools-setup.md` の手順で更新、または `CSP_RUN_CMD` を設定）。
 - `schema_version mismatch: expected 0.1` の場合は `cspx-result.json` の `schema_version` を確認し、現行の契約（`schema_version=0.1`）に合わせて `cspx` を更新してください。
-- `detailsFile` が `null` の場合、`cspx` が details JSON を生成できていません。`csp-output.txt` のCLIエラーを確認してください。
+- `detailsFile` が `null` の場合は、まず `csp-summary.json` の `backend` が `cspx:*` であることを確認してください。`backend` が `cspx:*` かつ `detailsFile` が `null` の場合、`cspx` が details JSON を生成できていません。`artifacts/hermetic-reports/formal/csp-output.txt`（または `outputFile`）の CLI エラーを確認してください（`backend` が `CSP_RUN_CMD` / `refines` / `cspmchecker` の場合、`detailsFile: null` は通常動作です）。
 
 ### 実行方法
 

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -32,7 +32,7 @@ Full smoke test instructions: `docs/quality/formal-full-run.md`.
 - `pnpm run verify:spin` — Promela/SPIN runner
 - `pnpm run verify:csp` — CSP runner（`CSP_RUN_CMD`/`cspx`/`refines`/`cspmchecker`）
   - `cspx` 使用時は `csp-summary.json` と `cspx-result.json` を出力
-  - `schema_version=0.1` 非互換は `status=unsupported` として記録
+  - `schema_version=0.1` 非互換は `status: "unsupported"` として記録
   - Details (artifacts / example outputs): `docs/quality/formal-csp.md`
 - `pnpm run verify:lean` — Lean4 `lake build` runner
 - `pnpm run verify:formal` — 上記の連続実行（ローカル確認用、non-blocking）
@@ -75,8 +75,9 @@ Timeout（任意）
 - PATH: `apalache` または `apalache-mc` が見つからない場合は `node scripts/formal/check-apalache.mjs` で存在/バージョンを確認
 - Timeout: 長時間のログが出続ける場合は `--timeout` を設定し、aggregate コメントの `status: "timeout"` を目安に切り上げ
 - CSP unsupported:
-  - `csp-summary.json` が `status=unsupported` かつ `output` に `--summary-json` のエラーが含まれる場合、`cspx` が古く互換性がありません（`cspx typecheck --help | grep -- --summary-json` で確認し、`docs/quality/formal-tools-setup.md` のピン留め手順で更新）
+  - `artifacts/hermetic-reports/formal/csp-summary.json` の `status` が `"unsupported"` で、`output` または `outputFile`（例: `artifacts/hermetic-reports/formal/csp-output.txt`）に `--summary-json` に関する CLI エラー（例: `unexpected argument`, `unknown argument`, `wasn't expected` 等）が含まれる場合、`cspx` が古く互換性がありません（`cspx typecheck --help | grep -- --summary-json` で確認し、`docs/quality/formal-tools-setup.md` のピン留め手順で更新。代替として `CSP_RUN_CMD` も利用可能）
   - `schema_version mismatch` の場合は `cspx-result.json` の `schema_version` を確認し、現行の契約（`schema_version=0.1`）に合わせて `cspx` を更新してください
+  - 詳細: `docs/quality/formal-csp.md`
 - Logs: 生ログは `artifacts/hermetic-reports/formal/<tool>-output.txt` に保存（例: `apalache-output.txt`, `tla-output.txt`, `smt-output.txt`, `alloy-output.txt`, `spin-output.txt`, `csp-output.txt`, `lean-output.txt`）
   - Formal Summary v1（`artifacts/formal/formal-summary-v1.json`）の `results[].logPath` は、ログが存在する場合にそのパス（repo-relative）を設定します
 


### PR DESCRIPTION
背景
- `verify:csp` 実行時に `status=unsupported` となるケース（cspx の `--summary-json` 非対応 / schema_version 不一致）を、成果物だけで自己診断できるようにしたい。

変更
- `docs/quality/formal-runbook.md` に `CSP unsupported` の確認ポイントを追記。
- `docs/quality/formal-csp.md` に `Troubleshooting/トラブルシューティング` を追加。

影響範囲
- ドキュメントのみ（実装変更なし）。
