### PR TITLE
docs(quality): add counterexample GWT parity

### DIFF
--- a/docs/quality/counterexample-gwt.md
+++ b/docs/quality/counterexample-gwt.md
@@ -19,8 +19,8 @@ lastVerified: '2026-03-26'
 
 ### Short GWT (example)
 ```text
-Given inventory onHand=10
-When allocate qty=12
+Given {"onHand":10}
+When {"command":"allocate","qty":12}
 Then invariant "allocated <= onHand" fails
 ```
 
@@ -32,13 +32,17 @@ Then invariant "allocated <= onHand" fails
 
 ```json
 {
-  "property": "allocated <= onHand",
-  "gwt": "Given inventory onHand=10\nWhen allocate qty=12\nThen invariant \"allocated <= onHand\" fails",
-  "json": {
-    "given": { "onHand": 10 },
-    "when": { "command": "allocate", "qty": 12 },
-    "then": { "violated": "allocated <= onHand" }
-  }
+  "items": [
+    {
+      "property": "allocated <= onHand",
+      "gwt": "Given {\"onHand\":10}\nWhen {\"command\":\"allocate\",\"qty\":12}\nThen invariant \"allocated <= onHand\" fails",
+      "json": {
+        "given": { "onHand": 10 },
+        "when": { "command": "allocate", "qty": 12 },
+        "then": { "violated": "allocated <= onHand" }
+      }
+    }
+  ]
 }
 ```
 
@@ -50,8 +54,8 @@ Then invariant "allocated <= onHand" fails
 
 ### Short GWT（例）
 ```text
-Given inventory onHand=10
-When allocate qty=12
+Given {"onHand":10}
+When {"command":"allocate","qty":12}
 Then invariant "allocated <= onHand" fails
 ```
 
@@ -63,12 +67,16 @@ Then invariant "allocated <= onHand" fails
 
 ```json
 {
-  "property": "allocated <= onHand",
-  "gwt": "Given inventory onHand=10\nWhen allocate qty=12\nThen invariant \"allocated <= onHand\" fails",
-  "json": {
-    "given": { "onHand": 10 },
-    "when": { "command": "allocate", "qty": 12 },
-    "then": { "violated": "allocated <= onHand" }
-  }
+  "items": [
+    {
+      "property": "allocated <= onHand",
+      "gwt": "Given {\"onHand\":10}\nWhen {\"command\":\"allocate\",\"qty\":12}\nThen invariant \"allocated <= onHand\" fails",
+      "json": {
+        "given": { "onHand": 10 },
+        "when": { "command": "allocate", "qty": 12 },
+        "then": { "violated": "allocated <= onHand" }
+      }
+    }
+  ]
 }
 ```


### PR DESCRIPTION
## Summary
- convert `docs/quality/counterexample-gwt.md` to the standard bilingual layout
- clarify the legacy `formal/summary.json` source and the derived `artifacts/formal/gwt.summary.json` output in both languages
- keep the GWT and machine JSON examples aligned

## Testing
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts /home/devuser/work/CodeX/ae-frameworkA/ae-framework-2937-counterexample-gwt/docs/quality/counterexample-gwt.md`
- `git diff --check`

## Acceptance
- the doc follows the standard bilingual structure
- English and Japanese sections describe the same current counterexample contract

## Rollback
- revert this PR to restore the previous layout
