### PR TITLE
docs(ci): add rerun guidance for stale gate failures

### DIFF
--- a/docs/ci/ci-troubleshooting-guide.md
+++ b/docs/ci/ci-troubleshooting-guide.md
@@ -26,7 +26,7 @@ Purpose: Provide a short, deterministic path to diagnose common CI failures.
 - `pr-ci-status-comment`（PR Maintenance）が behind の PR を自動更新します。競合時は手動解決が必要です。
 - `gateExpected` / `verify-liteExpected` が "Waiting for status to be reported" の場合、auto update で作られたマージコミットにチェックが載っていない可能性があります。対処: PRブランチに空コミットを追加してPRイベントを再発火、またはPR画面から再実行します。恒久策として `AE_AUTO_UPDATE_TOKEN` をSecretsに設定し、auto update の更新コミットから required checks が走るようにします。
 - `Copilot Review Gate` の `pull_request_review` 実行が `action_required` でも、PR head SHA 上の `Copilot Review Gate / gate` が green ならマージ判定としては問題ありません。必要時は `workflow_dispatch`（`pr_number` 指定）で再実行します。
-- `Copilot Review Gate / gate` が success/failure 混在のまま残る場合は、失敗した gate ランを rerun します（`gh run rerun <run-id> --failed`）。
+- `Copilot Review Gate / gate` が success/failure 混在のまま残る場合は、失敗した `Copilot Review Gate` ランを rerun します（`gh run rerun <runId> --failed`）。
 - GitHub API の 429 / secondary rate limit が出る場合、Actions の rerun を優先します。`AE_GH_THROTTLE_MS` の既定は `250`（`0` で無効化）で、必要に応じて `AE_GH_RETRY_*` と合わせて調整します（詳細: `docs/ci/pr-automation.md` / 実装: `scripts/ci/lib/gh-exec.mjs`）。
 - `pnpm run lint:actions` で `ghcr.io/rhysd/actionlint` pull が 403 の場合、`ACTIONLINT_BIN` でローカルバイナリを指定できます（例: `ACTIONLINT_BIN=/usr/local/bin/actionlint pnpm run lint:actions`）。
 

--- a/docs/ci/copilot-review-gate.md
+++ b/docs/ci/copilot-review-gate.md
@@ -42,7 +42,7 @@
 - スレッドが解決にならない場合、PR画面で各会話の「Resolve conversation」を押すか、対応コメントを行ってから解決してください。
 - Copilot Auto Fix がスレッドを resolve しても、変更が push されない場合（既適用など）は、ゲートの再評価が走らないことがあります。Actions から `Copilot Review Gate` を再実行してください。
 - `pull_request_review` 経路の実行が `action_required` になる場合があります。最終判定は PR の `Copilot Review Gate / gate` が PR head SHA で green かどうかで確認してください（必要なら `workflow_dispatch` で `pr_number` を指定して再実行）。
-- `Copilot Review Gate / gate` が同一 head SHA で success/failure 混在になった場合は、失敗した gate run を再実行してください（Actions UI または `gh run rerun <run-id> --failed`）。最新 head SHA の check-runs を優先して判定します。
+- `Copilot Review Gate / gate` が同一 head SHA で success/failure 混在になった場合は、失敗した `Copilot Review Gate` の workflow run を再実行してください（Actions UI または `gh run rerun <runId> --failed`）。最新 head SHA の check-runs を優先して判定します。
 - ゲートが検出しない場合、`COPILOT_ACTORS` の一覧に実際のアカウント名が含まれているか確認してください。
 - fork PR では Actions がコメントを投稿できないため、ゲートはコメントを残さず `notice` のみ出力します（判定自体は実行されます）。
 - Required checks が `Expected — Waiting for status to be reported` のまま止まる場合は、branch protection に登録したチェック名が実際のジョブ名と一致しているか、PR条件でワークフローが実行されているかを確認してください。

--- a/docs/ci/pr-automation.md
+++ b/docs/ci/pr-automation.md
@@ -124,7 +124,7 @@ auto-merge（ラベルopt-in）:
   - `pull_request_review` 経路の実行が `action_required` になる場合があります
   - 最終判定は PR の `Copilot Review Gate / gate` が PR head SHA で green かどうかで確認し、必要なら `workflow_dispatch`（`pr_number` 指定）で再実行
 - "Copilot Review Gate / gate が success/failure 混在で残る"
-  - 同一 head SHA 上で `gate` の success と failure が混在した場合、失敗した `Copilot Review Gate` ランを `rerun failed jobs` で再実行してください（CLI例: `gh run rerun <run-id> --failed`）
+  - 同一 head SHA 上で `gate` の success と failure が混在した場合、失敗した `Copilot Review Gate` ランを `Re-run failed jobs` で再実行してください（CLI例: `gh run rerun <runId> --failed`）
   - head SHA 単位で check-runs を確認し、最新 SHA 上の `gate` を基準に判定してください
 
 ### 5.2 Copilot Auto Fix がスキップされる


### PR DESCRIPTION
## 目的
Copilot Review Gate で同一 head SHA に success/failure が混在した際の対処手順を明確化し、運用停止を減らす。

## 変更内容
- `docs/ci/copilot-review-gate.md`
  - troubleshooting に「失敗 gate run の rerun」手順を追記
- `docs/ci/pr-automation.md`
  - 5.1 に success/failure 混在時の手順を追記
- `docs/ci/ci-troubleshooting-guide.md`
  - automation notes に rerun 手順を追記

## 補足
本PRはドキュメント更新のみです。
