### PR TITLE
chore: ignore local generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,19 @@ temp-reports/
 .cache/
 _apalache-out/
 
+# Local generated files (dev/test)
+artifacts/formal/
+test-results/
+test-results-run/
+tmp-gh-event*.json
+generated-*.json
+filtered-test.json
+parallel-test.json
+run-suite.json
+run-test.json
+workflow-test.json
+verify-lite-lint-summary.json
+
 # Generated reports and artifacts
 cegis-report-*.json
 *-report-*.json


### PR DESCRIPTION
目的
- ローカル実行/ワークフローテストで生成される一時ファイルが git status に大量に出て、誤ってコミットされるのを防ぐ

変更
- `.gitignore` に以下を追加
  - `artifacts/formal/`
  - `test-results/`
  - `test-results-run/`
  - `tmp-gh-event*.json`
  - `generated-*.json`
  - `filtered-test.json`
  - `parallel-test.json`
  - `run-suite.json`
  - `run-test.json`
  - `workflow-test.json`
  - `verify-lite-lint-summary.json`

備考
- 既存の追跡ファイルには影響しない（未追跡の生成物のみ対象）