### PR TITLE
refactor: remove any from approval service types

### DIFF
--- a/src/services/approval-service.ts
+++ b/src/services/approval-service.ts
@@ -16,7 +16,7 @@ export interface ApprovalRequest {
   requestedAt: Date;
   artifacts: string[];
   summary?: string;
-  metadata?: Record<string, any>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface ApprovalResponse {
@@ -536,7 +536,7 @@ export class ApprovalService extends EventEmitter {
       if (loaded) {
         return { 
           required: true, 
-          status: loaded.status as any,
+          status: loaded.status,
           details: loaded 
         };
       }
@@ -545,7 +545,7 @@ export class ApprovalService extends EventEmitter {
     if (pendingApproval) {
       return { 
         required: true, 
-        status: pendingApproval.status as any,
+        status: pendingApproval.status,
         details: pendingApproval 
       };
     }


### PR DESCRIPTION
## 概要
- `src/services/approval-service.ts` の `any` を削減
  - `metadata?: Record<string, any>` → `Record<string, unknown>`
  - `status as any` を除去
- 実行時挙動は変更なし

## 検証
- `pnpm -s types:check`
