### PR TITLE
docs(quality): add formal tools setup parity

### DIFF
--- a/docs/quality/formal-tools-setup.md
+++ b/docs/quality/formal-tools-setup.md
@@ -119,7 +119,7 @@ This guide outlines local setup for formal verification tools used alongside AE-
 - TLA+ (TLC)
 - Apalache（SMT/BMC と帰納的不変条件）
 - Alloy（Alloy Analyzer / Alloy 6 CLI）
-- SMT solver: Z3, cvc5
+- SMT solvers: Z3, cvc5
 - Kani（Rust bounded model checking）
 - SPIN（Promela model checking）
 - CSP（`cspx` または構成済み backend による CSPM check）


### PR DESCRIPTION
## Summary
- normalize `docs/quality/formal-tools-setup.md` to the standard bilingual layout
- add a Japanese section mirroring local tool setup, verification commands, and backend notes
- update `lastVerified` to the current baseline

## Validation
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/quality/formal-tools-setup.md`
- `git diff --check`

Closes #2971
