### PR TITLE
refactor(types): remove any casts in task scheduler affinity tags

### DIFF
--- a/src/optimization/parallel/task-scheduler.ts
+++ b/src/optimization/parallel/task-scheduler.ts
@@ -716,12 +716,14 @@ export class TaskScheduler extends EventEmitter {
     tags.push(task.type);
     
     // Extract tags from metadata
-    if ((task.metadata as any)['component']) {
-      tags.push(`component:${(task.metadata as any)['component']}`);
+    const component = task.metadata['component'];
+    if (typeof component === 'string' && component.length > 0) {
+      tags.push(`component:${component}`);
     }
     
-    if ((task.metadata as any)['language']) {
-      tags.push(`language:${(task.metadata as any)['language']}`);
+    const language = task.metadata['language'];
+    if (typeof language === 'string' && language.length > 0) {
+      tags.push(`language:${language}`);
     }
     
     return tags;


### PR DESCRIPTION
## 概要
- タスクスケジューラの affinity tag 抽出で残っていた `any` キャストを除去

## 変更内容
- `src/optimization/parallel/task-scheduler.ts`
  - `task.metadata` から `component` / `language` を取り出す際の `as any` を削除
  - `unknown` 値を `typeof value === 'string' && value.length > 0` で絞り込んでタグ化

## 意図
- 既存挙動を維持しつつ、`ParallelTask.metadata: Record<string, unknown>` と整合させる
- 不正型メタデータの文字列化混入を防止

## 検証
- `pnpm -s types:check`
- `pnpm vitest run tests/optimization/parallel.test.ts`
