### PR TITLE
docs(cli): circuit-breaker health の使用例を実装に合わせる

### DIFF
--- a/docs/reference/CLI-COMMANDS-REFERENCE.md
+++ b/docs/reference/CLI-COMMANDS-REFERENCE.md
@@ -253,7 +253,7 @@ ae setup list
  ae circuit-breaker create --name demo
  ae circuit-breaker list
  ae circuit-breaker stats --name demo
- ae circuit-breaker health --name demo
+ ae circuit-breaker health
 ```
 
 ### Other Utilities
@@ -466,7 +466,7 @@ ae resilience create --name default
 ae circuit-breaker create --name demo
  ae circuit-breaker list
  ae circuit-breaker stats --name demo
- ae circuit-breaker health --name demo
+ ae circuit-breaker health
 ```
 
 ### ベンチマーク（Req2Run）


### PR DESCRIPTION
## 背景
`docs/reference/CLI-COMMANDS-REFERENCE.md` の使用例で `ae circuit-breaker health --name demo` を記載していましたが、現行CLI実装の `health` サブコマンドは `--name` を受け取りません。

## 変更内容
- `docs/reference/CLI-COMMANDS-REFERENCE.md` の2箇所を修正
  - `ae circuit-breaker health --name demo`
  - → `ae circuit-breaker health`

## 影響
- ドキュメントと実装の不整合を解消
- 実行時の誤操作を防止

