### PR TITLE
refactor(container): remove catch-any from docker/podman engines

### DIFF
--- a/src/services/container/podman-engine.ts
+++ b/src/services/container/podman-engine.ts
@@ -33,6 +33,7 @@ import type {
 } from './container-engine-output-types.js';
 
 const execAsync = promisify(exec);
+const getErrorMessage = (error: unknown): string => toExecErrorLike(error).message;
 
 interface PodmanInfoResponse {
   host?: {
@@ -155,13 +156,13 @@ export class PodmanEngine extends ContainerEngine {
       });
 
       return containerId;
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'createContainer',
-        error: error.message,
+        error: getErrorMessage(error),
         config
       });
-      throw new Error(`Failed to create container: ${error.message}`);
+      throw new Error(`Failed to create container: ${getErrorMessage(error)}`);
     }
   }
 
@@ -176,13 +177,13 @@ export class PodmanEngine extends ContainerEngine {
       });
 
       this.emit('containerStarted', { containerId });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'startContainer',
-        error: error.message,
+        error: getErrorMessage(error),
         containerId
       });
-      throw new Error(`Failed to start container: ${error.message}`);
+      throw new Error(`Failed to start container: ${getErrorMessage(error)}`);
     }
   }
 
@@ -191,13 +192,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} stop --time ${timeout} ${containerId}`);
       
       this.emit('containerStopped', { containerId });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'stopContainer',
-        error: error.message,
+        error: getErrorMessage(error),
         containerId
       });
-      throw new Error(`Failed to stop container: ${error.message}`);
+      throw new Error(`Failed to stop container: ${getErrorMessage(error)}`);
     }
   }
 
@@ -210,13 +211,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} ${args.join(' ')}`);
       
       this.emit('containerRemoved', { containerId, force });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'removeContainer',
-        error: error.message,
+        error: getErrorMessage(error),
         containerId
       });
-      throw new Error(`Failed to remove container: ${error.message}`);
+      throw new Error(`Failed to remove container: ${getErrorMessage(error)}`);
     }
   }
 
@@ -225,13 +226,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} restart ${containerId}`);
       
       this.emit('containerRestarted', { containerId });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'restartContainer',
-        error: error.message,
+        error: getErrorMessage(error),
         containerId
       });
-      throw new Error(`Failed to restart container: ${error.message}`);
+      throw new Error(`Failed to restart container: ${getErrorMessage(error)}`);
     }
   }
 
@@ -371,8 +372,8 @@ export class PodmanEngine extends ContainerEngine {
         ...(containerInfo.State.ExitCode !== undefined ? { exitCode: containerInfo.State.ExitCode } : {}),
         health: containerInfo.State.Health?.Status || 'none'
       };
-    } catch (error: any) {
-      throw new Error(`Failed to get container status: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to get container status: ${getErrorMessage(error)}`);
     }
   }
 
@@ -397,8 +398,8 @@ export class PodmanEngine extends ContainerEngine {
         createdAt: new Date(container.CreatedAt * 1000),
         ...(container.Ports ? { ports: parsePublishedPorts(container.Ports) } : {})
       }));
-    } catch (error: any) {
-      throw new Error(`Failed to list containers: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to list containers: ${getErrorMessage(error)}`);
     }
   }
 
@@ -427,8 +428,8 @@ export class PodmanEngine extends ContainerEngine {
           combined: result.stdout + result.stderr,
           timestamp: new Date()
         };
-      } catch (error: any) {
-        throw new Error(`Failed to get container logs: ${error.message}`);
+      } catch (error: unknown) {
+        throw new Error(`Failed to get container logs: ${getErrorMessage(error)}`);
       }
     }
   }
@@ -484,8 +485,8 @@ export class PodmanEngine extends ContainerEngine {
         },
         timestamp: new Date()
       };
-    } catch (error: any) {
-      throw new Error(`Failed to get container stats: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to get container stats: ${getErrorMessage(error)}`);
     }
   }
 
@@ -533,14 +534,14 @@ export class PodmanEngine extends ContainerEngine {
       });
 
       return imageId;
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'buildImage',
-        error: error.message,
+        error: getErrorMessage(error),
         imageTag,
         buildContext
       });
-      throw new Error(`Failed to build image: ${error.message}`);
+      throw new Error(`Failed to build image: ${getErrorMessage(error)}`);
     }
   }
 
@@ -550,13 +551,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} pull ${fullImage}`);
       
       this.emit('imagePulled', { image: fullImage });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'pullImage',
-        error: error.message,
+        error: getErrorMessage(error),
         image: `${image}:${tag}`
       });
-      throw new Error(`Failed to pull image: ${error.message}`);
+      throw new Error(`Failed to pull image: ${getErrorMessage(error)}`);
     }
   }
 
@@ -566,13 +567,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} push ${fullImage}`);
       
       this.emit('imagePushed', { image: fullImage });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'pushImage',
-        error: error.message,
+        error: getErrorMessage(error),
         image: `${image}:${tag}`
       });
-      throw new Error(`Failed to push image: ${error.message}`);
+      throw new Error(`Failed to push image: ${getErrorMessage(error)}`);
     }
   }
 
@@ -585,13 +586,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} ${args.join(' ')}`);
       
       this.emit('imageRemoved', { image, force });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'removeImage',
-        error: error.message,
+        error: getErrorMessage(error),
         image
       });
-      throw new Error(`Failed to remove image: ${error.message}`);
+      throw new Error(`Failed to remove image: ${getErrorMessage(error)}`);
     }
   }
 
@@ -616,8 +617,8 @@ export class PodmanEngine extends ContainerEngine {
         ...(image.Digest ? { digest: image.Digest } : {}),
         ...(image.Labels ? { labels: image.Labels } : {})
       }));
-    } catch (error: any) {
-      throw new Error(`Failed to list images: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to list images: ${getErrorMessage(error)}`);
     }
   }
 
@@ -626,14 +627,14 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} tag ${sourceImage} ${targetImage}`);
       
       this.emit('imageTagged', { sourceImage, targetImage });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'tagImage',
-        error: error.message,
+        error: getErrorMessage(error),
         sourceImage,
         targetImage
       });
-      throw new Error(`Failed to tag image: ${error.message}`);
+      throw new Error(`Failed to tag image: ${getErrorMessage(error)}`);
     }
   }
 
@@ -653,13 +654,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} ${args.join(' ')}`);
       
       this.emit('volumeCreated', { name, labels });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'createVolume',
-        error: error.message,
+        error: getErrorMessage(error),
         name
       });
-      throw new Error(`Failed to create volume: ${error.message}`);
+      throw new Error(`Failed to create volume: ${getErrorMessage(error)}`);
     }
   }
 
@@ -672,13 +673,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} ${args.join(' ')}`);
       
       this.emit('volumeRemoved', { name, force });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'removeVolume',
-        error: error.message,
+        error: getErrorMessage(error),
         name
       });
-      throw new Error(`Failed to remove volume: ${error.message}`);
+      throw new Error(`Failed to remove volume: ${getErrorMessage(error)}`);
     }
   }
 
@@ -699,8 +700,8 @@ export class PodmanEngine extends ContainerEngine {
         ...(volume.Labels ? { labels: volume.Labels } : {}),
         ...(volume.Size !== undefined ? { size: volume.Size } : {})
       }));
-    } catch (error: any) {
-      throw new Error(`Failed to list volumes: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to list volumes: ${getErrorMessage(error)}`);
     }
   }
 
@@ -727,13 +728,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} ${args.join(' ')}`);
       
       this.emit('networkCreated', { name, options });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'createNetwork',
-        error: error.message,
+        error: getErrorMessage(error),
         name
       });
-      throw new Error(`Failed to create network: ${error.message}`);
+      throw new Error(`Failed to create network: ${getErrorMessage(error)}`);
     }
   }
 
@@ -742,13 +743,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.podmanPath} network rm ${name}`);
       
       this.emit('networkRemoved', { name });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'removeNetwork',
-        error: error.message,
+        error: getErrorMessage(error),
         name
       });
-      throw new Error(`Failed to remove network: ${error.message}`);
+      throw new Error(`Failed to remove network: ${getErrorMessage(error)}`);
     }
   }
 
@@ -769,8 +770,8 @@ export class PodmanEngine extends ContainerEngine {
         driver: network.Driver,
         ...(network.Labels ? { labels: network.Labels } : {})
       }));
-    } catch (error: any) {
-      throw new Error(`Failed to list networks: ${error.message}`);
+    } catch (error: unknown) {
+      throw new Error(`Failed to list networks: ${getErrorMessage(error)}`);
     }
   }
 
@@ -802,13 +803,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.composePath} ${args.join(' ')}`, { env });
       
       this.emit('composeUp', { composeFile, options });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'runCompose',
-        error: error.message,
+        error: getErrorMessage(error),
         composeFile
       });
-      throw new Error(`Failed to run compose: ${error.message}`);
+      throw new Error(`Failed to run compose: ${getErrorMessage(error)}`);
     }
   }
 
@@ -829,13 +830,13 @@ export class PodmanEngine extends ContainerEngine {
       await execAsync(`${this.composePath} ${args.join(' ')}`);
       
       this.emit('composeDown', { composeFile, projectName });
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'stopCompose',
-        error: error.message,
+        error: getErrorMessage(error),
         composeFile
       });
-      throw new Error(`Failed to stop compose: ${error.message}`);
+      throw new Error(`Failed to stop compose: ${getErrorMessage(error)}`);
     }
   }
 
@@ -891,13 +892,13 @@ export class PodmanEngine extends ContainerEngine {
 
       this.emit('cleanup', results);
       return results;
-    } catch (error: any) {
+    } catch (error: unknown) {
       this.emit('error', {
         operation: 'cleanup',
-        error: error.message,
+        error: getErrorMessage(error),
         options
       });
-      throw new Error(`Failed to cleanup: ${error.message}`);
+      throw new Error(`Failed to cleanup: ${getErrorMessage(error)}`);
     }
   }
 


### PR DESCRIPTION
## 概要
- `docker-engine.ts` / `podman-engine.ts` の `catch (error: any)` を廃止し、`unknown` ベースに統一
- 例外メッセージ抽出を `toExecErrorLike` ベースで共通化し、型安全にエラー処理

## 変更内容
- `src/services/container/docker-engine.ts`
  - `catch (error: any)` を `catch (error: unknown)` に置換
  - `getErrorMessage` ヘルパーを導入
  - 例外オブジェクト参照（`message/code/stdout/stderr`）を安全な抽出経由へ統一
- `src/services/container/podman-engine.ts`
  - `catch (error: any)` を `catch (error: unknown)` に置換
  - `getErrorMessage` ヘルパーを導入
  - 例外メッセージ参照を安全な抽出経由へ統一

## 効果
- `any` 件数
  - `src/services/container/docker-engine.ts`: 25 -> 0
  - `src/services/container/podman-engine.ts`: 24 -> 0

## 検証
- `pnpm -s run types:check`
- `pnpm -s exec vitest run tests/unit/utils/container-engine-utils.test.ts`
- `pnpm -s run test:container`
