### PR TITLE
refactor: remove any from test generation agent

### DIFF
--- a/src/agents/test-generation-agent.ts
+++ b/src/agents/test-generation-agent.ts
@@ -620,8 +620,7 @@ export class TestGenerationAgent {
     }));
   }
 
-  private generateE2ETests(architecture: IntegrationArchitecture): IntegrationPlannedTest[] {
-    void architecture;
+  private generateE2ETests(_architecture: IntegrationArchitecture): IntegrationPlannedTest[] {
     return [
       {
         name: 'End-to-end flow test',
@@ -704,8 +703,7 @@ export class TestGenerationAgent {
     };
   }
 
-  private generateFuzzingTest(endpoint: SecurityEndpoint): TestCase {
-    void endpoint;
+  private generateFuzzingTest(_endpoint: SecurityEndpoint): TestCase {
     return {
       name: 'Fuzzing Test',
       type: 'unit',


### PR DESCRIPTION
## 概要
- `src/agents/test-generation-agent.ts` の `any` を型定義へ置換
- Property/Integration/Security/Performance の入力契約を interface/type に集約
- 補助メソッドの引数・戻り値を明示型へ更新

## 変更詳細
- `PropertyTestContract` / `IntegrationArchitecture` / `SecurityEndpoint` / `PerformanceSLA` などを追加
- `generateImports` のマップ参照を `Record<TestGenerationRequest['testFramework'], string>` に変更
- XSS判定ロジックを `isStringEndpointInput` で型安全に分離
- `IntegrationTestPlan.phases[].tests` を `IntegrationPlannedTest[]` に強化

## 検証
- `pnpm -s run types:check`
- `pnpm -s vitest run tests/commands/slash-command-manager.test.ts`

Related to #2031
