### PR TITLE
docs(quality): deepen run manifest freshness parity

### DIFF
--- a/docs/quality/run-manifest-freshness-contract.md
+++ b/docs/quality/run-manifest-freshness-contract.md
@@ -3,7 +3,7 @@ docRole: derived
 canonicalSource:
 - docs/quality/ARTIFACTS-CONTRACT.md
 - docs/reference/CONTRACT-CATALOG.md
-lastVerified: '2026-03-22'
+lastVerified: '2026-04-02'
 ---
 # Run Manifest Freshness Contract
 
@@ -61,12 +61,12 @@ If `producedByCommit` cannot be extracted and `staleComparedToCurrentCommit == n
 
 ## 日本語
 
-## 1. 目的
+### 1. 目的
 成果物が「存在する」だけでは、**現コミットに対して最新（fresh）**である保証になりません。部分的な再実行やローカル検証で古い成果物が残っていると、誤って成功判定になるリスクがあります。
 
 本契約は、`run-manifest.json` により成果物の **producedByCommit** と **staleComparedToCurrentCommit** を記録し、CI/ローカルの両方で鮮度違反を検出できるようにします。
 
-## 2. 生成（generate）
+### 2. 生成（generate）
 `node scripts/ci/generate-run-manifest.mjs` を実行し、既定では `artifacts/run-manifest.json` を生成します。
 
 ```bash
@@ -74,7 +74,7 @@ node scripts/ci/generate-run-manifest.mjs \
   --top-level-command "pnpm run verify:lite"
 ```
 
-## 3. 検証（check）
+### 3. 検証（check）
 `node scripts/ci/check-run-manifest.mjs` で検証します。
 
 ```bash
@@ -84,19 +84,19 @@ node scripts/ci/check-run-manifest.mjs \
   --result artifacts/run-manifest-check.json
 ```
 
-### `--require-fresh`
+#### `--require-fresh`
 指定した名前（例: `verifyLite`）について、以下を必須化します。
 - `status == "present"`
 - `staleComparedToCurrentCommit == false`
 
-`producedByCommit` が取れず `staleComparedToCurrentCommit == null` の場合は **freshness_unknown** として失敗扱いにします（strict）。
+`producedByCommit` が取れず `staleComparedToCurrentCommit == null` の場合は **freshness_unknown** として violation を記録します。上位の workflow や運用レイヤーでは、その結果を blocking と扱うか report-only と扱うかを別途判断できます。
 
-## 4. フィールド概要
+### 4. フィールド概要
 - `metadata.gitCommit`: 現在のコミット（マニフェスト生成時点）
 - `summaries.<name>.producedByCommit`: 成果物JSON内部から抽出したコミット（best-effort）
 - `summaries.<name>.staleComparedToCurrentCommit`: `producedByCommit` と `metadata.gitCommit` の比較結果（best-effort）
 
-## 5. 参照
+### 5. 参照
 - `schema/run-manifest.schema.json`
 - `scripts/ci/generate-run-manifest.mjs`
 - `scripts/ci/check-run-manifest.mjs`


### PR DESCRIPTION
## Summary
- deepen Japanese parity in `docs/quality/run-manifest-freshness-contract.md`
- align the `freshness_unknown` operational boundary with the English section
- normalize Japanese heading structure and refresh verification metadata

## Testing
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
- DOCTEST_ENFORCE=1 /home/devuser/work/CodeX/ae-frameworkA/ae-framework/node_modules/.bin/tsx /home/devuser/work/CodeX/ae-frameworkA/ae-framework/scripts/doctest.ts docs/quality/run-manifest-freshness-contract.md
- git diff --check

## Issue
- Closes #3084
