### PR TITLE
feat(nl): conflict detection を高度化して回帰テストを追加

### DIFF
--- a/tests/unit/agents/natural-language-task-adapter.test.ts
+++ b/tests/unit/agents/natural-language-task-adapter.test.ts
@@ -27,6 +27,18 @@ describe('NaturalLanguageTaskAdapter conflict detection', () => {
     expect(result.conflicts.some((conflict) => conflict.includes('Permission intent differs'))).toBe(true);
   });
 
+  it('detects access conflicts when requirements use disallow wording', async () => {
+    const adapter = new NaturalLanguageTaskAdapter();
+    const result = await adapter.processNaturalLanguageRequirements(
+      [
+        'The admin role must disallow exporting all audit logs.',
+        'The admin role must allow exporting all audit logs.',
+      ].join(' '),
+    );
+
+    expect(result.conflicts.some((conflict) => conflict.includes('Permission intent differs'))).toBe(true);
+  });
+
   it('detects incompatible numeric constraints', async () => {
     const adapter = new NaturalLanguageTaskAdapter();
     const result = await adapter.processNaturalLanguageRequirements(
@@ -39,6 +51,32 @@ describe('NaturalLanguageTaskAdapter conflict detection', () => {
     expect(result.conflicts.some((conflict) => conflict.includes('Numeric constraints are incompatible'))).toBe(
       true,
     );
+  });
+
+  it('detects incompatible numeric constraints across minute and second units', async () => {
+    const adapter = new NaturalLanguageTaskAdapter();
+    const result = await adapter.processNaturalLanguageRequirements(
+      [
+        'API response time must be at most 2 minutes for checkout requests.',
+        'API response time must be at least 180 seconds for checkout requests.',
+      ].join(' '),
+    );
+
+    expect(result.conflicts.some((conflict) => conflict.includes('Numeric constraints are incompatible'))).toBe(
+      true,
+    );
+  });
+
+  it('detects conflicts for japanese requirements using deny and allow intent', async () => {
+    const adapter = new NaturalLanguageTaskAdapter();
+    const result = await adapter.processNaturalLanguageRequirements(
+      [
+        '管理者は監査ログの削除を禁止する必要がある.',
+        '管理者は監査ログの削除を許可する必要がある.',
+      ].join(' '),
+    );
+
+    expect(result.conflicts.some((conflict) => conflict.includes('Permission intent differs'))).toBe(true);
   });
 
   it('does not flag unrelated requirements as conflicts', async () => {


### PR DESCRIPTION
## 概要
Issue #2230 の `NL task adapter: conflict detection ロジック高度化` を対応しました。

## 変更点
- `NaturalLanguageTaskAdapter.detectConflicts` を強化
  - 同一文面で type/priority が異なる場合の衝突検知
  - 類似スコープでの modality 衝突（required vs optional）検知
  - 類似スコープでの permission 衝突（allow vs deny）検知
  - 類似スコープでの数値制約矛盾（upper/lower bound 不整合）検知
  - 競合メッセージの重複排除
- 競合検知用ヘルパを追加
  - 正規化、トークン抽出、類似度計算、モダリティ/アクセス意図判定、数値制約抽出
- ユニットテスト追加
  - modality conflict
  - permission conflict
  - numeric constraint conflict
  - unrelated requirements では衝突しないこと

## テスト
- `pnpm vitest run tests/unit/agents/natural-language-task-adapter.test.ts`

## 補足
本PRは #2230 の一部対応です（残: req2run UI/UX phase / UI-UX adapter 実エージェント連携）。
