### PR TITLE
docs(quality): deepen formal mini flow terminology parity

### DIFF
--- a/docs/quality/formal-mini-flow.md
+++ b/docs/quality/formal-mini-flow.md
@@ -40,9 +40,9 @@ lastVerified: '2026-04-04'
 - Trace validation: `pnpm run trace:validate` (lightweight schema consistency check)
 - Conformance: `pnpm run verify:conformance [-i file --disable-invariants ...]`
 
-### 運用メモ
+### Tips
 
-- Start with 安全性 invariants first and keep the loop small.
+- Start with safety invariants first and keep the loop small.
 - CI runs via the `run-formal` label in non-blocking mode.
 - See `docs/quality/formal-runbook.md` and `docs/quality/formal-gates.md` for the full operating model.
 


### PR DESCRIPTION
## Summary
- normalize English-heavy terminology in the Japanese section of `docs/quality/formal-mini-flow.md`
- keep commands and identifiers unchanged
- refresh `lastVerified` to 2026-04-04

## Validation
- pnpm -s run check:doc-consistency
- pnpm -s run check:ci-doc-index-consistency
- DOCTEST_ENFORCE=1 /home/devuser/work/CodeX/ae-frameworkA/ae-framework/node_modules/.bin/tsx scripts/doctest.ts docs/quality/formal-mini-flow.md
- git diff --check