### PR TITLE
docs: deepen README parity follow-up

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,9 +74,7 @@ See `reference/DOC-GOVERNANCE.md` for the front matter fields and lint rules.
 - Release / telemetry operations: `operate/release-engineering.md`, `operate/telemetry-as-context.md`
 
 ### Documentation language policy
-- Keep English and Japanese aligned for operational sections such as commands, thresholds, workflow inputs, and CI examples.
-- When one side intentionally stays shorter, add a clear note pointing to the detailed side instead of letting the two sections silently drift.
-- Prefer executable snippets and repository-owned paths over abstract examples whenever the document is used as a runbook.
+See **Docs Language Policy / ドキュメント言語方針** below for the canonical documentation language policy (single source of truth).
 
 ### Getting Started
 Entry path for first-time setup, baseline verification, and the shortest route to a usable local environment.


### PR DESCRIPTION
## Summary
- deepen the English guidance in `docs/README.md`
- add use-case-based routes, current-state operator entrypoints, and language-policy guidance
- keep all links aligned with the current repository structure

## Testing
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
- DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/README.md
- git diff --check

## Acceptance
- the English section provides navigation detail closer to the Japanese side
- docs checks and doctest pass

## Rollback
- revert this PR if the expanded index guidance introduces stale or redundant navigation
