### PR TITLE
docs(ci): deepen automation failure policy parity

### DIFF
--- a/docs/ci/automation-failure-policies.md
+++ b/docs/ci/automation-failure-policies.md
@@ -6,7 +6,7 @@ verificationCommand: pnpm -s run check:doc-consistency
 ---
 # Automation Failure Policies and Comment Templates
 
-PR 自動化ワークフローの fail-open / fail-closed 方針と、運用で参照するコメントテンプレートを定義します。
+This document defines the fail-open / fail-closed policy for PR automation workflows and the comment templates used during operation. / PR 自動化ワークフローの fail-open / fail-closed 方針と、運用で参照するコメントテンプレートを定義します。
 
 > Language / 言語: English | 日本語
 


### PR DESCRIPTION
## Summary
- expand the English guidance in `docs/ci/automation-failure-policies.md` to the same operating level as the Japanese section
- document the fail-open / fail-closed policy matrix, comment markers, and minimum operating rules in English
- refresh `lastVerified` and sync `docs/agents/commands.md`

## Validation
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts /home/devuser/work/CodeX/ae-frameworkA/ae-framework-2875-automation-failure-policies/docs/ci/automation-failure-policies.md`
- `git diff --check`

## Acceptance
- English section covers policy matrix, marker templates, and minimum operating rules
- `lastVerified` is updated to 2026-03-24

## Rollback
- revert `docs/ci/automation-failure-policies.md` and generated `docs/agents/commands.md`
