### PR TITLE
docs(quality): deepen cedar quality gates terminology parity

### DIFF
--- a/docs/quality/cedar-quality-gates.md
+++ b/docs/quality/cedar-quality-gates.md
@@ -17,8 +17,8 @@ This workflow scans `policies/cedar/` for `.json` (Cedar JSON) and `.cedar` / `.
 
 ### Current behavior
 
-- 実行スクリプト: `scripts/policies/validate-cedar.mjs`
-- 成果物: `artifacts/policies/cedar-summary.json`
+- Runner: `scripts/policies/validate-cedar.mjs`
+- Artifact: `artifacts/policies/cedar-summary.json`
 - PR comment header: `<!-- AE-CEDAR-SUMMARY -->`
 - Trigger: add label `run-security` (or `run-cedar`)
 - Enforcement: add label `enforce-security` (fails when `ngCount > 0`)


### PR DESCRIPTION
## Summary
- normalize Japanese terminology in `docs/quality/cedar-quality-gates.md`
- keep the English section unchanged
- refresh `lastVerified`

## Verification
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/quality/cedar-quality-gates.md docs/agents/commands.md`
- `git diff --check`