### PR TITLE
refactor: replace any with unknown in failure artifact schema

### DIFF
--- a/src/cegis/failure-artifact-schema.ts
+++ b/src/cegis/failure-artifact-schema.ts
@@ -213,8 +213,8 @@ export class FailureArtifactFactory {
 
   static fromContractViolation(
     contractName: string, 
-    expected: any, 
-    actual: any, 
+    expected: unknown,
+    actual: unknown,
     location?: FailureLocation
   ): FailureArtifact {
     return this.create({


### PR DESCRIPTION
## 概要
- `src/cegis/failure-artifact-schema.ts` の `fromContractViolation` 引数型 `any` を `unknown` へ置換
- 挙動変更なし（文字列化・ログ出力は現状維持）

## 検証
- `pnpm -s types:check`
