### PR TITLE
docs(quality): add PR summary template parity

### DIFF
--- a/docs/quality/pr-summary-template.md
+++ b/docs/quality/pr-summary-template.md
@@ -101,4 +101,4 @@ Quality: {{coverage.value*100 | round}}% (>= {{coverage.threshold*100 | round}})
 - 入力は `docs/quality/pr-summary-tool.md` で定義された正規化済み artifact と `combined.json` を前提とします。
 - template engine 自体は実装依存です。ここでは renderer 固有仕様ではなく、期待される field surface を示します。
 - 有効化されている gate だけを含め、未使用 section は省略して summary を簡潔に保ちます。
-- artifact の lineage や stricter schema rule は `docs/quality/ARTIFACTS-CONTRACT.md` に従います。
+- artifact の lineage や stricter schema rules は `docs/quality/ARTIFACTS-CONTRACT.md` に従います。


### PR DESCRIPTION
## Summary
- normalize `docs/quality/pr-summary-template.md` to the standard bilingual layout
- align alerts, digest, detailed template, and notes across English and Japanese
- update `lastVerified` to `2026-03-29`

## Testing
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 /home/devuser/work/CodeX/ae-frameworkA/ae-framework/node_modules/.bin/tsx /home/devuser/work/CodeX/ae-frameworkA/ae-framework/scripts/doctest.ts docs/quality/pr-summary-template.md`
- `git diff --check`

Closes #3012
