### PR TITLE
refactor: remove any from phase validator error handling

### DIFF
--- a/src/cli/validators/PhaseValidator.ts
+++ b/src/cli/validators/PhaseValidator.ts
@@ -4,6 +4,11 @@ import { glob } from 'glob';
 import type { AEFrameworkConfig, Phase, ValidationResult, ValidationDetail, Prerequisite } from '../types.js';
 import { toMessage } from '../../utils/error-utils.js';
 
+type ExecErrorOutput = {
+  stdout?: unknown;
+  stderr?: unknown;
+};
+
 export class PhaseValidator {
   constructor(private config: AEFrameworkConfig) {}
 
@@ -287,14 +292,11 @@ export class PhaseValidator {
       return '';
     }
 
-    const stdout = this.normalizeExecStream(
-      'stdout' in error ? (error as { stdout?: unknown }).stdout : undefined
-    );
-    const stderr = this.normalizeExecStream(
-      'stderr' in error ? (error as { stderr?: unknown }).stderr : undefined
-    );
+    const candidate = error as ExecErrorOutput;
+    const stdout = this.normalizeExecStream(candidate.stdout);
+    const stderr = this.normalizeExecStream(candidate.stderr);
 
-    return stdout || stderr;
+    return stdout.length > 0 ? stdout : stderr;
   }
 
   private normalizeExecStream(value: unknown): string {


### PR DESCRIPTION
## 概要
- `PhaseValidator` の `catch (error: any)` を `catch (error: unknown)` に置換
- `execSync` 例外から `stdout`/`stderr` を安全に取り出す `extractExecOutput` / `normalizeExecStream` を追加
- テスト失敗メッセージの抽出ロジックを型安全化

## 検証
- `pnpm -s types:check`
- `pnpm -s eslint src/cli/validators/PhaseValidator.ts --no-warn-ignored`
