### PR TITLE
docs(integrations): deepen English parity for workflow guide

### DIFF
--- a/docs/integrations/CLAUDECODE-WORKFLOW.md
+++ b/docs/integrations/CLAUDECODE-WORKFLOW.md
@@ -281,25 +281,31 @@ jobs:
 
 
 #### Operator Workflow Patterns (English)
-- **Full-flow execution**: best for small projects or greenfield spikes. Run Intent -> Natural Language -> Validation -> Modeling -> UI/UX without long pauses, then review the generated artifacts together.
+- **Full-flow execution**: best for small projects or greenfield spikes. Run Intent -> Natural Language -> Stories -> Validation -> Modeling -> UI/UX without long pauses, then review the generated artifacts together.
 - **Checkpointed execution**: best for medium projects. Pause after Validation and Modeling, confirm that requirements and boundaries are stable, and only then generate UI/UX.
 - **Bounded-context slicing**: best for large projects. Split the problem into bounded contexts, run the same six-phase flow for each slice, and aggregate artifacts at the PR layer.
 
 #### Extended Commands (English)
 Use these when the default phase commands are not enough for diagnostics or guided improvements.
 
-```bash
-# Integrated analysis and repository understanding
-ae-framework analyze --architecture
-ae-framework doc generate --all
+```text
+# Claude Code slash commands (inside the chat/session)
+/ae:analyze ./src/auth --depth=deep --security --performance
+/ae:document ./src --type=api --format=openapi --include-examples
+/ae:improve ./src/tasks --focus=performance --suggest-refactoring
+```
 
-# Improvement and optimization pass
-ae-framework improve --code-quality
-ae-framework benchmark run
+```bash
+# Benchmark and performance characterization
+#ae-benchmark is a separate binary
+ae-benchmark run --ci --dry-run
 
 # Delivery-side verification pass
-ae-framework verify --full
-ae-framework traceability generate
+ae entry verify --profile lite
+
+ae traceability extract-ids   --issue "https://github.com/<org>/<repo>/issues/1"   --pattern "(?:LG|REQ)-[A-Z0-9_-]+"   --output docs/specs/issue-traceability-map.json
+
+ae traceability matrix   --map docs/specs/issue-traceability-map.json   --tests "tests/**/*"   --code "src/**/*"   --context-pack "spec/context-pack/**/*.{yml,yaml,json}"   --discovery-pack "spec/discovery-pack/**/*.{yml,yaml,json}"   --format json   --output docs/specs/ISSUE-TRACEABILITY-MATRIX.json
 ```
 
 #### Best Practices (English)
@@ -324,12 +330,12 @@ ae-framework traceability generate
 
 #### Practical Session Guidance (English)
 A productive Claude Code session usually follows this order:
-1. start with a concrete user goal and bounded scope
-2. run Intent and Natural Language analysis
-3. review the structured outputs, not just the narrative explanation
-4. proceed to Validation and Modeling only after requirement meaning is stable
-5. generate implementation artifacts after the model is accepted
-6. finish with verify-lite, formal/security opt-ins, and PR artifact upload
+1. Start with a concrete user goal and bounded scope.
+2. Run Intent and Natural Language analysis.
+3. Review the structured outputs, not just the narrative explanation.
+4. Proceed to Validation and Modeling only after requirement meaning is stable.
+5. Generate implementation artifacts after the model is accepted.
+6. Finish with verify-lite, formal/security opt-ins, and PR artifact upload.
 
 ---
 


### PR DESCRIPTION
## Summary
- deepen the English section in `docs/integrations/CLAUDECODE-WORKFLOW.md`
- add operator workflow patterns, extended commands, best practices, and troubleshooting guidance

## Validation
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/integrations/CLAUDECODE-WORKFLOW.md`
- `git diff --check`

Closes #2824