### PR TITLE
feat(security): add security assurance contracts

### DIFF
--- a/docs/reference/CONTRACT-CATALOG.md
+++ b/docs/reference/CONTRACT-CATALOG.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-04-28'
+lastVerified: '2026-05-07'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -45,6 +45,9 @@ Some schemas are dual-role. This catalog records the primary role used in the cu
 - `schema/formal-plan.schema.json`
 - `schema/issue-traceability-map.schema.json`
 - `schema/policy-input-v1.schema.json`
+- `schema/security-audit-scope-v1.schema.json`
+- `schema/security-claim-v1.schema.json`
+- `schema/security-threat-model-v1.schema.json`
 - `schema/release-policy.schema.json`
 - `schema/state-machine.schema.json`
 - `schema/trace-map.schema.json`
@@ -119,6 +122,9 @@ The table below keeps the current producer/consumer baseline for representative 
 | `artifacts/discovery-pack/context-pack-scaffold.yaml` | `schema/context-pack-v1.schema.json` (scaffold-compatible, non-authoritative) | `scripts/discovery-pack/compile.mjs` (`--target context-pack-scaffold`), `src/cli/discovery-cli.ts` | manual editing before Context Pack SSOT promotion, future Context Pack validation |
 | `artifacts/assurance/assurance-summary.json` | `schema/assurance-summary.schema.json` | `scripts/assurance/aggregate-lanes.mjs`, `.github/workflows/verify-lite.yml` | `scripts/ci/validate-assurance-summary.mjs`, `scripts/ci/validate-artifacts-ajv.mjs`, `scripts/ci/validate-json.mjs`, `scripts/ci/enforce-assurance-summary.mjs`, `scripts/quality/build-quality-scorecard.mjs`, `scripts/agents/build-hook-feedback.mjs`, `scripts/agents/create-handoff.mjs`, `scripts/summary/render-pr-summary.mjs`, `.github/workflows/pr-ci-status-comment.yml` |
 | `artifacts/assurance/claim-evidence-manifest.json` | `schema/claim-evidence-manifest.schema.json` | `scripts/assurance/build-claim-evidence-manifest.mjs`, `.github/workflows/verify-lite.yml`, `fixtures/assurance/sample.claim-evidence-manifest.json` (schema contract fixture) | `scripts/ci/validate-json.mjs`, `scripts/ci/validate-artifacts-ajv.mjs`, `tests/contracts/claim-evidence-manifest-contract.test.ts`, `scripts/summary/render-pr-summary.mjs`, `.github/workflows/pr-ci-status-comment.yml`; future policy-gate consumers |
+| `artifacts/security/security-claims.json` | `schema/security-claim-v1.schema.json` | manual authoring, future `ae security extract-claims`, `fixtures/security-assurance/sample.security-claims.json` (schema contract fixture) | future Security Assurance Lane producers, `scripts/ci/validate-json.mjs`, `tests/contracts/security-assurance-contract.test.ts`; downstream artifacts reference `claims[].id` |
+| `artifacts/security/security-threat-model.json` | `schema/security-threat-model-v1.schema.json` | manual authoring, future SPECA-compatible import, `fixtures/security-assurance/sample.security-threat-model.json` (schema contract fixture) | future security audit and review producers, `scripts/ci/validate-json.mjs`, `tests/contracts/security-assurance-contract.test.ts`; references security claim ids through `threats[].relatedClaimIds[]` |
+| `artifacts/security/security-audit-scope.json` | `schema/security-audit-scope-v1.schema.json` | manual authoring, bug-bounty/audit scope translation, `fixtures/security-assurance/sample.security-audit-scope.json` (schema contract fixture) | future security claim extraction, code-map, audit, and review producers; scope remains glob-based in the MVP contract |
 | `artifacts/temporal/*/temporal-run-summary.json` | `schema/temporal-run-summary.schema.json` | `examples/temporal-workflow-adapter`, `fixtures/temporal/sample.temporal-run-summary.json` (schema contract fixture) | `scripts/ci/validate-json.mjs`, `tests/contracts/temporal-run-summary-contract.test.ts`, operator review; Temporal-specific metadata remains confined to this adapter sidecar |
 | `spec/assurance-profile/upstream-context-promotion-v1.json` | `schema/assurance-profile.schema.json` | manual authoring in `spec/assurance-profile/` | `scripts/assurance/aggregate-lanes.mjs`, `docs/guides/upstream-context-promotion.md`, `tests/fixtures/upstream-context-promotion-minimal.assurance.test.ts` |
 | `artifacts/report-envelope.json` | `schema/envelope.schema.json` | `scripts/trace/create-report-envelope.mjs` | `scripts/ci/validate-artifacts-ajv.mjs`, `scripts/trace/publish-envelope.mjs` |
@@ -215,6 +221,9 @@ The table below keeps the current producer/consumer baseline for representative 
 - `schema/formal-plan.schema.json`
 - `schema/issue-traceability-map.schema.json`
 - `schema/policy-input-v1.schema.json`
+- `schema/security-audit-scope-v1.schema.json`
+- `schema/security-claim-v1.schema.json`
+- `schema/security-threat-model-v1.schema.json`
 - `schema/release-policy.schema.json`
 - `schema/state-machine.schema.json`
 - `schema/trace-map.schema.json`
@@ -287,6 +296,9 @@ The table below keeps the current producer/consumer baseline for representative 
 | `artifacts/discovery-pack/context-pack-scaffold.yaml` | `schema/context-pack-v1.schema.json` (scaffold-compatible, non-authoritative) | `scripts/discovery-pack/compile.mjs` (`--target context-pack-scaffold`), `src/cli/discovery-cli.ts` | manual editing before Context Pack SSOT promotion, future Context Pack validation |
 | `artifacts/assurance/assurance-summary.json` | `schema/assurance-summary.schema.json` | `scripts/assurance/aggregate-lanes.mjs`, `.github/workflows/verify-lite.yml` | `scripts/ci/validate-assurance-summary.mjs`, `scripts/ci/validate-artifacts-ajv.mjs`, `scripts/ci/validate-json.mjs`, `scripts/ci/enforce-assurance-summary.mjs`, `scripts/quality/build-quality-scorecard.mjs`, `scripts/agents/build-hook-feedback.mjs`, `scripts/agents/create-handoff.mjs`, `scripts/summary/render-pr-summary.mjs`, `.github/workflows/pr-ci-status-comment.yml` |
 | `artifacts/assurance/claim-evidence-manifest.json` | `schema/claim-evidence-manifest.schema.json` | `scripts/assurance/build-claim-evidence-manifest.mjs`、`.github/workflows/verify-lite.yml`、`fixtures/assurance/sample.claim-evidence-manifest.json`（schema contract fixture） | `scripts/ci/validate-json.mjs`、`scripts/ci/validate-artifacts-ajv.mjs`、`tests/contracts/claim-evidence-manifest-contract.test.ts`、`scripts/summary/render-pr-summary.mjs`、`.github/workflows/pr-ci-status-comment.yml`。将来の policy-gate consumer が参照予定 |
+| `artifacts/security/security-claims.json` | `schema/security-claim-v1.schema.json` | manual authoring、将来の `ae security extract-claims`、`fixtures/security-assurance/sample.security-claims.json`（schema contract fixture） | 将来の Security Assurance Lane producer、`scripts/ci/validate-json.mjs`、`tests/contracts/security-assurance-contract.test.ts`。後続 artifact は `claims[].id` を参照する |
+| `artifacts/security/security-threat-model.json` | `schema/security-threat-model-v1.schema.json` | manual authoring、将来の SPECA-compatible import、`fixtures/security-assurance/sample.security-threat-model.json`（schema contract fixture） | 将来の security audit / review producer、`scripts/ci/validate-json.mjs`、`tests/contracts/security-assurance-contract.test.ts`。`threats[].relatedClaimIds[]` で security claim id を参照する |
+| `artifacts/security/security-audit-scope.json` | `schema/security-audit-scope-v1.schema.json` | manual authoring、bug-bounty / audit scope translation、`fixtures/security-assurance/sample.security-audit-scope.json`（schema contract fixture） | 将来の security claim extraction、code-map、audit、review producer。MVP contract では glob-based scope に限定する |
 | `artifacts/temporal/*/temporal-run-summary.json` | `schema/temporal-run-summary.schema.json` | `examples/temporal-workflow-adapter`、`fixtures/temporal/sample.temporal-run-summary.json`（schema contract fixture） | `scripts/ci/validate-json.mjs`、`tests/contracts/temporal-run-summary-contract.test.ts`、operator review。Temporal 固有 metadata はこの adapter sidecar に閉じる |
 | `spec/assurance-profile/upstream-context-promotion-v1.json` | `schema/assurance-profile.schema.json` | manual authoring in `spec/assurance-profile/` | `scripts/assurance/aggregate-lanes.mjs`, `docs/guides/upstream-context-promotion.md`, `tests/fixtures/upstream-context-promotion-minimal.assurance.test.ts` |
 | `artifacts/report-envelope.json` | `schema/envelope.schema.json` | `scripts/trace/create-report-envelope.mjs` | `scripts/ci/validate-artifacts-ajv.mjs`, `scripts/trace/publish-envelope.mjs` |

--- a/fixtures/security-assurance/sample.security-audit-scope.json
+++ b/fixtures/security-assurance/sample.security-audit-scope.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "security-audit-scope/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "target": {
+    "repository": "example/repo",
+    "commit": "HEAD",
+    "defaultBranch": "main",
+    "description": "Fixture target for Security Assurance Lane contract validation."
+  },
+  "inScope": [
+    "src/**/*.ts",
+    "packages/**/src/**/*.ts"
+  ],
+  "outOfScope": [
+    "test/**",
+    "tests/**",
+    "docs/**",
+    "examples/**"
+  ],
+  "trustBoundaries": [
+    {
+      "id": "TB-001",
+      "name": "External verification request boundary",
+      "entryPoints": [
+        "api",
+        "p2p"
+      ],
+      "attackerControlled": true,
+      "description": "Input received from outside the trusted process boundary.",
+      "dataClasses": [
+        "verification-input"
+      ],
+      "scopeRefs": [
+        "src/**/*.ts"
+      ]
+    }
+  ],
+  "notes": [
+    "MVP scope uses glob boundaries only; reachability analysis is out of scope for #3258."
+  ]
+}

--- a/fixtures/security-assurance/sample.security-claims.json
+++ b/fixtures/security-assurance/sample.security-claims.json
@@ -1,0 +1,62 @@
+{
+  "schemaVersion": "security-claim/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "claims": [
+    {
+      "id": "SEC-CLAIM-001",
+      "type": "invariant",
+      "statement": "Cache key must include all attacker-controlled fields that affect the verification result.",
+      "sourceRefs": [
+        {
+          "kind": "spec",
+          "uri": "spec/security/cache-key.md",
+          "section": "Verification cache"
+        }
+      ],
+      "criticality": "high",
+      "targetLevel": "A2",
+      "threatTags": {
+        "stride": [
+          "Tampering"
+        ],
+        "cwe": [
+          "CWE-20"
+        ]
+      },
+      "trustBoundary": {
+        "boundaryIds": [
+          "TB-001"
+        ],
+        "entryPoints": [
+          "api",
+          "p2p"
+        ],
+        "attackerControlled": true,
+        "dataClasses": [
+          "verification-input"
+        ]
+      },
+      "requiredLanes": [
+        "spec",
+        "adversarial",
+        "behavior"
+      ],
+      "provenance": {
+        "origin": "manual",
+        "generator": "security-claim-author"
+      },
+      "notes": [
+        "Fixture claim for Security Assurance Lane contract validation."
+      ]
+    }
+  ],
+  "summary": {
+    "totalClaims": 1,
+    "byCriticality": {
+      "low": 0,
+      "medium": 0,
+      "high": 1,
+      "critical": 0
+    }
+  }
+}

--- a/fixtures/security-assurance/sample.security-threat-model.json
+++ b/fixtures/security-assurance/sample.security-threat-model.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "security-threat-model/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "frameworks": [
+    "STRIDE",
+    "CWE_TOP_25"
+  ],
+  "threats": [
+    {
+      "id": "THREAT-001",
+      "stride": "Tampering",
+      "cwe": "CWE-20",
+      "description": "Attacker-controlled input changes the verification result when cache-key material is incomplete.",
+      "relatedClaimIds": [
+        "SEC-CLAIM-001"
+      ],
+      "trustBoundaryIds": [
+        "TB-001"
+      ]
+    }
+  ],
+  "summary": {
+    "totalThreats": 1
+  }
+}

--- a/schema/security-audit-scope-v1.schema.json
+++ b/schema/security-audit-scope-v1.schema.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/security-audit-scope-v1.schema.json",
+  "title": "Security Audit Scope v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "target",
+    "inScope",
+    "outOfScope",
+    "trustBoundaries"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "security-audit-scope/v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "target": {
+      "$ref": "#/$defs/target"
+    },
+    "inScope": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "outOfScope": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "trustBoundaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/trustBoundary"
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "commit"
+      ],
+      "properties": {
+        "repository": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "commit": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "defaultBranch": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "trustBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "entryPoints",
+        "attackerControlled"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "entryPoints": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "attackerControlled": {
+          "type": "boolean"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "dataClasses": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "scopeRefs": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/security-claim-v1.schema.json
+++ b/schema/security-claim-v1.schema.json
@@ -1,0 +1,333 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/security-claim-v1.schema.json",
+  "title": "Security Claim v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "claims"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "security-claim/v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/claim"
+      }
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "assuranceLevel": {
+      "type": "string",
+      "enum": [
+        "A0",
+        "A1",
+        "A2",
+        "A3",
+        "A4"
+      ]
+    },
+    "criticality": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "stride": {
+      "type": "string",
+      "enum": [
+        "Spoofing",
+        "Tampering",
+        "Repudiation",
+        "Information Disclosure",
+        "Denial of Service",
+        "Elevation of Privilege"
+      ]
+    },
+    "cwe": {
+      "type": "string",
+      "pattern": "^CWE-[0-9]+$"
+    },
+    "claimType": {
+      "type": "string",
+      "enum": [
+        "invariant",
+        "precondition",
+        "postcondition",
+        "assumption"
+      ]
+    },
+    "sourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "uri"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "spec",
+            "design",
+            "bug-bounty-scope",
+            "issue",
+            "security-policy",
+            "other"
+          ]
+        },
+        "uri": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "section": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "threatTags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "stride",
+        "cwe"
+      ],
+      "properties": {
+        "stride": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/stride"
+          }
+        },
+        "cwe": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/cwe"
+          }
+        },
+        "owasp": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      }
+    },
+    "trustBoundary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "entryPoints",
+        "attackerControlled"
+      ],
+      "properties": {
+        "boundaryIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "entryPoints": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "attackerControlled": {
+          "type": "boolean"
+        },
+        "dataClasses": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      }
+    },
+    "requiredLane": {
+      "type": "string",
+      "enum": [
+        "spec",
+        "adversarial",
+        "behavior",
+        "formal",
+        "runtime",
+        "policy",
+        "manual"
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "origin",
+        "generator"
+      ],
+      "properties": {
+        "origin": {
+          "type": "string",
+          "enum": [
+            "manual",
+            "manual-block",
+            "imported",
+            "codex-generated",
+            "generated"
+          ]
+        },
+        "generator": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "source": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "version": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "statement",
+        "sourceRefs",
+        "criticality",
+        "targetLevel",
+        "threatTags",
+        "trustBoundary",
+        "requiredLanes",
+        "provenance"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "type": {
+          "$ref": "#/$defs/claimType"
+        },
+        "statement": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sourceRefs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/sourceRef"
+          }
+        },
+        "criticality": {
+          "$ref": "#/$defs/criticality"
+        },
+        "targetLevel": {
+          "$ref": "#/$defs/assuranceLevel"
+        },
+        "threatTags": {
+          "$ref": "#/$defs/threatTags"
+        },
+        "trustBoundary": {
+          "$ref": "#/$defs/trustBoundary"
+        },
+        "requiredLanes": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/requiredLane"
+          }
+        },
+        "provenance": {
+          "$ref": "#/$defs/provenance"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalClaims",
+        "byCriticality"
+      ],
+      "properties": {
+        "totalClaims": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "byCriticality": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "properties": {
+            "low": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "medium": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "high": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "critical": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/security-claim-v1.schema.json
+++ b/schema/security-claim-v1.schema.json
@@ -187,12 +187,11 @@
       "type": "string",
       "enum": [
         "spec",
-        "adversarial",
         "behavior",
-        "formal",
-        "runtime",
-        "policy",
-        "manual"
+        "adversarial",
+        "model",
+        "proof",
+        "runtime"
       ]
     },
     "provenance": {

--- a/schema/security-threat-model-v1.schema.json
+++ b/schema/security-threat-model-v1.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/security-threat-model-v1.schema.json",
+  "title": "Security Threat Model v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "frameworks",
+    "threats"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "security-threat-model/v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "frameworks": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": [
+          "STRIDE",
+          "CWE_TOP_25",
+          "OWASP_TOP_10",
+          "custom"
+        ]
+      }
+    },
+    "threats": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/threat"
+      }
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stride": {
+      "type": "string",
+      "enum": [
+        "Spoofing",
+        "Tampering",
+        "Repudiation",
+        "Information Disclosure",
+        "Denial of Service",
+        "Elevation of Privilege"
+      ]
+    },
+    "cwe": {
+      "type": "string",
+      "pattern": "^CWE-[0-9]+$"
+    },
+    "threat": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "stride",
+        "cwe",
+        "description",
+        "relatedClaimIds"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "stride": {
+          "$ref": "#/$defs/stride"
+        },
+        "cwe": {
+          "$ref": "#/$defs/cwe"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "relatedClaimIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "trustBoundaryIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalThreats"
+      ],
+      "properties": {
+        "totalThreats": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/schema/security-threat-model-v1.schema.json
+++ b/schema/security-threat-model-v1.schema.json
@@ -26,9 +26,7 @@
         "type": "string",
         "enum": [
           "STRIDE",
-          "CWE_TOP_25",
-          "OWASP_TOP_10",
-          "custom"
+          "CWE_TOP_25"
         ]
       }
     },

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -127,6 +127,21 @@ const checks = [
     semanticValidate: validateClaimEvidenceManifestSemantics
   },
   {
+    schema: 'schema/security-claim-v1.schema.json',
+    fixtures: ['fixtures/security-assurance/sample.security-claims.json'],
+    label: 'Security claim v1 schema validation'
+  },
+  {
+    schema: 'schema/security-threat-model-v1.schema.json',
+    fixtures: ['fixtures/security-assurance/sample.security-threat-model.json'],
+    label: 'Security threat model v1 schema validation'
+  },
+  {
+    schema: 'schema/security-audit-scope-v1.schema.json',
+    fixtures: ['fixtures/security-assurance/sample.security-audit-scope.json'],
+    label: 'Security audit scope v1 schema validation'
+  },
+  {
     schema: 'schema/temporal-run-summary.schema.json',
     fixtures: ['fixtures/temporal/sample.temporal-run-summary.json'],
     label: 'Temporal run summary schema validation'

--- a/tests/contracts/security-assurance-contract.test.ts
+++ b/tests/contracts/security-assurance-contract.test.ts
@@ -98,6 +98,19 @@ describe('security assurance contracts', () => {
     }
   });
 
+
+  it('constrains threat model frameworks to represented STRIDE and CWE taxonomies', () => {
+    const validate = buildValidator(schemas.threatModel);
+    const invalidFixture = structuredClone(fixtures.threatModel) as {
+      frameworks: string[];
+    };
+
+    invalidFixture.frameworks = ['STRIDE', 'OWASP_TOP_10'];
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/frameworks/1')).toBe(true);
+  });
+
   it('requires the audit scope to include at least one in-scope glob', () => {
     const validate = buildValidator(schemas.auditScope);
     const invalidFixture = structuredClone(fixtures.auditScope) as {

--- a/tests/contracts/security-assurance-contract.test.ts
+++ b/tests/contracts/security-assurance-contract.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+type JsonObject = Record<string, unknown>;
+
+const loadJson = (path: string) =>
+  JSON.parse(readFileSync(resolve(path), 'utf8')) as JsonObject;
+
+const schemas = {
+  claims: loadJson('schema/security-claim-v1.schema.json'),
+  threatModel: loadJson('schema/security-threat-model-v1.schema.json'),
+  auditScope: loadJson('schema/security-audit-scope-v1.schema.json'),
+};
+
+const fixtures = {
+  claims: loadJson('fixtures/security-assurance/sample.security-claims.json'),
+  threatModel: loadJson('fixtures/security-assurance/sample.security-threat-model.json'),
+  auditScope: loadJson('fixtures/security-assurance/sample.security-audit-scope.json'),
+};
+
+const buildValidator = (schema: JsonObject) => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv.compile(schema);
+};
+
+describe('security assurance contracts', () => {
+  it('validates the sample security claim, threat model, and audit scope fixtures', () => {
+    for (const [name, schema] of Object.entries(schemas)) {
+      const validate = buildValidator(schema);
+      const fixture = fixtures[name as keyof typeof fixtures];
+
+      expect(validate(fixture), `${name}: ${JSON.stringify(validate.errors)}`).toBe(true);
+    }
+  });
+
+  it('requires security claims to carry the fields needed by downstream artifacts', () => {
+    const validate = buildValidator(schemas.claims);
+    const invalidFixture = structuredClone(fixtures.claims) as {
+      claims: Array<Record<string, unknown>>;
+    };
+
+    delete invalidFixture.claims[0].sourceRefs;
+    delete invalidFixture.claims[0].threatTags;
+    delete invalidFixture.claims[0].trustBoundary;
+    delete invalidFixture.claims[0].requiredLanes;
+    delete invalidFixture.claims[0].provenance;
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/claims/0')).toBe(true);
+  });
+
+  it('allows the MVP security claim type set required by #3258', () => {
+    const validate = buildValidator(schemas.claims);
+    const validFixture = structuredClone(fixtures.claims) as {
+      claims: Array<Record<string, unknown>>;
+      summary: { totalClaims: number; byCriticality: Record<string, number> };
+    };
+
+    const baseClaim = validFixture.claims[0];
+    validFixture.claims = ['invariant', 'precondition', 'postcondition', 'assumption'].map(
+      (type, index) => ({
+        ...baseClaim,
+        id: `SEC-CLAIM-TYPE-${index + 1}`,
+        type,
+      }),
+    );
+    validFixture.summary.totalClaims = validFixture.claims.length;
+    validFixture.summary.byCriticality.high = validFixture.claims.length;
+
+    expect(validate(validFixture), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it('rejects unsupported security claim types', () => {
+    const validate = buildValidator(schemas.claims);
+    const invalidFixture = structuredClone(fixtures.claims) as {
+      claims: Array<Record<string, unknown>>;
+    };
+
+    invalidFixture.claims[0].type = 'vulnerability';
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/claims/0/type')).toBe(true);
+  });
+
+  it('keeps threat model claim references aligned with the security claim fixture', () => {
+    const claimIds = new Set(
+      ((fixtures.claims.claims as Array<{ id: string }>)).map((claim) => claim.id),
+    );
+    const threats = fixtures.threatModel.threats as Array<{ relatedClaimIds: string[] }>;
+
+    expect(threats).not.toHaveLength(0);
+    for (const threat of threats) {
+      expect(threat.relatedClaimIds.every((claimId) => claimIds.has(claimId))).toBe(true);
+    }
+  });
+
+  it('requires the audit scope to include at least one in-scope glob', () => {
+    const validate = buildValidator(schemas.auditScope);
+    const invalidFixture = structuredClone(fixtures.auditScope) as {
+      inScope: string[];
+    };
+
+    invalidFixture.inScope = [];
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/inScope')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `security-claim/v1`, `security-threat-model/v1`, and `security-audit-scope/v1` JSON Schema contracts.
- Add sample Security Assurance Lane fixtures under `fixtures/security-assurance/`.
- Wire the new fixtures into `scripts/ci/validate-json.mjs` and add contract tests.
- Update `docs/reference/CONTRACT-CATALOG.md` with the new security contract roles and produced/consumed mapping.

Closes #3258

## Acceptance

- [x] 3つの schema を追加: `schema/security-claim-v1.schema.json`, `schema/security-threat-model-v1.schema.json`, `schema/security-audit-scope-v1.schema.json`
- [x] sample fixtures を追加し、schema validation に組み込み
- [x] `schemaVersion` を各 contract で明示
- [x] `claim.id` を後続 artifact から参照できるよう `threats[].relatedClaimIds[]` と fixture contract test で確認
- [x] claim `type` が `invariant | precondition | postcondition | assumption` を表現できる
- [x] `sourceRefs`, `threatTags`, `trustBoundary`, `requiredLanes`, `provenance` を claim 必須項目として定義
- [x] `docs/reference/CONTRACT-CATALOG.md` に contract role を追記

## Validation

- `pnpm -s exec vitest run tests/contracts/security-assurance-contract.test.ts`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`（既知の `docs/quality/quality-implementation-status.md:158` warning のみ）
- `git diff --check`

## Rollback

- Revert this PR to remove the new security assurance schemas, fixtures, validation wiring, contract test, and catalog entries. Existing runtime behavior and default CI paths are otherwise unchanged.