### PR TITLE
refactor(types): remove residual any in drift detector and contract conditions

### DIFF
--- a/src/contracts/conditions.ts
+++ b/src/contracts/conditions.ts
@@ -37,8 +37,9 @@ export function post(input: unknown, output: unknown): boolean {
     if (!parsedOutput.success) return false
     // If input provided sku, ensure it matches
     if (isObject(input) && 'sku' in input) {
-      if (typeof input['sku'] !== 'string') return false
-      if (parsedOutput.data.sku !== input['sku']) return false
+      const parsedInput = InventorySkuGetInput.safeParse(input)
+      if (!parsedInput.success) return false
+      if (parsedOutput.data.sku !== parsedInput.data.sku) return false
     }
     return true
   }

--- a/tests/contracts/conditions.test.ts
+++ b/tests/contracts/conditions.test.ts
@@ -14,6 +14,18 @@ describe('contracts/conditions post', () => {
     expect(post(input, output)).toBe(false)
   })
 
+  it('returns false when inventory input sku is not a string', () => {
+    const input = { sku: 123 }
+    const output = { sku: 'sku-1', stock: 10 }
+    expect(post(input, output)).toBe(false)
+  })
+
+  it('returns false when inventory output has negative stock', () => {
+    const input = { sku: 'sku-1' }
+    const output = { sku: 'sku-1', stock: -5 }
+    expect(post(input, output)).toBe(false)
+  })
+
   it('returns true when reservation output echoes input fields', () => {
     const input = { sku: 'sku-1', quantity: 2, orderId: 'order-1' }
     const output = {
@@ -36,5 +48,23 @@ describe('contracts/conditions post', () => {
       status: 'created',
     }
     expect(post(input, output)).toBe(false)
+  })
+
+  it('returns false when reservation output has an invalid status', () => {
+    const input = { sku: 'sku-1', quantity: 2, orderId: 'order-1' }
+    const output = {
+      id: 'res-1',
+      sku: 'sku-1',
+      quantity: 2,
+      orderId: 'order-1',
+      status: 'invalid-status',
+    }
+    expect(post(input, output)).toBe(false)
+  })
+
+  it('returns true when input/output do not match recognized patterns', () => {
+    const input = { foo: 'bar' }
+    const output = { baz: 'qux' }
+    expect(post(input, output)).toBe(true)
   })
 })


### PR DESCRIPTION
## 概要
- `src/codegen/drift-detector.ts` の `any` を除去し、`glob` オプション/manifest ファイル型を明示化
- `src/contracts/conditions.ts` の `as any` を除去し、Zod `safeParse` 後の型付きデータで比較
- `tests/contracts/conditions.test.ts` を追加し、`post()` の主要分岐を回帰テスト

## 変更詳細
- DriftDetector
  - `globOpts` を `GlobOptionsWithFileTypesFalse` で型付け
  - `calculateChangeConfidence` / `getOriginalLineCount` の入力型を `GeneratedFile` ベースへ整理
  - 未使用の `DriftDetectionResult` import を削除
- Contract Conditions
  - Inventory/Reservation 分岐で `safeParse` 済みオブジェクトを利用
  - `input['sku']` 形式に統一し、index signature ルールに準拠

## テスト
- `pnpm -s run types:check`
- `pnpm -s exec vitest run tests/contracts/conditions.test.ts`
