### PR TITLE
docs(product): expand English parity for adoption docs

### DIFF
--- a/docs/product/MINIMAL-ADOPTION.md
+++ b/docs/product/MINIMAL-ADOPTION.md
@@ -94,6 +94,7 @@ pnpm run codex:run
 
 ### 6. Definition of Done
 - `verify-lite` is green
+- `policy-gate` is green
 - `gate` is green
 - Minimum artifacts are generated
 - The team agrees on the opt-in rule for heavy checks

--- a/docs/product/USE-CASES.md
+++ b/docs/product/USE-CASES.md
@@ -24,7 +24,7 @@ pnpm run ae-framework -- <command> [args...]
 ```
 
 ### 0.2 Built CLI distribution
-After `pnpm run build`, use the packaged CLI through `ae` or `ae-framework`.
+After `pnpm run build`, invoke the packaged CLI through `pnpm exec ae ...` or `pnpm exec ae-framework ...` (see `docs/product/COMMAND-MODES.md`).
 
 ### 0.3 GitHub Actions CI
 The current main PR baseline assumes `verify-lite`, `policy-gate`, and `gate` as the default required checks.
@@ -96,10 +96,15 @@ node scripts/pipelines/compare-test-trends.mjs --json-output reports/heavy-test-
 ### Purpose
 Keep the daily PR baseline light and trigger stronger security checks only when needed.
 
-### Example
+### Local security example
 ```bash
 pnpm run security:integrated:quick
 ```
+
+### PR / CI trigger examples
+- Add the `run-security` label when the PR needs the security workflow
+- Use the SBOM workflow separately when repository policy requires package inventory output
+- See `.github/workflows/security.yml` and `.github/workflows/sbom-generation.yml` for the split execution paths
 
 ## 7. Agent Integration (Codex)
 ### Purpose
@@ -108,7 +113,7 @@ Run phased automation while preserving execution logs and artifact paths for con
 ### Example
 ```bash
 pnpm run codex:run
-node scripts/codex/ae-playbook.mjs --enable-formal --formal-timeout=60000
+node scripts/codex/ae-playbook.mjs --resume --enable-formal --formal-timeout=60000
 ```
 
 ---
@@ -297,7 +302,7 @@ pnpm run codex:run
 
 ### 発展（Formalを含める）
 ```bash
-node scripts/codex/ae-playbook.mjs --enable-formal --formal-timeout=60000
+node scripts/codex/ae-playbook.mjs --resume --enable-formal --formal-timeout=60000
 ```
 
 ### 参考（根拠）


### PR DESCRIPTION
## Summary
- expand the English sections in `MINIMAL-ADOPTION` and `USE-CASES` to the current operational depth of the Japanese sections
- align the English text with the current `verify-lite` / `policy-gate` / `gate` baseline
- refresh `lastVerified` metadata to 2026-03-22

## Verification
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
- DOCTEST_ENFORCE=1 pnpm -s tsx scripts/doctest.ts docs/product/MINIMAL-ADOPTION.md docs/product/USE-CASES.md
- git diff --check
