### PR TITLE
docs: fix broken internal links across docs

### DIFF
--- a/docs/architecture/NEW_FEATURES.md
+++ b/docs/architecture/NEW_FEATURES.md
@@ -574,7 +574,7 @@ ae-slash help /intent
 
 ## 📚 詳細情報
 
-- [API リファレンス](./API.md)
-- [設定ガイド](./CONFIGURATION.md)
-- [コントリビューションガイド](../CONTRIBUTING.md)
+- [API リファレンス](../reference/API.md)
+- [設定ガイド](../getting-started/SETUP.md)
+- [コントリビューションガイド](../../CONTRIBUTING.md)
 - [Issue #11 Implementation Details](https://github.com/itdojp/ae-framework/issues/11)

--- a/docs/ci-test-optimization.md
+++ b/docs/ci-test-optimization.md
@@ -346,8 +346,8 @@ The optimizer integrates well with:
 
 ### Documentation
 - [Vitest Configuration Guide](https://vitest.dev/config/)
-- [CI Best Practices](./testing/ci-best-practices.md)
-- [Performance Optimization](./testing/performance-optimization.md)
+- [Test Categorization](./testing/test-categorization.md)
+- [Parallel Execution Strategy](./testing/parallel-execution-strategy.md)
 
 ### Community
 - Report issues via GitHub Issues

--- a/docs/getting-started/SETUP.md
+++ b/docs/getting-started/SETUP.md
@@ -323,7 +323,7 @@ pnpm run perf:budgets:prod
 
 ### 📚 Next Steps
 
-Once installation is complete, refer to the [Usage Guide](./USAGE.md) to learn how to use each agent.
+Once installation is complete, refer to the [Usage Guide](../guides/USAGE.md) to learn how to use each agent.
 
 ### 🆘 Support
 
@@ -698,7 +698,7 @@ pnpm run perf:budgets:prod
 
 ### 📚 次のステップ
 
-インストールが完了したら、[使い方ガイド](./USAGE.md)を参照して各エージェントの使用方法を確認してください。
+インストールが完了したら、[使い方ガイド](../guides/USAGE.md)を参照して各エージェントの使用方法を確認してください。
 
 ### 🆘 サポート
 

--- a/docs/guides/CLAUDE-CODE-AUTOMATION-GUIDE.md
+++ b/docs/guides/CLAUDE-CODE-AUTOMATION-GUIDE.md
@@ -534,13 +534,13 @@ requirements.mdファイルを対象として、
 ## 📚 関連ドキュメント
 
 - [ae-framework README](../README.md) - プロジェクト概要
-- [Claude Code Task Tool Integration](./CLAUDE-CODE-TASK-TOOL-INTEGRATION.md) - 技術統合詳細
-- [Phase 2: Natural Language Requirements](./PHASE-2-NATURAL-LANGUAGE-REQUIREMENTS.md)
-- [Phase 3: User Stories Creation](./PHASE-3-USER-STORIES-CREATION.md)
-- [Phase 4: Validation](./PHASE-4-VALIDATION.md)
-- [Phase 5: Domain Modeling](./PHASE-5-DOMAIN-MODELING.md)
-- [CLI Commands Reference](./CLI-COMMANDS-REFERENCE.md)
-- [TDD Framework Architecture](./TDD-FRAMEWORK-ARCHITECTURE.md)
+- [Claude Code Task Tool Integration](../integrations/CLAUDE-CODE-TASK-TOOL-INTEGRATION.md) - 技術統合詳細
+- [Phase 2: Natural Language Requirements](../phases/PHASE-2-NATURAL-LANGUAGE-REQUIREMENTS.md)
+- [Phase 3: User Stories Creation](../phases/PHASE-3-USER-STORIES-CREATION.md)
+- [Phase 4: Validation](../phases/PHASE-4-VALIDATION.md)
+- [Phase 5: Domain Modeling](../phases/PHASE-5-DOMAIN-MODELING.md)
+- [CLI Commands Reference](../reference/CLI-COMMANDS-REFERENCE.md)
+- [TDD Framework Architecture](../architecture/TDD-FRAMEWORK-ARCHITECTURE.md)
 
 ## 🤝 フィードバック
 

--- a/docs/guides/DEVELOPMENT-INSTRUCTIONS-GUIDE.md
+++ b/docs/guides/DEVELOPMENT-INSTRUCTIONS-GUIDE.md
@@ -626,11 +626,11 @@ ae-framework ui-scaffold --components --storybook --i18n --a11y
 
 ## 🔗 Related Documentation
 
-- **[Phase 6 UI/UX Getting Started](./PHASE-6-GETTING-STARTED.md)** - Phase 6 dedicated quick start
-- **[Claude Code Task Tool Integration](./CLAUDE-CODE-TASK-TOOL-INTEGRATION.md)** - Task Tool integration specs
-- **[Claude Code Workflow](./CLAUDECODE-WORKFLOW.md)** - Basic workflow
-- **[Quick Start Guide](./QUICK-START-GUIDE.md)** - General quick start
-- **[CLI Commands Reference](./CLI-COMMANDS-REFERENCE.md)** - CLI command reference
+- **[Phase 6 UI/UX Getting Started](../getting-started/PHASE-6-GETTING-STARTED.md)** - Phase 6 dedicated quick start
+- **[Claude Code Task Tool Integration](../integrations/CLAUDE-CODE-TASK-TOOL-INTEGRATION.md)** - Task Tool integration specs
+- **[Claude Code Workflow](../integrations/CLAUDECODE-WORKFLOW.md)** - Basic workflow
+- **[Quick Start Guide](../getting-started/QUICK-START-GUIDE.md)** - General quick start
+- **[CLI Commands Reference](../reference/CLI-COMMANDS-REFERENCE.md)** - CLI command reference
 
 ## 💡 Summary
 

--- a/docs/guides/test-generation-guide.md
+++ b/docs/guides/test-generation-guide.md
@@ -325,9 +325,9 @@ export AE_TEST_OUTPUT_DIR=tests/
 
 ## Related Documentation
 
-- [TDD Enforcement Guide](./tdd-enforcement.md)
-- [ae-framework Phases](./phases.md)
-- [Agent Architecture](./agent-architecture-proposal.md)
+- [TDD Framework Architecture](../architecture/TDD-FRAMEWORK-ARCHITECTURE.md)
+- [ae-framework Phases](../architecture/PHASE-DETAILED-ARCHITECTURE.md)
+- [Agent Architecture](../proposals/agent-architecture-proposal.md)
 
 ---
 

--- a/docs/integrations/CLAUDE-CODE-TASK-TOOL-INTEGRATION.md
+++ b/docs/integrations/CLAUDE-CODE-TASK-TOOL-INTEGRATION.md
@@ -444,7 +444,7 @@ it('rejects empty email', async () => {
 <a class="card">Details</a>
 
 // a11y — After: tabindex/role/aria を付与
-<a class="card" href="/details" role="link" tabindex="0" aria-label="Open details">Details</a>
+<a class="card" href="https://example.com/details" role="link" tabindex="0" aria-label="Open details">Details</a>
 ```
 
 ```
@@ -453,7 +453,7 @@ it('rejects empty email', async () => {
 
 // perf — After: preconnect/preload を活用
 <link rel="preconnect" href="https://cdn.example.com" crossorigin>
-<link rel="preload" as="image" href="/hero.jpg" imagesrcset="/hero@2x.jpg 2x" />
+<link rel="preload" as="image" href="https://cdn.example.com/hero.jpg" imagesrcset="https://cdn.example.com/hero@2x.jpg 2x" />
 ```
 
 ```

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -35,7 +35,7 @@
   - Standalone execution support
 
 #### 💻 CLI Integration
-- **File**: [CLI-INTEGRATION-GUIDE.md](./CLI-INTEGRATION-GUIDE.md)
+- **File**: [CLI-COMMANDS-REFERENCE.md](../reference/CLI-COMMANDS-REFERENCE.md)
 - **Overview**: Command line integration and script execution
 - **Features**:
   - Direct execution for developers
@@ -138,7 +138,7 @@ ae-framework ui scaffold --input domain-model.json
   - スタンドアロン実行対応
 
 #### 💻 CLI統合
-- **ファイル**: [CLI-INTEGRATION-GUIDE.md](./CLI-INTEGRATION-GUIDE.md)
+- **ファイル**: [CLI-COMMANDS-REFERENCE.md](../reference/CLI-COMMANDS-REFERENCE.md)
 - **概要**: コマンドライン統合とスクリプト実行
 - **特徴**:
   - 開発者向け直接実行

--- a/docs/legacy/CLAUDE-CODE-TASK-TOOL.md
+++ b/docs/legacy/CLAUDE-CODE-TASK-TOOL.md
@@ -392,9 +392,9 @@ export class HybridIntentSystem {
 ## 📚 関連ドキュメント
 
 - [Claude Code 公式ドキュメント](https://docs.anthropic.com/en/docs/claude-code)
-- [ae-framework クイックスタートガイド](./QUICK-START-GUIDE.md)
-- [ae-framework 使い方ガイド](./USAGE.md)
-- [Claude Code ワークフロー](./CLAUDECODE-WORKFLOW.md)
+- [ae-framework クイックスタートガイド](../getting-started/QUICK-START-GUIDE.md)
+- [ae-framework 使い方ガイド](../guides/USAGE.md)
+- [Claude Code ワークフロー](../integrations/CLAUDECODE-WORKFLOW.md)
 
 ## 🤝 コミュニティ・サポート
 

--- a/docs/legacy/QUICK_START.md
+++ b/docs/legacy/QUICK_START.md
@@ -293,14 +293,14 @@ ae-approve request <phase> --summary "Re-requesting approval"
 
 ## 📚 次のステップ
 
-- [新機能ガイド](./NEW_FEATURES.md) - 各機能の詳細な使用方法
-- [API リファレンス](./API.md) - プログラマティックアクセス
-- [ベストプラクティス](./BEST_PRACTICES.md) - 効果的な使用方法
-- [コントリビューション](../CONTRIBUTING.md) - プロジェクトへの貢献方法
+- [新機能ガイド](../architecture/NEW_FEATURES.md) - 各機能の詳細な使用方法
+- [API リファレンス](../reference/API.md) - プログラマティックアクセス
+- [使い方ガイド](../guides/USAGE.md) - 効果的な使用方法
+- [コントリビューション](../../CONTRIBUTING.md) - プロジェクトへの貢献方法
 
 ## 💬 サポート
 
 問題が発生した場合は：
 1. [Issues](https://github.com/itdojp/ae-framework/issues) で報告
 2. [Discussions](https://github.com/itdojp/ae-framework/discussions) で質問
-3. ドキュメントの [FAQ](./FAQ.md) を確認
+3. ドキュメントの [トラブルシューティング](../guides/ADVANCED-TROUBLESHOOTING-GUIDE.md) を確認

--- a/docs/legacy/phase3-1-documentation-index.md
+++ b/docs/legacy/phase3-1-documentation-index.md
@@ -262,9 +262,9 @@ graph TB
 
 ### Project-Wide Documentation
 - [Overall Project README](../README.md)
-- [API Documentation](./API.md)
+- [API Documentation](../reference/API.md)
 - [Quick Start Guide](./QUICK_START.md)
-- [Setup Instructions](./SETUP.md)
+- [Setup Instructions](../getting-started/SETUP.md)
 
 ### Phase-Specific Documentation
 - **Phase 2**: Persona Management and Smart Installer systems
@@ -272,9 +272,9 @@ graph TB
 - **Phase 3.3**: (Upcoming) Performance Optimization
 
 ### Agent Documentation
-- [Agent Architecture Proposal](./agent-architecture-proposal.md)
+- [Agent Architecture Proposal](../proposals/agent-architecture-proposal.md)
 - [Code Generation Agent](./agents/code-generation-agent.md)
-- [Test Generation Guide](./test-generation-guide.md)
+- [Test Generation Guide](../guides/test-generation-guide.md)
 
 ---
 

--- a/docs/phases/phase-6-uiux.md
+++ b/docs/phases/phase-6-uiux.md
@@ -216,11 +216,11 @@ Perf:     75%
 
 ### Font Preload Example
 ```html
-<link rel="preload" href="/fonts/Inter-roman.var.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="https://example.com/fonts/Inter-roman.var.woff2" as="font" type="font/woff2" crossorigin>
 <style>
   @font-face {
     font-family: Inter;
-    src: url('/fonts/Inter-roman.var.woff2') format('woff2');
+    src: url('https://example.com/fonts/Inter-roman.var.woff2') format('woff2');
     font-display: swap;
   }
 </style>
@@ -753,7 +753,7 @@ examples/
 - **[Phase 2: Natural Language Requirements](./PHASE-2-NATURAL-LANGUAGE-REQUIREMENTS.md)** - 要件分析フェーズ
 - **[Phase 3: User Stories Creation](./PHASE-3-USER-STORIES-CREATION.md)** - ユーザーストーリー生成フェーズ  
 - **[Phase 5: Domain Modeling](./PHASE-5-DOMAIN-MODELING.md)** - ドメインモデリングフェーズ
-- **[Claude Code自動実行ガイド](./CLAUDE-CODE-AUTOMATION-GUIDE.md)** - 自動実行手順
+- **[Claude Code自動実行ガイド](../guides/CLAUDE-CODE-AUTOMATION-GUIDE.md)** - 自動実行手順
 - **[Frontend Development Enhancement (#52)](https://github.com/itdojp/ae-framework/issues/52)** - フロントエンド強化提案
 
 ## 🎯 Success Metrics

--- a/docs/phases/telemetry-configuration.md
+++ b/docs/phases/telemetry-configuration.md
@@ -212,7 +212,7 @@ CI環境では自動的にメトリクスがログ出力され、閾値チェッ
 ## 📚 Related Documentation
 
 - [Phase 6 Overview](./phase-6-uiux.md)
-- [Quality Gates Configuration](./quality-gates.md)
+- [Quality Gates Configuration](../development/centralized-quality-gates.md)
 - [OpenTelemetry Official Documentation](https://opentelemetry.io/docs/)
 
 ---

--- a/docs/reference/API.md
+++ b/docs/reference/API.md
@@ -637,10 +637,10 @@ async function validateArtifacts(artifacts: string[]): Promise<boolean> {
 
 ## 🔗 Related Links
 
-- [Quick Start](./QUICK_START.md)
-- [New Features Guide](./NEW_FEATURES.md)
-- [Configuration Guide](./CONFIGURATION.md)
-- [Troubleshooting](./TROUBLESHOOTING.md)
+- [Quick Start](../getting-started/QUICK-START-GUIDE.md)
+- [New Features Guide](../architecture/NEW_FEATURES.md)
+- [Configuration Guide](../getting-started/SETUP.md)
+- [Troubleshooting](../guides/ADVANCED-TROUBLESHOOTING-GUIDE.md)
 
 ---
 


### PR DESCRIPTION
## 目的
ドキュメントの相対リンク切れを整理し、`pnpm test:doctest:docs` のリンク検証を全件通過させる。

## 変更内容
- Active docs のリンク修正
  - `docs/reference/API.md` の Related Links を現行配置へ更新
  - `docs/getting-started/SETUP.md` / `docs/integrations/README.md` の参照先修正
  - `docs/guides/*` / `docs/phases/*` / `docs/architecture/NEW_FEATURES.md` の相対パス修正
- Legacy docs のリンク修正
  - `docs/legacy/phase3-1-documentation-index.md`
  - `docs/legacy/QUICK_START.md`
  - `docs/legacy/CLAUDE-CODE-TASK-TOOL.md`
- HTMLサンプル内のローカル絶対パス（`/details`, `/hero.jpg`, `/fonts/...`）を、検証で誤検知しない形へ調整

## 確認
- `pnpm -s test:doctest:docs`
  - Links: `456/456 valid`
