### PR TITLE
docs(quality): deepen quality scorecard terminology parity

### DIFF
--- a/docs/quality/quality-scorecard.md
+++ b/docs/quality/quality-scorecard.md
@@ -17,11 +17,11 @@ lastVerified: '2026-04-02'
 
 `quality-scorecard/v1` is a read-only aggregation artifact that summarizes the health of recent summary artifacts and exposes a single decision/evidence view for PR and release review.
 
-- 正規 JSON: `artifacts/quality/quality-scorecard.json`
-- 正規 Markdown: `artifacts/quality/quality-scorecard.md`
+- canonical JSON: `artifacts/quality/quality-scorecard.json`
+- canonical Markdown: `artifacts/quality/quality-scorecard.md`
 - schema: `schema/quality-scorecard.schema.json`
-- 生成処理: `scripts/quality/build-quality-scorecard.mjs` / `pnpm run quality:scorecard:v1`
-- 検証処理: `scripts/ci/validate-quality-scorecard.mjs` / `pnpm run quality:scorecard:validate`
+- producer: `scripts/quality/build-quality-scorecard.mjs` / `pnpm run quality:scorecard:v1`
+- validator: `scripts/ci/validate-quality-scorecard.mjs` / `pnpm run quality:scorecard:validate`
 
 ### 2. Inputs
 


### PR DESCRIPTION
## Summary
- normalize Japanese terminology in `docs/quality/quality-scorecard.md`
- keep English structure and contract wording intact
- preserve scope as terminology-only cleanup

## Validation
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 /home/devuser/work/CodeX/ae-frameworkA/ae-framework/node_modules/.bin/tsx /home/devuser/work/CodeX/ae-frameworkA/ae-framework/scripts/doctest.ts docs/quality/quality-scorecard.md`
- `git diff --check`