### PR TITLE
test: add conformance JSON output schema contracts

### DIFF
--- a/docs/reference/CLI-COMMANDS-REFERENCE.md
+++ b/docs/reference/CLI-COMMANDS-REFERENCE.md
@@ -202,15 +202,18 @@ ae domain-model --language --sources "glossary.md"
 # Verify input data
  ae conformance verify --input data.json --rules rules.json \
    --context-file context.json --format json --output conformance-results.json
+# JSON schema (--format json): schema/conformance-verify-result.schema.json
 
 # Rules / config / metrics / status
  ae conformance rules --list
  ae conformance config --show
  ae conformance metrics --format json --export metrics.json
+# JSON schema (--format json): schema/conformance-metrics.schema.json
  ae conformance status
 
 # Aggregate reports
  ae conformance report --directory artifacts/hermetic-reports/conformance --format both
+# JSON schema (--format json): schema/conformance-report.schema.json
 ```
 
 ### Integration Testing (Phase 2.3)
@@ -509,12 +512,15 @@ ae conformance sample --rules configs/samples/sample-rules.json \
 
  ae conformance verify --input data.json --rules rules.json \
   --context-file context.json --format json --output conformance-results.json
+# JSON schema (--format json): schema/conformance-verify-result.schema.json
 
  ae conformance rules --list
  ae conformance config --show
  ae conformance metrics --format json --export metrics.json
+# JSON schema (--format json): schema/conformance-metrics.schema.json
  ae conformance status
  ae conformance report --directory artifacts/hermetic-reports/conformance --format both
+# JSON schema (--format json): schema/conformance-report.schema.json
 ```
 
 ### Integration Testing

--- a/fixtures/conformance/sample.conformance-metrics.json
+++ b/fixtures/conformance/sample.conformance-metrics.json
@@ -1,0 +1,36 @@
+{
+  "timestamp": "2026-02-18T09:10:00.000Z",
+  "period": {
+    "start": "2026-02-18T09:00:00.000Z",
+    "end": "2026-02-18T09:10:00.000Z"
+  },
+  "counts": {
+    "totalVerifications": 3,
+    "totalViolations": 2,
+    "uniqueRules": 5,
+    "uniqueViolations": 2
+  },
+  "performance": {
+    "averageExecutionTime": 42.5,
+    "p95ExecutionTime": 58.0,
+    "p99ExecutionTime": 65.0,
+    "timeouts": 0,
+    "errors": 0
+  },
+  "violationTrends": [
+    {
+      "category": "data_validation",
+      "severity": "major",
+      "count": 2,
+      "trend": "stable"
+    }
+  ],
+  "topViolations": [
+    {
+      "ruleId": "rule-required-email",
+      "ruleName": "Required Email Field",
+      "count": 2,
+      "lastOccurrence": "2026-02-18T09:09:30.000Z"
+    }
+  ]
+}

--- a/fixtures/conformance/sample.conformance-report.json
+++ b/fixtures/conformance/sample.conformance-report.json
@@ -1,0 +1,111 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-02-18T09:15:00.000Z",
+  "status": "failure",
+  "runsAnalyzed": 2,
+  "statusBreakdown": {
+    "pass": 1,
+    "fail": 1,
+    "skip": 0,
+    "error": 0,
+    "timeout": 0
+  },
+  "totals": {
+    "rulesExecuted": 4,
+    "rulesPassed": 3,
+    "rulesFailed": 1,
+    "rulesErrored": 0,
+    "rulesSkipped": 0,
+    "totalViolations": 1,
+    "uniqueRules": 4,
+    "uniqueViolationRules": 1
+  },
+  "severityTotals": {
+    "critical": 0,
+    "major": 1,
+    "minor": 0,
+    "info": 0,
+    "warning": 0
+  },
+  "categoryTotals": {
+    "data_validation": 1,
+    "api_contract": 0,
+    "business_logic": 0,
+    "security_policy": 0,
+    "performance_constraint": 0,
+    "resource_usage": 0,
+    "state_invariant": 0,
+    "behavioral_constraint": 0,
+    "integration_requirement": 0,
+    "compliance_rule": 0
+  },
+  "severityTrends": [
+    {
+      "severity": "critical",
+      "current": 0,
+      "previous": 0,
+      "trend": "stable"
+    },
+    {
+      "severity": "major",
+      "current": 1,
+      "previous": 0,
+      "trend": "increasing"
+    },
+    {
+      "severity": "minor",
+      "current": 0,
+      "previous": 0,
+      "trend": "stable"
+    },
+    {
+      "severity": "info",
+      "current": 0,
+      "previous": 0,
+      "trend": "stable"
+    },
+    {
+      "severity": "warning",
+      "current": 0,
+      "previous": 0,
+      "trend": "stable"
+    }
+  ],
+  "topViolations": [
+    {
+      "ruleId": "rule-required-email",
+      "ruleName": "Required Email Field",
+      "count": 1,
+      "lastObserved": "2026-02-18T09:00:06.000Z"
+    }
+  ],
+  "latestRun": {
+    "file": "fixtures/conformance/sample.conformance-verify-result.json",
+    "timestamp": "2026-02-18T09:00:06.000Z",
+    "status": "fail",
+    "environment": "cli",
+    "version": "2.2.0",
+    "rulesExecuted": 1,
+    "rulesFailed": 1,
+    "totalViolations": 1
+  },
+  "inputs": [
+    {
+      "file": "fixtures/conformance/sample.conformance-verify-result.json",
+      "timestamp": "2026-02-18T09:00:06.000Z",
+      "status": "fail",
+      "environment": "cli",
+      "version": "2.2.0",
+      "totalViolations": 1
+    },
+    {
+      "file": "fixtures/conformance/secondary.conformance-verify-result.json",
+      "timestamp": "2026-02-18T08:55:00.000Z",
+      "status": "pass",
+      "environment": "cli",
+      "version": "2.2.0",
+      "totalViolations": 0
+    }
+  ],
+  "notes": "One or more runs reported failures, errors, or timeouts."
+}

--- a/fixtures/conformance/sample.conformance-verify-result.json
+++ b/fixtures/conformance/sample.conformance-verify-result.json
@@ -1,0 +1,138 @@
+{
+  "overall": "fail",
+  "results": [
+    {
+      "id": "result-001",
+      "ruleId": "rule-required-email",
+      "status": "fail",
+      "timestamp": "2026-02-18T09:00:05.000Z",
+      "duration": 18,
+      "context": {
+        "timestamp": "2026-02-18T09:00:00.000Z",
+        "executionId": "run-001",
+        "environment": "cli",
+        "version": "2.2.0",
+        "metadata": {
+          "source": "cli",
+          "tool": "conformance-cli"
+        }
+      },
+      "violation": {
+        "ruleId": "rule-required-email",
+        "ruleName": "Required Email Field",
+        "category": "data_validation",
+        "severity": "major",
+        "message": "Required field is missing or null",
+        "actualValue": null,
+        "expectedValue": "Non-null value",
+        "context": {
+          "timestamp": "2026-02-18T09:00:00.000Z",
+          "executionId": "run-001",
+          "environment": "cli",
+          "version": "2.2.0",
+          "metadata": {
+            "source": "cli",
+            "tool": "conformance-cli"
+          }
+        },
+        "evidence": {
+          "inputData": {
+            "user": {}
+          },
+          "stateSnapshot": {},
+          "metrics": {},
+          "logs": [
+            "Validation failed for rule: Required Email Field"
+          ],
+          "traces": []
+        },
+        "remediation": {
+          "suggested": [
+            "Provide a non-null value for email"
+          ],
+          "automatic": false,
+          "priority": "high"
+        }
+      },
+      "metrics": {
+        "executionTime": 18,
+        "networkCalls": 0,
+        "dbQueries": 0
+      },
+      "metadata": {}
+    }
+  ],
+  "violations": [
+    {
+      "ruleId": "rule-required-email",
+      "ruleName": "Required Email Field",
+      "category": "data_validation",
+      "severity": "major",
+      "message": "Required field is missing or null",
+      "actualValue": null,
+      "expectedValue": "Non-null value",
+      "context": {
+        "timestamp": "2026-02-18T09:00:00.000Z",
+        "executionId": "run-001",
+        "environment": "cli",
+        "version": "2.2.0",
+        "metadata": {
+          "source": "cli",
+          "tool": "conformance-cli"
+        }
+      },
+      "evidence": {
+        "inputData": {
+          "user": {}
+        },
+        "stateSnapshot": {},
+        "metrics": {},
+        "logs": [
+          "Validation failed for rule: Required Email Field"
+        ],
+        "traces": []
+      },
+      "remediation": {
+        "suggested": [
+          "Provide a non-null value for email"
+        ],
+        "automatic": false,
+        "priority": "high"
+      }
+    }
+  ],
+  "summary": {
+    "totalRules": 1,
+    "rulesExecuted": 1,
+    "rulesPassed": 0,
+    "rulesFailed": 1,
+    "rulesSkipped": 0,
+    "rulesError": 0,
+    "totalDuration": 18,
+    "violationsBySeverity": {
+      "critical": 0,
+      "major": 1,
+      "minor": 0,
+      "info": 0,
+      "warning": 0
+    },
+    "violationsByCategory": {
+      "data_validation": 1,
+      "api_contract": 0,
+      "business_logic": 0,
+      "security_policy": 0,
+      "performance_constraint": 0,
+      "resource_usage": 0,
+      "state_invariant": 0,
+      "behavioral_constraint": 0,
+      "integration_requirement": 0,
+      "compliance_rule": 0
+    }
+  },
+  "metadata": {
+    "executionId": "run-001",
+    "timestamp": "2026-02-18T09:00:06.000Z",
+    "environment": "cli",
+    "version": "2.2.0"
+  }
+}

--- a/schema/conformance-metrics.schema.json
+++ b/schema/conformance-metrics.schema.json
@@ -1,0 +1,192 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/conformance-metrics.schema.json",
+  "title": "Conformance Metrics",
+  "description": "Machine-readable metrics emitted by `ae conformance metrics --format json`.",
+  "type": "object",
+  "required": [
+    "timestamp",
+    "period",
+    "counts",
+    "performance",
+    "violationTrends",
+    "topViolations"
+  ],
+  "properties": {
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "period": {
+      "type": "object",
+      "required": [
+        "start",
+        "end"
+      ],
+      "properties": {
+        "start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "counts": {
+      "type": "object",
+      "required": [
+        "totalVerifications",
+        "totalViolations",
+        "uniqueRules",
+        "uniqueViolations"
+      ],
+      "properties": {
+        "totalVerifications": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalViolations": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "uniqueRules": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "uniqueViolations": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "performance": {
+      "type": "object",
+      "required": [
+        "averageExecutionTime",
+        "p95ExecutionTime",
+        "p99ExecutionTime",
+        "timeouts",
+        "errors"
+      ],
+      "properties": {
+        "averageExecutionTime": {
+          "type": "number",
+          "minimum": 0
+        },
+        "p95ExecutionTime": {
+          "type": "number",
+          "minimum": 0
+        },
+        "p99ExecutionTime": {
+          "type": "number",
+          "minimum": 0
+        },
+        "timeouts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "errors": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "violationTrends": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "category",
+          "severity",
+          "count",
+          "trend"
+        ],
+        "properties": {
+          "category": {
+            "$ref": "#/$defs/conformanceRuleCategory"
+          },
+          "severity": {
+            "$ref": "#/$defs/violationSeverity"
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "trend": {
+            "type": "string",
+            "enum": [
+              "increasing",
+              "decreasing",
+              "stable"
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "topViolations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "ruleId",
+          "ruleName",
+          "count",
+          "lastOccurrence"
+        ],
+        "properties": {
+          "ruleId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "ruleName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "lastOccurrence": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "violationSeverity": {
+      "type": "string",
+      "enum": [
+        "critical",
+        "major",
+        "minor",
+        "info",
+        "warning"
+      ]
+    },
+    "conformanceRuleCategory": {
+      "type": "string",
+      "enum": [
+        "data_validation",
+        "api_contract",
+        "business_logic",
+        "security_policy",
+        "performance_constraint",
+        "resource_usage",
+        "state_invariant",
+        "behavioral_constraint",
+        "integration_requirement",
+        "compliance_rule"
+      ]
+    }
+  }
+}

--- a/schema/conformance-report.schema.json
+++ b/schema/conformance-report.schema.json
@@ -1,0 +1,405 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/conformance-report.schema.json",
+  "title": "Conformance Report Summary",
+  "description": "Machine-readable summary emitted by `ae conformance report --format json`.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "status",
+    "runsAnalyzed",
+    "statusBreakdown",
+    "totals",
+    "severityTotals",
+    "categoryTotals",
+    "severityTrends",
+    "topViolations",
+    "inputs"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "success",
+        "failure",
+        "skipped"
+      ]
+    },
+    "runsAnalyzed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "statusBreakdown": {
+      "type": "object",
+      "required": [
+        "pass",
+        "fail",
+        "skip",
+        "error",
+        "timeout"
+      ],
+      "properties": {
+        "pass": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "fail": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skip": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "error": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "timeout": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "totals": {
+      "type": "object",
+      "required": [
+        "rulesExecuted",
+        "rulesPassed",
+        "rulesFailed",
+        "rulesErrored",
+        "rulesSkipped",
+        "totalViolations",
+        "uniqueRules",
+        "uniqueViolationRules"
+      ],
+      "properties": {
+        "rulesExecuted": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesPassed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesFailed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesErrored": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesSkipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalViolations": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "uniqueRules": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "uniqueViolationRules": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "severityTotals": {
+      "$ref": "#/$defs/severityCounts"
+    },
+    "categoryTotals": {
+      "$ref": "#/$defs/categoryCounts"
+    },
+    "severityTrends": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "severity",
+          "current",
+          "previous",
+          "trend"
+        ],
+        "properties": {
+          "severity": {
+            "$ref": "#/$defs/violationSeverity"
+          },
+          "current": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "previous": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "trend": {
+            "type": "string",
+            "enum": [
+              "increasing",
+              "decreasing",
+              "stable"
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "topViolations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "ruleId",
+          "ruleName",
+          "count",
+          "lastObserved"
+        ],
+        "properties": {
+          "ruleId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "ruleName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "lastObserved": {
+            "oneOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "latestRun": {
+      "type": "object",
+      "required": [
+        "file",
+        "timestamp",
+        "status",
+        "environment",
+        "version",
+        "rulesExecuted",
+        "rulesFailed",
+        "totalViolations"
+      ],
+      "properties": {
+        "file": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "status": {
+          "$ref": "#/$defs/verificationStatus"
+        },
+        "environment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rulesExecuted": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesFailed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalViolations": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "file",
+          "timestamp",
+          "status",
+          "environment",
+          "version",
+          "totalViolations"
+        ],
+        "properties": {
+          "file": {
+            "type": "string",
+            "minLength": 1
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "$ref": "#/$defs/verificationStatus"
+          },
+          "environment": {
+            "type": "string",
+            "minLength": 1
+          },
+          "version": {
+            "type": "string",
+            "minLength": 1
+          },
+          "totalViolations": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "notes": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "verificationStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "skip",
+        "error",
+        "timeout"
+      ]
+    },
+    "violationSeverity": {
+      "type": "string",
+      "enum": [
+        "critical",
+        "major",
+        "minor",
+        "info",
+        "warning"
+      ]
+    },
+    "severityCounts": {
+      "type": "object",
+      "required": [
+        "critical",
+        "major",
+        "minor",
+        "info",
+        "warning"
+      ],
+      "properties": {
+        "critical": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "major": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "info": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warning": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "categoryCounts": {
+      "type": "object",
+      "required": [
+        "data_validation",
+        "api_contract",
+        "business_logic",
+        "security_policy",
+        "performance_constraint",
+        "resource_usage",
+        "state_invariant",
+        "behavioral_constraint",
+        "integration_requirement",
+        "compliance_rule"
+      ],
+      "properties": {
+        "data_validation": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "api_contract": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "business_logic": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "security_policy": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "performance_constraint": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resource_usage": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "state_invariant": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "behavioral_constraint": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "integration_requirement": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "compliance_rule": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schema/conformance-verify-result.schema.json
+++ b/schema/conformance-verify-result.schema.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/conformance-verify-result.schema.json",
+  "title": "Conformance Verify Result",
+  "description": "Machine-readable result emitted by `ae conformance verify --format json`.",
+  "type": "object",
+  "required": [
+    "overall",
+    "results",
+    "violations",
+    "summary",
+    "metadata"
+  ],
+  "properties": {
+    "overall": {
+      "$ref": "#/$defs/verificationStatus"
+    },
+    "results": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/verificationResult"
+      }
+    },
+    "violations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/violationDetails"
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "totalRules",
+        "rulesExecuted",
+        "rulesPassed",
+        "rulesFailed",
+        "rulesSkipped",
+        "rulesError",
+        "totalDuration",
+        "violationsBySeverity",
+        "violationsByCategory"
+      ],
+      "properties": {
+        "totalRules": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesExecuted": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesPassed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesFailed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesSkipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rulesError": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "totalDuration": {
+          "type": "number",
+          "minimum": 0
+        },
+        "violationsBySeverity": {
+          "$ref": "#/$defs/severityCounts"
+        },
+        "violationsByCategory": {
+          "$ref": "#/$defs/categoryCounts"
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "required": [
+        "executionId",
+        "timestamp",
+        "environment",
+        "version"
+      ],
+      "properties": {
+        "executionId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "environment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "verificationStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "skip",
+        "error",
+        "timeout"
+      ]
+    },
+    "violationSeverity": {
+      "type": "string",
+      "enum": [
+        "critical",
+        "major",
+        "minor",
+        "info",
+        "warning"
+      ]
+    },
+    "conformanceRuleCategory": {
+      "type": "string",
+      "enum": [
+        "data_validation",
+        "api_contract",
+        "business_logic",
+        "security_policy",
+        "performance_constraint",
+        "resource_usage",
+        "state_invariant",
+        "behavioral_constraint",
+        "integration_requirement",
+        "compliance_rule"
+      ]
+    },
+    "severityCounts": {
+      "type": "object",
+      "required": [
+        "critical",
+        "major",
+        "minor",
+        "info",
+        "warning"
+      ],
+      "properties": {
+        "critical": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "major": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minor": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "info": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "warning": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "categoryCounts": {
+      "type": "object",
+      "required": [
+        "data_validation",
+        "api_contract",
+        "business_logic",
+        "security_policy",
+        "performance_constraint",
+        "resource_usage",
+        "state_invariant",
+        "behavioral_constraint",
+        "integration_requirement",
+        "compliance_rule"
+      ],
+      "properties": {
+        "data_validation": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "api_contract": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "business_logic": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "security_policy": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "performance_constraint": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "resource_usage": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "state_invariant": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "behavioral_constraint": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "integration_requirement": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "compliance_rule": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "runtimeContext": {
+      "type": "object",
+      "required": [
+        "timestamp",
+        "executionId",
+        "environment",
+        "metadata"
+      ],
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "executionId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "functionName": {
+          "type": "string"
+        },
+        "modulePath": {
+          "type": "string"
+        },
+        "requestId": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        },
+        "sessionId": {
+          "type": "string"
+        },
+        "environment": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string"
+        },
+        "buildId": {
+          "type": "string"
+        },
+        "traceId": {
+          "type": "string"
+        },
+        "spanId": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "violationEvidence": {
+      "type": "object",
+      "required": [
+        "stateSnapshot",
+        "metrics",
+        "logs",
+        "traces"
+      ],
+      "properties": {
+        "inputData": {},
+        "outputData": {},
+        "stateSnapshot": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "logs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "traces": {
+          "type": "array"
+        }
+      },
+      "additionalProperties": true
+    },
+    "violationRemediation": {
+      "type": "object",
+      "required": [
+        "suggested",
+        "automatic",
+        "priority"
+      ],
+      "properties": {
+        "suggested": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "automatic": {
+          "type": "boolean"
+        },
+        "priority": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "violationDetails": {
+      "type": "object",
+      "required": [
+        "ruleId",
+        "ruleName",
+        "category",
+        "severity",
+        "message",
+        "context",
+        "evidence"
+      ],
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ruleName": {
+          "type": "string",
+          "minLength": 1
+        },
+        "category": {
+          "$ref": "#/$defs/conformanceRuleCategory"
+        },
+        "severity": {
+          "$ref": "#/$defs/violationSeverity"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "actualValue": {},
+        "expectedValue": {},
+        "context": {
+          "$ref": "#/$defs/runtimeContext"
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "evidence": {
+          "$ref": "#/$defs/violationEvidence"
+        },
+        "remediation": {
+          "$ref": "#/$defs/violationRemediation"
+        }
+      },
+      "additionalProperties": false
+    },
+    "verificationMetrics": {
+      "type": "object",
+      "required": [
+        "executionTime",
+        "networkCalls",
+        "dbQueries"
+      ],
+      "properties": {
+        "executionTime": {
+          "type": "number",
+          "minimum": 0
+        },
+        "memoryUsage": {
+          "type": "number",
+          "minimum": 0
+        },
+        "cpuUsage": {
+          "type": "number",
+          "minimum": 0
+        },
+        "networkCalls": {
+          "type": "number",
+          "minimum": 0
+        },
+        "dbQueries": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "verificationResult": {
+      "type": "object",
+      "required": [
+        "id",
+        "ruleId",
+        "status",
+        "timestamp",
+        "duration",
+        "context",
+        "metrics",
+        "metadata"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "ruleId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "$ref": "#/$defs/verificationStatus"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "duration": {
+          "type": "number",
+          "minimum": 0
+        },
+        "context": {
+          "$ref": "#/$defs/runtimeContext"
+        },
+        "violation": {
+          "$ref": "#/$defs/violationDetails"
+        },
+        "metrics": {
+          "$ref": "#/$defs/verificationMetrics"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -75,6 +75,21 @@ const checks = [
     schema: 'schema/quality-report.schema.json',
     fixtures: ['fixtures/quality-report/sample.quality-report.json'],
     label: 'Quality report schema validation'
+  },
+  {
+    schema: 'schema/conformance-verify-result.schema.json',
+    fixtures: ['fixtures/conformance/sample.conformance-verify-result.json'],
+    label: 'Conformance verify result schema validation'
+  },
+  {
+    schema: 'schema/conformance-metrics.schema.json',
+    fixtures: ['fixtures/conformance/sample.conformance-metrics.json'],
+    label: 'Conformance metrics schema validation'
+  },
+  {
+    schema: 'schema/conformance-report.schema.json',
+    fixtures: ['fixtures/conformance/sample.conformance-report.json'],
+    label: 'Conformance report schema validation'
   }
 ];
 


### PR DESCRIPTION
## Summary
- add JSON schema contracts for `ae conformance verify`, `ae conformance metrics --format json`, and `ae conformance report --format json`
- add representative fixtures and wire schema validation into `scripts/ci/validate-json.mjs`
- add contract tests validating conformance CLI JSON outputs against schemas
- document schema references in CLI command reference

## Testing
- node scripts/ci/validate-json.mjs
- pnpm vitest run tests/contracts/cli-artifacts-contracts.test.ts
- pnpm types:check
- pnpm docs:lint

Closes #2105