### PR TITLE
refactor: remove remaining any in verify helper and benchmark cli

### DIFF
--- a/src/agents/verify-agent.ts
+++ b/src/agents/verify-agent.ts
@@ -881,15 +881,15 @@ export class VerifyAgent {
     return [];
   }
 
-  private async scanForVulnerabilities(file: CodeFile): Promise<any[]> {
+  private async scanForVulnerabilities(file: CodeFile): Promise<Issue[]> {
     return [];
   }
 
-  private async checkDependencies(): Promise<any[]> {
+  private async checkDependencies(): Promise<Issue[]> {
     return [];
   }
 
-  private async scanForSecrets(files: CodeFile[]): Promise<any[]> {
+  private async scanForSecrets(files: CodeFile[]): Promise<Issue[]> {
     return [];
   }
 

--- a/src/cli/benchmark-cli.ts
+++ b/src/cli/benchmark-cli.ts
@@ -26,6 +26,16 @@ import { safeExit } from '../utils/safe-exit.js';
 
 const program = new Command();
 
+interface ConfigLoadOptions {
+  config?: string;
+  ci?: boolean;
+  light?: boolean;
+  difficulty?: DifficultyLevel;
+  category?: BenchmarkCategory;
+  parallel?: boolean;
+  timeout?: string;
+}
+
 program
   .name('ae-benchmark')
   .description('Run AE Framework benchmarks against Req2Run problems')
@@ -216,7 +226,7 @@ program
 /**
  * Load configuration from file or use defaults
  */
-async function loadConfiguration(options: any): Promise<BenchmarkConfig> {
+async function loadConfiguration(options: ConfigLoadOptions): Promise<BenchmarkConfig> {
   let config = DEFAULT_BENCHMARK_CONFIG;
   
   // Load from file if specified
@@ -240,7 +250,7 @@ async function loadConfiguration(options: any): Promise<BenchmarkConfig> {
     const enabled = config.problems.filter(p => p.enabled);
     config.problems = enabled.slice(0, Math.min(3, enabled.length));
     config.execution.parallel = false;
-    config.execution.maxConcurrency = 1 as any;
+    config.execution.maxConcurrency = 1;
   }
   
   if (options.difficulty) {


### PR DESCRIPTION
## 概要
- `src/agents/verify-agent.ts` のヘルパーメソッド戻り値 `Promise<any[]>` を `Promise<Issue[]>` に変更
- `src/cli/benchmark-cli.ts` の `loadConfiguration(options: any)` を型付きオプションに変更
- light モードの `maxConcurrency` 設定から `as any` を除去

## 検証
- `pnpm -s types:check`
- `pnpm -s eslint src/cli/benchmark-cli.ts --no-warn-ignored`
