### PR TITLE
docs(quality): add self-improvement summary parity

### DIFF
--- a/docs/quality/self-improvement-summary.md
+++ b/docs/quality/self-improvement-summary.md
@@ -10,11 +10,11 @@ lastVerified: '2026-04-02'
 
 ## English
 
-## Mission Accomplished: Self-Improving AI Framework
+### Mission Accomplished: Self-Improving AI Framework
 
 The ae-framework has successfully demonstrated its capability to analyze, improve, and enhance its own codebase through systematic application of its own agents and methodologies. This represents a significant milestone in autonomous software development.
 
-## Overall Results
+### Overall Results
 
 | Metric | Initial State | Final Achievement | Improvement |
 |--------|---------------|-------------------|-------------|
@@ -23,7 +23,7 @@ The ae-framework has successfully demonstrated its capability to analyze, improv
 | **Code Quality** | Multiple undefined access patterns | Safe property access patterns | **Type safety enhanced** |
 | **Framework Capability** | Manual error resolution | Automated systematic fixes | **Self-improvement proven** |
 
-## Phase-by-Phase Achievement Summary
+### Phase-by-Phase Achievement Summary
 
 ### Phase 0-2: Foundation (Pre-existing)
 - ✅ **TDD Foundation**: Test-driven development infrastructure
@@ -82,7 +82,7 @@ private async generateSpecificFix(errorCode: string, description: string): Promi
 - Systematic categorization: type-safety, interface, import, syntax
 - Risk-based application: low/medium/high confidence levels
 
-**Technical Implementation:**
+**Technical Implementation (simplified excerpt aligned with the current implementation):**
 ```typescript no-doctest
 // Systematic error categorization and resolution
 export class Phase5VerificationFinal {
@@ -90,16 +90,27 @@ export class Phase5VerificationFinal {
     const initialErrors = await this.analyzeAllErrors();
     const categorizedErrors = this.categorizeErrors(initialErrors);
 
-    // Apply fixes by priority and confidence
-    const criticalFixes = await this.applyCriticalFixes(categorizedErrors);
-    const systematicFixes = await this.applySystematicFixes(categorizedErrors);
+    await this.applyCriticalFixes(categorizedErrors);
+    await this.applySystematicFixes(categorizedErrors);
 
-    return { errorsResolved: 182, successRate: 64 };
+    const verificationResults = await this.performFinalVerification();
+    const finalErrorCount = await this.getCurrentErrorCount();
+    const completionTime = Date.now() - this.startTime;
+
+    return {
+      initialErrorCount: initialErrors.length,
+      finalErrorCount,
+      errorsResolved: Math.max(0, initialErrors.length - finalErrorCount),
+      appliedFixes: this.appliedFixes,
+      verificationResults,
+      overallSuccess: finalErrorCount === 0 && verificationResults.compilationSuccess,
+      completionTime
+    };
   }
 }
 ```
 
-## Technical Achievements by Category
+### Technical Achievements by Category
 
 ### Type Safety Improvements (TS2532) - 10 Fixes
 **Applied non-null assertions and optional chaining:**
@@ -153,7 +164,7 @@ return {
 };
 ```
 
-## Infrastructure Built
+### Infrastructure Built
 
 ### Self-Improvement Framework
 1. **Phase3FormalTesting**: Formal specification generation and TDD guidance
@@ -173,7 +184,7 @@ return {
 - Automated verification with TypeScript compilation
 - Comprehensive reporting with markdown and JSON outputs
 
-## Key Metrics & Success Indicators
+### Key Metrics & Success Indicators
 
 ### Error Resolution Success
 - **64% Error Reduction**: 285 → 103 errors
@@ -193,7 +204,7 @@ return {
 - **Type Assertions (`as any`)**: Useful for complex interface compatibility
 - **Systematic Categorization**: Critical for scalable error resolution
 
-## Demonstrated Self-Improvement Capabilities
+### Demonstrated Self-Improvement Capabilities
 
 ### 1. Autonomous Analysis
 The framework successfully:
@@ -219,7 +230,7 @@ The framework showed:
 - Refinement of confidence scoring over iterations
 - Systematic approach to remaining complex errors
 
-## Future Implications & Next Steps
+### Future Implications & Next Steps
 
 ### Immediate Opportunities
 1. **Remaining 103 Errors**: Apply enhanced patterns to resolve remaining compilation issues
@@ -240,7 +251,7 @@ This project demonstrates that AI frameworks can:
 - **Self-Verify**: Validate improvements through automated testing
 - **Self-Document**: Generate comprehensive reports of their improvement process
 
-## Conclusion: Proof of Self-Improving AI Systems
+### Conclusion: Proof of Self-Improving AI Systems
 
 The ae-framework self-improvement project represents a significant milestone in autonomous software development. By successfully reducing TypeScript compilation errors by 64% through systematic application of its own formal methods, TDD practices, and automated code generation, the framework has proven that AI systems can genuinely improve themselves.
 
@@ -255,7 +266,7 @@ This project establishes ae-framework as not just a tool for building AI systems
 
 The successful completion of this self-improvement cycle positions ae-framework as a leading example of autonomous software development and sets the foundation for continuous self-enhancement in AI systems.
 
-## Pull Requests Created
+### Pull Requests Created
 
 1. **[PR #194](https://github.com/itdojp/ae-framework/pull/194)**: Phase 3 - Formal Specification & Testing Framework
 2. **[PR #195](https://github.com/itdojp/ae-framework/pull/195)**: Phase 4 - Code Generation & Implementation Framework
@@ -269,11 +280,11 @@ The successful completion of this self-improvement cycle positions ae-framework 
 
 ## 日本語
 
-## ミッション達成: 自己改善する AI フレームワーク
+### ミッション達成: 自己改善する AI フレームワーク
 
 ae-framework は、自身の agent と方法論を用いて、自身のコードベースを分析・改善・強化できることを実証しました。これは自律的ソフトウェア開発における重要な到達点です。
 
-## 全体結果
+### 全体結果
 
 | 指標 | 初期状態 | 最終到達点 | 改善 |
 |--------|---------------|-------------------|-------------|
@@ -282,7 +293,7 @@ ae-framework は、自身の agent と方法論を用いて、自身のコード
 | **Code Quality** | undefined access pattern が多発 | 安全な property access pattern へ改善 | **型安全性を強化** |
 | **Framework Capability** | 手動での error resolution | 自動化された体系的 fix | **自己改善能力を実証** |
 
-## フェーズ別の達成サマリ
+### フェーズ別の達成サマリ
 
 ### Phase 0-2: 基盤整備（既存）
 - ✅ **TDD Foundation**: test-driven development の基盤を整備
@@ -341,7 +352,7 @@ private async generateSpecificFix(errorCode: string, description: string): Promi
 - type-safety / interface / import / syntax で体系的に分類
 - low / medium / high の confidence level に基づいて適用
 
-**技術実装:**
+**技術実装（現行実装に沿った簡略抜粋）:**
 ```typescript no-doctest
 // Systematic error categorization and resolution
 export class Phase5VerificationFinal {
@@ -349,16 +360,27 @@ export class Phase5VerificationFinal {
     const initialErrors = await this.analyzeAllErrors();
     const categorizedErrors = this.categorizeErrors(initialErrors);
 
-    // Apply fixes by priority and confidence
-    const criticalFixes = await this.applyCriticalFixes(categorizedErrors);
-    const systematicFixes = await this.applySystematicFixes(categorizedErrors);
+    await this.applyCriticalFixes(categorizedErrors);
+    await this.applySystematicFixes(categorizedErrors);
 
-    return { errorsResolved: 182, successRate: 64 };
+    const verificationResults = await this.performFinalVerification();
+    const finalErrorCount = await this.getCurrentErrorCount();
+    const completionTime = Date.now() - this.startTime;
+
+    return {
+      initialErrorCount: initialErrors.length,
+      finalErrorCount,
+      errorsResolved: Math.max(0, initialErrors.length - finalErrorCount),
+      appliedFixes: this.appliedFixes,
+      verificationResults,
+      overallSuccess: finalErrorCount === 0 && verificationResults.compilationSuccess,
+      completionTime
+    };
   }
 }
 ```
 
-## 技術カテゴリ別の達成事項
+### 技術カテゴリ別の達成事項
 
 ### Type Safety Improvements (TS2532) - 10 Fixes
 **non-null assertion と optional chaining を適用:**
@@ -412,7 +434,7 @@ return {
 };
 ```
 
-## 構築した基盤
+### 構築した基盤
 
 ### Self-Improvement Framework
 1. **Phase3FormalTesting**: formal specification 生成と TDD guidance
@@ -432,7 +454,7 @@ return {
 - TypeScript compilation による自動 verification
 - Markdown / JSON の包括的 reporting
 
-## 主要指標と成功要因
+### 主要指標と成功要因
 
 ### Error Resolution Success
 - **64% Error Reduction**: 285 → 103 errors
@@ -452,7 +474,7 @@ return {
 - **Type Assertions (`as any`)**: 複雑な interface compatibility に有効
 - **Systematic Categorization**: scalable な error resolution の前提として有効
 
-## 実証された自己改善能力
+### 実証された自己改善能力
 
 ### 1. Autonomous Analysis
 本 framework は以下を実現しました。
@@ -478,7 +500,7 @@ return {
 - iteration ごとの confidence scoring 改善
 - 残存する複雑な error への体系的アプローチ
 
-## 今後の示唆と次のステップ
+### 今後の示唆と次のステップ
 
 ### Immediate Opportunities
 1. **残る 103 件の error**: 改善した pattern を用いて compilation issue をさらに削減する
@@ -499,7 +521,7 @@ return {
 - **Self-Verify**: 自動 test で改善内容を検証する
 - **Self-Document**: 改善プロセスの包括的 report を生成する
 
-## 結論: 自己改善する AI system の実証
+### 結論: 自己改善する AI system の実証
 
 本 self-improvement project は、自律的ソフトウェア開発における重要な到達点です。ae-framework は、formal methods、TDD practices、automated code generation を体系的に適用することで、TypeScript compilation error を 64% 削減し、AI system が実際に自身を改善できることを示しました。
 
@@ -514,7 +536,7 @@ return {
 
 この self-improvement cycle の完了により、ae-framework は autonomous software development の先行事例となり、AI system における継続的 self-enhancement の基盤を築きました。
 
-## 作成した Pull Request
+### 作成した Pull Request
 
 1. **[PR #194](https://github.com/itdojp/ae-framework/pull/194)**: Phase 3 - Formal Specification & Testing Framework
 2. **[PR #195](https://github.com/itdojp/ae-framework/pull/195)**: Phase 4 - Code Generation & Implementation Framework


### PR DESCRIPTION
## Summary
- normalize docs/quality/self-improvement-summary.md into the standard bilingual structure
- add Japanese-side summaries for results, phase achievements, technical categories, infrastructure, metrics, and next steps
- refresh lastVerified to 2026-04-02

## Verification
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
- DOCTEST_ENFORCE=1 /home/devuser/work/CodeX/ae-frameworkA/ae-framework/node_modules/.bin/tsx /home/devuser/work/CodeX/ae-frameworkA/ae-framework/scripts/doctest.ts docs/quality/self-improvement-summary.md docs/agents/commands.md
- git diff --check
