### PR TITLE
feat: support --format json in quality run/reconcile

### DIFF
--- a/docs/product/USER-MANUAL.md
+++ b/docs/product/USER-MANUAL.md
@@ -214,10 +214,12 @@ pnpm run ae-framework -- sbom --help
 | --- | --- | --- | --- | --- |
 | `ae spec lint --format json` | `0` | `2` (`SPEC_INVALID_INPUT`) | `1` (`SPEC_INTERNAL_ERROR`) | `schema/spec-validation-report.schema.json` |
 | `ae spec validate --format json` | `0` | `2` (`SPEC_INVALID_INPUT`) | `1` (`SPEC_INTERNAL_ERROR`) | `schema/spec-validation-report.schema.json` |
+| `ae quality run --format json` | `0` | `2` (`--format` 不正値) | `1`（blocker失敗/実行エラー） | `QualityReport`（`src/quality/policy-loader.ts`） |
+| `ae quality reconcile --format json` | `0` | `2` (`--format` 不正値) | `1`（blocker残存/実行エラー） | `QualityReport`（`src/quality/policy-loader.ts`） |
 | `pnpm run verify:profile -- --json` | `0` | `2` (unknown profile) / `3` (invalid args) | `1` (summary write failure 等) | `schema/verify-profile-summary.schema.json` |
 
 補足:
-- `ae quality run` は現行実装に `--format json` を持ちません（テキスト出力）。JSON契約が必要な場合は `ae quality report --format json` または `reports/quality-gates/*.json` を利用してください。
+- `ae quality run --format json` / `ae quality reconcile --format json` は、標準出力に `QualityReport` を出力します（デフォルト `text`）。
 - 成果物配置の契約（`artifacts/**`）と root 汚染検知は `docs/quality/ARTIFACTS-CONTRACT.md` と `scripts/ci/check-no-root-generated-files.mjs` を参照してください。
 
 ## 6. エージェント統合

--- a/docs/reference/CLI-COMMANDS-REFERENCE.md
+++ b/docs/reference/CLI-COMMANDS-REFERENCE.md
@@ -237,9 +237,11 @@ ae domain-model --language --sources "glossary.md"
 # Run quality gates
  ae quality run --env development
  ae quality run --env development --no-history
+ ae quality run --env development --dry-run --format json
 
 # Reconcile (run + auto-fix rounds)
  ae quality reconcile --env development --max-rounds 3 --fix-input .ae/failures.json
+ ae quality reconcile --env development --dry-run --format json
 
 # List / policy / validate / report
  ae quality list --env development --format summary
@@ -555,7 +557,9 @@ ae setup list
 # Quality
 ae quality run --env development
  ae quality run --env development --no-history
+ ae quality run --env development --dry-run --format json
  ae quality reconcile --env development --max-rounds 3 --fix-input .ae/failures.json
+ ae quality reconcile --env development --dry-run --format json
  ae quality list --env development --format summary
  ae quality policy --env development
  ae quality validate

--- a/tests/cli/quality-cli.test.ts
+++ b/tests/cli/quality-cli.test.ts
@@ -1,0 +1,145 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const safeExitMock = vi.fn();
+const executeGatesMock = vi.fn();
+const executeFixesMock = vi.fn();
+
+vi.mock('../../src/utils/safe-exit.js', () => ({
+  safeExit: (...args: unknown[]) => safeExitMock(...args),
+}));
+
+vi.mock('../../src/quality/quality-gate-runner.js', () => ({
+  QualityGateRunner: class {
+    executeGates(...args: unknown[]) {
+      return executeGatesMock(...args);
+    }
+  },
+}));
+
+vi.mock('../../src/cegis/auto-fix-engine.js', () => ({
+  AutoFixEngine: class {
+    executeFixes(...args: unknown[]) {
+      return executeFixesMock(...args);
+    }
+  },
+}));
+
+let createQualityCommand: () => any;
+
+beforeAll(async () => {
+  ({ createQualityCommand } = await import('../../src/cli/quality-cli.js'));
+});
+
+beforeEach(() => {
+  safeExitMock.mockReset();
+  executeGatesMock.mockReset();
+  executeFixesMock.mockReset();
+});
+
+const createReport = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  timestamp: '2026-02-18T00:00:00.000Z',
+  environment: 'development',
+  overallScore: 100,
+  totalGates: 1,
+  passedGates: 1,
+  failedGates: 0,
+  results: [],
+  summary: {
+    byCategory: {},
+    executionTime: 1000,
+    blockers: [],
+  },
+  ...overrides,
+});
+
+const findJsonPayload = (calls: Array<[unknown, ...unknown[]]>): Record<string, unknown> => {
+  for (const call of calls) {
+    const [first] = call;
+    if (typeof first !== 'string') {
+      continue;
+    }
+    const text = first.trim();
+    if (!text.startsWith('{')) {
+      continue;
+    }
+    try {
+      return JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      // continue
+    }
+  }
+  throw new Error('JSON payload not found in console.log calls');
+};
+
+describe('quality CLI format option', () => {
+  it('run --format json emits report JSON and passes silent/summary options to runner', async () => {
+    executeGatesMock.mockResolvedValueOnce(createReport());
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const command = createQualityCommand();
+    await command.parseAsync(['node', 'cli', 'run', '--format', 'json', '--dry-run']);
+
+    expect(executeGatesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dryRun: true,
+        printSummary: false,
+        silent: true,
+      }),
+    );
+    const payload = findJsonPayload(consoleLogSpy.mock.calls as Array<[unknown, ...unknown[]]>);
+    expect(payload['environment']).toBe('development');
+    expect(payload['overallScore']).toBe(100);
+    expect(safeExitMock).not.toHaveBeenCalled();
+    consoleLogSpy.mockRestore();
+  });
+
+  it('run rejects unsupported --format with exit code 2', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const command = createQualityCommand();
+    await command.parseAsync(['node', 'cli', 'run', '--format', 'xml']);
+
+    expect(executeGatesMock).not.toHaveBeenCalled();
+    expect(safeExitMock).toHaveBeenCalledWith(2);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('reconcile --format json emits final report JSON and keeps blocker exit code', async () => {
+    executeGatesMock.mockResolvedValueOnce(
+      createReport({
+        overallScore: 70,
+        passedGates: 0,
+        failedGates: 1,
+        summary: {
+          byCategory: {},
+          executionTime: 1000,
+          blockers: ['coverage'],
+        },
+      }),
+    );
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const command = createQualityCommand();
+    await command.parseAsync([
+      'node',
+      'cli',
+      'reconcile',
+      '--format',
+      'json',
+      '--dry-run',
+      '--max-rounds',
+      '1',
+    ]);
+
+    expect(executeGatesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        printSummary: false,
+        silent: true,
+      }),
+    );
+    const payload = findJsonPayload(consoleLogSpy.mock.calls as Array<[unknown, ...unknown[]]>);
+    expect(payload['failedGates']).toBe(1);
+    expect(safeExitMock).toHaveBeenCalledWith(1);
+    consoleLogSpy.mockRestore();
+  });
+});

--- a/tests/contracts/cli-artifacts-contracts.test.ts
+++ b/tests/contracts/cli-artifacts-contracts.test.ts
@@ -238,4 +238,65 @@ describe('CLI/Artifacts contract conformance', () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('quality run --format json follows output/exit contract (success/input)', () => {
+    const successResult = runAeCli([
+      'quality',
+      'run',
+      '--format',
+      'json',
+      '--dry-run',
+      '--gates',
+      'linting',
+    ]);
+    expect(successResult.status).toBe(0);
+    const payload = parseJsonFromStdout(successResult.stdout);
+    expect(payload).toEqual(
+      expect.objectContaining({
+        environment: expect.any(String),
+        overallScore: expect.any(Number),
+        totalGates: expect.any(Number),
+        passedGates: expect.any(Number),
+        failedGates: expect.any(Number),
+        results: expect.any(Array),
+        summary: expect.any(Object),
+      }),
+    );
+
+    const invalidFormatResult = runAeCli([
+      'quality',
+      'run',
+      '--format',
+      'xml',
+      '--dry-run',
+    ]);
+    expect(invalidFormatResult.status).toBe(2);
+  });
+
+  it('quality reconcile --format json follows output contract (success)', () => {
+    const result = runAeCli([
+      'quality',
+      'reconcile',
+      '--format',
+      'json',
+      '--dry-run',
+      '--max-rounds',
+      '1',
+      '--gates',
+      'linting',
+    ]);
+    expect(result.status).toBe(0);
+    const payload = parseJsonFromStdout(result.stdout);
+    expect(payload).toEqual(
+      expect.objectContaining({
+        environment: expect.any(String),
+        overallScore: expect.any(Number),
+        totalGates: expect.any(Number),
+        passedGates: expect.any(Number),
+        failedGates: expect.any(Number),
+        results: expect.any(Array),
+        summary: expect.any(Object),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## 概要
Issue #2100 の実装です。`ae quality run` / `ae quality reconcile` に `--format json` を追加し、機械可読な出力契約を提供します。

## 変更内容
- `src/cli/quality-cli.ts`
  - `quality run` / `quality reconcile` に `--format <text|json>` を追加（default: `text`）
  - `--format json` で `QualityReport` を stdout に出力
  - 不正な `--format` は exit code `2` に統一
- `src/quality/quality-gate-runner.ts`
  - 実行オプションに `silent` / `printSummary` を追加
  - JSONモード時は runner 側テキストログを抑止し、stdout の JSON 契約を安定化
- テスト
  - `tests/cli/quality-cli.test.ts` 追加（unit: format挙動/exit code）
  - `tests/contracts/cli-artifacts-contracts.test.ts` 拡張（e2e: `quality run/reconcile --format json` 契約）
- ドキュメント
  - `docs/product/USER-MANUAL.md`（CLI契約表に quality run/reconcile を追加）
  - `docs/reference/CLI-COMMANDS-REFERENCE.md`（実行例追加）

## 検証
- `pnpm -s vitest run tests/cli/quality-cli.test.ts tests/contracts/cli-artifacts-contracts.test.ts tests/quality/quality-runner.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run docs:lint`

## 関連
- #2100
