### PR TITLE
docs(quality): deepen formal ops guidelines terminology parity

### DIFF
--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -2,7 +2,7 @@
 docRole: derived
 canonicalSource:
   - .github/workflows/agent-commands.yml
-lastVerified: '2026-04-12'
+lastVerified: '2026-04-13'
 ---
 
 # Agent Commands Catalog

--- a/docs/quality/formal-ops-guidelines.md
+++ b/docs/quality/formal-ops-guidelines.md
@@ -3,7 +3,7 @@ docRole: derived
 canonicalSource:
 - docs/quality/formal-runbook.md
 - docs/quality/formal-tools-setup.md
-lastVerified: '2026-03-28'
+lastVerified: '2026-04-14'
 ---
 # Formal Verification Ops Guidelines
 
@@ -135,7 +135,7 @@ Notes:
 
 ## 日本語
 
-フォーマル検証を運用する際の **推奨パターン / 命名 / 証跡 / CI 分割** を整理したガイドです。
+フォーマル検証を運用する際の **推奨パターン・命名規約・証跡・CI 分割** を整理したガイドです。
 
 ## 1. 推奨運用パターン（TLC / Apalache / SMT / Alloy）
 
@@ -144,20 +144,20 @@ Notes:
 | TLC (TLA+) | 小さな状態空間の網羅探索 | 縮約モデルでの高速フィードバック |
 | Apalache (TLA+) | 大きめの整数範囲 / BMC + 逐次改善 | 大数・前提付きモデルの検査 |
 | SMT (Z3 / cvc5) | 数式系制約の検証 | パス条件や不変条件の局所検証 |
-| Alloy | 構造・関係モデル | Small scope での構造整合性 |
+| Alloy | 構造・関係モデル | スモールスコープでの構造整合性 |
 
 **基本方針**
 - TLC は「縮約モデル」で高速に回し、境界条件や反例探索を早く回収する。
 - Apalache/SMT は「大数・前提付きモデル」で広い範囲を扱う。
 - 同じモデル名でも前提・縮約が違う場合は **明示的に注記** する（誤解防止）。
 
-## 2. 命名規約（ツール共通 vs ツール専用）
+## 2. 命名規約（ツール非依存 vs ツール専用）
 
-**共通仕様（tool-agnostic）**
+**共通仕様（tool-agnostic / ツール非依存）**
 - `spec/tla/DomainSpec.tla`（共通）
 - `spec/tla/DomainSpec.cfg`（TLC 用）
 
-**ツール専用（tool-specific）**
+**ツール専用（tool-specific / ツール固有）**
 - `spec/tla/DomainSpec_apalache.tla`
 - `spec/tla/DomainSpec_apalache.cfg`
 
@@ -192,14 +192,14 @@ Spec == Init /\ [][Next]_vars
 - **stuttering を許容**する場合:
   - `StutterEnabled` のような **ガード条件**を用意し、意図的な停止と区別する。
 
-## 4. 証跡のスケーリング（Git vs 外部）
+## 4. 証跡のスケーリング（Git vs 外部保存）
 
 **Git に残すべき最小セット**
 - `summary.json`（要約）
 - 重要ログの短い抜粋（エラー断片）
 - 反例の **最小セット**（再現に必要な範囲のみ）
 
-**外部（CI artifacts / ストレージ）に出すべきもの**
+**外部（CI artifacts / ストレージ）へ出すべきもの**
 - 詳細ログ全文
 - 大きな反例 JSON
 - 大量のトレース / サンプル
@@ -212,7 +212,7 @@ Spec == Init /\ [][Next]_vars
 
 **verify-lite（必須）**: PR 毎に安定して実行する最小ゲート。
 
-**verify-formal（任意 / 夜間）**: 時間・依存が重い検証はラベルやスケジュールで実行。
+**verify-formal（任意 / 夜間）**: 実行時間や依存が重い検証は、ラベルやスケジュールで実行します。
 
 ```yaml
 # .github/workflows/verify-lite.yml
@@ -251,5 +251,5 @@ jobs:
 ```
 
 補足:
-- `enforce-formal` ラベルで Apalache の `ran/ok` をゲート化する運用が可能。
+- `enforce-formal` ラベルにより、Apalache の `ran/ok` をゲート化する運用が可能です。
 - 詳細な実行方法は `docs/quality/formal-runbook.md` を参照。


### PR DESCRIPTION
## Summary
- deepen Japanese terminology parity in `docs/quality/formal-ops-guidelines.md`
- keep English text, commands, examples, and operational behavior unchanged
- regenerate `docs/agents/commands.md` to restore derived-doc sync

## Changes
- align Japanese wording around naming rules, evidence scaling, and formal CI lane guidance
- update `lastVerified` in `docs/quality/formal-ops-guidelines.md` to `2026-04-14`
- update `docs/agents/commands.md` `lastVerified` via the repo sync script
  - observed generated value: `2026-04-13` (the generator uses UTC via `new Date().toISOString().slice(0, 10)`)

## Validation
- `node scripts/docs/check-agent-commands-doc-sync.mjs --write`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:ci-doc-index-consistency`
- `git diff --check`

## Acceptance
- Japanese terminology in `docs/quality/formal-ops-guidelines.md` is more consistent with adjacent formal docs
- no workflow, policy, or verification behavior changes are introduced
- doc consistency checks pass locally on `2026-04-14` JST

## Rollback
- revert this PR to restore the previous wording and derived-doc timestamp

Closes #3229
