### PR TITLE
chore(maintenance): finalize remote branch cleanup report

### DIFF
--- a/docs/maintenance/branch-cleanup-report-2026-02-28.md
+++ b/docs/maintenance/branch-cleanup-report-2026-02-28.md
@@ -43,6 +43,7 @@ pnpm run maintenance:branch:inventory
   - remote branches: 908
   - local merged safe-delete candidates: 2
   - remote merged safe-delete candidates: 0
+  - note: The remote branch delta (1168 -> 908, -260) is 1 greater than the documented remote deletions (100 + 159 = 259) because the latest inventory excludes the `origin` pseudo-ref.
 
 ## Failed branches and reasons
 

--- a/scripts/maintenance/branch-inventory.mjs
+++ b/scripts/maintenance/branch-inventory.mjs
@@ -152,11 +152,7 @@ try {
 
   const localRefs = parseRefs(localRefRaw, options.remote);
   const remoteRefs = parseRefs(remoteRefRaw, options.remote).filter(
-    (ref) =>
-      ref.name !== options.remote &&
-      ref.name !== `${options.remote}/HEAD` &&
-      ref.shortName !== '' &&
-      ref.shortName !== 'HEAD',
+    (ref) => ref.name !== options.remote && ref.name !== `${options.remote}/HEAD`,
   );
 
   const mergedLocal = parseBranchList(mergedLocalRaw);


### PR DESCRIPTION
## 概要
ブランチ整理 #2321 の最終フェーズとして、remote merged branches の追加削除結果を反映し、inventory の集計ノイズを修正しました。

## 変更内容
- `scripts/maintenance/branch-inventory.mjs`
  - remote pseudo-ref (`origin`) を除外して集計精度を修正
- `docs/maintenance/branch-cleanup-report-2026-02-28.md`
  - Phase 3（remote -159）の結果を追記
  - 最終値を更新（remote merged candidates: 0）
  - 残件（local 2件）の扱いを明記

## 実行結果（最終）
- remote branches: `1068 -> 908`（Phase 3で `-159`）
- remote merged safe-delete candidates: `160 -> 0`
- local merged safe-delete candidates: `2`（理由付き保留）

## 検証
- `pnpm run maintenance:branch:inventory`
- `node scripts/maintenance/branch-cleanup.mjs --scope remote --max 200`
- `node scripts/maintenance/branch-cleanup.mjs --scope remote --max 200 --apply`
- `pnpm run check:doc-consistency`

関連: #2321（クローズ済み）
