### PR TITLE
docs(quality): expand English parity for contracts

### DIFF
--- a/docs/quality/path-normalization-contract.md
+++ b/docs/quality/path-normalization-contract.md
@@ -13,12 +13,12 @@ lastVerified: '2026-03-22'
 
 ## English
 
-## 1. Purpose
+### 1. Purpose
 When artifact or report JSON includes environment-specific absolute paths or inconsistent separators, pull request diffs become noisy and outputs stop being portable across local and CI environments.
 
 This contract standardizes how path-like fields are written inside generated JSON artifacts and reports.
 
-## 2. Normalization rules
+### 2. Normalization rules
 1. If the input is already relative, keep it relative but normalize separators to `/`
 2. If the input is absolute and inside the repository, convert it to a repo-relative path
 3. If the input is absolute and outside the repository, keep it absolute so the external dependency remains explicit
@@ -28,19 +28,19 @@ Notes:
 - Do not rewrite external absolute paths to `../..` style relative paths
 - Windows-originated paths such as `C:\\...` or `\\\\server\\share\\...` should remain external absolute paths on POSIX hosts, but their displayed separators should still be normalized to `C:/...` or `//server/share/...`
 
-## 3. Example target fields
+### 3. Example target fields
 - `artifacts[].path` in report envelope style outputs
 - `*.file`, `detailsFile`, `logPath`, `summaryPath` in formal or conformance summary JSON
 - `sources.*` in aggregate JSON such as progress summaries
 
-## 4. Implementation reference
+### 4. Implementation reference
 The repository treats the following as the standard implementations:
 - Node scripts: `scripts/ci/lib/path-normalization.mjs` -> `normalizeArtifactPath()`
 - TypeScript: `src/utils/path-normalization.ts` -> `normalizeArtifactPath()`
 
 Call sites should normally pass `repoRoot: process.cwd()`, which is expected to be the repository root at execution time.
 
-## 5. Examples
+### 5. Examples
 - Input: `/home/runner/work/repo/repo/artifacts/report-envelope.json` -> Output: `artifacts/report-envelope.json`
 - Input: `/tmp/tool.log` -> Output: `/tmp/tool.log`
 - Input: `reports\\lint\\verify-lite-lint-summary.json` -> Output: `reports/lint/verify-lite-lint-summary.json`

--- a/docs/quality/run-manifest-freshness-contract.md
+++ b/docs/quality/run-manifest-freshness-contract.md
@@ -13,7 +13,7 @@ lastVerified: '2026-03-22'
 
 ## English
 
-## 1. Purpose
+### 1. Purpose
 Artifact presence alone does not prove freshness for the current commit. When a local run or partial rerun leaves old artifacts behind, CI or operator judgment can incorrectly treat them as valid evidence.
 
 This contract defines how `run-manifest.json` records:
@@ -22,7 +22,7 @@ This contract defines how `run-manifest.json` records:
 
 The goal is to make freshness checks deterministic in both CI and local execution.
 
-## 2. Generation
+### 2. Generation
 Generate the manifest with `node scripts/ci/generate-run-manifest.mjs`. By default it writes `artifacts/run-manifest.json`.
 
 ```bash
@@ -30,7 +30,7 @@ node scripts/ci/generate-run-manifest.mjs \
   --top-level-command "pnpm run verify:lite"
 ```
 
-## 3. Validation
+### 3. Validation
 Validate the manifest with `node scripts/ci/check-run-manifest.mjs`.
 
 ```bash
@@ -40,19 +40,19 @@ node scripts/ci/check-run-manifest.mjs \
   --result artifacts/run-manifest-check.json
 ```
 
-### `--require-fresh`
+#### `--require-fresh`
 For each named summary such as `verifyLite`, validation requires:
 - `status == "present"`
 - `staleComparedToCurrentCommit == false`
 
-If `producedByCommit` cannot be extracted and `staleComparedToCurrentCommit == null`, the result is treated as `freshness_unknown` and fails in strict mode.
+If `producedByCommit` cannot be extracted and `staleComparedToCurrentCommit == null`, the result is treated as `freshness_unknown` and the script records it as a violation. Higher-level workflows may still decide whether that failure is blocking or report-only.
 
-## 4. Field overview
+### 4. Field overview
 - `metadata.gitCommit`: current commit at manifest generation time
 - `summaries.<name>.producedByCommit`: commit extracted from the artifact JSON on a best-effort basis
 - `summaries.<name>.staleComparedToCurrentCommit`: comparison result between `producedByCommit` and `metadata.gitCommit`
 
-## 5. References
+### 5. References
 - `schema/run-manifest.schema.json`
 - `scripts/ci/generate-run-manifest.mjs`
 - `scripts/ci/check-run-manifest.mjs`


### PR DESCRIPTION
## Summary
- expand the English sections of the freshness and path normalization quality contracts
- align the English content with the Japanese operational detail level
- update `lastVerified` to 2026-03-22

## Validation
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
- DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/quality/run-manifest-freshness-contract.md docs/quality/path-normalization-contract.md
- git diff --check