### PR TITLE
docs(ci): add workflow topology bilingual parity

### DIFF
--- a/docs/ci/workflow-topology-mapping-2026-03-04.md
+++ b/docs/ci/workflow-topology-mapping-2026-03-04.md
@@ -8,6 +8,8 @@ verificationCommand: pnpm -s run check:doc-consistency
 
 > 🌍 Language / 言語: English | 日本語
 
+---
+
 対象Issue / Target issue: `#2404`
 目的 / Purpose: 現行の `.github/workflows/*.yml`（56本）を、理想設計の4系統へ再配置する。 / Re-map the current `.github/workflows/*.yml` set (56 workflows) into the four-track target topology.
 


### PR DESCRIPTION
## Summary
- convert `docs/ci/workflow-topology-mapping-2026-03-04.md` into a bilingual current-state reference
- add the missing English definitions, 56-workflow mapping, target counts, rollout order, and completion criteria
- align `lastVerified` with the current baseline

## Testing
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts /home/devuser/work/CodeX/ae-frameworkA/ae-framework-2933-workflow-topology/docs/ci/workflow-topology-mapping-2026-03-04.md`
- `git diff --check`

## Acceptance
- English readers can understand the four-track workflow remap without relying on the Japanese section
- workflow names, migration notes, and completion criteria remain aligned with current `main`

## Rollback
- revert this PR to restore the previous Japanese-only layout
