### PR TITLE
chore(schema): normalize github.com-style schema IDs

### DIFF
--- a/schema/artifact-metadata.schema.json
+++ b/schema/artifact-metadata.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/itdojp/ae-framework/schema/artifact-metadata.schema.json",
+  "$id": "https://ae-framework/schema/artifact-metadata.schema.json",
   "title": "Artifact Metadata",
   "type": "object",
   "additionalProperties": false,

--- a/schema/formal-summary-v1.schema.json
+++ b/schema/formal-summary-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/itdojp/ae-framework/schema/formal-summary-v1.schema.json",
+  "$id": "https://ae-framework/schema/formal-summary-v1.schema.json",
   "title": "Formal Summary v1",
   "type": "object",
   "additionalProperties": false,
@@ -57,7 +57,7 @@
       "description": "When this summary was generated (UTC ISO8601)."
     },
     "metadata": {
-      "$ref": "https://github.com/itdojp/ae-framework/schema/artifact-metadata.schema.json"
+      "$ref": "https://ae-framework/schema/artifact-metadata.schema.json"
     },
     "results": {
       "type": "array",

--- a/schema/issue-traceability-map.schema.json
+++ b/schema/issue-traceability-map.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/itdojp/ae-framework/schema/issue-traceability-map.schema.json",
+  "$id": "https://ae-framework/schema/issue-traceability-map.schema.json",
   "title": "Issue Traceability Map",
   "type": "object",
   "additionalProperties": false,

--- a/schema/issue-traceability-matrix.schema.json
+++ b/schema/issue-traceability-matrix.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/itdojp/ae-framework/schema/issue-traceability-matrix.schema.json",
+  "$id": "https://ae-framework/schema/issue-traceability-matrix.schema.json",
   "title": "Issue Traceability Matrix",
   "type": "object",
   "additionalProperties": false,

--- a/schema/run-manifest.schema.json
+++ b/schema/run-manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/itdojp/ae-framework/schema/run-manifest.schema.json",
+  "$id": "https://ae-framework/schema/run-manifest.schema.json",
   "title": "Run Manifest",
   "type": "object",
   "additionalProperties": false,
@@ -27,7 +27,7 @@
       "description": "When the manifest was generated (UTC ISO8601)."
     },
     "metadata": {
-      "$ref": "https://github.com/itdojp/ae-framework/schema/artifact-metadata.schema.json"
+      "$ref": "https://ae-framework/schema/artifact-metadata.schema.json"
     },
     "summaries": {
       "type": "object",

--- a/schema/usefulness-evaluation-report.schema.json
+++ b/schema/usefulness-evaluation-report.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/itdojp/ae-framework/schema/usefulness-evaluation-report.schema.json",
+  "$id": "https://ae-framework/schema/usefulness-evaluation-report.schema.json",
   "title": "Usefulness Evaluation Report",
   "type": "object",
   "additionalProperties": false,

--- a/schema/verify-lite-run-summary.schema.json
+++ b/schema/verify-lite-run-summary.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/itdojp/ae-framework/schema/verify-lite-run-summary.schema.json",
+  "$id": "https://ae-framework/schema/verify-lite-run-summary.schema.json",
   "title": "Verify Lite Run Summary",
   "type": "object",
   "additionalProperties": false,
@@ -23,7 +23,7 @@
       "format": "date-time"
     },
     "metadata": {
-      "$ref": "https://github.com/itdojp/ae-framework/schema/artifact-metadata.schema.json"
+      "$ref": "https://ae-framework/schema/artifact-metadata.schema.json"
     },
     "flags": {
       "type": "object",


### PR DESCRIPTION
## Summary
- normalize remaining `schema/*` entries using `https://github.com/itdojp/ae-framework/schema/...` to `https://ae-framework/schema/...`
- keep `https://itdojp.github.io/...` entries unchanged (out of this scope)
- update internal `$ref` targets that pointed to github.com schema URLs for consistency

## Changed files
- `schema/artifact-metadata.schema.json`
- `schema/formal-summary-v1.schema.json`
- `schema/issue-traceability-map.schema.json`
- `schema/issue-traceability-matrix.schema.json`
- `schema/run-manifest.schema.json`
- `schema/usefulness-evaluation-report.schema.json`
- `schema/verify-lite-run-summary.schema.json`

## Validation
- `node scripts/ci/validate-json.mjs`
- `pnpm vitest run tests/contracts/cli-artifacts-contracts.test.ts`
- `pnpm types:check`
- `pnpm docs:lint`

Closes #2108
