### PR TITLE
refactor: remove any from base agent metadata

### DIFF
--- a/src/agents/base-agent.ts
+++ b/src/agents/base-agent.ts
@@ -15,7 +15,7 @@ export interface AgentOutput {
   type: 'requirements' | 'specifications' | 'tests' | 'code' | 'verification' | 'deployment' | 'generic';
   content: string;
   artifacts: string[];
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
   quality?: {
     score: number;
     metrics: Record<string, number>;
@@ -138,12 +138,12 @@ export abstract class BaseAgent {
   /**
    * Log phase activity
    */
-  protected async logActivity(activity: string, metadata?: any): Promise<void> {
+  protected async logActivity(activity: string, metadata?: Record<string, unknown>): Promise<void> {
     const key = `${this.phaseName}_activity_${Date.now()}`;
     const value = {
       activity,
       timestamp: new Date().toISOString(),
-      ...metadata,
+      ...(metadata ?? {}),
     };
     
     await this.phaseStateManager.addMetadata(key, value);
@@ -280,7 +280,7 @@ export abstract class BaseAgent {
    * Safe logging method that never throws exceptions
    * Falls back to console logging if phase state logging fails
    */
-  private safeLogActivity(activity: string, metadata?: any): void {
+  private safeLogActivity(activity: string, metadata?: Record<string, unknown>): void {
     // Don't await - run async without blocking validation
     this.logActivity(activity, metadata).catch(error => {
       // Fallback to console logging if phase state logging fails


### PR DESCRIPTION
## 概要
- `AgentOutput.metadata` を `Record<string, unknown>` に変更
- `logActivity` / `safeLogActivity` の `metadata` を `Record<string, unknown>` に変更
- object spread で `undefined` を安全に扱うため `...(metadata ?? {})` を適用

## 検証
- `pnpm -s types:check`
- `pnpm -s eslint src/agents/base-agent.ts --no-warn-ignored`