### PR TITLE
fix(ci): post quality comment file contents

### DIFF
--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -187,11 +187,17 @@ jobs:
             cat artifacts/quality/summary.json
             printf ' -->\n'
           } > artifacts/quality/comment-body.txt
+          node - <<'NODE'
+          const fs = require('fs');
+          const body = fs.readFileSync('artifacts/quality/comment-body.txt', 'utf8');
+          fs.writeFileSync('artifacts/quality/comment-body.json', JSON.stringify({ body }));
+          NODE
           existing_id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .id' | head -n1 || true)
           if [ -n "$existing_id" ]; then
-            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing_id" -f body=@artifacts/quality/comment-body.txt
+            # Use --input with JSON payload so gh api posts file contents, not the literal path string.
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing_id" --input artifacts/quality/comment-body.json
           else
-            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" -f body=@artifacts/quality/comment-body.txt
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --input artifacts/quality/comment-body.json
           fi
   types-tests:
     uses: ./.github/workflows/ci-core.yml


### PR DESCRIPTION
## Overview
- fix `pr-quality-comment` so GitHub comments receive the generated file contents instead of the literal `@artifacts/quality/comment-body.txt` path
- keep the existing marker/update flow intact
- scope is limited to the workflow posting step

## Changes
- generate `artifacts/quality/comment-body.json` from the rendered markdown/text payload
- switch `gh api` create/update calls from raw field usage to `--input` JSON payloads
- add an inline note explaining why the workflow uses `--input`

## Validation
- `python` + `yaml.safe_load` on `.github/workflows/quality-gates-centralized.yml`
- local payload generation smoke check for `comment-body.json`
- `git diff --check`

## Acceptance
- `pr-quality-comment` no longer posts `@artifacts/quality/comment-body.txt` as a literal string
- the existing quality comment update path remains marker-based

## Rollback
- revert this PR to restore the previous `gh api -f body=@...` behavior

Closes #2478
