### PR TITLE
ci: enforce root layout and required artifacts in verify-lite

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -32,6 +32,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # Intentional: run before docs-only detection to fail fast on root pollution
+      # regardless of PR change scope.
       - name: Enforce root layout policy
         run: node scripts/ci/check-root-layout.mjs
       - name: Detect docs-only change

--- a/docs/ci/pr-automation.md
+++ b/docs/ci/pr-automation.md
@@ -83,7 +83,7 @@ PR運用を以下の形に収束させます。
 ### 3.1 推奨導入順（手戻りを減らす）
 
 1. Branch protection で Required checks を整備（最小: `Verify Lite / verify-lite` + `Copilot Review Gate / gate`）
-   - `verify-lite` は root layout 検査と required artifacts 検査を必須で実行します（非 docs-only 変更）
+   - `verify-lite` は root layout 検査を全PRで必須実行し、required artifacts 検査を非 docs-only 変更で必須実行します
 2. `AE_AUTOMATION_PROFILE=conservative` で docs領域 + label opt-in から段階導入
 3. 問題がなければ `balanced` / `aggressive` へ拡張
 4. 必要時のみ個別変数で上書き


### PR DESCRIPTION
## 概要
Issue #2031 の Phase 3（PRゲート強化）として、`verify-lite` に root layout 検査と required artifacts 検査を必須化しました。

## 変更内容
- `.github/workflows/verify-lite.yml`
  - `Enforce root layout policy` を追加（`node scripts/ci/check-root-layout.mjs`）
  - `Check required artifacts` を常時 strict 化（`REQUIRED_ARTIFACTS_STRICT='1'`）
  - `continue-on-error` のラベル依存を削除
- `docs/ci/pr-automation.md`
  - `verify-lite` が root layout / required artifacts を必須実行する旨を追記

## 目的
- レイアウト違反検知を Required check に統合（Phase 3: レイアウト違反検知を必須化）
- 生成物検証を Required check で fail-open させない（Phase 3: 生成物混入防止チェックを必須化）

## 検証
- `pnpm -s vitest run tests/unit/ci/check-root-layout.test.ts tests/unit/ci/run-manifest.test.ts`
- `pnpm -s run types:check`
