### PR TITLE
docs(ci): refresh heavy-test alerting status and todos

### DIFF
--- a/docs/ci/heavy-test-alerts.md
+++ b/docs/ci/heavy-test-alerts.md
@@ -23,9 +23,9 @@
 1. `render-heavy-trend-summary.mjs` に閾値判定オプションを追加し、Markdown 出力内に :warning:/:rotating_light: を埋め込む。
 2. Warning 以上の項目が存在する場合は Slack Webhook（`ci-extended.yml` スケジュール実行に追加済み）でメッセージ送信。
 3. Critical 判定時は GitHub Issue（`flaky-test` ラベル）を自動作成し、関連ログ／アーティファクトへのリンクを添付。
-4. PR 上で手動 rerun を行う際も同スクリプトを実行し、Step Summary に判定結果を表示する。
+4. スケジュール実行（または `workflow_dispatch` で `trigger=schedule` 指定時）に同スクリプトを実行し、Step Summary に判定結果を表示する（通常の PR rerun では実行されない）。
 
-### Critical 判定時の Issue 起票案
+### Critical 判定時の Issue 起票（現行実装）
 - 作成先: `itdojp/ae-framework` / labels: `flaky-test`, `ci-stability`, `needs-investigation`
 - タイトル例: `[CI Extended] Heavy test critical alert - mutation score < 96`
 - 本文テンプレート:
@@ -34,8 +34,8 @@
   - Workflow: ${{ github.workflow }} (run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
   - Severity: critical
   - Snapshot: <timestamp>
-  - Summary: heavy-test-trends-history/summary.md
-  - JSON: heavy-test-trends-history/summary.json
+  - Summary: reports/heavy-test-trends-history/summary.md
+  - JSON: reports/heavy-test-trends-history/summary.json
 
   ## Next Steps
   - [ ] Download artifacts and inspect mutation/property/MBT outputs
@@ -55,7 +55,7 @@
 - 閾値は初期案。実データに基づき 2〜3 週間運用した後に見直す。
 - false positive を避けるため、`Δ` 判定は 2 回連続で閾値を下回った場合にエスカレーションするモードも検討する。
 - Slack 通知は深夜帯（JST）に偏るため、通知チャンネルのサイレンス設定を確認する。
-- Issue 起票時には関連する `heavy-test-trends-history/<timestamp>.json` と `summary.md`、該当 run の URL を必ず添付する。
+- Issue 起票時には関連する `reports/heavy-test-trends-history/<timestamp>.json` と `reports/heavy-test-trends-history/summary.md`、該当 run の URL を必ず添付する。
 
 ## TODO
 - [x] `render-heavy-trend-summary.mjs` への閾値オプション追加


### PR DESCRIPTION
## 目的
`docs/ci/heavy-test-alerts.md` の記述を現行実装（`ci-extended.yml`）に合わせ、重複・古い表現を整理する。

## 変更内容
- 通知フロー見出しを「案」から「現行実装」へ更新
- 重複していた通知フロー手順を削除
- Issue 起票手順の記載を「実装済み」に更新
- 実装状況チェックリストを追加し、未完タスクを閾値リファインに集約
- TODO を現状に合わせて更新

## 影響範囲
- ドキュメントのみ（コード/ワークフローの挙動変更なし）
