### PR TITLE
refactor(monitoring): remove any from active alert iteration

### DIFF
--- a/src/optimization/monitoring/demo.ts
+++ b/src/optimization/monitoring/demo.ts
@@ -262,7 +262,7 @@ function showActiveAlerts(system: MonitoringSystem): void {
     return;
   }
 
-  alerts.forEach((alert: any, index: number) => {
+  alerts.forEach((alert) => {
     const icon = alert.severity === 'critical' ? '🚨' : 
                  alert.severity === 'warning' ? '⚠️' : 'ℹ️';
     const duration = formatDuration(alert.duration);


### PR DESCRIPTION
## 概要
- `src/optimization/monitoring/demo.ts` の `any` を除去
- `getActiveAlerts()` の戻り型推論を利用して `alert` の型を保持
- 未使用だった `index` 引数も合わせて削除

## 検証
- `pnpm -s types:check`
