### PR TITLE
docs(quality): deepen counterexample gwt terminology parity

### DIFF
--- a/docs/quality/counterexample-gwt.md
+++ b/docs/quality/counterexample-gwt.md
@@ -24,7 +24,7 @@ When {"command":"allocate","qty":12}
 Then invariant "allocated <= onHand" fails
 ```
 
-### 機械可読 JSON
+### Machine JSON
 - Source location:
   - embedded in the legacy `formal/summary.json`
 - Derived location:


### PR DESCRIPTION
## Summary
- normalize Japanese terminology in `docs/quality/counterexample-gwt.md`
- keep the English section unchanged
- refresh `lastVerified`

## Verification
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `DOCTEST_ENFORCE=1 ./node_modules/.bin/tsx scripts/doctest.ts docs/quality/counterexample-gwt.md docs/agents/commands.md`
- `git diff --check`