### PR TITLE
refactor(types): remove any from task request context

### DIFF
--- a/src/agents/task-types.ts
+++ b/src/agents/task-types.ts
@@ -2,11 +2,18 @@
  * Common types for Claude Code Task Tool integration
  */
 
+export interface TaskRequestContext {
+  validationTaskType?: string;
+  strict?: boolean;
+  sources?: string | string[];
+  [key: string]: unknown;
+}
+
 export interface TaskRequest {
   description: string;
   prompt: string;
   subagent_type: string;
-  context?: any;
+  context?: TaskRequestContext;
 }
 
 export interface TaskResponse {


### PR DESCRIPTION
## 概要
- `src/agents/task-types.ts` の `TaskRequest.context` から `any` を除去
- `TaskRequestContext` 型を導入し、既存利用プロパティ（`validationTaskType`/`strict`/`sources`）を明示
- 拡張用の index signature (`[key: string]: unknown`) で互換性を維持

## 検証
- `pnpm -s types:check`
