### PR TITLE
feat(ci): connect trace validation to policy-gate label gate

### DIFF
--- a/.github/workflows/spec-generate-model.yml
+++ b/.github/workflows/spec-generate-model.yml
@@ -455,7 +455,7 @@ jobs:
             }
 
       - name: Publish trace validation check
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
         uses: actions/github-script@v7
         env:
           TRACE_JOB_STATUS: ${{ job.status }}
@@ -493,15 +493,39 @@ jobs:
               `NDJSON: ${validNdjson} (issues: ${issuesNdjson})`,
             ];
 
-            await github.rest.checks.create({
+            const checkName = 'KvOnce Trace Validation';
+            const updatePayload = {
               owner,
               repo,
-              name: 'KvOnce Trace Validation',
-              head_sha: headSha,
               status: 'completed',
               conclusion,
               output: {
-                title: 'KvOnce Trace Validation',
+                title: checkName,
                 summary: summaryLines.join('\n'),
               },
+            };
+
+            const existing = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref: headSha,
+              check_name: checkName,
+              per_page: 100,
             });
+            const runs = (existing.data.check_runs || []).filter((run) => run.name === checkName);
+
+            if (runs.length === 0) {
+              await github.rest.checks.create({
+                ...updatePayload,
+                name: checkName,
+                head_sha: headSha,
+              });
+              return;
+            }
+
+            for (const run of runs) {
+              await github.rest.checks.update({
+                ...updatePayload,
+                check_run_id: run.id,
+              });
+            }

--- a/docs/ci/OPT-IN-CONTROLS.md
+++ b/docs/ci/OPT-IN-CONTROLS.md
@@ -31,7 +31,7 @@ PRやIssueで **必要な検証だけを opt-in で起動** し、CIコストと
 | `run-resilience` | Resilience quick実行 | `verify-lite.yml` 内 `Resilience quick` | `/run-resilience` で付与 |
 | `run-hermetic` | Hermetic CI 実行 | `ci.yml`, `hermetic-ci.yml` | `/run-hermetic` で付与 |
 | `run-spec` | fail-fast spec validation | `spec-validation.yml` | `/run-spec` で付与 |
-| `run-trace` | KvOnce trace validation を required gate 対象として再評価 | `spec-generate-model.yml`（check: `KvOnce Trace Validation`） | 高リスクPRで `policy-gate` が参照 |
+| `run-trace` | KvOnce trace validation を required gate 対象として再評価 | `spec-generate-model.yml`（checks: `trace-conformance`, `KvOnce Trace Validation`） | 高リスクPRで `policy-gate` が参照（fork PRは `trace-conformance` で判定） |
 | `run-drift` | codegen drift detection | `codegen-drift-check.yml` | `/run-drift` で付与 |
 | `enforce-bdd-lint` | BDD lint を strict 化 | `verify-lite.yml` | `/enforce-bdd-lint` で付与 |
 | `enforce-verify-lite-lint` | verify-lite lint baseline を enforce | `verify-lite.yml` | PRラベルで制御 |

--- a/docs/ci/ci-troubleshooting-guide.md
+++ b/docs/ci/ci-troubleshooting-guide.md
@@ -51,7 +51,7 @@ Purpose: Provide a short, deterministic path to diagnose common CI failures.
 | `Copilot Review Gate / gate` fail | 未解決レビューthread数、失敗runのconclusion | thread解消 → `gh run rerun <runId> --failed` |
 | `PR Self-Heal` が `blocked` | PRコメントの reason、`status:blocked` ラベル | 競合解消/失敗チェック修復後に手動rerun |
 | `auto-merge` が有効化されない | `AE_AUTO_MERGE*`、required checks、reviewDecision | `docs/ci/auto-merge.md` に沿って条件修正 |
-| `policy-gate` fail（`run-trace`） | `run-trace` ラベル有無、`KvOnce Trace Validation` の conclusion | `run-trace` を付与し `Spec Generate & Model Tests` を PR文脈で再実行 |
+| `policy-gate` fail（`run-trace`） | `run-trace` ラベル有無、`trace-conformance` / `KvOnce Trace Validation` の conclusion | `run-trace` を付与し `Spec Generate & Model Tests` を PR文脈で再実行 |
 | 429 / secondary rate limit | `gh-exec` retryログ、失敗タイミング | rerun優先、必要なら `AE_GH_THROTTLE_MS` と `AE_GH_RETRY_*` を調整 |
 | unified exec process 上限警告 | 長時間ジョブ数、同時セッション数 | 長時間セッション停止・既存セッション再利用・並列度を抑制 |
 
@@ -87,7 +87,7 @@ gh workflow run "Codex Autopilot Lane" -f pr_number=12345 -f dry_run=false
 2. PR文脈の trace check を再実行
    - `gh run list --workflow "Spec Generate & Model Tests" --branch <head-branch> --limit 20`
    - `gh run rerun <runId> --failed`
-3. `KvOnce Trace Validation` が `success` になったことを確認し、`policy-gate` を再評価
+3. `trace-conformance`（fork含む）または `KvOnce Trace Validation`（non-fork）が `success` になったことを確認し、`policy-gate` を再評価
    - `gh run list --workflow "Policy Gate" --branch <head-branch> --limit 20`
 
 ## 8) 失敗時の切り分け（5分版）

--- a/docs/ci/label-gating.md
+++ b/docs/ci/label-gating.md
@@ -34,7 +34,7 @@ Labels
 - `run-property`: run only the property harness portion of CI Extended
 - `run-mbt`: run only the MBT smoke (`test:mbt:ci`) portion of CI Extended
 - `run-mutation`: run only the mutation auto diff step of CI Extended
-- `run-trace`: trigger KvOnce trace validation check (`KvOnce Trace Validation`) on PR context
+- `run-trace`: trigger trace gate checks (`trace-conformance`, `KvOnce Trace Validation`) on PR context
 - Opt-in (heavy/conditional)
   - `run-security`: trigger Security/SBOM on PRs when deps/crypto/security code change or before release (otherwise weekly cron covers baseline)
   - `run-hermetic`: run Hermetic CI on PRs to validate determinism/network isolation when needed
@@ -47,7 +47,7 @@ Workflows
 - validate-artifacts-ajv.yml: reads `enforce-artifacts`; strict の場合は trace/verify-lite artifacts を先に生成してから `pnpm run artifacts:validate` を実行
 - testing-ddd-scripts.yml: reads `enforce-testing` and makes property/replay/BDD lint blocking only in strict mode; reads `trace:<id>` to focus runs
 - context-pack-quality-gate.yml: reads `enforce-context-pack`; runs `context-pack:deps` + `context-pack:e2e-fixture` in report-only/blocking mode
-- spec-generate-model.yml: publishes `KvOnce Trace Validation`; `policy-gate` treats this check as blocking when `run-trace` is required on high-risk PRs
+- spec-generate-model.yml: publishes `KvOnce Trace Validation` (non-fork PR) and always emits `trace-conformance`; `policy-gate` treats these checks as blocking when `run-trace` is required on high-risk PRs
 - pr-ci-status-comment.yml: reads `pr-summary:detailed` to switch summary mode; also generates `artifacts/ci/harness-health.{json,md}` and appends Harness Health section to PR summary
 
 Harness Health recommendation

--- a/policy/risk-policy.yml
+++ b/policy/risk-policy.yml
@@ -123,4 +123,5 @@ gate_checks:
   enforce-context-pack:
     - "context-pack-e2e"
   run-trace:
+    - "trace-conformance"
     - "KvOnce Trace Validation"

--- a/tests/unit/ci/policy-gate.test.ts
+++ b/tests/unit/ci/policy-gate.test.ts
@@ -108,6 +108,31 @@ describe('policy-gate', () => {
     expect(result.errors).toContain('required gate check not green for label run-trace (missing)');
   });
 
+  it('passes high-risk PR when run-trace is satisfied by trace-conformance check', () => {
+    const result = evaluatePolicyGate({
+      policy,
+      pullRequest: {
+        labels: [{ name: 'risk:high' }, { name: 'run-trace' }],
+        body: '## Rollback\nnone\n\n## Acceptance\nok',
+      },
+      changedFiles: ['.github/workflows/spec-generate-model.yml'],
+      reviews: [
+        {
+          id: 211,
+          state: 'APPROVED',
+          submitted_at: '2026-03-01T00:05:00Z',
+          user: { login: 'reviewer1', type: 'User' },
+        },
+      ],
+      statusRollup: [
+        checkRun('verify-lite'),
+        checkRun('trace-conformance'),
+      ],
+    });
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
   it('fails high-risk PR when KvOnce trace validation check fails', () => {
     const result = evaluatePolicyGate({
       policy,

--- a/tests/unit/ci/risk-policy.test.ts
+++ b/tests/unit/ci/risk-policy.test.ts
@@ -49,6 +49,7 @@ describe('risk-policy', () => {
 
   it('returns trace validation check pattern for run-trace', () => {
     const patterns = getGateCheckPatternsForLabel(policy, 'run-trace');
+    expect(patterns).toContain('trace-conformance');
     expect(patterns).toContain('KvOnce Trace Validation');
   });
 


### PR DESCRIPTION
## 概要
- `policy/risk-policy.yml` に `run-trace` の required label / gate mapping を追加
- `KvOnce Trace Validation` を policy-gate の label-gated blocking 判定に接続
- `Spec Generate & Model Tests` で PR 文脈の trace check を labeled イベントでも再評価できるよう補強
- CI runbook に `run-trace` の解除手順（必要ラベル・再実行コマンド）を追記

## テスト
- `pnpm exec vitest run tests/unit/ci/policy-gate.test.ts tests/unit/ci/risk-policy.test.ts`
- `pnpm exec node scripts/docs/check-runbook-command-blocks.mjs --docs docs/ci/ci-troubleshooting-guide.md`

Closes #2393