### PR TITLE
docs(quality): add verify-first diagnostic template parity

### DIFF
--- a/docs/quality/verify-first-failure-diagnostic-template.md
+++ b/docs/quality/verify-first-failure-diagnostic-template.md
@@ -78,7 +78,7 @@ lastVerified: '2026-03-27'
 
 > PR/CI 失敗時の最小診断テンプレート（再現手順付き）
 
-### 0. Context
+### 0. Context / コンテキスト
 
 - PR / Issue:
 - Commit SHA:
@@ -107,7 +107,7 @@ lastVerified: '2026-03-27'
 - Expected:
 - Actual:
 
-### 4. Spec / Policy linkage
+### 4. Spec / Policy linkage / 仕様・ポリシーとのひも付け
 
 - Related spec path(s):
 - Related acceptance criteria:
@@ -130,7 +130,7 @@ lastVerified: '2026-03-27'
 - Artifact path(s):
 - Log excerpt location:
 
-### 8. Decision
+### 8. Decision / 決定
 
 - [ ] Re-run only
 - [ ] Fix + re-run


### PR DESCRIPTION
## Summary
- add bilingual parity to `docs/quality/verify-first-failure-diagnostic-template.md`
- align template fields and operator notes in English and Japanese
- refresh generated `docs/agents/commands.md` sync

## Validation
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/quality/verify-first-failure-diagnostic-template.md`
- `git diff --check`
