### PR TITLE
fix: harden Security/Docker workflows for missing inputs (#2212)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -119,4 +119,5 @@ scripts/
 hooks/
 
 # Allow build/CI helper scripts consumed during image build
+!scripts/
 !scripts/**

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -124,14 +124,14 @@ jobs:
         id: license_gate
         run: |
           if [ -z "${{ secrets.GITLEAKS_LICENSE }}" ]; then
-            if [ "${{ github.event_name }}" = "pull_request" ]; then
-              printf '%s\n' "skip=true" >> "$GITHUB_OUTPUT"
-              echo "GITLEAKS_LICENSE is not set; skipping gitleaks for PR."
-            else
-              printf '%s\n' "skip=false" >> "$GITHUB_OUTPUT"
-              echo "GITLEAKS_LICENSE is required on push/schedule. Failing."
-              exit 1
-            fi
+            printf '%s\n' "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::GITLEAKS_LICENSE is not set; skipping gitleaks scan."
+            {
+              printf "%s\n" "### Secrets Scanning"
+              printf "%s\n" "- skipped: true"
+              printf "%s\n" "- reason: GITLEAKS_LICENSE is not set"
+              printf "%s\n" "- action: add repository secret GITLEAKS_LICENSE to enable gitleaks"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             printf '%s\n' "skip=false" >> "$GITHUB_OUTPUT"
           fi
@@ -311,9 +311,19 @@ jobs:
 
       - name: Upload Trivy scan results
         uses: github/codeql-action/upload-sarif@v3
-        if: always() && steps.container_manifest.outputs.skip != 'true'
+        if: ${{ always() && steps.container_manifest.outputs.skip != 'true' && hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: 'trivy-results.sarif'
+
+      - name: Note missing Trivy SARIF
+        if: ${{ always() && steps.container_manifest.outputs.skip != 'true' && hashFiles('trivy-results.sarif') == '' }}
+        run: |
+          printf "%s\n" "::warning::trivy-results.sarif was not generated; skipping SARIF upload"
+          {
+            printf "%s\n" "### Container Security"
+            printf "%s\n" "- trivy-results.sarif: missing"
+            printf "%s\n" "- upload-sarif: skipped"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   security-notification:
     name: Security Notification

--- a/docs/ci/ci-troubleshooting-guide.md
+++ b/docs/ci/ci-troubleshooting-guide.md
@@ -32,6 +32,8 @@ Purpose: Provide a short, deterministic path to diagnose common CI failures.
 - `pnpm run lint:actions` で `ghcr.io/rhysd/actionlint` pull が 403 の場合、`ACTIONLINT_BIN` でローカルバイナリを指定できます（例: `ACTIONLINT_BIN=/usr/local/bin/actionlint pnpm run lint:actions`）。
 - `automation-observability-weekly` の通知判定は `weekly-alert-summary.json` に保存されます。通知が来ない場合は `suppressed` / `suppressedReason` を確認します。
 - SLO/MTTR の判定基準は `docs/ci/automation-slo-mttr.md` を参照し、週次 artifact（`automation-observability-weekly`）で確認します。
+- `Security Analysis` の `Secrets Scanning` は `GITLEAKS_LICENSE` 未設定時に skip されます。scan を有効化する場合は repository secret `GITLEAKS_LICENSE` を設定してください。
+- `Container Security` は `trivy-results.sarif` 未生成時に upload を skip し warning を出します。build失敗ログを先に確認してください。
 
 ## 6) 症状 → runbook 対応表
 


### PR DESCRIPTION
## 背景
Issue #2212 の対応です。  
`Security Analysis` / `Docker Tests` の失敗要因に対し、設定不足時のハンドリングを強化しました。

## 変更内容
- `.dockerignore`
  - `!scripts/` を追加し、`docker/Dockerfile.test` の `COPY scripts/ ./scripts/` と整合
- `.github/workflows/security.yml`
  - `GITLEAKS_LICENSE` 未設定時に `Secrets Scanning` を warning + skip に統一（push/schedule 含む）
  - Trivy SARIF (`trivy-results.sarif`) 未生成時は upload を skip し、Step Summary に理由を出力
- `docs/ci/ci-troubleshooting-guide.md`
  - 上記挙動（Gitleaks secret / Trivy SARIF skip）を運用手順として追記

## 動作確認
- `python` + `PyYAML` で `security.yml` / `coverage-check.yml` の構文確認
- `pnpm -s check:doc-consistency`

Closes #2212
