### PR TITLE
refactor: split code-generation agent type definitions

### DIFF
--- a/src/agents/code-generation-agent.ts
+++ b/src/agents/code-generation-agent.ts
@@ -7,95 +7,39 @@ import type { readFileSync, existsSync, writeFileSync } from 'fs';
 import type { execSync } from 'child_process';
 import * as path from 'path';
 
-export interface CodeGenerationRequest {
-  tests: TestFile[];
-  specifications?: Specification;
-  architecture?: ArchitecturePattern;
-  language: 'typescript' | 'javascript' | 'python' | 'go' | 'rust' | 'elixir';
-  framework?: string;
-  style?: CodingStyle;
-}
+import type {
+  CodeGenerationRequest,
+  TestFile,
+  ArchitecturePattern,
+  GeneratedCode,
+  CodeFile,
+  ProjectStructure,
+  TestResult,
+  TestAnalysis,
+  DatabaseSchema,
+  Table,
+  Column,
+  PerformanceImprovement,
+  Benchmark,
+  RefactoringChange,
+  CodeMetrics,
+} from './code-generation-agent.types.js';
 
-export interface TestFile {
-  path: string;
-  content: string;
-  type: 'unit' | 'integration' | 'e2e';
-}
-
-export interface Specification {
-  openapi?: string;
-  tla?: string;
-  contracts?: Contract[];
-  requirements?: string[];
-}
-
-export interface Contract {
-  name: string;
-  preconditions: string[];
-  postconditions: string[];
-  invariants: string[];
-}
-
-export interface ArchitecturePattern {
-  pattern: 'mvc' | 'hexagonal' | 'clean' | 'ddd' | 'microservice';
-  layers?: Layer[];
-  dependencies?: Dependency[];
-}
-
-export interface Layer {
-  name: string;
-  responsibilities: string[];
-  allowedDependencies: string[];
-}
-
-export interface Dependency {
-  from: string;
-  to: string;
-  type: 'uses' | 'implements' | 'extends';
-}
-
-export interface CodingStyle {
-  naming: 'camelCase' | 'snake_case' | 'PascalCase';
-  indentation: 'spaces' | 'tabs';
-  indentSize?: number;
-  maxLineLength?: number;
-  preferConst?: boolean;
-  preferArrowFunctions?: boolean;
-}
-
-export interface GeneratedCode {
-  files: CodeFile[];
-  structure: ProjectStructure;
-  dependencies: string[];
-  testResults: TestResult[];
-  coverage: number;
-  suggestions: string[];
-}
-
-export interface CodeFile {
-  path: string;
-  content: string;
-  purpose: string;
-  tests: string[];
-}
-
-export interface ProjectStructure {
-  directories: string[];
-  entryPoint: string;
-  configFiles: ConfigFile[];
-}
-
-export interface ConfigFile {
-  name: string;
-  content: string;
-  purpose: string;
-}
-
-export interface TestResult {
-  test: string;
-  status: 'passing' | 'failing' | 'pending';
-  error?: string;
-}
+export type {
+  CodeGenerationRequest,
+  TestFile,
+  Specification,
+  Contract,
+  ArchitecturePattern,
+  Layer,
+  Dependency,
+  CodingStyle,
+  GeneratedCode,
+  CodeFile,
+  ProjectStructure,
+  ConfigFile,
+  TestResult,
+} from './code-generation-agent.types.js';
 
 export class CodeGenerationAgent {
   /**
@@ -1311,67 +1255,3 @@ export class ${table.name} {
   }
 }
 
-// Type definitions
-interface TestAnalysis {
-  functions: string[];
-  classes: string[];
-  expectedBehaviors: string[];
-}
-
-interface DatabaseSchema {
-  tables: Table[];
-  relations: Relation[];
-}
-
-interface Table {
-  name: string;
-  columns: Column[];
-  indexes: Index[];
-}
-
-interface Column {
-  name: string;
-  type: string;
-  nullable: boolean;
-  primary?: boolean;
-  unique?: boolean;
-}
-
-interface Index {
-  name: string;
-  columns: string[];
-  unique: boolean;
-}
-
-interface Relation {
-  from: string;
-  to: string;
-  type: 'one-to-one' | 'one-to-many' | 'many-to-many';
-}
-
-interface PerformanceImprovement {
-  location: string;
-  type: string;
-  description: string;
-  impact: 'high' | 'medium' | 'low';
-}
-
-interface Benchmark {
-  name: string;
-  before: number;
-  after: number;
-  improvement: number;
-}
-
-interface RefactoringChange {
-  type: string;
-  location: string;
-  description: string;
-}
-
-interface CodeMetrics {
-  complexity: number;
-  maintainability: number;
-  duplication: number;
-  testCoverage: number;
-}

--- a/src/agents/code-generation-agent.types.ts
+++ b/src/agents/code-generation-agent.types.ts
@@ -1,0 +1,159 @@
+/**
+ * Code Generation Agent type definitions
+ * Extracted to keep implementation focused and reviewable.
+ */
+
+export interface CodeGenerationRequest {
+  tests: TestFile[];
+  specifications?: Specification;
+  architecture?: ArchitecturePattern;
+  language: 'typescript' | 'javascript' | 'python' | 'go' | 'rust' | 'elixir';
+  framework?: string;
+  style?: CodingStyle;
+}
+
+export interface TestFile {
+  path: string;
+  content: string;
+  type: 'unit' | 'integration' | 'e2e';
+}
+
+export interface Specification {
+  openapi?: string;
+  tla?: string;
+  contracts?: Contract[];
+  requirements?: string[];
+}
+
+export interface Contract {
+  name: string;
+  preconditions: string[];
+  postconditions: string[];
+  invariants: string[];
+}
+
+export interface ArchitecturePattern {
+  pattern: 'mvc' | 'hexagonal' | 'clean' | 'ddd' | 'microservice';
+  layers?: Layer[];
+  dependencies?: Dependency[];
+}
+
+export interface Layer {
+  name: string;
+  responsibilities: string[];
+  allowedDependencies: string[];
+}
+
+export interface Dependency {
+  from: string;
+  to: string;
+  type: 'uses' | 'implements' | 'extends';
+}
+
+export interface CodingStyle {
+  naming: 'camelCase' | 'snake_case' | 'PascalCase';
+  indentation: 'spaces' | 'tabs';
+  indentSize?: number;
+  maxLineLength?: number;
+  preferConst?: boolean;
+  preferArrowFunctions?: boolean;
+}
+
+export interface GeneratedCode {
+  files: CodeFile[];
+  structure: ProjectStructure;
+  dependencies: string[];
+  testResults: TestResult[];
+  coverage: number;
+  suggestions: string[];
+}
+
+export interface CodeFile {
+  path: string;
+  content: string;
+  purpose: string;
+  tests: string[];
+}
+
+export interface ProjectStructure {
+  directories: string[];
+  entryPoint: string;
+  configFiles: ConfigFile[];
+}
+
+export interface ConfigFile {
+  name: string;
+  content: string;
+  purpose: string;
+}
+
+export interface TestResult {
+  test: string;
+  status: 'passing' | 'failing' | 'pending';
+  error?: string;
+}
+
+
+export interface TestAnalysis {
+  functions: string[];
+  classes: string[];
+  expectedBehaviors: string[];
+}
+
+export interface DatabaseSchema {
+  tables: Table[];
+  relations: Relation[];
+}
+
+export interface Table {
+  name: string;
+  columns: Column[];
+  indexes: Index[];
+}
+
+export interface Column {
+  name: string;
+  type: string;
+  nullable: boolean;
+  primary?: boolean;
+  unique?: boolean;
+}
+
+export interface Index {
+  name: string;
+  columns: string[];
+  unique: boolean;
+}
+
+export interface Relation {
+  from: string;
+  to: string;
+  type: 'one-to-one' | 'one-to-many' | 'many-to-many';
+}
+
+export interface PerformanceImprovement {
+  location: string;
+  type: string;
+  description: string;
+  impact: 'high' | 'medium' | 'low';
+}
+
+export interface Benchmark {
+  name: string;
+  before: number;
+  after: number;
+  improvement: number;
+}
+
+export interface RefactoringChange {
+  type: string;
+  location: string;
+  description: string;
+}
+
+export interface CodeMetrics {
+  complexity: number;
+  maintainability: number;
+  duplication: number;
+  testCoverage: number;
+}


### PR DESCRIPTION
## 概要
Issue #2031 の継続タスクとして、`CodeGenerationAgent` の型定義を分離しました。

## 変更内容
- 追加: `src/agents/code-generation-agent.types.ts`
  - `CodeGenerationAgent` の公開型（request/response/構成型）
  - ファイル末尾の内部補助型（`TestAnalysis`, `DatabaseSchema` など）
- 更新: `src/agents/code-generation-agent.ts`
  - 型定義を `code-generation-agent.types.ts` から import
  - 既存公開API維持のため `export type { ... } from './code-generation-agent.types.js'`

## 効果
- `src/agents/code-generation-agent.ts` 行数: `1377 -> 1257`
- 実装と型定義の責務分離によりレビュー容易性を改善

## テスト
- `pnpm -s vitest run tests/commands/slash-command-manager.test.ts`
- `pnpm -s run types:check`
