### PR TITLE
docs(ci): deepen docs doctest parity

### DIFF
--- a/docs/ci/docs-doctest-policy.md
+++ b/docs/ci/docs-doctest-policy.md
@@ -23,10 +23,10 @@ This document defines the operating policy for the docs doctest lanes that prote
 
 | Lane | Trigger | Execution |
 | --- | --- | --- |
-| `doctest-index` | `pull_request` / `push(main)` / `workflow_dispatch` | `check-doc-consistency-all` plus doctest for `../../README.md` and `../README.md`; on `pull_request`, changed Markdown files are also validated |
+| `doctest-index` | `pull_request` / `push(main)` / `workflow_dispatch` | `check-doc-consistency-all` plus doctest for README.md and docs/README.md; on `pull_request`, changed Markdown files are also validated |
 | `doctest-full` | `schedule` / `workflow_dispatch(full=true)` | full doctest for `docs/**/*.md` |
 
-Workflow: `../../.github/workflows/docs-doctest.yml`
+Workflow: `.github/workflows/docs-doctest.yml`
 
 ### Operating rules
 


### PR DESCRIPTION
## Summary
- deepen the English section in `docs/ci/docs-doctest-policy.md` to match the current Japanese runbook
- document execution scope, operating rules, failure handling, and local reproduction commands in bilingual form

## Validation
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/ci/docs-doctest-policy.md`
- `git diff --check`

## Acceptance
- English section covers lane scope, runbook steps, and local reproduction at current-state depth
- doc consistency / CI doc index / touched-doc doctest pass

## Rollback
- revert this PR
