### PR TITLE
feat(integration): API inline assertion検証とAEIR型参照を実装

### DIFF
--- a/src/integration/runners/api-runner.ts
+++ b/src/integration/runners/api-runner.ts
@@ -315,9 +315,8 @@ export class APITestRunner implements TestRunner {
       step._requestDuration = duration;
 
       // Validate response if configured
-      if (step.data?.assertions) {
-        // TODO(#2230): Implement validateResponse method
-        // await this.validateResponse(response, step.data.assertions);
+      if (Array.isArray(step.data?.assertions) && step.data.assertions.length > 0) {
+        await this.validateResponse(response, step.data.assertions as APIAssertion[]);
       }
 
       return `${requestConfig.method} ${url} → ${response.status} ${response.statusText} (${duration}ms)`;
@@ -346,6 +345,15 @@ export class APITestRunner implements TestRunner {
     }
 
     return `Validated ${assertions.length} assertions: ${results.join(', ')}`;
+  }
+
+  /**
+   * Validate inline assertions attached to request steps.
+   */
+  private async validateResponse(response: HttpResponse, assertions: APIAssertion[]): Promise<void> {
+    for (const assertion of assertions) {
+      await this.validateAssertion(assertion, response);
+    }
   }
 
   /**

--- a/src/utils/enhanced-state-manager.ts
+++ b/src/utils/enhanced-state-manager.ts
@@ -8,19 +8,7 @@ import { gzip, gunzip } from 'zlib';
 import { performance } from 'perf_hooks';
 import { encodeSpecialValue } from './state-serialization.js';
 import { reviveStateEntryData } from './state-entry-revival.js';
-// import { AEIR } from '@ae-framework/spec-compiler';  // Temporarily disabled for build fix
-
-/**
- * Minimal AEIR stub type for build fix.
- * TODO(#2230): Replace with import from '@ae-framework/spec-compiler' when available.
- */
-export interface AEIR {
-  id?: string;
-  name?: string;
-  type?: string;
-  version?: string;
-  // Add other properties as needed based on usage in this file.
-}
+import type { AEIR } from '@ae-framework/spec-compiler';
 
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);

--- a/tests/unit/integration/runners/api-runner.test.ts
+++ b/tests/unit/integration/runners/api-runner.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { APITestRunner, type APIAssertion, type APITestConfig } from '../../../../src/integration/runners/api-runner';
+import type { TestCase, TestEnvironment } from '../../../../src/integration/types';
+
+const DEFAULT_CONFIG: APITestConfig = {
+  timeout: 5000,
+  retries: 0,
+  validateSchema: true,
+  followRedirects: true,
+  validateSSL: true,
+  maxResponseSize: 1024 * 1024,
+  defaultHeaders: {},
+};
+
+function createEnvironment(): TestEnvironment {
+  return {
+    name: 'test',
+    apiUrl: 'http://localhost:3000',
+    variables: {},
+    timeouts: {
+      default: 30000,
+      api: 10000,
+      ui: 5000,
+      database: 15000,
+    },
+    retries: {
+      max: 0,
+      delay: 0,
+    },
+  };
+}
+
+function createRequestTestCase(assertions: APIAssertion[]): TestCase {
+  return {
+    id: 'api-inline-assertion-test',
+    name: 'API request with inline assertions',
+    description: 'Validate inline assertions attached to request steps',
+    category: 'integration',
+    severity: 'major',
+    enabled: true,
+    preconditions: [],
+    steps: [
+      {
+        id: 'step-1',
+        description: 'Request users endpoint',
+        action: 'api:request:GET:/users',
+        data: { assertions },
+      },
+    ],
+    expectedResults: ['Request should satisfy inline assertions'],
+    fixtures: [],
+    dependencies: [],
+    tags: [],
+    metadata: {
+      complexity: 'low',
+      stability: 'stable',
+      lastUpdated: new Date().toISOString(),
+    },
+  };
+}
+
+describe('APITestRunner', () => {
+  it('passes request step when inline assertions are satisfied', async () => {
+    const runner = new APITestRunner(DEFAULT_CONFIG);
+    const testCase = createRequestTestCase([
+      { type: 'status', operator: 'equals', expected: 200 },
+      { type: 'body', field: 'name', operator: 'equals', expected: 'Test User' },
+    ]);
+
+    const result = await runner.runTest(testCase, createEnvironment());
+
+    expect(result.status).toBe('passed');
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0]?.status).toBe('passed');
+    expect(result.error).toBeUndefined();
+  });
+
+  it('fails request step when inline assertions are violated', async () => {
+    const runner = new APITestRunner(DEFAULT_CONFIG);
+    const testCase = createRequestTestCase([
+      { type: 'status', operator: 'equals', expected: 201 },
+    ]);
+
+    const result = await runner.runTest(testCase, createEnvironment());
+
+    expect(result.status).toBe('failed');
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0]?.status).toBe('failed');
+    expect(result.error).toContain('Assertion failed');
+  });
+});


### PR DESCRIPTION
## 概要
Issue #2230 のうち、短期で着手可能な2点を実装しました。

- `api-runner` の request ステップに付与された inline assertions を実行する `validateResponse` を実装
- `enhanced-state-manager` の AEIR 型をローカルstubから `@ae-framework/spec-compiler` の正式型 import に置換
- inline assertions の成功/失敗ケースの unit test を追加

## 変更ファイル
- `src/integration/runners/api-runner.ts`
- `src/utils/enhanced-state-manager.ts`
- `tests/unit/integration/runners/api-runner.test.ts`

## テスト
- `pnpm -s vitest run tests/unit/integration/runners/api-runner.test.ts tests/utils/enhanced-state-manager-import-bytes.test.ts --run`

## 備考
- #2230 の残タスク（UI/UX generation、NL conflict detection 高度化）は別PRで継続します。

Refs #2230
