### PR TITLE
fix(operation): stabilize Temporal adapter CLI restart drill

### DIFF
--- a/examples/temporal-workflow-adapter/src/cli-options.ts
+++ b/examples/temporal-workflow-adapter/src/cli-options.ts
@@ -1,0 +1,186 @@
+import {
+  DEFAULT_NAMESPACE,
+  DEFAULT_REPOSITORY,
+  DEFAULT_SCENARIO,
+  DEFAULT_TASK_QUEUE,
+} from './types.js';
+import type { ApprovalPayload, WorkflowInput } from './types.js';
+
+export interface CliOptions {
+  command: 'start' | 'signal-approval' | 'result' | 'help';
+  workflowId: string;
+  scenario: string;
+  repository: string;
+  prNumber: number | null;
+  generatedAt?: string;
+  outputDir?: string;
+  namespace: string;
+  taskQueue: string;
+  address: string;
+  autoApprove: boolean;
+  wait: boolean;
+  restartValidationStatus?: WorkflowInput['restartValidationStatus'];
+  approval: ApprovalPayload;
+}
+
+function readValue(argv: string[], index: number, option: string): string {
+  const value = argv[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function parseBool(value: string): boolean {
+  return !['0', 'false', 'no'].includes(value.toLowerCase());
+}
+
+function parsePositiveInteger(value: string, option: string): number {
+  if (!/^[1-9][0-9]*$/.test(value)) {
+    throw new Error(`${option} requires a positive integer`);
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${option} is outside the supported integer range`);
+  }
+  return parsed;
+}
+
+export function parseArgs(argv = process.argv.slice(2)): CliOptions {
+  const command = (argv[0] ?? 'help') as CliOptions['command'];
+  const options: CliOptions = {
+    command: ['start', 'signal-approval', 'result'].includes(command) ? command : 'help',
+    workflowId: `ae-assurance-${DEFAULT_SCENARIO}`,
+    scenario: DEFAULT_SCENARIO,
+    repository: DEFAULT_REPOSITORY,
+    prNumber: null,
+    namespace: process.env.TEMPORAL_NAMESPACE ?? DEFAULT_NAMESPACE,
+    taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? DEFAULT_TASK_QUEUE,
+    address: process.env.TEMPORAL_ADDRESS ?? 'localhost:7233',
+    autoApprove: false,
+    wait: command !== 'start',
+    approval: {
+      approvedBy: '@team-risk',
+      waiverId: 'change-package-v2:waiver:0:manual-fraud-review',
+      expires: '2099-12-31',
+      reason: 'approval accepted for manual-fraud-review waiver',
+    },
+  };
+
+  for (let index = 1; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') {
+      continue;
+    }
+    if (arg === '--workflow-id') {
+      options.workflowId = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--scenario') {
+      options.scenario = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--repository') {
+      options.repository = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--pr-number') {
+      options.prNumber = parsePositiveInteger(readValue(argv, index, arg), arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--generated-at') {
+      options.generatedAt = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--output-dir') {
+      options.outputDir = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--namespace') {
+      options.namespace = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--task-queue') {
+      options.taskQueue = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--address') {
+      options.address = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--auto-approve') {
+      options.autoApprove = true;
+      options.wait = true;
+      continue;
+    }
+    if (arg === '--wait') {
+      options.wait = true;
+      continue;
+    }
+    if (arg === '--no-wait') {
+      options.wait = false;
+      continue;
+    }
+    if (arg === '--restart-validation-status') {
+      options.restartValidationStatus = readValue(argv, index, arg) as WorkflowInput['restartValidationStatus'];
+      index += 1;
+      continue;
+    }
+    if (arg === '--approved-by') {
+      options.approval.approvedBy = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--waiver-id') {
+      options.approval.waiverId = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--approval-reason') {
+      options.approval.reason = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--approval-expires') {
+      options.approval.expires = readValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--auto-approve=')) {
+      options.autoApprove = parseBool(arg.slice('--auto-approve='.length));
+      if (options.autoApprove) options.wait = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+export function usage(): string {
+  return `Usage:
+  pnpm run start -- [options]
+  pnpm run signal:approval -- [options]
+  pnpm run result -- [options]
+
+Common options:
+  --workflow-id <id>             Workflow ID (default: ae-assurance-inventory-waiver)
+  --scenario <name>              Fixture scenario (default: inventory-waiver)
+  --address <host:port>          Temporal address (default: localhost:7233)
+  --namespace <name>             Temporal namespace (default: default)
+  --task-queue <name>            Temporal task queue (default: ae-assurance-temporal-poc)
+  --generated-at <iso>           Override generatedAt; defaults to the Workflow start time
+  --output-dir <path>            Output directory for generated artifacts
+  --pr-number <number>           Optional PR number recorded in operation metadata
+  --auto-approve                 Send the approval signal immediately after start
+  --no-wait                      Start only; use signal/result commands later
+`;
+}

--- a/examples/temporal-workflow-adapter/src/client.ts
+++ b/examples/temporal-workflow-adapter/src/client.ts
@@ -1,187 +1,8 @@
 import { Client, Connection } from '@temporalio/client';
+import { parseArgs, usage } from './cli-options.js';
 import { approvalSignal, assuranceWorkflow } from './workflows.js';
-import {
-  DEFAULT_NAMESPACE,
-  DEFAULT_REPOSITORY,
-  DEFAULT_SCENARIO,
-  DEFAULT_TASK_QUEUE,
-} from './types.js';
-import type { ApprovalPayload, WorkflowInput } from './types.js';
-
-interface CliOptions {
-  command: 'start' | 'signal-approval' | 'result' | 'help';
-  workflowId: string;
-  scenario: string;
-  repository: string;
-  prNumber: number | null;
-  generatedAt?: string;
-  outputDir?: string;
-  namespace: string;
-  taskQueue: string;
-  address: string;
-  autoApprove: boolean;
-  wait: boolean;
-  restartValidationStatus?: WorkflowInput['restartValidationStatus'];
-  approval: ApprovalPayload;
-}
-
-function readValue(argv: string[], index: number, option: string): string {
-  const value = argv[index + 1];
-  if (!value || value.startsWith('--')) {
-    throw new Error(`${option} requires a value`);
-  }
-  return value;
-}
-
-function parseBool(value: string): boolean {
-  return !['0', 'false', 'no'].includes(value.toLowerCase());
-}
-
-function parsePositiveInteger(value: string, option: string): number {
-  if (!/^[1-9][0-9]*$/.test(value)) {
-    throw new Error(`${option} requires a positive integer`);
-  }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isSafeInteger(parsed)) {
-    throw new Error(`${option} is outside the supported integer range`);
-  }
-  return parsed;
-}
-
-function parseArgs(argv = process.argv.slice(2)): CliOptions {
-  const command = (argv[0] ?? 'help') as CliOptions['command'];
-  const options: CliOptions = {
-    command: ['start', 'signal-approval', 'result'].includes(command) ? command : 'help',
-    workflowId: `ae-assurance-${DEFAULT_SCENARIO}`,
-    scenario: DEFAULT_SCENARIO,
-    repository: DEFAULT_REPOSITORY,
-    prNumber: 3247,
-    namespace: process.env.TEMPORAL_NAMESPACE ?? DEFAULT_NAMESPACE,
-    taskQueue: process.env.TEMPORAL_TASK_QUEUE ?? DEFAULT_TASK_QUEUE,
-    address: process.env.TEMPORAL_ADDRESS ?? 'localhost:7233',
-    autoApprove: false,
-    wait: command !== 'start',
-    approval: {
-      approvedBy: '@team-risk',
-      waiverId: 'change-package-v2:waiver:0:manual-fraud-review',
-      expires: '2099-12-31',
-      reason: 'approval accepted for manual-fraud-review waiver',
-    },
-  };
-
-  for (let index = 1; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === '--workflow-id') {
-      options.workflowId = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--scenario') {
-      options.scenario = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--repository') {
-      options.repository = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--pr-number') {
-      options.prNumber = parsePositiveInteger(readValue(argv, index, arg), arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--generated-at') {
-      options.generatedAt = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--output-dir') {
-      options.outputDir = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--namespace') {
-      options.namespace = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--task-queue') {
-      options.taskQueue = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--address') {
-      options.address = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--auto-approve') {
-      options.autoApprove = true;
-      options.wait = true;
-      continue;
-    }
-    if (arg === '--wait') {
-      options.wait = true;
-      continue;
-    }
-    if (arg === '--no-wait') {
-      options.wait = false;
-      continue;
-    }
-    if (arg === '--restart-validation-status') {
-      options.restartValidationStatus = readValue(argv, index, arg) as WorkflowInput['restartValidationStatus'];
-      index += 1;
-      continue;
-    }
-    if (arg === '--approved-by') {
-      options.approval.approvedBy = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--waiver-id') {
-      options.approval.waiverId = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--approval-reason') {
-      options.approval.reason = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg === '--approval-expires') {
-      options.approval.expires = readValue(argv, index, arg);
-      index += 1;
-      continue;
-    }
-    if (arg.startsWith('--auto-approve=')) {
-      options.autoApprove = parseBool(arg.slice('--auto-approve='.length));
-      if (options.autoApprove) options.wait = true;
-      continue;
-    }
-    throw new Error(`Unknown argument: ${arg}`);
-  }
-  return options;
-}
-
-function usage(): void {
-  console.log(`Usage:
-  pnpm run start -- [options]
-  pnpm run signal:approval -- [options]
-  pnpm run result -- [options]
-
-Common options:
-  --workflow-id <id>             Workflow ID (default: ae-assurance-inventory-waiver)
-  --scenario <name>              Fixture scenario (default: inventory-waiver)
-  --address <host:port>          Temporal address (default: localhost:7233)
-  --namespace <name>             Temporal namespace (default: default)
-  --task-queue <name>            Temporal task queue (default: ae-assurance-temporal-poc)
-  --generated-at <iso>           Override generatedAt; defaults to the Workflow start time
-  --output-dir <path>            Output directory for generated artifacts
-  --auto-approve                 Send the approval signal immediately after start
-  --no-wait                      Start only; use signal/result commands later
-`);
-}
+import type { CliOptions } from './cli-options.js';
+import type { WorkflowInput } from './types.js';
 
 async function createClient(options: CliOptions): Promise<{ client: Client; connection: Connection }> {
   const connection = await Connection.connect({ address: options.address });
@@ -189,10 +10,27 @@ async function createClient(options: CliOptions): Promise<{ client: Client; conn
   return { client, connection };
 }
 
+async function writeStream(stream: NodeJS.WriteStream, text: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    stream.write(text, (error?: Error | null) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+async function writeStdout(text: string): Promise<void> {
+  await writeStream(process.stdout, text);
+}
+
+async function writeStderr(text: string): Promise<void> {
+  await writeStream(process.stderr, text);
+}
+
 async function run(): Promise<void> {
   const options = parseArgs();
   if (options.command === 'help') {
-    usage();
+    await writeStdout(usage());
     return;
   }
   const { client, connection } = await createClient(options);
@@ -216,17 +54,17 @@ async function run(): Promise<void> {
         taskQueue: options.taskQueue,
         args: [workflowInput],
       });
-      console.log(`Started workflowId=${handle.workflowId}`);
+      await writeStdout(`Started workflowId=${handle.workflowId}\n`);
       if (options.autoApprove) {
         await handle.signal(approvalSignal, {
           ...options.approval,
           receivedAt: new Date().toISOString(),
         });
-        console.log(`Sent approval signal to workflowId=${handle.workflowId}`);
+        await writeStdout(`Sent approval signal to workflowId=${handle.workflowId}\n`);
       }
       if (options.wait) {
         const result = await handle.result();
-        console.log(JSON.stringify(result, null, 2));
+        await writeStdout(`${JSON.stringify(result, null, 2)}\n`);
       }
       return;
     }
@@ -237,18 +75,32 @@ async function run(): Promise<void> {
         ...options.approval,
         receivedAt: new Date().toISOString(),
       });
-      console.log(`Sent approval signal to workflowId=${options.workflowId}`);
+      await writeStdout(`Sent approval signal to workflowId=${options.workflowId}\n`);
       return;
     }
 
     const result = await handle.result();
-    console.log(JSON.stringify(result, null, 2));
+    await writeStdout(`${JSON.stringify(result, null, 2)}\n`);
   } finally {
     await connection.close();
   }
 }
 
-run().catch((error: unknown) => {
-  console.error(error);
-  process.exitCode = 1;
-});
+function exitAfterCli(status: number): void {
+  // This standalone example is executed through tsx; force the process to
+  // exit after awaited client cleanup so native SDK handles do not leave
+  // documented one-shot commands hanging in local restart drills.
+  process.exitCode = status;
+  setImmediate(() => process.exit(status));
+}
+
+run()
+  .then(() => exitAfterCli(0))
+  .catch(async (error: unknown) => {
+    const message = error instanceof Error && error.stack ? error.stack : String(error);
+    try {
+      await writeStderr(`${message}\n`);
+    } finally {
+      exitAfterCli(1);
+    }
+  });

--- a/tests/contracts/temporal-workflow-adapter-cli-options.test.ts
+++ b/tests/contracts/temporal-workflow-adapter-cli-options.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { parseArgs } from '../../examples/temporal-workflow-adapter/src/cli-options.js';
+
+describe('Temporal Workflow adapter CLI options', () => {
+  it('accepts the pnpm argument separator before documented options', () => {
+    const options = parseArgs([
+      'start',
+      '--',
+      '--workflow-id',
+      'ae-assurance-restart-demo',
+      '--scenario',
+      'inventory-waiver',
+      '--output-dir',
+      'artifacts/temporal-restart-drill/inventory-waiver',
+      '--restart-validation-status',
+      'manual-pass',
+      '--no-wait',
+    ]);
+
+    expect(options.command).toBe('start');
+    expect(options.workflowId).toBe('ae-assurance-restart-demo');
+    expect(options.scenario).toBe('inventory-waiver');
+    expect(options.outputDir).toBe('artifacts/temporal-restart-drill/inventory-waiver');
+    expect(options.restartValidationStatus).toBe('manual-pass');
+    expect(options.prNumber).toBe(null);
+    expect(options.wait).toBe(false);
+  });
+
+  it('preserves validation for options after the pnpm argument separator', () => {
+    expect(() => parseArgs(['start', '--', '--pr-number', 'not-a-number'])).toThrow(
+      '--pr-number requires a positive integer',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extract the Temporal adapter client option parser into an importable `cli-options` module.
- Accept the literal `--` separator that `pnpm run <script> -- ...` forwards to the example script, matching the documented commands.
- Add parser regression coverage for documented restart-drill arguments and `--pr-number` validation after the separator.
- Force the standalone `tsx` client process to exit after awaited Temporal client cleanup so one-shot commands such as `start -- --no-wait`, `signal:approval`, and `result` do not hang during local drills.

## Root cause

PR #3255 documented commands such as:

```bash
pnpm --dir examples/temporal-workflow-adapter run start -- --workflow-id ...
```

In this package, pnpm forwards the separator as a literal `--` argument to `src/client.ts`. The prior parser treated that value as an unknown option, so the documented command failed before connecting to Temporal. During live validation, the no-wait client path also left the one-shot `tsx` process alive after printing `Started workflowId=...`; the client now exits explicitly after awaited cleanup.

## Validation

- `pnpm --dir examples/temporal-workflow-adapter run typecheck`
- `../node_modules/.bin/vitest run tests/contracts/temporal-workflow-adapter-cli-options.test.ts tests/contracts/temporal-run-summary-contract.test.ts` => 2 files / 8 tests passed
- `pnpm --dir examples/temporal-workflow-adapter run start -- --pr-number not-a-number --no-wait` => exits non-zero with `--pr-number requires a positive integer`
- `pnpm --dir examples/temporal-workflow-adapter run start -- --workflow-id ae-assurance-start-exit-check-20260507-0516 --scenario inventory-waiver --output-dir artifacts/temporal-restart-drill/start-exit-check --no-wait` => prints `Started workflowId=...` and exits cleanly
- live Temporal restart drill on local dev server:
  - Temporal CLI `1.7.0`, Server `1.31.0`
  - workflowId `ae-assurance-restart-demo-20260507-0512`
  - runId `019e00da-0fb7-7b59-b91b-0dbc87511ee5`
  - worker stopped while the workflow was awaiting approval, then restarted before sending approval
  - `temporal-run-summary.json` schema validation OK
  - final workflow status `WORKFLOW_EXECUTION_STATUS_COMPLETED`, history length `41`
  - summary: `restartValidation=manual-pass`, `awaited=received`, `assuranceResult=waived`, `outputArtifactCount=7`
- `node scripts/ci/validate-json.mjs`
- `git diff --check`

## Acceptance

- [x] Documented pnpm `--` separator commands are accepted by the adapter CLI.
- [x] Option validation still applies after the separator.
- [x] One-shot client commands exit after completion in local drill usage.
- [x] Worker restart drill completed against a live Temporal dev server.
- [x] Temporal sidecar output remains adapter-local and schema-valid.

## Rollback

Revert this PR. The Temporal example remains optional, but operators would need to omit the pnpm separator or work around the one-shot client hang manually during local restart drills.

Closes #3247
Refs #3248