### PR TITLE
refactor(testing): remove any from fc assert error handling

### DIFF
--- a/src/testing/fc-assert.ts
+++ b/src/testing/fc-assert.ts
@@ -2,7 +2,9 @@ import fc from 'fast-check';
 import { writeRepro } from './repro-writer.js';
 
 function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 export function aeAssert<T>(prop: fc.IProperty<T>, opts?: Partial<fc.Parameters<T>>) {


### PR DESCRIPTION
## 概要
- `src/testing/fc-assert.ts` の `catch (e: any)` を除去
- `unknown` 例外を扱う補助関数を追加して `message/counterexample/shrunk/value` 参照を型安全化
- 既存のエラーレポート生成とフォールバック挙動は維持

## 検証
- `pnpm -s types:check`
