### PR TITLE
Phase1: docs-doctest同期チェックを構造検証化

### DIFF
--- a/.github/workflows/docs-doctest.yml
+++ b/.github/workflows/docs-doctest.yml
@@ -51,10 +51,10 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '20'
-      - name: Validate docs-doctest policy sync
-        run: node scripts/ci/check-docs-doctest-policy-sync.mjs
       - name: Install dependencies
         run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+      - name: Validate docs-doctest policy sync
+        run: node scripts/ci/check-docs-doctest-policy-sync.mjs
       - name: Check documentation consistency
         run: node scripts/docs/check-doc-consistency.mjs
       - name: Run doctest (README + docs index)
@@ -106,10 +106,10 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '20'
-      - name: Validate docs-doctest policy sync
-        run: node scripts/ci/check-docs-doctest-policy-sync.mjs
       - name: Install dependencies
         run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+      - name: Validate docs-doctest policy sync
+        run: node scripts/ci/check-docs-doctest-policy-sync.mjs
       - name: Run full docs doctest
         env:
           DOCTEST_ENFORCE: '1'


### PR DESCRIPTION
## 概要
- `scripts/ci/check-docs-doctest-policy-sync.mjs` を YAML/JSON の構造検証ベースへ改修
- workflow の trigger/job/step/順序/条件式を構造的に検証
- package scripts と policy 文書の検証を関数分割
- 単体テストを新仕様に更新し malformed YAML のケースを追加

## 検証
- `pnpm -s vitest run tests/unit/ci/check-docs-doctest-policy-sync.test.ts`
- `node scripts/ci/check-docs-doctest-policy-sync.mjs`
- `pnpm -s run check:doc-consistency`

Closes #2270
