### PR TITLE
refactor: split language helpers from code-generation-agent

### DIFF
--- a/src/agents/code-generation-agent.ts
+++ b/src/agents/code-generation-agent.ts
@@ -34,6 +34,13 @@ import {
   generateValidationMiddleware,
   parseOpenAPI,
 } from './code-generation-openapi.js';
+import {
+  generateFunctionImplementation,
+  getFileExtension,
+  getSourceDirectory,
+  getTestDirectory,
+  getTestExtension,
+} from './code-generation-language.js';
 
 export type {
   CodeGenerationRequest,
@@ -449,210 +456,25 @@ export class CodeGenerationAgent {
     const files: CodeFile[] = [];
     
     for (const func of analysis.functions) {
-      const implementation = this.generateFunctionImplementation(
-        func, 
-        analysis.expectedBehaviors, 
+      const implementation = generateFunctionImplementation(
+        func,
+        analysis.expectedBehaviors,
         request.language,
         request.framework
       );
       
-      const fileExtension = this.getFileExtension(request.language);
-      const testExtension = this.getTestExtension(request.language);
+      const fileExtension = getFileExtension(request.language);
+      const testExtension = getTestExtension(request.language);
       
       files.push({
-        path: `${this.getSourceDirectory(request.language)}/${func}.${fileExtension}`,
+        path: `${getSourceDirectory(request.language)}/${func}.${fileExtension}`,
         content: implementation,
         purpose: `Implementation of ${func}`,
-        tests: [`${this.getTestDirectory(request.language)}/${func}.${testExtension}`],
+        tests: [`${getTestDirectory(request.language)}/${func}.${testExtension}`],
       });
     }
     
     return files;
-  }
-
-  private generateFunctionImplementation(
-    funcName: string, 
-    behaviors: string[], 
-    language: string,
-    framework?: string
-  ): string {
-    switch (language) {
-      case 'elixir':
-        return this.generateElixirFunction(funcName, behaviors, framework);
-      case 'typescript':
-      case 'javascript':
-        return this.generateTSFunction(funcName, behaviors);
-      case 'python':
-        return this.generatePythonFunction(funcName, behaviors);
-      case 'rust':
-        return this.generateRustFunction(funcName, behaviors);
-      case 'go':
-        return this.generateGoFunction(funcName, behaviors);
-      default:
-        return this.generateTSFunction(funcName, behaviors);
-    }
-  }
-
-  private generateElixirFunction(funcName: string, behaviors: string[], framework?: string): string {
-    if (framework === 'phoenix') {
-      return this.generatePhoenixModule(funcName, behaviors);
-    }
-    
-    // Standard Elixir module
-    let implementation = `defmodule ${this.capitalize(funcName)} do\n`;
-    implementation += `  @moduledoc """\n`;
-    implementation += `  ${this.capitalize(funcName)} module\n`;
-    implementation += `  """\n\n`;
-    
-    // Add function implementation
-    implementation += `  @doc """\n`;
-    implementation += `  Main function for ${funcName}\n`;
-    implementation += `  """\n`;
-    implementation += `  def ${funcName}(args) do\n`;
-    
-    // Add basic implementation based on expected behaviors
-    for (const behavior of behaviors) {
-      implementation += `    # ${behavior}\n`;
-    }
-    
-    implementation += `    # TODO: Implement based on tests\n`;
-    implementation += `    {:ok, "not implemented"}\n`;
-    implementation += `  end\n`;
-    implementation += `end\n`;
-    
-    return implementation;
-  }
-
-  private generatePhoenixModule(funcName: string, behaviors: string[]): string {
-    const moduleName = this.capitalize(funcName);
-    let implementation = `defmodule MyAppWeb.${moduleName}Controller do\n`;
-    implementation += `  use MyAppWeb, :controller\n\n`;
-    
-    implementation += `  @doc """\n`;
-    implementation += `  ${moduleName} action\n`;
-    implementation += `  """\n`;
-    implementation += `  def ${funcName}(conn, _params) do\n`;
-    
-    for (const behavior of behaviors) {
-      implementation += `    # ${behavior}\n`;
-    }
-    
-    implementation += `    # TODO: Implement based on tests\n`;
-    implementation += `    json(conn, %{message: "not implemented"})\n`;
-    implementation += `  end\n`;
-    implementation += `end\n`;
-    
-    return implementation;
-  }
-
-  private generateTSFunction(funcName: string, behaviors: string[]): string {
-    let implementation = `export function ${funcName}(...args: any[]): any {\n`;
-    
-    for (const behavior of behaviors) {
-      if (behavior.includes('return')) {
-        implementation += `  // ${behavior}\n`;
-      }
-    }
-    
-    implementation += `  // TODO: Implement based on tests\n`;
-    implementation += `  return {};\n`;
-    implementation += `}\n`;
-    
-    return implementation;
-  }
-
-  private generatePythonFunction(funcName: string, behaviors: string[]): string {
-    let implementation = `def ${funcName}(*args, **kwargs):\n`;
-    implementation += `    """${this.capitalize(funcName)} function"""\n`;
-    
-    for (const behavior of behaviors) {
-      implementation += `    # ${behavior}\n`;
-    }
-    
-    implementation += `    # TODO: Implement based on tests\n`;
-    implementation += `    return {}\n`;
-    
-    return implementation;
-  }
-
-  private generateRustFunction(funcName: string, behaviors: string[]): string {
-    let implementation = `pub fn ${funcName}() -> Result<(), Box<dyn std::error::Error>> {\n`;
-    
-    for (const behavior of behaviors) {
-      implementation += `    // ${behavior}\n`;
-    }
-    
-    implementation += `    // TODO: Implement based on tests\n`;
-    implementation += `    Ok(())\n`;
-    implementation += `}\n`;
-    
-    return implementation;
-  }
-
-  private generateGoFunction(funcName: string, behaviors: string[]): string {
-    let implementation = `func ${this.capitalize(funcName)}() error {\n`;
-    
-    for (const behavior of behaviors) {
-      implementation += `    // ${behavior}\n`;
-    }
-    
-    implementation += `    // TODO: Implement based on tests\n`;
-    implementation += `    return nil\n`;
-    implementation += `}\n`;
-    
-    return implementation;
-  }
-
-  private getFileExtension(language: string): string {
-    const extensions: Record<string, string> = {
-      'typescript': 'ts',
-      'javascript': 'js',
-      'python': 'py',
-      'elixir': 'ex',
-      'rust': 'rs',
-      'go': 'go'
-    };
-    return extensions[language] || 'ts';
-  }
-
-  private getTestExtension(language: string): string {
-    const extensions: Record<string, string> = {
-      'typescript': 'test.ts',
-      'javascript': 'test.js',
-      'python': 'test.py',
-      'elixir': '_test.exs',
-      'rust': 'rs',
-      'go': 'test.go'
-    };
-    return extensions[language] || 'test.ts';
-  }
-
-  private getSourceDirectory(language: string): string {
-    const directories: Record<string, string> = {
-      'typescript': 'src',
-      'javascript': 'src',
-      'python': 'src',
-      'elixir': 'lib',
-      'rust': 'src',
-      'go': '.'
-    };
-    return directories[language] || 'src';
-  }
-
-  private getTestDirectory(language: string): string {
-    const directories: Record<string, string> = {
-      'typescript': 'tests',
-      'javascript': 'tests', 
-      'python': 'tests',
-      'elixir': 'test',
-      'rust': 'tests',
-      'go': '.'
-    };
-    return directories[language] || 'tests';
-  }
-
-  private capitalize(str: string): string {
-    return str.charAt(0).toUpperCase() + str.slice(1);
   }
 
   private async runTests(files: CodeFile[], tests: TestFile[]): Promise<TestResult[]> {

--- a/src/agents/code-generation-language.ts
+++ b/src/agents/code-generation-language.ts
@@ -1,0 +1,181 @@
+export function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function generatePhoenixModule(funcName: string, behaviors: string[]): string {
+  const moduleName = capitalize(funcName);
+  let implementation = `defmodule MyAppWeb.${moduleName}Controller do\n`;
+  implementation += '  use MyAppWeb, :controller\n\n';
+
+  implementation += '  @doc """\n';
+  implementation += `  ${moduleName} action\n`;
+  implementation += '  """\n';
+  implementation += `  def ${funcName}(conn, _params) do\n`;
+
+  for (const behavior of behaviors) {
+    implementation += `    # ${behavior}\n`;
+  }
+
+  implementation += '    # TODO: Implement based on tests\n';
+  implementation += '    json(conn, %{message: "not implemented"})\n';
+  implementation += '  end\n';
+  implementation += 'end\n';
+
+  return implementation;
+}
+
+function generateElixirFunction(funcName: string, behaviors: string[], framework?: string): string {
+  if (framework === 'phoenix') {
+    return generatePhoenixModule(funcName, behaviors);
+  }
+
+  let implementation = `defmodule ${capitalize(funcName)} do\n`;
+  implementation += '  @moduledoc """\n';
+  implementation += `  ${capitalize(funcName)} module\n`;
+  implementation += '  """\n\n';
+
+  implementation += '  @doc """\n';
+  implementation += `  Main function for ${funcName}\n`;
+  implementation += '  """\n';
+  implementation += `  def ${funcName}(args) do\n`;
+
+  for (const behavior of behaviors) {
+    implementation += `    # ${behavior}\n`;
+  }
+
+  implementation += '    # TODO: Implement based on tests\n';
+  implementation += '    {:ok, "not implemented"}\n';
+  implementation += '  end\n';
+  implementation += 'end\n';
+
+  return implementation;
+}
+
+function generateTSFunction(funcName: string, behaviors: string[]): string {
+  let implementation = `export function ${funcName}(...args: any[]): any {\n`;
+
+  for (const behavior of behaviors) {
+    if (behavior.includes('return')) {
+      implementation += `  // ${behavior}\n`;
+    }
+  }
+
+  implementation += '  // TODO: Implement based on tests\n';
+  implementation += '  return {};\n';
+  implementation += '}\n';
+
+  return implementation;
+}
+
+function generatePythonFunction(funcName: string, behaviors: string[]): string {
+  let implementation = `def ${funcName}(*args, **kwargs):\n`;
+  implementation += `    """${capitalize(funcName)} function"""\n`;
+
+  for (const behavior of behaviors) {
+    implementation += `    # ${behavior}\n`;
+  }
+
+  implementation += '    # TODO: Implement based on tests\n';
+  implementation += '    return {}\n';
+
+  return implementation;
+}
+
+function generateRustFunction(funcName: string, behaviors: string[]): string {
+  let implementation = `pub fn ${funcName}() -> Result<(), Box<dyn std::error::Error>> {\n`;
+
+  for (const behavior of behaviors) {
+    implementation += `    // ${behavior}\n`;
+  }
+
+  implementation += '    // TODO: Implement based on tests\n';
+  implementation += '    Ok(())\n';
+  implementation += '}\n';
+
+  return implementation;
+}
+
+function generateGoFunction(funcName: string, behaviors: string[]): string {
+  let implementation = `func ${capitalize(funcName)}() error {\n`;
+
+  for (const behavior of behaviors) {
+    implementation += `    // ${behavior}\n`;
+  }
+
+  implementation += '    // TODO: Implement based on tests\n';
+  implementation += '    return nil\n';
+  implementation += '}\n';
+
+  return implementation;
+}
+
+export function generateFunctionImplementation(
+  funcName: string,
+  behaviors: string[],
+  language: string,
+  framework?: string,
+): string {
+  switch (language) {
+    case 'elixir':
+      return generateElixirFunction(funcName, behaviors, framework);
+    case 'typescript':
+    case 'javascript':
+      return generateTSFunction(funcName, behaviors);
+    case 'python':
+      return generatePythonFunction(funcName, behaviors);
+    case 'rust':
+      return generateRustFunction(funcName, behaviors);
+    case 'go':
+      return generateGoFunction(funcName, behaviors);
+    default:
+      return generateTSFunction(funcName, behaviors);
+  }
+}
+
+export function getFileExtension(language: string): string {
+  const extensions: Record<string, string> = {
+    typescript: 'ts',
+    javascript: 'js',
+    python: 'py',
+    elixir: 'ex',
+    rust: 'rs',
+    go: 'go',
+  };
+  return extensions[language] || 'ts';
+}
+
+export function getTestExtension(language: string): string {
+  const extensions: Record<string, string> = {
+    typescript: 'test.ts',
+    javascript: 'test.js',
+    python: 'test.py',
+    elixir: '_test.exs',
+    rust: 'rs',
+    go: 'test.go',
+  };
+  return extensions[language] || 'test.ts';
+}
+
+export function getSourceDirectory(language: string): string {
+  const directories: Record<string, string> = {
+    typescript: 'src',
+    javascript: 'src',
+    python: 'src',
+    elixir: 'lib',
+    rust: 'src',
+    go: '.',
+  };
+  return directories[language] || 'src';
+}
+
+export function getTestDirectory(language: string): string {
+  const directories: Record<string, string> = {
+    typescript: 'tests',
+    javascript: 'tests',
+    python: 'tests',
+    elixir: 'test',
+    rust: 'tests',
+    go: '.',
+  };
+  return directories[language] || 'tests';
+}

--- a/tests/unit/agents/code-generation-language.test.ts
+++ b/tests/unit/agents/code-generation-language.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  capitalize,
+  generateFunctionImplementation,
+  getFileExtension,
+  getSourceDirectory,
+  getTestDirectory,
+  getTestExtension,
+} from '../../../src/agents/code-generation-language';
+
+describe('code-generation-language helpers', () => {
+  it('generates TypeScript implementation and keeps return-related behavior comments', () => {
+    const code = generateFunctionImplementation(
+      'buildReport',
+      ['should return a response object', 'logs metrics'],
+      'typescript',
+    );
+
+    expect(code).toContain('export function buildReport');
+    expect(code).toContain('// should return a response object');
+    expect(code).toContain('return {};');
+  });
+
+  it('generates Phoenix controller for elixir+phoenix', () => {
+    const code = generateFunctionImplementation('create_order', ['validates input'], 'elixir', 'phoenix');
+
+    expect(code).toContain('use MyAppWeb, :controller');
+    expect(code).toContain('def create_order(conn, _params) do');
+  });
+
+  it('falls back to TypeScript for unknown language', () => {
+    const code = generateFunctionImplementation('unknownLangFn', [], 'kotlin');
+    expect(code).toContain('export function unknownLangFn');
+  });
+
+  it('resolves file/test extensions and directories', () => {
+    expect(getFileExtension('python')).toBe('py');
+    expect(getFileExtension('unknown')).toBe('ts');
+    expect(getTestExtension('elixir')).toBe('_test.exs');
+    expect(getTestExtension('rust')).toBe('rs');
+    expect(getSourceDirectory('go')).toBe('.');
+    expect(getTestDirectory('go')).toBe('.');
+  });
+
+  it('capitalizes first character only', () => {
+    expect(capitalize('helloWorld')).toBe('HelloWorld');
+  });
+});


### PR DESCRIPTION
## 概要
- `src/agents/code-generation-agent.ts` から言語別コード生成ヘルパーを `src/agents/code-generation-language.ts` に分離
- `CodeGenerationAgent` は新ヘルパー関数を利用するように変更
- 既存挙動維持を担保する unit test を追加

## 変更点
- 追加: `src/agents/code-generation-language.ts`
  - `generateFunctionImplementation`
  - `getFileExtension` / `getTestExtension`
  - `getSourceDirectory` / `getTestDirectory`
- 更新: `src/agents/code-generation-agent.ts`
  - 言語生成関連の private method 群を削除し、外部ヘルパーへ委譲
  - 行数: `982 -> 804`
- 追加: `tests/unit/agents/code-generation-language.test.ts`

## テスト
- `pnpm -s vitest run tests/unit/agents/code-generation-language.test.ts tests/unit/agents/code-generation-openapi.test.ts`
- `pnpm -s run types:check`
