### PR TITLE
refactor: remove any casts in property test generation server contract

### DIFF
--- a/src/mcp-server/schemas.ts
+++ b/src/mcp-server/schemas.ts
@@ -128,7 +128,10 @@ export const PropertyTestsArgsSchema = z.object({
   functionName: z.string().min(1),
   inputs: z.array(InputParamSchema).min(1),
   outputs: z
-    .object({ type: z.string().min(1) })
+    .object({
+      type: z.string().min(1),
+      constraints: z.array(z.string()).optional(),
+    })
     .optional()
     .default({ type: 'any' }),
   invariants: z.array(z.string()).min(1),

--- a/src/mcp-server/test-generation-server.ts
+++ b/src/mcp-server/test-generation-server.ts
@@ -343,10 +343,7 @@ class TestGenerationServer {
 
   private async handleGeneratePropertyTests(args: unknown) {
     const parsed: PropertyTestsArgs = parseOrThrow(PropertyTestsArgsSchema, args);
-    const outputConstraints =
-      'constraints' in parsed.outputs && Array.isArray(parsed.outputs.constraints)
-        ? parsed.outputs.constraints.filter((constraint): constraint is string => typeof constraint === 'string')
-        : undefined;
+    const outputConstraints = parsed.outputs.constraints;
     const contract: Parameters<TestGenerationAgent['generatePropertyTests']>[0] = {
       function: parsed.functionName,
       inputs: parsed.inputs.map((i) => ({


### PR DESCRIPTION
## Overview
- remove `parsed.outputs as any` cast in `handleGeneratePropertyTests`
- type `contract` using `Parameters<TestGenerationAgent['generatePropertyTests']>[0]`
- remove `contract as any` call-site cast while keeping existing JSON/artifact behavior

## Verification
- pnpm -s types:check