### PR TITLE
fix(formal): ignore Apalache no-error lines

### DIFF
--- a/tests/formal/verify-apalache.error-extraction.test.ts
+++ b/tests/formal/verify-apalache.error-extraction.test.ts
@@ -42,6 +42,25 @@ describe('verify-apalache error extraction', () => {
     expect(extractErrorSnippet(output)).toBeNull();
   });
 
+  it('still reports real errors when success markers are present', () => {
+    const output = [
+      'Checker reports no error up to computation length 10',
+      'violation detected',
+      'The outcome is: NoError'
+    ].join('\n');
+
+    const errors = extractErrors(output);
+    expect(errors).toContain('violation detected');
+    expect(errors).not.toContain('Checker reports no error up to computation length 10');
+    expect(countErrors(output)).toBe(1);
+  });
+
+  it('treats mixed success/error on one line as an error', () => {
+    const output = 'Checker reports no error ... violation detected';
+    expect(extractErrors(output)).toEqual([output]);
+    expect(countErrors(output)).toBe(1);
+  });
+
   it('returns a snippet around the first matched line', () => {
     const output = [
       'line 1',


### PR DESCRIPTION
目的
- Apalache の成功ログ（例: `Checker reports no error`）が `errorCount` に誤計上される問題を修正し、集約コメント/サマリの誤解を減らす

変更
- `scripts/formal/verify-apalache.mjs`
  - `no error` 系の成功マーカーを除外して error 抽出/件数カウント/スニペット対象から外す
  - `Found 0 error(s)` も成功扱いで除外
- `tests/formal/verify-apalache.error-extraction.test.ts`
  - 成功マーカーが errors として扱われないことを追加テスト

備考
- `ok` 判定（`computeOkFromOutput`）のロジック自体は変更しない