### PR TITLE
docs(governance): cover workflow docs

### DIFF
--- a/docs/quality/doc-consistency-lint.md
+++ b/docs/quality/doc-consistency-lint.md
@@ -22,7 +22,7 @@ Together they validate that onboarding + CI operation docs stay aligned with the
 Checks:
 - `pnpm run <script>` references exist in `package.json`.
 - Local file/path references in markdown links and inline code resolve to real files/directories.
-- `docs/README.md` から辿れる `docs/ci/*` / `docs/quality/*` の主要ドキュメントに加え、`docs/getting-started/*` / `docs/guides/*` / `docs/integrations/*` / `docs/operate/*` / `docs/product/*` / `docs/project/*` / `docs/reference/*` の trust-tier front matter も既定スコープで検証する。
+- `docs/README.md` から辿れる `docs/ci/*` / `docs/quality/*` の主要ドキュメントに加え、`docs/getting-started/*` / `docs/guides/*` / `docs/integrations/*` / `docs/operate/*` / `docs/product/*` / `docs/project/*` / `docs/reference/*` / `docs/workflows/*` の trust-tier front matter も既定スコープで検証する。
 - `docs/README.md` / `docs/ci-policy.md` include the canonical CI operation links.
 - CI reference sections in `docs/ci-policy.md` avoid duplicate entries.
 - `docs/agents/commands.md` stays synchronized with `.github/workflows/agent-commands.yml`.

--- a/docs/reference/DOC-GOVERNANCE.md
+++ b/docs/reference/DOC-GOVERNANCE.md
@@ -57,6 +57,7 @@ verificationCommand: pnpm ...   # ssot のとき必須
 - `docs/project/*.md`
 - `docs/quality/*.md`
 - `docs/reference/*.md`
+- `docs/workflows/*.md`
 
 ## 5. Validation
 

--- a/docs/workflows/NL-to-AE-Spec-Workflow.md
+++ b/docs/workflows/NL-to-AE-Spec-Workflow.md
@@ -1,3 +1,11 @@
+---
+docRole: derived
+canonicalSource:
+  - docs/reference/SCHEMA-GOVERNANCE.md
+  - docs/reference/SPEC-VERIFICATION-KIT-EXTENSIONS.md
+lastVerified: '2026-03-11'
+---
+
 # Natural Language → AE‑Spec → IR → Code Workflow (CodeX / Claude Code)
 
 > 🌍 Language / 言語: English | 日本語

--- a/scripts/docs/check-doc-governance.mjs
+++ b/scripts/docs/check-doc-governance.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const ROOT_DOCS = ['README.md', 'AGENTS.md', 'docs/README.md'];
 const GOVERNED_EXTRA_DOCS = ['docs/reference/DOC-GOVERNANCE.md'];
-const GOVERNED_PREFIX_DIRS = ['docs/agents', 'docs/getting-started', 'docs/guides', 'docs/integrations', 'docs/operate', 'docs/product', 'docs/project', 'docs/quality', 'docs/reference'];
+const GOVERNED_PREFIX_DIRS = ['docs/agents', 'docs/getting-started', 'docs/guides', 'docs/integrations', 'docs/operate', 'docs/product', 'docs/project', 'docs/quality', 'docs/reference', 'docs/workflows'];
 const DOC_ROLE_VALUES = new Set(['ssot', 'derived', 'narrative']);
 const NARRATIVE_NORMATIVE_PATTERNS = [
   /\bmust\b/giu,

--- a/tests/unit/docs/check-doc-governance.test.ts
+++ b/tests/unit/docs/check-doc-governance.test.ts
@@ -19,6 +19,7 @@ function makeRoot() {
   mkdirSync(path.join(rootDir, 'docs', 'project'), { recursive: true });
   mkdirSync(path.join(rootDir, 'docs', 'quality'), { recursive: true });
   mkdirSync(path.join(rootDir, 'docs', 'reference'), { recursive: true });
+  mkdirSync(path.join(rootDir, 'docs', 'workflows'), { recursive: true });
   tempRoots.push(rootDir);
   return rootDir;
 }
@@ -598,6 +599,110 @@ describe('check-doc-governance', () => {
     expect(payload.failures).toEqual([]);
     expect(payload.warnings).toHaveLength(0);
     expect(payload.docsScanned).toBe(6);
+  });
+
+  it('governs docs/workflows files', () => {
+    const rootDir = makeRoot();
+
+    writeMarkdown(rootDir, 'README.md', [
+      '---',
+      'docRole: narrative',
+      'lastVerified: 2026-03-11',
+      '---',
+      '',
+      '# Root',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'AGENTS.md', [
+      '---',
+      'docRole: derived',
+      'canonicalSource:',
+      '  - docs/agents/agents-doc-boundary-matrix.md',
+      'lastVerified: 2026-03-11',
+      '---',
+      '',
+      '# Agents',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/README.md', [
+      '---',
+      'docRole: narrative',
+      'lastVerified: 2026-03-11',
+      '---',
+      '',
+      '# Docs',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/agents/agents-doc-boundary-matrix.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-11',
+      'owner: agent-ops',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Matrix',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/reference/DOC-GOVERNANCE.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-11',
+      'owner: docs-governance',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Governance',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/reference/SCHEMA-GOVERNANCE.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-11',
+      'owner: docs-governance',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Schema Governance',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/reference/SPEC-VERIFICATION-KIT-EXTENSIONS.md', [
+      '---',
+      'docRole: ssot',
+      'lastVerified: 2026-03-11',
+      'owner: docs-governance',
+      'verificationCommand: pnpm -s run check:doc-consistency',
+      '---',
+      '',
+      '# Spec Verification Kit Extensions',
+      '',
+    ].join('\n'));
+    writeMarkdown(rootDir, 'docs/workflows/NL-to-AE-Spec-Workflow.md', [
+      '---',
+      'docRole: derived',
+      'canonicalSource:',
+      '  - docs/reference/SCHEMA-GOVERNANCE.md',
+      '  - docs/reference/SPEC-VERIFICATION-KIT-EXTENSIONS.md',
+      'lastVerified: 2026-03-11',
+      '---',
+      '',
+      '# Workflow',
+      '',
+    ].join('\n'));
+
+    const result = withCapturedOutput(() => main([
+      'node',
+      'scripts/docs/check-doc-governance.mjs',
+      '--root',
+      rootDir,
+      '--format=json',
+    ]));
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.failures).toEqual([]);
+    expect(payload.warnings).toHaveLength(0);
+    expect(payload.docsScanned).toBe(8);
   });
 
   it('fails when a derived doc omits canonicalSource', () => {


### PR DESCRIPTION
## Summary
- extend doc governance coverage to `docs/workflows/*`
- add trust-tier front matter to `docs/workflows/NL-to-AE-Spec-Workflow.md`
- update governance docs and regression coverage

## Testing
- `node scripts/docs/check-doc-governance.mjs --format json`
- `pnpm exec vitest run tests/unit/docs/check-doc-governance.test.ts`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`

## Acceptance
- `docs/workflows/*` is covered by trust-tier front matter checks
- doc governance reports `failures=0` and `warnings=0`

## Rollback
- revert this PR to remove workflow docs from the governed scope

Closes #2570
