### PR TITLE
refactor: remove any from dependency node metadata

### DIFF
--- a/src/engines/sequential-inference-engine.ts
+++ b/src/engines/sequential-inference-engine.ts
@@ -67,7 +67,7 @@ export interface DependencyNode {
   dependencies: string[];
   dependents: string[];
   weight: number;
-  metadata: Record<string, any>;
+  metadata: Record<string, unknown>;
 }
 
 export interface DependencyGraph {


### PR DESCRIPTION
## 概要
- `DependencyNode.metadata` の型を `Record<string, any>` から `Record<string, unknown>` に変更
- `any` を排除し、依存解析ノードのメタデータアクセスを型安全化

## 検証
- `pnpm -s types:check`
- `pnpm -s eslint src/engines/sequential-inference-engine.ts --no-warn-ignored`
