### PR TITLE
ci: rerun Copilot Review Gate on auto-fix comment

### DIFF
--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -15,7 +15,10 @@ on:
         type: number
 
 concurrency:
-  group: copilot-review-gate-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref }}
+  group: >-
+    copilot-review-gate-${{ github.event_name == 'issue_comment' && 'issue' || 'pr' }}-${{
+      github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number || github.ref
+    }}
   cancel-in-progress: true
 
 permissions:
@@ -24,10 +27,49 @@ permissions:
   issues: write
 
 jobs:
-  gate:
+  dispatch:
     if: >-
-      github.event_name != 'issue_comment'
-      || (github.event.issue.pull_request && contains(github.event.comment.body, '<!-- AE-COPILOT-AUTO-FIX v1 -->'))
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && contains(github.event.comment.body, '<!-- AE-COPILOT-AUTO-FIX v1 -->')
+      && github.event.comment.user.type == 'Bot'
+      && github.event.comment.user.login == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Dispatch gate run on PR head
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.issue?.number;
+            if (!prNumber) {
+              core.setFailed('Missing PR number in issue_comment payload');
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber
+            });
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: 'copilot-review-gate.yml',
+              ref: pr.head.ref,
+              inputs: { pr_number: String(prNumber) }
+            });
+
+            core.notice(`Dispatched gate for PR #${prNumber} at ${pr.head.ref}`);
+
+  gate:
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     steps:
       - name: Check Copilot review presence and resolution

--- a/docs/ci/copilot-review-gate.md
+++ b/docs/ci/copilot-review-gate.md
@@ -4,7 +4,9 @@
 
 ## 仕組み
 - Workflow: `.github/workflows/copilot-review-gate.yml`
-- トリガー: `pull_request`, `pull_request_review`, `issue_comment`（auto-fix結果コメント更新時）, `workflow_dispatch`
+- トリガー: `pull_request`, `pull_request_review`, `workflow_dispatch`
+- 補助トリガー: `issue_comment`（auto-fix結果コメント `<!-- AE-COPILOT-AUTO-FIX v1 -->` が作成/更新されたとき）
+  - `issue_comment` のランは Required checks を直接更新しないため、PR head の ref に対して `workflow_dispatch` を起動して再評価します
 - 動作: PRのレビュー一覧とレビュー・スレッドをGraphQLで取得
   - Copilot アカウント（`github-copilot` / `github-copilot[bot]`）のレビューが存在するか
   - Copilot が関与したスレッド（コメントを含む）がすべて `isResolved=true` であるか

--- a/docs/ci/pr-automation.md
+++ b/docs/ci/pr-automation.md
@@ -119,7 +119,7 @@ auto-merge（ラベルopt-in）:
 - "Unresolved Copilot review threads"
   - PR上で Resolve conversation
   - auto-fix が commit/push を行わない場合（既適用など）、ゲート再評価が走らないことがあるため、Actions から gate を rerun
-  - auto-fix が動作している場合は、auto-fix の結果コメント更新をトリガーに gate が再実行されます（`issue_comment` 経路）
+  - auto-fix が動作している場合は、auto-fix の結果コメント更新をトリガーに dispatcher が `workflow_dispatch` で gate を PR head に対して再実行します（`issue_comment` -> `workflow_dispatch` 経路）
 
 ### 5.2 Copilot Auto Fix がスキップされる
 


### PR DESCRIPTION
Copilot Auto Fix がスレッドを resolve しても、push が発生しないケース（既適用など）では Copilot Review Gate の再評価が走らず、手動 rerun が必要になることがありました。

このPRでは、auto-fix の結果コメント更新をトリガーに Copilot Review Gate を再実行できるようにし、(2)→(3)→(4省略) の自動化を途切れにくくします。

- `.github/workflows/copilot-review-gate.yml`
  - `issue_comment`（created/edited）を追加
  - ただし auto-fix の結果コメント（`<!-- AE-COPILOT-AUTO-FIX v1 -->`）に限定して実行（ループ/無駄な実行を抑制）
  - `issue_comment` 経路でも PR 番号を解決できるよう github-script を修正
- ドキュメント更新: `docs/ci/pr-automation.md`, `docs/ci/copilot-review-gate.md`

備考: ローカルで `pnpm -s lint:actions` を実行しようとしましたが、`ghcr.io/rhysd/actionlint` のpullが 403 で失敗し、actionlint は実行できませんでした。
