### PR TITLE
refactor(cli): remove any from resilience execution options

### DIFF
--- a/src/cli/resilience-cli.ts
+++ b/src/cli/resilience-cli.ts
@@ -216,6 +216,12 @@ export class ResilienceCLI {
 
     for (let i = 0; i < operations; i++) {
       try {
+        const executeOptions: Parameters<ResilienceSystem['executeResilient']>[1] = {
+          operationName: `test-op-${i + 1}`,
+          timeoutMs: 5000,
+          useAdaptiveTimeout: true,
+          ...(options.bulkheadName ? { bulkheadName: options.bulkheadName } : {}),
+        };
         await system.executeResilient(
           async () => {
             // Simulate operation with potential failure
@@ -225,12 +231,7 @@ export class ResilienceCLI {
             await new Promise(resolve => setTimeout(resolve, Math.random() * 100));
             return `Operation ${i + 1} success`;
           },
-          ({
-            operationName: `test-op-${i + 1}`,
-            timeoutMs: 5000,
-            useAdaptiveTimeout: true,
-            ...(options.bulkheadName ? { bulkheadName: options.bulkheadName } : {}),
-          } as any)
+          executeOptions,
         );
         successes++;
         process.stdout.write(chalk.green('.'));


### PR DESCRIPTION
## 概要
- `src/cli/resilience-cli.ts` の `as any` を除去
- `executeResilient` のオプションを型導出 (`Parameters<ResilienceSystem['executeResilient']>[1]`) で明示
- 実行時挙動は変更なし

## 検証
- `pnpm -s types:check`
