### PR TITLE
docs(agents): AGENTS を 1ページルータへ再構成

### DIFF
--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,26 @@
+# Agent Docs Index
+
+`AGENTS.md` から参照する、エージェント向けの索引です。  
+ここでは一次情報の場所のみを示し、方針本文の重複を避けます。
+
+## 主要ドメインと一次情報
+
+- CI方針（SSOT）: `docs/ci-policy.md`
+- CI運用: `docs/ci/ci-operations-handbook.md`
+- CI障害復旧: `docs/ci/ci-troubleshooting-guide.md`
+- PR自動化運用: `docs/ci/pr-automation.md`
+- 権限境界: `docs/ci/automation-permission-boundaries.md`
+- Risk/Label判定: `policy/risk-policy.yml`
+- Slash Commands実装: `.github/workflows/agent-commands.yml`
+- Workflow責務整理: `docs/ci/workflow-role-matrix.md`
+
+## 利用順
+
+1. `AGENTS.md` の Decision Table で作業タイプを決める
+2. この索引から一次情報を開く
+3. 実行結果を PR コメントと artifacts に残す
+
+## 今後の拡張
+
+- ドメイン別runbook（`docs/agents/ci.md`, `pr.md`, `spec.md`, `formal.md`, `context-pack.md`, `security.md`）は #2292 で追加する。
+- Agent文書の境界表（一次情報/二次情報）は #2293 で定義する。


### PR DESCRIPTION
## 概要
- AGENTS.md を詳細列挙型からルータ型へ再構成
- Decision Table / Invariants / Progressive Disclosure を明示
- 参照先索引として `docs/agents/README.md` を新設

## 変更内容
- `AGENTS.md`
  - Slash Commandsや運用詳細の網羅列挙を削除
  - 一次情報参照を前提にした最小構成へ変更
- `docs/agents/README.md`
  - エージェント向け索引を追加
  - 主要ドメインごとのSSOT参照先を整理

## 影響範囲
- ドキュメントのみ（CI挙動・ポリシー挙動の変更なし）

## 検証
- `pnpm -s run check:doc-consistency`

## Rollback
- 本PRをrevertすれば即時復旧可能

## 関連
- Closes #2291
- #2292（runbook拡張予定）
- #2293（文書境界表の追加予定）