### PR TITLE
feat(bench): #2431 checksum一致率を bench-compare に追加

### DIFF
--- a/docs/quality/poc-success-criteria-2409.md
+++ b/docs/quality/poc-success-criteria-2409.md
@@ -78,6 +78,7 @@ node scripts/quality/bench-compare.mjs \
 - 出力Markdown: `artifacts/bench-compare.md`
 - 必須判定: `p95 ratio <= 0.85`, `throughput ratio >= 1.20`, `error rate <= max(0.5, baseline + 0.2pt)`, `peak RSS ratio <= 1.15`
 - 再現性判定: `p95 CV <= 0.05`, `throughput CV <= 0.05`（runCount >= 2 のとき）
+- 出力整合判定: `checksum match rate == 100%`
 - 参考判定: `cold start ratio <= 1.10`
 
 ### 5.2 指標の一次データ源と算出方式（確定）
@@ -96,6 +97,7 @@ node scripts/quality/bench-compare.mjs \
   - `p95 CV`: 複数runの `metrics.p95` から算出
   - `throughput CV`: 複数runの `sum(summary[].hz)` から算出
   - run が1件のみの場合、CVは `null`（non-applicable）
+- checksum 一致率: run群の `benchmark-report/v1` から `schemaVersion + summary + metrics` を正規化（summaryはname順、JSON key安定化）して `sha256` 比較し、先頭runと一致した件数/全件数で算出
 - error rate 上限: `max(0.5, baseline.errorRate + 0.2)`（percentage point）
 - 比較成果物契約: `artifacts/bench-compare.json`（`schemaVersion: bench-compare/v1`、schema: `schema/bench-compare.schema.json`）
 

--- a/docs/templates/quality/poc-comparison-metrics-template.md
+++ b/docs/templates/quality/poc-comparison-metrics-template.md
@@ -108,6 +108,7 @@
 - `throughput` = `sum(summary[].hz)`
 - `ratio = candidate / baseline`（baseline が `<= 0` の場合は `null` として non-applicable 扱い）
 - `CV = stddev / mean`（runCount >= 2 のとき算出、1件時は `null`）
+- `checksum match rate` = `schemaVersion + summary + metrics` を正規化（summaryはname順、JSON keyを安定化）したハッシュの一致件数 / run件数（%）
 
 ```text
 # TS baseline（機械可読: artifacts/bench.json）

--- a/schema/bench-compare.schema.json
+++ b/schema/bench-compare.schema.json
@@ -75,6 +75,7 @@
         "path",
         "paths",
         "runCount",
+        "checksums",
         "metrics",
         "throughputHz",
         "taskCount",
@@ -97,6 +98,14 @@
           "type": "integer",
           "minimum": 1
         },
+        "checksums": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          }
+        },
         "metrics": {
           "$ref": "#/$defs/metrics"
         },
@@ -117,7 +126,8 @@
       "additionalProperties": false,
       "required": [
         "p95Cv",
-        "throughputCv"
+        "throughputCv",
+        "checksumMatchRate"
       ],
       "properties": {
         "p95Cv": {
@@ -125,6 +135,14 @@
         },
         "throughputCv": {
           "$ref": "#/$defs/ratioOrNull"
+        },
+        "checksumMatchRate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 100
         }
       }
     },
@@ -170,7 +188,8 @@
         "peakRss",
         "coldStartReference",
         "p95Cv",
-        "throughputCv"
+        "throughputCv",
+        "checksum"
       ],
       "properties": {
         "p95": {
@@ -193,6 +212,9 @@
         },
         "throughputCv": {
           "type": "boolean"
+        },
+        "checksum": {
+          "type": "boolean"
         }
       }
     },
@@ -204,6 +226,7 @@
         "path",
         "paths",
         "runCount",
+        "checksums",
         "metrics",
         "throughputHz",
         "reproducibility",
@@ -231,6 +254,14 @@
         "runCount": {
           "type": "integer",
           "minimum": 1
+        },
+        "checksums": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          }
         },
         "metrics": {
           "$ref": "#/$defs/metrics"

--- a/scripts/quality/bench-compare.mjs
+++ b/scripts/quality/bench-compare.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { createHash } from 'node:crypto';
 
 const DEFAULT_OUTPUT_JSON = 'artifacts/bench-compare.json';
 const DEFAULT_OUTPUT_MD = 'artifacts/bench-compare.md';
@@ -110,9 +111,47 @@ function parseCandidateArg(raw) {
   };
 }
 
-function readJsonFile(filePath) {
-  const raw = fs.readFileSync(filePath, 'utf8');
-  return JSON.parse(raw);
+function sha256Hex(payload) {
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+function canonicalizeValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalizeValue(entry));
+  }
+  if (value && typeof value === 'object') {
+    const normalized = {};
+    for (const key of Object.keys(value).sort()) {
+      const normalizedValue = canonicalizeValue(value[key]);
+      if (normalizedValue !== undefined) {
+        normalized[key] = normalizedValue;
+      }
+    }
+    return normalized;
+  }
+  return value;
+}
+
+function canonicalChecksumPayload(report) {
+  const summary = report.summary.map((task, index) => {
+    const normalizedName = typeof task?.name === 'string' ? task.name.trim() : '';
+    return {
+      name: normalizedName.length > 0 ? normalizedName : `#${index + 1}`,
+      meanMs: task?.meanMs,
+      hz: task?.hz,
+      sdMs: task?.sdMs,
+      samples: task?.samples,
+      p95: task?.p95,
+      errorRate: task?.errorRate,
+      coldStartMs: task?.coldStartMs,
+    };
+  });
+  summary.sort((left, right) => String(left.name).localeCompare(String(right.name)));
+  return canonicalizeValue({
+    schemaVersion: report.schemaVersion,
+    summary,
+    metrics: report.metrics,
+  });
 }
 
 function assertNonNegativeFiniteNumber(value, label) {
@@ -135,7 +174,8 @@ function readBenchmarkReport(filePath) {
     throw new Error(`benchmark report not found: ${filePath}`);
   }
 
-  const report = readJsonFile(filePath);
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const report = JSON.parse(raw);
   if (report?.schemaVersion !== 'benchmark-report/v1') {
     throw new Error(`unsupported schemaVersion at ${filePath}: ${String(report?.schemaVersion || '')}`);
   }
@@ -164,6 +204,7 @@ function readBenchmarkReport(filePath) {
 
   return {
     path: filePath,
+    checksumSha256: sha256Hex(JSON.stringify(canonicalChecksumPayload(report))),
     metrics,
     throughputHz,
     taskCount: report.summary.length,
@@ -239,6 +280,23 @@ function assertConsistentRunShape(reports) {
   }
 }
 
+function checksumMatchRate(checksums) {
+  if (!Array.isArray(checksums) || checksums.length === 0) {
+    return null;
+  }
+  const baseline = checksums[0];
+  const matched = checksums.filter((entry) => entry === baseline).length;
+  return (matched / checksums.length) * 100;
+}
+
+function allChecksumsMatch(checksums) {
+  if (!Array.isArray(checksums) || checksums.length <= 1) {
+    return true;
+  }
+  const baseline = checksums[0];
+  return checksums.every((entry) => entry === baseline);
+}
+
 function aggregateBenchmarkRuns(reports) {
   if (!Array.isArray(reports) || reports.length === 0) {
     throw new Error('at least one benchmark report is required');
@@ -250,12 +308,14 @@ function aggregateBenchmarkRuns(reports) {
   const coldStartValues = reports.map((report) => report.metrics.coldStartMs);
   const peakRssValues = reports.map((report) => report.metrics.peakRssMb);
   const throughputValues = reports.map((report) => report.throughputHz);
+  const checksums = reports.map((report) => report.checksumSha256);
 
   return {
     paths: reports.map((report) => report.path),
     path: reports[0]?.path || '',
     runCount: reports.length,
     taskCount: reports[0]?.taskCount || 0,
+    checksums,
     metrics: {
       p95: round(median(p95Values), 4),
       errorRate: round(median(errorRateValues), 4),
@@ -266,6 +326,7 @@ function aggregateBenchmarkRuns(reports) {
     reproducibility: {
       p95Cv: roundOrNull(coefficientOfVariation(p95Values), 4),
       throughputCv: roundOrNull(coefficientOfVariation(throughputValues), 4),
+      checksumMatchRate: roundOrNull(checksumMatchRate(checksums), 2),
     },
   };
 }
@@ -307,6 +368,7 @@ function evaluateCandidate(candidate, baseline) {
     coldStartReference: upperBoundCheck(coldStartRatio, 1.1),
     p95Cv: upperBoundCheck(candidate.reproducibility.p95Cv, 0.05),
     throughputCv: upperBoundCheck(candidate.reproducibility.throughputCv, 0.05),
+    checksum: allChecksumsMatch(candidate.checksums),
   };
 
   const overallPass = checks.p95
@@ -314,13 +376,15 @@ function evaluateCandidate(candidate, baseline) {
     && checks.errorRate
     && checks.peakRss
     && checks.p95Cv
-    && checks.throughputCv;
+    && checks.throughputCv
+    && checks.checksum;
 
   return {
     name: candidate.name,
     path: candidate.path,
     paths: candidate.paths,
     runCount: candidate.runCount,
+    checksums: candidate.checksums,
     metrics: candidate.metrics,
     throughputHz: candidate.throughputHz,
     reproducibility: candidate.reproducibility,
@@ -351,15 +415,15 @@ function renderMarkdown(result) {
     '# Bench Comparison Report',
     '',
     `- Generated: ${result.generatedAt}`,
-    `- Baseline: ${result.baseline.path} (runs=${result.baseline.runCount}, p95 CV=${fmtNumber(result.baseline.reproducibility.p95Cv, 4)}, throughput CV=${fmtNumber(result.baseline.reproducibility.throughputCv, 4)})`,
+    `- Baseline: ${result.baseline.path} (runs=${result.baseline.runCount}, p95 CV=${fmtNumber(result.baseline.reproducibility.p95Cv, 4)}, throughput CV=${fmtNumber(result.baseline.reproducibility.throughputCv, 4)}, checksum match=${fmtNumber(result.baseline.reproducibility.checksumMatchRate, 2)}%)`,
     '',
-    '| candidate | runs | overall | p95 ratio | throughput ratio | error rate(%) | error limit(%) | peak RSS ratio | cold start ratio | p95 CV | throughput CV |',
-    '|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|',
+    '| candidate | runs | overall | p95 ratio | throughput ratio | error rate(%) | error limit(%) | peak RSS ratio | cold start ratio | p95 CV | throughput CV | checksum match(%) |',
+    '|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|',
   ];
 
   for (const candidate of result.candidates) {
     lines.push(
-      `| ${candidate.name} | ${candidate.runCount} | ${candidate.overall.toUpperCase()} | ${fmtNumber(candidate.comparison.p95Ratio, 4)} | ${fmtNumber(candidate.comparison.throughputRatio, 4)} | ${fmtNumber(candidate.metrics.errorRate, 2)} | ${fmtNumber(candidate.comparison.errorRateLimit, 2)} | ${fmtNumber(candidate.comparison.peakRssRatio, 4)} | ${fmtNumber(candidate.comparison.coldStartRatio, 4)} | ${fmtNumber(candidate.reproducibility.p95Cv, 4)} | ${fmtNumber(candidate.reproducibility.throughputCv, 4)} |`,
+      `| ${candidate.name} | ${candidate.runCount} | ${candidate.overall.toUpperCase()} | ${fmtNumber(candidate.comparison.p95Ratio, 4)} | ${fmtNumber(candidate.comparison.throughputRatio, 4)} | ${fmtNumber(candidate.metrics.errorRate, 2)} | ${fmtNumber(candidate.comparison.errorRateLimit, 2)} | ${fmtNumber(candidate.comparison.peakRssRatio, 4)} | ${fmtNumber(candidate.comparison.coldStartRatio, 4)} | ${fmtNumber(candidate.reproducibility.p95Cv, 4)} | ${fmtNumber(candidate.reproducibility.throughputCv, 4)} | ${fmtNumber(candidate.reproducibility.checksumMatchRate, 2)} |`,
     );
   }
 
@@ -372,6 +436,7 @@ function renderMarkdown(result) {
     '- peak RSS ratio <= 1.15',
     '- p95 CV <= 0.05 (when runCount >= 2)',
     '- throughput CV <= 0.05 (when runCount >= 2)',
+    '- checksum match rate == 100%',
     '',
     '## Reference check',
     '- cold start ratio <= 1.10',
@@ -397,6 +462,7 @@ function main() {
       path: baseline.path,
       paths: baseline.paths,
       runCount: baseline.runCount,
+      checksums: baseline.checksums,
       metrics: baseline.metrics,
       throughputHz: baseline.throughputHz,
       taskCount: baseline.taskCount,

--- a/tests/scripts/bench-compare.test.ts
+++ b/tests/scripts/bench-compare.test.ts
@@ -122,7 +122,7 @@ describe.sequential('bench-compare script', () => {
 
       const payload = JSON.parse(readFileSync(outJsonPath, 'utf8')) as {
         schemaVersion: string;
-        candidates: Array<{ name: string; overall: string; checks: { throughput: boolean } }>;
+        candidates: Array<{ name: string; overall: string; checks: { throughput: boolean; checksum: boolean }; reproducibility: { checksumMatchRate: number | null } }>;
       };
       const markdown = readFileSync(outMdPath, 'utf8');
 
@@ -131,6 +131,8 @@ describe.sequential('bench-compare script', () => {
       expect(payload.candidates.find((candidate) => candidate.name === 'go')?.overall).toBe('pass');
       expect(payload.candidates.find((candidate) => candidate.name === 'rust')?.overall).toBe('fail');
       expect(payload.candidates.find((candidate) => candidate.name === 'go')?.checks.throughput).toBe(true);
+      expect(payload.candidates.find((candidate) => candidate.name === 'go')?.checks.checksum).toBe(true);
+      expect(payload.candidates.find((candidate) => candidate.name === 'go')?.reproducibility.checksumMatchRate).toBe(100);
       expect(markdown).toContain('# Bench Comparison Report');
       expect(markdown).toContain('| go | 1 | PASS |');
       expect(markdown).toContain('| rust | 1 | FAIL |');
@@ -362,27 +364,94 @@ describe.sequential('bench-compare script', () => {
 
       expect(result.status).toBe(1);
       const payload = JSON.parse(readFileSync(outJsonPath, 'utf8')) as {
-        baseline: { runCount: number; reproducibility: { p95Cv: number | null } };
+        baseline: { runCount: number; reproducibility: { p95Cv: number | null; checksumMatchRate: number | null } };
         candidates: Array<{
           name: string;
           runCount: number;
-          reproducibility: { throughputCv: number | null };
-          checks: { throughputCv: boolean };
+          reproducibility: { throughputCv: number | null; checksumMatchRate: number | null };
+          checks: { throughputCv: boolean; checksum: boolean };
           overall: string;
         }>;
       };
 
       expect(payload.baseline.runCount).toBe(2);
       expect(payload.baseline.reproducibility.p95Cv).not.toBeNull();
+      expect(payload.baseline.reproducibility.checksumMatchRate).toBe(50);
       expect(payload.candidates[0]?.name).toBe('go');
       expect(payload.candidates[0]?.runCount).toBe(2);
       expect(payload.candidates[0]?.reproducibility.throughputCv).not.toBeNull();
+      expect(payload.candidates[0]?.reproducibility.checksumMatchRate).toBe(50);
       expect(payload.candidates[0]?.checks.throughputCv).toBe(false);
+      expect(payload.candidates[0]?.checks.checksum).toBe(false);
       expect(payload.candidates[0]?.overall).toBe('fail');
 
       const markdown = readFileSync(outMdPath, 'utf8');
       expect(markdown).toMatch(/\|\s*go\s*\|\s*2\s*\|\s*FAIL\s*\|/);
       expect(markdown).toContain('throughput CV');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps checksum match rate stable when only volatile metadata differs', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'ae-bench-compare-checksum-stable-'));
+
+    try {
+      const baseline1Path = join(tempDir, 'baseline-1.json');
+      const baseline2Path = join(tempDir, 'baseline-2.json');
+      const candidatePath = join(tempDir, 'candidate.json');
+      const outJsonPath = join(tempDir, 'bench-compare.json');
+      const outMdPath = join(tempDir, 'bench-compare.md');
+
+      const baseline1 = createBenchReport({
+        p95: 100,
+        errorRate: 0.1,
+        coldStartMs: 50,
+        peakRssMb: 100,
+        hz: 1000,
+      });
+      const baseline2 = createBenchReport({
+        p95: 100,
+        errorRate: 0.1,
+        coldStartMs: 50,
+        peakRssMb: 100,
+        hz: 1000,
+      });
+      baseline1.meta.date = '2026-03-04T00:00:00.000Z';
+      baseline2.meta.date = '2026-03-05T00:00:00.000Z';
+      const candidate = createBenchReport({
+        p95: 80,
+        errorRate: 0.2,
+        coldStartMs: 45,
+        peakRssMb: 105,
+        hz: 1300,
+      });
+
+      writeFileSync(baseline1Path, JSON.stringify(baseline1), 'utf8');
+      writeFileSync(baseline2Path, JSON.stringify(baseline2), 'utf8');
+      writeFileSync(candidatePath, JSON.stringify(candidate), 'utf8');
+
+      const result = spawnSync(
+        'node',
+        [
+          compareScript,
+          '--baseline',
+          `${baseline1Path},${baseline2Path}`,
+          '--candidate',
+          `go=${candidatePath}`,
+          '--out-json',
+          outJsonPath,
+          '--out-md',
+          outMdPath,
+        ],
+        { encoding: 'utf8', timeout: 120_000 },
+      );
+
+      expect(result.status).toBe(0);
+      const payload = JSON.parse(readFileSync(outJsonPath, 'utf8')) as {
+        baseline: { reproducibility: { checksumMatchRate: number | null } };
+      };
+      expect(payload.baseline.reproducibility.checksumMatchRate).toBe(100);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## 背景
Issue #2431 対応。PoC 成功基準の「checksum 一致率」を `bench-compare` で機械判定可能にします。

## 変更内容
- `scripts/quality/bench-compare.mjs`
  - runごとの `bench.json` SHA-256 を算出
  - `checksumMatchRate`（先頭run一致率）を再現性指標に追加
  - required check に `checksum match rate == 100%` を追加
- `schema/bench-compare.schema.json`
  - `checksums` / `reproducibility.checksumMatchRate` / `checks.checksum` を契約化
- `tests/scripts/bench-compare.test.ts`
  - 単一runで checksum=100 の検証
  - 複数runで checksum mismatch を検知する検証
- docs更新
  - `docs/quality/poc-success-criteria-2409.md`
  - `docs/templates/quality/poc-comparison-metrics-template.md`

## テスト
- `pnpm exec vitest run tests/scripts/bench-compare.test.ts tests/scripts/bench-compare-schema.test.ts tests/unit/ci/validate-artifacts-ajv.test.ts`
- `pnpm exec tsc --noEmit`

## 備考
- 本PRは #2430（複数run/CV対応）の上に積んだ stacked PR です。
