### PR TITLE
refactor: remove any from resilience backoff status handling

### DIFF
--- a/src/resilience/backoff-strategies.ts
+++ b/src/resilience/backoff-strategies.ts
@@ -206,8 +206,8 @@ export class BackoffStrategy {
     }
 
     // HTTP status codes that are retryable
-    if ('status' in error) {
-      const status = getErrorStatus(error);
+    const status = getErrorStatus(error);
+    if (status !== undefined) {
       return status === 429 || // Too Many Requests
              status === 502 || // Bad Gateway
              status === 503 || // Service Unavailable


### PR DESCRIPTION
## 概要
- `src/resilience/backoff-strategies.ts` の `any` / `as any` を除去
- `ErrorWithStatus` と `getErrorStatus` を導入し、HTTP status 付きエラーを型安全に処理
- `CircuitBreakerStats` への optional フィールド代入を直接代入に変更

## 検証
- `pnpm -s types:check`
- `pnpm -s eslint src/resilience/backoff-strategies.ts --no-warn-ignored`（warningのみ、errorなし）
