### PR TITLE
ci: add default gh throttle to reduce API 429s

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -40,7 +40,7 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           AE_COPILOT_AUTO_FIX_SCOPE: ${{ vars.AE_COPILOT_AUTO_FIX_SCOPE || 'docs' }}
           AE_COPILOT_AUTO_FIX_LABEL: ${{ vars.AE_COPILOT_AUTO_FIX_LABEL || '' }}
-          AE_GH_THROTTLE_MS: ${{ vars.AE_GH_THROTTLE_MS || '0' }}
+          AE_GH_THROTTLE_MS: ${{ vars.AE_GH_THROTTLE_MS || '250' }}
           AE_GH_RETRY_MAX_ATTEMPTS: ${{ vars.AE_GH_RETRY_MAX_ATTEMPTS || '' }}
           AE_GH_RETRY_INITIAL_DELAY_MS: ${{ vars.AE_GH_RETRY_INITIAL_DELAY_MS || '' }}
           AE_GH_RETRY_MAX_DELAY_MS: ${{ vars.AE_GH_RETRY_MAX_DELAY_MS || '' }}

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -328,7 +328,7 @@ jobs:
       - name: Post CI status summary
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
-          AE_GH_THROTTLE_MS: ${{ vars.AE_GH_THROTTLE_MS || '0' }}
+          AE_GH_THROTTLE_MS: ${{ vars.AE_GH_THROTTLE_MS || '250' }}
           AE_GH_RETRY_MAX_ATTEMPTS: ${{ vars.AE_GH_RETRY_MAX_ATTEMPTS || '' }}
           AE_GH_RETRY_INITIAL_DELAY_MS: ${{ vars.AE_GH_RETRY_INITIAL_DELAY_MS || '' }}
           AE_GH_RETRY_MAX_DELAY_MS: ${{ vars.AE_GH_RETRY_MAX_DELAY_MS || '' }}
@@ -353,7 +353,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           AE_AUTO_MERGE_MODE: ${{ vars.AE_AUTO_MERGE_MODE || 'all' }}
           AE_AUTO_MERGE_LABEL: ${{ vars.AE_AUTO_MERGE_LABEL || '' }}
-          AE_GH_THROTTLE_MS: ${{ vars.AE_GH_THROTTLE_MS || '0' }}
+          AE_GH_THROTTLE_MS: ${{ vars.AE_GH_THROTTLE_MS || '250' }}
           AE_GH_RETRY_MAX_ATTEMPTS: ${{ vars.AE_GH_RETRY_MAX_ATTEMPTS || '' }}
           AE_GH_RETRY_INITIAL_DELAY_MS: ${{ vars.AE_GH_RETRY_INITIAL_DELAY_MS || '' }}
           AE_GH_RETRY_MAX_DELAY_MS: ${{ vars.AE_GH_RETRY_MAX_DELAY_MS || '' }}
@@ -379,7 +379,7 @@ jobs:
           ENABLE_AUTO_MERGE: ${{ inputs.enable_auto_merge }}
           AE_AUTO_MERGE_MODE: ${{ vars.AE_AUTO_MERGE_MODE || 'all' }}
           AE_AUTO_MERGE_LABEL: ${{ vars.AE_AUTO_MERGE_LABEL || '' }}
-          AE_GH_THROTTLE_MS: ${{ vars.AE_GH_THROTTLE_MS || '0' }}
+          AE_GH_THROTTLE_MS: ${{ vars.AE_GH_THROTTLE_MS || '250' }}
           AE_GH_RETRY_MAX_ATTEMPTS: ${{ vars.AE_GH_RETRY_MAX_ATTEMPTS || '' }}
           AE_GH_RETRY_INITIAL_DELAY_MS: ${{ vars.AE_GH_RETRY_INITIAL_DELAY_MS || '' }}
           AE_GH_RETRY_MAX_DELAY_MS: ${{ vars.AE_GH_RETRY_MAX_DELAY_MS || '' }}

--- a/docs/ci/OPT-IN-CONTROLS.md
+++ b/docs/ci/OPT-IN-CONTROLS.md
@@ -55,7 +55,7 @@ GitHub API の 429 / secondary rate limit が出る場合は、以下の Reposit
 
 | 変数 | 役割 | 既定 | 詳細 |
 | --- | --- | --- | --- |
-| `AE_GH_THROTTLE_MS` | `gh` 呼び出し間の最小間隔（ms） | `0` | `docs/ci/pr-automation.md` |
+| `AE_GH_THROTTLE_MS` | `gh` 呼び出し間の最小間隔（ms） | `250`（`0`で無効化） | `docs/ci/pr-automation.md` |
 | `AE_GH_RETRY_MAX_ATTEMPTS` | 最大試行回数（初回実行を含む） | `8` | `docs/ci/pr-automation.md` |
 | `AE_GH_RETRY_INITIAL_DELAY_MS` | retry初期待ち（ms） | `750` | `docs/ci/pr-automation.md` |
 | `AE_GH_RETRY_MAX_DELAY_MS` | retry最大待ち（ms） | `60000` | `docs/ci/pr-automation.md` |

--- a/docs/ci/ci-troubleshooting-guide.md
+++ b/docs/ci/ci-troubleshooting-guide.md
@@ -26,7 +26,7 @@ Purpose: Provide a short, deterministic path to diagnose common CI failures.
 - `pr-ci-status-comment`（PR Maintenance）が behind の PR を自動更新します。競合時は手動解決が必要です。
 - `gateExpected` / `verify-liteExpected` が "Waiting for status to be reported" の場合、auto update で作られたマージコミットにチェックが載っていない可能性があります。対処: PRブランチに空コミットを追加してPRイベントを再発火、またはPR画面から再実行します。恒久策として `AE_AUTO_UPDATE_TOKEN` をSecretsに設定し、auto update の更新コミットから required checks が走るようにします。
 - `Copilot Review Gate` の `pull_request_review` 実行が `action_required` でも、PR head SHA 上の `Copilot Review Gate / gate` が green ならマージ判定としては問題ありません。必要時は `workflow_dispatch`（`pr_number` 指定）で再実行します。
-- GitHub API の 429 / secondary rate limit が出る場合、Actions の rerun を優先します。必要に応じて `AE_GH_THROTTLE_MS` と `AE_GH_RETRY_*` を調整します（詳細: `docs/ci/pr-automation.md` / 実装: `scripts/ci/lib/gh-exec.mjs`）。
+- GitHub API の 429 / secondary rate limit が出る場合、Actions の rerun を優先します。`AE_GH_THROTTLE_MS` の既定は `250`（`0` で無効化）で、必要に応じて `AE_GH_RETRY_*` と合わせて調整します（詳細: `docs/ci/pr-automation.md` / 実装: `scripts/ci/lib/gh-exec.mjs`）。
 
 ## References
 - `docs/ci/ci-baseline-checklist.md`

--- a/docs/ci/pr-automation.md
+++ b/docs/ci/pr-automation.md
@@ -148,7 +148,7 @@ auto-merge（ラベルopt-in）:
 - `AE_GH_RETRY_MAX_ATTEMPTS`（既定 8）
 - `AE_GH_RETRY_INITIAL_DELAY_MS`（既定 750）
 - `AE_GH_RETRY_MAX_DELAY_MS`（既定 60000）
-- `AE_GH_THROTTLE_MS`（既定 0。`gh` 呼び出し間の最小間隔ms）
+- `AE_GH_THROTTLE_MS`（既定 250。`gh` 呼び出し間の最小間隔ms。`0` で無効化）
 - `AE_GH_RETRY_DEBUG=1`（retryログ出力）
 - `AE_GH_RETRY_NO_SLEEP=1`（テスト用途: sleep無効）
 

--- a/scripts/ci/lib/gh-exec.mjs
+++ b/scripts/ci/lib/gh-exec.mjs
@@ -3,7 +3,8 @@ import { execFileSync } from 'node:child_process';
 const DEFAULT_MAX_ATTEMPTS = 8;
 const DEFAULT_INITIAL_DELAY_MS = 750;
 const DEFAULT_MAX_DELAY_MS = 60_000;
-const DEFAULT_THROTTLE_MS = 0;
+// Add a small default spacing between gh calls to reduce secondary rate-limit bursts.
+const DEFAULT_THROTTLE_MS = 250;
 
 let lastGhInvocationAtMs = 0;
 

--- a/tests/unit/ci/gh-exec.test.ts
+++ b/tests/unit/ci/gh-exec.test.ts
@@ -5,6 +5,7 @@ const baseEnv = {
   AE_GH_RETRY_MAX_ATTEMPTS: process.env.AE_GH_RETRY_MAX_ATTEMPTS,
   AE_GH_RETRY_INITIAL_DELAY_MS: process.env.AE_GH_RETRY_INITIAL_DELAY_MS,
   AE_GH_RETRY_MAX_DELAY_MS: process.env.AE_GH_RETRY_MAX_DELAY_MS,
+  AE_GH_THROTTLE_MS: process.env.AE_GH_THROTTLE_MS,
 };
 
 const resetEnv = () => {


### PR DESCRIPTION
## 目的
GitHub API の secondary rate limit（HTTP 429）による CI 停止を減らすため、`gh` 呼び出しの既定スロットリングを導入する。

## 変更内容
- `scripts/ci/lib/gh-exec.mjs`
  - `AE_GH_THROTTLE_MS` の既定値を `0` -> `250` に変更（`0` 指定で無効化可能）。
- `.github/workflows/copilot-auto-fix.yml`
- `.github/workflows/pr-ci-status-comment.yml`
  - `AE_GH_THROTTLE_MS` の workflow 側既定値を `250` に変更。
- docs 更新
  - `docs/ci/pr-automation.md`
  - `docs/ci/OPT-IN-CONTROLS.md`
  - `docs/ci/ci-troubleshooting-guide.md`
- test 更新
  - `tests/unit/ci/gh-exec.test.ts` に `AE_GH_THROTTLE_MS` の環境復元対象を追加。

## 検証
- ✅ `pnpm -s vitest run tests/unit/ci/gh-exec.test.ts`
- ⚠️ `pnpm -s lint:actions` は `ghcr.io/rhysd/actionlint:latest` pull 時に 403 で実行不可（環境制約）
