### PR TITLE
docs(readme): docs 配下 README の相対参照を修正

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -84,7 +84,7 @@ Comprehensive documentation for the agentic SDLC orchestrator & spec/verificatio
 - Verify-first artifacts catalog: `quality/verify-first-artifacts-catalog.md`
 - Verify-first implementation runbook: `quality/verify-first-implementation-runbook.md`
 - Adoption sample flow: `quality/adoption-sample-flow.md`
-- Runbooks / Traceability / Runtime Contracts: see `docs/quality` and `docs/verify`
+- Runbooks / Traceability / Runtime Contracts: see `./quality` and `./verify`
  - Coverage policy: `quality/coverage-policy.md`（しきい値の由来/Required化の運用）
  - Formal runbook: `quality/formal-runbook.md`（ラベル/dispatch/要約/環境変数）
  - CSP verification (cspx runner): `quality/formal-csp.md`（使い方/成果物/実行結果例）


### PR DESCRIPTION
## 背景
Issue #1985 対応です。`docs/README.md` に `docs/` 配下文書としては誤解を招く相対参照（`docs/quality`, `docs/verify`）がありました。

## 変更内容
- `docs/README.md`
  - `Runbooks / Traceability / Runtime Contracts: see \`docs/quality\` and \`docs/verify\``
  - を `./quality` / `./verify` に修正

## 影響
- `docs/docs/...` の誤認を防止
- ドキュメント探索時の混乱を削減

## 関連
- Closes #1985
