### PR TITLE
docs(artifacts): sync trace and formal path references

### DIFF
--- a/docs/architecture/CURRENT-SYSTEM-OVERVIEW.md
+++ b/docs/architecture/CURRENT-SYSTEM-OVERVIEW.md
@@ -12,7 +12,7 @@ verificationCommand: pnpm -s run check:doc-consistency
 
 ## English (Summary)
 
-This document captures the implementation-aligned architecture of `ae-framework` as of 2026-03-14, including review-topology aware policy gates, OPA shadow-compare migration, assurance/quality aggregation artifacts, handoff adapters, trace-required check integration, release verify operations, and the expanded formal-verification stack with CSP (`cspx`) integration.
+This document captures the implementation-aligned architecture of `ae-framework` as of 2026-03-16, including review-topology aware policy gates, OPA shadow-compare migration, assurance/quality aggregation artifacts, handoff adapters, trace-required check integration, release verify operations, and the expanded formal-verification stack with CSP (`cspx`) integration.
 
 ---
 
@@ -216,7 +216,13 @@ CI pin（再現性）:
 - CSP詳細: `docs/quality/formal-csp.md`
 - 全ドキュメント索引: `docs/README.md`
 
-## 9. 更新サマリ（2026-03-14）
+## 9. 更新サマリ（2026-03-16）
+
+- formal / trace artifact path の current contract 追従
+  - `artifacts/formal/formal-summary-v1.json`
+  - `artifacts/formal/formal-summary-v2.json`
+  - `artifacts/trace/report-envelope.json`
+  - `artifacts/hermetic-reports/trace/kvonce-validation.json`
 
 更新内容:
 - `codex-autopilot-lane.yml` の収束フロー（actionable非suggestion対応を含む）を CIモデルへ統合

--- a/docs/ddd/events.md
+++ b/docs/ddd/events.md
@@ -13,7 +13,7 @@ verificationCommand: pnpm -s run check:doc-consistency
 
 ## 日本語（概要）
 
-`domainEvents[]` から Zod 契約とリプレイ用フィクスチャを生成し、イベント列に対する集約不変量を検証します。成果物（events.json / replay.summary / formal-summary-v1-v2 / properties.summary）と、Zod/Replay のスケッチ、CLI と PR 要件を記載しています。
+`domainEvents[]` から Zod 契約とリプレイ用フィクスチャを生成し、イベント列に対する集約不変量を検証します。成果物（`artifacts/domain/events.json` / `artifacts/domain/replay.summary.json` / `artifacts/formal/formal-summary-v1.json` / `artifacts/formal/formal-summary-v2.json` / `artifacts/properties/summary.json`）と、Zod/Replay のスケッチ、CLI と PR 要件を記載しています。
 
 Goals
 - From `domainEvents[]`, generate:

--- a/docs/guides/artifacts-normalization.md
+++ b/docs/guides/artifacts-normalization.md
@@ -13,14 +13,14 @@ lastVerified: '2026-03-16'
 
 ## 日本語（概要）
 
-機械可読な成果物は JSON/JUnit に統一し、`docs/schemas/` のスキーマに準拠します。アダプター要約（`artifacts/*/summary.json`）、フォーマル要約（`artifacts/formal/formal-summary-v1.json`, `artifacts/formal/formal-summary-v2.json`）、プロパティ要約（`artifacts/properties/summary.json`）では可能な限り `traceId` を含めます。
+機械可読な成果物は JSON/JUnit に統一し、`docs/schemas/` と `schema/` のスキーマに準拠します。アダプター要約（`artifacts/*/summary.json`）、フォーマル要約（`artifacts/formal/formal-summary-v1.json`, `artifacts/formal/formal-summary-v2.json`）、プロパティ要約（`artifacts/properties/summary.json`）では可能な限り `traceId` を含めます。
 
 - Store machine-readable results as JSON and JUnit only.
 - Paths:
   - `artifacts/*/summary.json` for adapters
   - `artifacts/formal/formal-summary-v1.json` and `artifacts/formal/formal-summary-v2.json` for formal verification
   - `artifacts/properties/summary.json` for property tests
-- Conform to schemas in `docs/schemas/`.
+- Conform to schemas in `docs/schemas/` and `schema/`.
 - Include `traceId` wherever applicable.
 
 ## JSON Schema 2020-12 policy / 運用方針


### PR DESCRIPTION
## Summary
- sync current trace/formal artifact paths in system overview, normalization guide, and DDD events docs
- replace stale `formal/summary.json` references with current formal summary v1/v2 paths where these docs describe normalized machine-readable outputs
- update replay-linked evidence guidance to current `artifacts/domain/replay.summary.json` path

## Testing
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
- DOCTEST_ENFORCE=1 pnpm exec tsx scripts/doctest.ts docs/architecture/CURRENT-SYSTEM-OVERVIEW.md docs/guides/artifacts-normalization.md docs/ddd/events.md
- git diff --check

Closes #2700