### PR TITLE
docs(governance): cover project and operate docs

### DIFF
--- a/docs/operate/monitor.md
+++ b/docs/operate/monitor.md
@@ -1,3 +1,10 @@
+---
+docRole: ssot
+lastVerified: '2026-03-10'
+owner: observability-ops
+verificationCommand: pnpm -s run check:doc-consistency
+---
+
 # Operate: Runtime Conformance Monitor (Draft)
 
 ## Purpose

--- a/docs/operate/release-engineering.md
+++ b/docs/operate/release-engineering.md
@@ -1,3 +1,10 @@
+---
+docRole: ssot
+lastVerified: '2026-03-10'
+owner: release-ops
+verificationCommand: pnpm -s run check:doc-consistency
+---
+
 # Release Engineering (Policy v1 / Post-deploy Verify)
 
 Issue: `#2288`

--- a/docs/operate/telemetry-as-context.md
+++ b/docs/operate/telemetry-as-context.md
@@ -1,3 +1,10 @@
+---
+docRole: ssot
+lastVerified: '2026-03-10'
+owner: observability-ops
+verificationCommand: pnpm -s run check:doc-consistency
+---
+
 # Telemetry-as-Context（Trace Bundle v1）
 
 運用テレメトリを `ae conformance verify` の入力へ接続するために、まず Trace Bundle を生成します。  

--- a/docs/project/GOVERNANCE.md
+++ b/docs/project/GOVERNANCE.md
@@ -1,3 +1,10 @@
+---
+docRole: ssot
+lastVerified: '2026-03-10'
+owner: project-governance
+verificationCommand: pnpm -s run check:doc-consistency
+---
+
 # Governance Model / 運営モデル
 
 > 🌍 Language / 言語: English | 日本語

--- a/docs/project/RELEASE.md
+++ b/docs/project/RELEASE.md
@@ -1,3 +1,10 @@
+---
+docRole: ssot
+lastVerified: '2026-03-10'
+owner: release-ops
+verificationCommand: pnpm -s run check:doc-consistency
+---
+
 # Release Guide (Quality Artifacts) / リリース手順（品質エビデンス）
 
 > 🌍 Language / 言語: English | 日本語

--- a/docs/quality/doc-consistency-lint.md
+++ b/docs/quality/doc-consistency-lint.md
@@ -22,7 +22,7 @@ Together they validate that onboarding + CI operation docs stay aligned with the
 Checks:
 - `pnpm run <script>` references exist in `package.json`.
 - Local file/path references in markdown links and inline code resolve to real files/directories.
-- `docs/README.md` から辿れる `docs/ci/*` / `docs/quality/*` の主要ドキュメントに加え、`docs/product/*` の trust-tier front matter も既定スコープで検証する。
+- `docs/README.md` から辿れる `docs/ci/*` / `docs/quality/*` の主要ドキュメントに加え、`docs/operate/*` / `docs/product/*` / `docs/project/*` の trust-tier front matter も既定スコープで検証する。
 - `docs/README.md` / `docs/ci-policy.md` include the canonical CI operation links.
 - CI reference sections in `docs/ci-policy.md` avoid duplicate entries.
 - `docs/agents/commands.md` stays synchronized with `.github/workflows/agent-commands.yml`.

--- a/docs/reference/DOC-GOVERNANCE.md
+++ b/docs/reference/DOC-GOVERNANCE.md
@@ -49,7 +49,9 @@ verificationCommand: pnpm ...   # ssot のとき必須
 - `docs/README.md`
 - `docs/reference/DOC-GOVERNANCE.md`
 - `docs/agents/*.md`
+- `docs/operate/*.md`
 - `docs/product/*.md`
+- `docs/project/*.md`
 - `docs/quality/*.md`
 
 ## 5. Validation

--- a/scripts/docs/check-doc-governance.mjs
+++ b/scripts/docs/check-doc-governance.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const ROOT_DOCS = ['README.md', 'AGENTS.md', 'docs/README.md'];
 const GOVERNED_EXTRA_DOCS = ['docs/reference/DOC-GOVERNANCE.md'];
-const GOVERNED_PREFIX_DIRS = ['docs/agents', 'docs/product', 'docs/quality'];
+const GOVERNED_PREFIX_DIRS = ['docs/agents', 'docs/operate', 'docs/product', 'docs/project', 'docs/quality'];
 const DOC_ROLE_VALUES = new Set(['ssot', 'derived', 'narrative']);
 const NARRATIVE_NORMATIVE_PATTERNS = [
   /\bmust\b/giu,

--- a/tests/unit/docs/check-doc-governance.test.ts
+++ b/tests/unit/docs/check-doc-governance.test.ts
@@ -11,7 +11,9 @@ const tempRoots: string[] = [];
 function makeRoot() {
   const rootDir = mkdtempSync(path.join(tmpdir(), 'ae-doc-governance-'));
   mkdirSync(path.join(rootDir, 'docs', 'agents'), { recursive: true });
+  mkdirSync(path.join(rootDir, 'docs', 'operate'), { recursive: true });
   mkdirSync(path.join(rootDir, 'docs', 'product'), { recursive: true });
+  mkdirSync(path.join(rootDir, 'docs', 'project'), { recursive: true });
   mkdirSync(path.join(rootDir, 'docs', 'quality'), { recursive: true });
   mkdirSync(path.join(rootDir, 'docs', 'reference'), { recursive: true });
   tempRoots.push(rootDir);
@@ -127,6 +129,28 @@ describe('check-doc-governance', () => {
       '# Governance',
       '',
     ].join('\n'));
+    writeMarkdown(rootDir, 'docs/project/RELEASE.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-10',
+      'owner: release-ops',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Release',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/operate/monitor.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-10',
+      'owner: observability-ops',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Monitor',
+      '',
+    ].join('\n'));
 
     const result = withCapturedOutput(() => main([
       'node',
@@ -138,11 +162,103 @@ describe('check-doc-governance', () => {
 
     expect(result.exitCode).toBe(0);
     const payload = JSON.parse(result.stdout);
-    expect(payload.docsScanned).toBe(6);
+    expect(payload.docsScanned).toBe(8);
     expect(payload.failures).toEqual([]);
     expect(payload.warnings).toHaveLength(1);
     expect(payload.warnings[0].markdownPath).toBe('README.md');
     expect(result.stderr).toBe('');
+  });
+
+  it('governs docs/project and docs/operate files', () => {
+    const rootDir = makeRoot();
+
+    writeMarkdown(rootDir, 'README.md', [
+      '---',
+      'docRole: narrative',
+      'lastVerified: 2026-03-10',
+      '---',
+      '',
+      '# Root',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'AGENTS.md', [
+      '---',
+      'docRole: derived',
+      'canonicalSource:',
+      '  - docs/agents/agents-doc-boundary-matrix.md',
+      'lastVerified: 2026-03-10',
+      '---',
+      '',
+      '# Agents',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/README.md', [
+      '---',
+      'docRole: narrative',
+      'lastVerified: 2026-03-10',
+      '---',
+      '',
+      '# Docs',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/agents/agents-doc-boundary-matrix.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-10',
+      'owner: agent-ops',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Matrix',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/reference/DOC-GOVERNANCE.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-10',
+      'owner: docs-governance',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Governance',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/project/GOVERNANCE.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-10',
+      'owner: project-governance',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Project Governance',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/operate/release-engineering.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-10',
+      'owner: release-ops',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Release Engineering',
+      '',
+    ].join('\n'));
+
+    const result = withCapturedOutput(() => main([
+      'node',
+      'scripts/docs/check-doc-governance.mjs',
+      '--root',
+      rootDir,
+      '--format=json',
+    ]));
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.failures).toEqual([]);
+    expect(payload.warnings).toHaveLength(0);
+    expect(payload.docsScanned).toBe(7);
   });
 
   it('fails when a derived doc omits canonicalSource', () => {


### PR DESCRIPTION
## Summary
- extend doc governance coverage to `docs/project/*` and `docs/operate/*`
- add trust-tier front matter to release and operations docs
- update governance scope docs and regression tests

## Testing
- node scripts/docs/check-doc-governance.mjs --format json
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
- pnpm exec vitest run tests/unit/docs/check-doc-governance.test.ts

## Acceptance
- `check-doc-governance` reports `failures=0` and `warnings=0`
- `docs/project/*` and `docs/operate/*` are covered by trust-tier front matter lint

## Rollback
- revert this PR to restore the previous governance scope
