### PR TITLE
docs: README/docs索引の整合チェック結果を反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ When using `@ts-expect-error` comments, follow this structured format:
 
 ```typescript
 // @ts-expect-error owner:@username expires:YYYY-MM-DD reason: detailed description
+const _example: number = 'type mismatch for policy example';
 ```
 
 **Required fields:**
@@ -151,10 +152,10 @@ When using `@ts-expect-error` comments, follow this structured format:
 
 **Examples:**
 ```typescript
-// @ts-expect-error owner:@alice expires:2025-12-31 reason: narrowing todo for complex union
+// @ts-expect-error owner:@alice expires:2027-12-31 reason: narrowing todo for complex union
 const result = complexUnion as string;
 
-// @ts-expect-error owner:@bob expires:2025-06-15 reason: legacy API compatibility until v2 migration
+// @ts-expect-error owner:@bob expires:2027-06-15 reason: legacy API compatibility until v2 migration
 legacyApi.unsafeMethod(data);
 ```
 


### PR DESCRIPTION
## 概要
README と docs 索引（`docs/README.md`）の直近マージ分に対して整合チェックを実施し、README の doctest 失敗要因を修正しました。

## 変更内容
- `README.md`
  - `@ts-expect-error` のフォーマット例に、doctest で `Unused '@ts-expect-error'` にならない最小コード行を追加
  - 例示の `expires` 日付を現時点より未来日に更新（2027年）

## チェック結果
- `pnpm -s run check:doc-consistency` ✅
- `DOCTEST_ENFORCE=1 pnpm exec tsx scripts/doctest.ts 'README.md'` ✅（4/4 code blocks, 14/14 links）
- `DOCTEST_ENFORCE=1 pnpm exec tsx scripts/doctest.ts 'docs/README.md'` ✅（131/131 links）

## 補足
- README / docs 索引の参照パス解決を追加で確認し、欠落参照はありませんでした。
