### PR TITLE
chore(ci/docs): #2419 enforce CONTRACT-CATALOG coverage for policy schemas

### DIFF
--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -43,6 +43,8 @@ jobs:
         run: node scripts/ci/check-todo-issue-links.mjs
       - name: Check documentation consistency
         run: node scripts/docs/check-doc-consistency.mjs
+      - name: Check contract catalog coverage (required)
+        run: node scripts/docs/check-contract-catalog-coverage.mjs
       - name: Detect docs-only change
         id: docs-only
         shell: bash

--- a/docs/reference/CONTRACT-CATALOG.md
+++ b/docs/reference/CONTRACT-CATALOG.md
@@ -45,6 +45,7 @@
 - `schema/flow.schema.json`
 - `schema/formal-plan.schema.json`
 - `schema/issue-traceability-map.schema.json`
+- `schema/policy-input-v1.schema.json`
 - `schema/release-policy.schema.json`
 - `schema/state-machine.schema.json`
 - `schema/trace-map.schema.json`
@@ -55,6 +56,7 @@
 - `schema/conformance-report.schema.json`
 - `schema/conformance-verify-result.schema.json`
 - `schema/issue-traceability-matrix.schema.json`
+- `schema/policy-decision-v1.schema.json`
 - `schema/pr-state-v1.schema.json`
 - `schema/policy-gate-summary-v1.schema.json`
 - `schema/quality-report.schema.json`
@@ -99,6 +101,8 @@
 | `artifacts/observability/trace-bundle.json` | `schema/trace-bundle.schema.json` | `src/cli/conformance-cli.ts` (`ae conformance ingest`) | `src/cli/conformance-cli.ts` (`ae conformance verify --trace-bundle`) |
 | `artifacts/hermetic-reports/trace/**/kvonce-validation.json` | `schema/trace-validation.schema.json` | `scripts/trace/run-kvonce-conformance.sh` | `scripts/ci/validate-artifacts-ajv.mjs`, `scripts/trace/render-trace-summary.mjs` |
 | `artifacts/change-package/change-package.json` | `schema/change-package.schema.json` | `scripts/change-package/generate.mjs` | `scripts/change-package/validate.mjs`, `.github/workflows/pr-ci-status-comment.yml` |
+| `artifacts/ci/policy-input-v1.json` | `schema/policy-input-v1.schema.json` | `scripts/ci/policy-gate.mjs`, `.github/workflows/policy-gate.yml` | `scripts/ci/policy-gate.mjs`, `scripts/ci/policy-shadow-compare.mjs`, `scripts/ci/validate-json.mjs` |
+| `artifacts/ci/policy-decision-js-v1.json`, `artifacts/ci/policy-decision-opa-v1.json` | `schema/policy-decision-v1.schema.json` | `scripts/ci/policy-gate.mjs`, `scripts/ci/policy-shadow-compare.mjs`, `.github/workflows/policy-gate.yml` | `scripts/ci/policy-shadow-compare.mjs`, `scripts/ci/validate-json.mjs` |
 | `artifacts/ci/policy-gate-summary.json` | `schema/policy-gate-summary-v1.schema.json` | `scripts/ci/policy-gate.mjs`, `.github/workflows/policy-gate.yml` | `scripts/ci/validate-policy-gate-summary.mjs`, `scripts/ci/validate-artifacts-ajv.mjs` |
 | `artifacts/ci/automation-report.json` | `schema/automation-observability-v1.schema.json` | `scripts/ci/lib/automation-report.mjs`, `.github/workflows/codex-autopilot-lane.yml` | `scripts/ci/validate-automation-report.mjs`, `scripts/ci/validate-artifacts-ajv.mjs` |
 | `artifacts/ci/pr-state-v1.json` | `schema/pr-state-v1.schema.json` | `scripts/ci/codex-autopilot-lane.mjs` | `scripts/ci/validate-json.mjs`, `docs/ci/codex-autopilot-lane.md` |


### PR DESCRIPTION
## 対応Issue
- closes #2419

## 変更内容
- `docs/reference/CONTRACT-CATALOG.md` に #2407 の policy 契約を追加
  - `policy-input-v1`
  - `policy-decision-v1`
- `verify-lite` で契約カタログ coverage チェックを required 実行に変更

## 変更ファイル
- `docs/reference/CONTRACT-CATALOG.md`
- `.github/workflows/verify-lite.yml`

## 検証
- `node scripts/docs/check-contract-catalog-coverage.mjs`
- `pnpm exec vitest run tests/unit/docs/check-contract-catalog-coverage.test.ts`
