### PR TITLE
refactor: remove any from resilience system health type

### DIFF
--- a/src/resilience/index.ts
+++ b/src/resilience/index.ts
@@ -341,7 +341,7 @@ export class ResilienceSystem {
       rateLimiter?: { availableTokens: number; maxTokens: number };
       bulkheads: Record<string, BulkheadStats>;
       timeouts: Record<string, TimeoutStats>;
-      http?: any;
+      http?: ReturnType<ResilientHttpClient['getHealthStats']>;
     };
     bulkheadSystem: ReturnType<BulkheadManager['getSystemHealth']>;
   } {
@@ -352,7 +352,7 @@ export class ResilienceSystem {
       rateLimiter?: { availableTokens: number; maxTokens: number };
       bulkheads: Record<string, BulkheadStats>;
       timeouts: Record<string, TimeoutStats>;
-      http?: any;
+      http?: ReturnType<ResilientHttpClient['getHealthStats']>;
     } = {
       bulkheads: this.bulkheadManager.getAllStats(),
       timeouts: this.timeoutManager.getAllStats(),


### PR DESCRIPTION
## 概要
- `src/resilience/index.ts` の `getSystemHealth` 返却型にある `http?: any` を具体型に変更
- `http` は `ReturnType<ResilientHttpClient['getHealthStats']>` を使用

## 検証
- `pnpm -s types:check`
