### PR TITLE
docs(release): sync cli and PR automation guidance

### DIFF
--- a/docs/ci/pr-automation.md
+++ b/docs/ci/pr-automation.md
@@ -222,6 +222,9 @@ Settings（Repository）で次を確認してください。
 
 - PRマージ後の運用判定は `post-deploy-verify.yml`（workflow_dispatch）で実施します。
 - ローカル再現は `pnpm run ae-framework -- release verify ...`（または `ae release verify`）を使用します。
+- `release_tag` は、release asset `quality-artifacts.tgz` から assurance summary を取得して Step Summary に追記したい場合だけ指定します。
+- assurance summary は optional / report-only であり、`post-deploy-verify.json` の gate 判定そのものは変えません。
+- `release-quality-artifacts` を manual 実行しただけでは Actions artifact しか作られないため、`release_tag` で参照できるのは公開済み release asset がある場合だけです。
 - 手順詳細: `docs/operate/release-engineering.md`
 
 ## 5. トラブルシューティング

--- a/docs/reference/CLI-COMMANDS-REFERENCE.md
+++ b/docs/reference/CLI-COMMANDS-REFERENCE.md
@@ -250,6 +250,9 @@ ae domain-model --language --sources "glossary.md"
 # optional: --trace-bundle artifacts/observability/trace-bundle.json
 # outputs: artifacts/release/post-deploy-verify.{json,md}
 # status: pass | warn | fail, with rollbackRecommended
+# note: fixtures/release/sample.* are for local CLI validation only; workflow_dispatch rejects them
+# note: omitting --synthetic-checks or --trace-bundle can surface as missingEvidence, but a provided unreadable path fails the command
+# note: workflow input release_tag is not a CLI flag; it is used only by post-deploy-verify.yml to append optional assurance summary output
 ```
 
 ### Integration Testing (Phase 2.3)
@@ -591,6 +594,9 @@ ae release verify --policy policy/release-policy.yml \
 # 任意: --trace-bundle artifacts/observability/trace-bundle.json
 # 出力: artifacts/release/post-deploy-verify.{json,md}
 # 判定: pass | warn | fail（rollbackRecommended を返却）
+# 注: fixtures/release/sample.* はローカル CLI 検証用であり、workflow_dispatch では拒否される
+# 注: --synthetic-checks / --trace-bundle は未指定なら missingEvidence になり得るが、指定したパスが読めない場合はコマンドが失敗する
+# 注: workflow input の release_tag は CLI 引数ではなく、post-deploy-verify.yml が optional な assurance summary を追記するために使う
 ```
 
 ### Integration Testing


### PR DESCRIPTION
## Summary
- sync CLI reference with the current release verify and post-deploy verify behavior
- document the workflow-only role of `release_tag` and the local-only nature of sample release fixtures
- align PR automation guidance with the current release-quality-artifacts and assurance summary flow

## Testing
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
