### PR TITLE
test: add quality-report JSON schema contract

### DIFF
--- a/docs/product/USER-MANUAL.md
+++ b/docs/product/USER-MANUAL.md
@@ -214,8 +214,8 @@ pnpm run ae-framework -- sbom --help
 | --- | --- | --- | --- | --- |
 | `ae spec lint --format json` | `0` | `2` (`SPEC_INVALID_INPUT`) | `1` (`SPEC_INTERNAL_ERROR`) | `schema/spec-validation-report.schema.json` |
 | `ae spec validate --format json` | `0` | `2` (`SPEC_INVALID_INPUT`) | `1` (`SPEC_INTERNAL_ERROR`) | `schema/spec-validation-report.schema.json` |
-| `ae quality run --format json` | `0` | `2` (`--format` 不正値) | `1`（blocker失敗/実行エラー） | `QualityReport`（`src/quality/policy-loader.ts`） |
-| `ae quality reconcile --format json` | `0` | `2` (`--format` 不正値) | `1`（blocker残存/実行エラー） | `QualityReport`（`src/quality/policy-loader.ts`） |
+| `ae quality run --format json` | `0` | `2` (`--format` 不正値) | `1`（blocker失敗/実行エラー） | `schema/quality-report.schema.json` |
+| `ae quality reconcile --format json` | `0` | `2` (`--format` 不正値) | `1`（blocker残存/実行エラー） | `schema/quality-report.schema.json` |
 | `pnpm run verify:profile -- --json` | `0` | `2` (unknown profile) / `3` (invalid args) | `1` (summary write failure 等) | `schema/verify-profile-summary.schema.json` |
 
 補足:

--- a/fixtures/quality-report/sample.quality-report.json
+++ b/fixtures/quality-report/sample.quality-report.json
@@ -1,0 +1,41 @@
+{
+  "timestamp": "2026-02-19T00:00:00.000Z",
+  "environment": "development",
+  "meta": {
+    "runId": "local-1234567890",
+    "createdAt": "2026-02-19T00:00:00.000Z"
+  },
+  "overallScore": 100,
+  "totalGates": 1,
+  "passedGates": 1,
+  "failedGates": 0,
+  "results": [
+    {
+      "gateKey": "linting",
+      "gateName": "Code Linting",
+      "passed": true,
+      "score": 100,
+      "violations": [],
+      "executionTime": 0,
+      "environment": "development",
+      "threshold": {
+        "maxErrors": 0,
+        "maxWarnings": 0,
+        "blockOnErrors": false
+      },
+      "details": {
+        "dryRun": true
+      }
+    }
+  ],
+  "summary": {
+    "byCategory": {
+      "code-quality": {
+        "passed": 1,
+        "total": 1
+      }
+    },
+    "executionTime": 0,
+    "blockers": []
+  }
+}

--- a/schema/quality-report.schema.json
+++ b/schema/quality-report.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://itdojp.github.io/ae-framework/schema/quality-report.schema.json",
+  "title": "Quality Report",
+  "description": "Machine-readable report emitted by quality run/reconcile in JSON mode.",
+  "type": "object",
+  "required": [
+    "timestamp",
+    "environment",
+    "overallScore",
+    "totalGates",
+    "passedGates",
+    "failedGates",
+    "results",
+    "summary"
+  ],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "environment": {
+      "type": "string"
+    },
+    "meta": {
+      "type": "object",
+      "required": [
+        "runId",
+        "createdAt"
+      ],
+      "properties": {
+        "runId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "commitSha": {
+          "type": "string"
+        },
+        "branch": {
+          "type": "string"
+        },
+        "agent": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "traceId": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "overallScore": {
+      "type": "number"
+    },
+    "totalGates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "passedGates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failedGates": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "gateKey",
+          "gateName",
+          "passed",
+          "violations",
+          "executionTime",
+          "environment",
+          "threshold"
+        ],
+        "properties": {
+          "gateKey": {
+            "type": "string",
+            "minLength": 1
+          },
+          "gateName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "passed": {
+            "type": "boolean"
+          },
+          "score": {
+            "type": "number"
+          },
+          "violations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "executionTime": {
+            "type": "number",
+            "minimum": 0
+          },
+          "environment": {
+            "type": "string"
+          },
+          "threshold": {
+            "type": "object",
+            "additionalProperties": {
+              "type": [
+                "number",
+                "string",
+                "boolean"
+              ]
+            }
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "composites": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "gates",
+          "passed",
+          "failedGates"
+        ],
+        "properties": {
+          "gates": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "passed": {
+            "type": "boolean"
+          },
+          "failedGates": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "byCategory",
+        "executionTime",
+        "blockers"
+      ],
+      "properties": {
+        "byCategory": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "passed",
+              "total"
+            ],
+            "properties": {
+              "passed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "total": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "executionTime": {
+          "type": "number",
+          "minimum": 0
+        },
+        "blockers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -70,6 +70,11 @@ const checks = [
     schema: 'schema/trace-map.schema.json',
     fixtures: ['fixtures/trace-map/sample.trace-map.json'],
     label: 'Trace map schema validation'
+  },
+  {
+    schema: 'schema/quality-report.schema.json',
+    fixtures: ['fixtures/quality-report/sample.quality-report.json'],
+    label: 'Quality report schema validation'
   }
 ];
 

--- a/tests/contracts/cli-artifacts-contracts.test.ts
+++ b/tests/contracts/cli-artifacts-contracts.test.ts
@@ -13,6 +13,7 @@ const nodeBin = process.execPath;
 
 const specReportSchema = JSON.parse(readFileSync(resolve('schema/spec-validation-report.schema.json'), 'utf8'));
 const verifyProfileSchema = JSON.parse(readFileSync(resolve('schema/verify-profile-summary.schema.json'), 'utf8'));
+const qualityReportSchema = JSON.parse(readFileSync(resolve('schema/quality-report.schema.json'), 'utf8'));
 
 const runAeCli = (args: string[]) =>
   spawnSync(tsxBin, ['src/cli/index.ts', ...args], {
@@ -251,17 +252,10 @@ describe('CLI/Artifacts contract conformance', () => {
     ]);
     expect(successResult.status).toBe(0);
     const payload = parseJsonFromStdout(successResult.stdout);
-    expect(payload).toEqual(
-      expect.objectContaining({
-        environment: expect.any(String),
-        overallScore: expect.any(Number),
-        totalGates: expect.any(Number),
-        passedGates: expect.any(Number),
-        failedGates: expect.any(Number),
-        results: expect.any(Array),
-        summary: expect.any(Object),
-      }),
-    );
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(qualityReportSchema);
+    expect(validate(payload), JSON.stringify(validate.errors)).toBe(true);
 
     const invalidFormatResult = runAeCli([
       'quality',
@@ -287,16 +281,9 @@ describe('CLI/Artifacts contract conformance', () => {
     ]);
     expect(result.status).toBe(0);
     const payload = parseJsonFromStdout(result.stdout);
-    expect(payload).toEqual(
-      expect.objectContaining({
-        environment: expect.any(String),
-        overallScore: expect.any(Number),
-        totalGates: expect.any(Number),
-        passedGates: expect.any(Number),
-        failedGates: expect.any(Number),
-        results: expect.any(Array),
-        summary: expect.any(Object),
-      }),
-    );
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(qualityReportSchema);
+    expect(validate(payload), JSON.stringify(validate.errors)).toBe(true);
   });
 });

--- a/tests/scripts/quality-report-schema.test.ts
+++ b/tests/scripts/quality-report-schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const schemaPath = resolve('schema/quality-report.schema.json');
+const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+
+describe('quality report schema', () => {
+  it('accepts valid payload', () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(schema);
+
+    const payload = {
+      timestamp: '2026-02-19T00:00:00.000Z',
+      environment: 'development',
+      meta: {
+        runId: 'local-123',
+        createdAt: '2026-02-19T00:00:00.000Z',
+      },
+      overallScore: 95,
+      totalGates: 2,
+      passedGates: 2,
+      failedGates: 0,
+      results: [
+        {
+          gateKey: 'linting',
+          gateName: 'Code Linting',
+          passed: true,
+          score: 95,
+          violations: [],
+          executionTime: 10,
+          environment: 'development',
+          threshold: {
+            maxErrors: 0,
+            maxWarnings: 0,
+            blockOnErrors: true,
+          },
+          details: {
+            dryRun: true,
+          },
+        },
+      ],
+      summary: {
+        byCategory: {
+          'code-quality': {
+            passed: 2,
+            total: 2,
+          },
+        },
+        executionTime: 10,
+        blockers: [],
+      },
+    };
+
+    expect(validate(payload), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it('rejects missing summary', () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(schema);
+
+    const payload = {
+      timestamp: '2026-02-19T00:00:00.000Z',
+      environment: 'development',
+      overallScore: 95,
+      totalGates: 1,
+      passedGates: 1,
+      failedGates: 0,
+      results: [],
+    };
+
+    expect(validate(payload)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
Issue #2102 の実装です。`quality run/reconcile` の JSON 出力契約を `schema/quality-report.schema.json` として明文化し、契約テストを schema ベースに強化しました。

## 変更内容
- `schema/quality-report.schema.json` を追加
  - `QualityReport` / `QualityGateResult` / `summary` / `composites` を定義
- `fixtures/quality-report/sample.quality-report.json` を追加
- `scripts/ci/validate-json.mjs` に quality-report schema 検証を追加
- `tests/scripts/quality-report-schema.test.ts` を追加
  - valid/invalid ペイロードの schema 検証
- `tests/contracts/cli-artifacts-contracts.test.ts` を更新
  - `quality run/reconcile --format json` の検証を objectContaining から schema 検証へ変更
- `docs/product/USER-MANUAL.md` の契約表を更新
  - quality run/reconcile の schema 参照を `schema/quality-report.schema.json` に統一

## 検証
- `pnpm -s vitest run tests/scripts/quality-report-schema.test.ts tests/contracts/cli-artifacts-contracts.test.ts`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run docs:lint`
- `pnpm -s run types:check`

## 関連
- #2102
