### PR TITLE
refactor(types): remove any from parallel system config

### DIFF
--- a/src/optimization/parallel/index.ts
+++ b/src/optimization/parallel/index.ts
@@ -4,8 +4,11 @@
  */
 
 import { ParallelOptimizer } from './parallel-optimizer.js';
+import type { OptimizationStrategy } from './parallel-optimizer.js';
 import { TaskScheduler } from './task-scheduler.js';
+import type { SchedulingPolicy } from './task-scheduler.js';
 import { ResourcePool } from './resource-pool.js';
+import type { PoolConfiguration } from './resource-pool.js';
 
 export { ParallelOptimizer } from './parallel-optimizer.js';
 export { TaskScheduler } from './task-scheduler.js';
@@ -84,9 +87,9 @@ export class ParallelOptimizationSystem {
   private resourcePool: ResourcePool;
 
   constructor(
-    optimizerConfig?: any,
-    schedulerConfig?: any,
-    poolConfig?: any
+    optimizerConfig?: Partial<OptimizationStrategy>,
+    schedulerConfig?: Partial<SchedulingPolicy>,
+    poolConfig?: Partial<PoolConfiguration>
   ) {
     this.resourcePool = new ResourcePool(poolConfig);
     this.scheduler = new TaskScheduler(schedulerConfig);


### PR DESCRIPTION
## 概要
- `ParallelOptimizationSystem` のコンストラクタ引数から `any` を除去し、既存構成型に置換

## 変更内容
- `src/optimization/parallel/index.ts`
  - `optimizerConfig?: any` -> `optimizerConfig?: Partial<OptimizationStrategy>`
  - `schedulerConfig?: any` -> `schedulerConfig?: Partial<SchedulingPolicy>`
  - `poolConfig?: any` -> `poolConfig?: Partial<PoolConfiguration>`
  - 上記に合わせて type import を追加

## 意図
- 実行時挙動を変えずに型安全性を向上
- 呼び出し側の補完・静的検証を強化

## 検証
- `pnpm -s types:check`
- `pnpm vitest run tests/optimization/parallel.test.ts`
