### PR TITLE
docs(ci): clarify gate action_required handling

### DIFF
--- a/docs/ci/ci-troubleshooting-guide.md
+++ b/docs/ci/ci-troubleshooting-guide.md
@@ -25,6 +25,7 @@ Purpose: Provide a short, deterministic path to diagnose common CI failures.
 - Failed job は `ci-auto-rerun-failed` が **1回だけ**自動再実行します（再実行ログを確認）。
 - `pr-ci-status-comment`（PR Maintenance）が behind の PR を自動更新します。競合時は手動解決が必要です。
 - `gateExpected` / `verify-liteExpected` が "Waiting for status to be reported" の場合、auto update で作られたマージコミットにチェックが載っていない可能性があります。対処: PRブランチに空コミットを追加してPRイベントを再発火、またはPR画面から再実行します。恒久策として `AE_AUTO_UPDATE_TOKEN` をSecretsに設定し、auto update の更新コミットから required checks が走るようにします。
+- `Copilot Review Gate` の `pull_request_review` 実行が `action_required` でも、PR head SHA 上の `Copilot Review Gate / gate` が green ならマージ判定としては問題ありません。必要時は `workflow_dispatch`（`pr_number` 指定）で再実行します。
 - GitHub API の 429 / secondary rate limit が出る場合、Actions の rerun を優先します。必要に応じて `AE_GH_THROTTLE_MS` と `AE_GH_RETRY_*` を調整します（詳細: `docs/ci/pr-automation.md` / 実装: `scripts/ci/lib/gh-exec.mjs`）。
 
 ## References

--- a/docs/ci/copilot-review-gate.md
+++ b/docs/ci/copilot-review-gate.md
@@ -41,6 +41,7 @@
 - Copilotレビューが「コメント」のみで「レビュー」として表示されない場合は、Copilotレビューの起動方法を見直してください（PR画面のCopilotパネルからの実行を推奨）。
 - スレッドが解決にならない場合、PR画面で各会話の「Resolve conversation」を押すか、対応コメントを行ってから解決してください。
 - Copilot Auto Fix がスレッドを resolve しても、変更が push されない場合（既適用など）は、ゲートの再評価が走らないことがあります。Actions から `Copilot Review Gate` を再実行してください。
+- `pull_request_review` 経路の実行が `action_required` になる場合があります。最終判定は PR の `Copilot Review Gate / gate` が PR head SHA で green かどうかで確認してください（必要なら `workflow_dispatch` で `pr_number` を指定して再実行）。
 - ゲートが検出しない場合、`COPILOT_ACTORS` の一覧に実際のアカウント名が含まれているか確認してください。
 - fork PR では Actions がコメントを投稿できないため、ゲートはコメントを残さず `notice` のみ出力します（判定自体は実行されます）。
 - Required checks が `Expected — Waiting for status to be reported` のまま止まる場合は、branch protection に登録したチェック名が実際のジョブ名と一致しているか、PR条件でワークフローが実行されているかを確認してください。

--- a/docs/ci/pr-automation.md
+++ b/docs/ci/pr-automation.md
@@ -120,6 +120,9 @@ auto-merge（ラベルopt-in）:
   - PR上で Resolve conversation
   - auto-fix が commit/push を行わない場合（既適用など）、ゲート再評価が走らないことがあるため、Actions から gate を rerun
   - auto-fix が動作している場合は、auto-fix の結果コメント更新をトリガーに Copilot Review Gate の `dispatch` job（issue_comment→workflow_dispatch）が gate を PR head に対して再実行します（`issue_comment` -> `workflow_dispatch` 経路）
+- "pull_request_review run is action_required"
+  - `pull_request_review` 経路の実行が `action_required` になる場合があります
+  - 最終判定は PR の `Copilot Review Gate / gate` が PR head SHA で green かどうかで確認し、必要なら `workflow_dispatch`（`pr_number` 指定）で再実行
 
 ### 5.2 Copilot Auto Fix がスキップされる
 


### PR DESCRIPTION
- Clarify how to interpret `pull_request_review` runs that appear as `action_required` for Copilot Review Gate.
- Add operational rule: final merge judgment is based on `Copilot Review Gate / gate` on the PR head SHA.
- Fix clear broken links in active docs:
  - `docs/integrations/README.md` (`CLI-INTEGRATION-GUIDE.md` -> `../reference/CLI-COMMANDS-REFERENCE.md`)
  - `docs/getting-started/SETUP.md` (`./USAGE.md` -> `../guides/USAGE.md`)
  - `docs/ci-test-optimization.md` (non-existent testing links -> existing testing docs)
