### PR TITLE
docs(quality): deepen quality scorecard terminology parity

### DIFF
--- a/docs/quality/quality-scorecard.md
+++ b/docs/quality/quality-scorecard.md
@@ -19,7 +19,7 @@ lastVerified: '2026-04-06'
 
 - canonical JSON: `artifacts/quality/quality-scorecard.json`
 - canonical Markdown: `artifacts/quality/quality-scorecard.md`
-- スキーマ: `schema/quality-scorecard.schema.json`
+- schema: `schema/quality-scorecard.schema.json`
 - producer: `scripts/quality/build-quality-scorecard.mjs` / `pnpm run quality:scorecard:v1`
 - validator: `scripts/ci/validate-quality-scorecard.mjs` / `pnpm run quality:scorecard:validate`
 


### PR DESCRIPTION
## Summary
- normalize Japanese terminology in `docs/quality/quality-scorecard.md`
- keep the English section unchanged
- refresh `lastVerified`

## Verification
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/quality/quality-scorecard.md docs/agents/commands.md`
- `git diff --check`