### PR TITLE
ci: remove lockfile fallback from heavy reusable lanes

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -121,7 +121,8 @@ jobs:
 
       - name: Install dependencies
         if: ${{ steps.flags.outputs.should_run == 'true' }}
-        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+        # Required lane policy: detect lockfile drift immediately in reusable CI entry lanes.
+        run: pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true
 
       - name: Determine heavy test cache key
         if: ${{ steps.flags.outputs.should_run == 'true' }}

--- a/.github/workflows/hermetic-ci.yml
+++ b/.github/workflows/hermetic-ci.yml
@@ -130,8 +130,8 @@ jobs:
           
       - name: Install dependencies (hermetic)
         run: |
-          # Use lockfile for hermetic builds
-          pnpm install --frozen-lockfile --prefer-offline || pnpm install --no-frozen-lockfile --prefer-offline
+          # Hermetic lane should fail fast on lockfile drift instead of self-healing it.
+          pnpm install --frozen-lockfile --prefer-offline --config.use-lockfile=true --config.package-lock=true
           
       - name: Run hermetic tests
         run: |
@@ -204,7 +204,8 @@ jobs:
           node-version: '20'
           
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline || pnpm install --no-frozen-lockfile --prefer-offline
+        # Hermetic lane should fail fast on lockfile drift instead of self-healing it.
+        run: pnpm install --frozen-lockfile --prefer-offline --config.use-lockfile=true --config.package-lock=true
         
       - name: Setup test isolation
         run: |

--- a/.github/workflows/parallel-test-execution.yml
+++ b/.github/workflows/parallel-test-execution.yml
@@ -65,7 +65,8 @@ jobs:
 
       - name: Install deps
         run: |
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+          # CI reusable lane policy: fail fast when the lockfile is stale.
+          pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true
 
       - name: Create reports/logs directory
         run: |
@@ -128,7 +129,8 @@ jobs:
       
       - name: Install deps
         run: |
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+          # CI reusable lane policy: fail fast when the lockfile is stale.
+          pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true
 
       - name: Create reports directory
         run: |
@@ -179,7 +181,8 @@ jobs:
       
       - name: Install deps
         run: |
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+          # CI reusable lane policy: fail fast when the lockfile is stale.
+          pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true
 
       - name: Create reports directory
         run: |
@@ -222,7 +225,8 @@ jobs:
       
       - name: Install deps
         run: |
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+          # CI reusable lane policy: fail fast when the lockfile is stale.
+          pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true
 
       - name: Run performance tests
         run: |
@@ -259,7 +263,8 @@ jobs:
       
       - name: Install deps
         run: |
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+          # CI reusable lane policy: fail fast when the lockfile is stale.
+          pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true
 
 
       - name: Download all test artifacts
@@ -330,7 +335,8 @@ jobs:
       
       - name: Install deps
         run: |
-          pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+          # CI reusable lane policy: fail fast when the lockfile is stale.
+          pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true
 
       - name: Retry failed tests with enhanced detection
         run: |


### PR DESCRIPTION
## Background
Issue #2450 の継続として、`ci.yml` から呼ばれる reusable heavy lane に残る `--no-frozen-lockfile` フォールバックを除去します。

## Changes
- `ci-extended.yml` の install step を fail-fast 化
- `parallel-test-execution.yml` の 6 箇所の install step を fail-fast 化
- `hermetic-ci.yml` の 2 箇所の install step を fail-fast 化
- 各所に lockfile drift を即時検知する意図をコメントで明記

## Validation
- `pnpm -s run check:doc-consistency`
- workflow 妥当性は CI で確認

Refs #2450
Refs #2452