### PR TITLE
feat(security): add security finding review contracts

### DIFF
--- a/docs/reference/CONTRACT-CATALOG.md
+++ b/docs/reference/CONTRACT-CATALOG.md
@@ -25,7 +25,7 @@ This document is the baseline inventory created for Issue #2406. It classifies t
 
 Some schemas are dual-role. This catalog records the primary role used in the current implementation.
 
-### 3. Schema inventory (snapshot: 2026-03-04)
+### 3. Schema inventory (snapshot: 2026-05-07)
 
 #### 3.1 input
 
@@ -169,7 +169,7 @@ The table below keeps the current producer/consumer baseline for representative 
 
 - `security-finding/v1` is candidate-first: `status=candidate` and `status=needs-human-review` are audit evidence, not confirmed vulnerabilities. Only `status=confirmed` represents a confirmed vulnerability.
 - `security-review/v1` applies three narrow gates: Dead Code, Trust Boundary, and Scope. Each gate records `pass | fail | unknown | not-applicable` plus a rationale.
-- `falsePositiveRootCause` uses `dead-code`, `trust-boundary-misunderstanding`, `out-of-scope`, `code-reading-error`, `spec-misinterpretation`, or `insufficient-evidence`; it remains `null` while the review is unresolved.
+- `falsePositiveRootCause` uses `dead-code`, `trust-boundary-misunderstanding`, `out-of-scope`, `code-reading-error`, `spec-misinterpretation`, or `insufficient-evidence` only for resolved false positives (`rejected` or `out-of-scope`); it remains `null` for `needs-human-review`, `confirmed`, and `waived` results.
 - Policy-gate blocking behavior is intentionally out of scope for these schema contracts; downstream integration starts in report-only mode.
 
 ### 6. Current gaps (next stage)
@@ -212,7 +212,7 @@ The table below keeps the current producer/consumer baseline for representative 
 - `evidence`: 監査・再現・可観測性の証跡契約（summary、report、metrics）
 - `operation`: 実行計画や進行制御に関わる運用契約（plan、manifest、package）
 
-## 3. schema 一覧（2026-03-04時点）
+## 3. schema 一覧（2026-05-07時点）
 
 ### 3.1 input
 
@@ -350,11 +350,11 @@ The table below keeps the current producer/consumer baseline for representative 
 | `artifacts/e2e/ui-e2e-summary.json` | `schema/ui-e2e-summary.schema.json` | `scripts/e2e/run-ui-e2e-semantic.mjs`, `.github/workflows/parallel-test-execution.yml` | `scripts/ci/build-harness-health.mjs`, `scripts/ci/validate-json.mjs`, `scripts/ci/validate-artifacts-ajv.mjs` |
 | `artifacts/e2e/summary.json` | `docs/schemas/artifacts-adapter-summary.schema.json` | `scripts/e2e/run-ui-e2e-semantic.mjs` | `scripts/ci/validate-artifacts-ajv.mjs`, future adapter-summary aggregators |
 
-## 5. Security Assurance Lane status semantics
+## 5. Security Assurance Lane のステータス意味論
 
 - `security-finding/v1` は candidate-first として扱う。`status=candidate` と `status=needs-human-review` は監査 evidence であり、confirmed vulnerability ではない。confirmed vulnerability を表すのは `status=confirmed` のみ。
 - `security-review/v1` は Dead Code / Trust Boundary / Scope の 3 gate を適用し、各 gate は `pass | fail | unknown | not-applicable` と rationale を保持する。
-- `falsePositiveRootCause` は `dead-code`, `trust-boundary-misunderstanding`, `out-of-scope`, `code-reading-error`, `spec-misinterpretation`, `insufficient-evidence` のいずれか。未解決 review では `null` のままにする。
+- `falsePositiveRootCause` は `dead-code`, `trust-boundary-misunderstanding`, `out-of-scope`, `code-reading-error`, `spec-misinterpretation`, `insufficient-evidence` のいずれかで、resolved false positive（`rejected` または `out-of-scope`）のときだけ設定する。`needs-human-review`, `confirmed`, `waived` では `null` のままにする。
 - これらの schema contract では policy-gate の block logic は扱わず、後続統合は report-only から開始する。
 
 ## 6. 現時点の未整備（次段階）

--- a/docs/reference/CONTRACT-CATALOG.md
+++ b/docs/reference/CONTRACT-CATALOG.md
@@ -62,6 +62,7 @@ Some schemas are dual-role. This catalog records the primary role used in the cu
 - `schema/policy-decision-v1.schema.json`
 - `schema/pr-state-v1.schema.json`
 - `schema/policy-gate-summary-v1.schema.json`
+- `schema/security-review-v1.schema.json`
 - `schema/quality-report.schema.json`
 - `schema/trace-validation.schema.json`
 - `schema/verify-profile-summary.schema.json`
@@ -73,6 +74,7 @@ Some schemas are dual-role. This catalog records the primary role used in the cu
 - `schema/artifact-metadata.schema.json`
 - `schema/assurance-summary.schema.json`
 - `schema/claim-evidence-manifest.schema.json`
+- `schema/security-finding-v1.schema.json`
 - `schema/temporal-run-summary.schema.json`
 - `schema/bench-criteria.schema.json`
 - `schema/bench-compare.schema.json`
@@ -125,6 +127,8 @@ The table below keeps the current producer/consumer baseline for representative 
 | `artifacts/security/security-claims.json` | `schema/security-claim-v1.schema.json` | manual authoring, future `ae security extract-claims`, `fixtures/security-assurance/sample.security-claims.json` (schema contract fixture) | future Security Assurance Lane producers, `scripts/ci/validate-json.mjs`, `tests/contracts/security-assurance-contract.test.ts`; downstream artifacts reference `claims[].id` |
 | `artifacts/security/security-threat-model.json` | `schema/security-threat-model-v1.schema.json` | manual authoring, future SPECA-compatible import, `fixtures/security-assurance/sample.security-threat-model.json` (schema contract fixture) | future security audit and review producers, `scripts/ci/validate-json.mjs`, `tests/contracts/security-assurance-contract.test.ts`; references security claim ids through `threats[].relatedClaimIds[]` |
 | `artifacts/security/security-audit-scope.json` | `schema/security-audit-scope-v1.schema.json` | manual authoring, bug-bounty/audit scope translation, `fixtures/security-assurance/sample.security-audit-scope.json` (schema contract fixture) | future security claim extraction, code-map, audit, and review producers; scope remains glob-based in the MVP contract |
+| `artifacts/security/security-findings.json` | `schema/security-finding-v1.schema.json` | future proof-attempt audit producers, SPECA-compatible import, `fixtures/security-assurance/sample.security-findings.json` (schema contract fixture) | future security review, assurance summary, claim-evidence manifest, and policy-gate report-only consumers; `status=candidate` is not a confirmed vulnerability |
+| `artifacts/security/security-review.json` | `schema/security-review-v1.schema.json` | future three-gate security review producer, `fixtures/security-assurance/sample.security-review.json` (schema contract fixture) | future assurance summary / PR summary consumers; captures Dead Code / Trust Boundary / Scope gates and false-positive root-cause classification |
 | `artifacts/temporal/*/temporal-run-summary.json` | `schema/temporal-run-summary.schema.json` | `examples/temporal-workflow-adapter`, `fixtures/temporal/sample.temporal-run-summary.json` (schema contract fixture) | `scripts/ci/validate-json.mjs`, `tests/contracts/temporal-run-summary-contract.test.ts`, operator review; Temporal-specific metadata remains confined to this adapter sidecar |
 | `spec/assurance-profile/upstream-context-promotion-v1.json` | `schema/assurance-profile.schema.json` | manual authoring in `spec/assurance-profile/` | `scripts/assurance/aggregate-lanes.mjs`, `docs/guides/upstream-context-promotion.md`, `tests/fixtures/upstream-context-promotion-minimal.assurance.test.ts` |
 | `artifacts/report-envelope.json` | `schema/envelope.schema.json` | `scripts/trace/create-report-envelope.mjs` | `scripts/ci/validate-artifacts-ajv.mjs`, `scripts/trace/publish-envelope.mjs` |
@@ -161,7 +165,14 @@ The table below keeps the current producer/consumer baseline for representative 
 | `artifacts/e2e/ui-e2e-summary.json` | `schema/ui-e2e-summary.schema.json` | `scripts/e2e/run-ui-e2e-semantic.mjs`, `.github/workflows/parallel-test-execution.yml` | `scripts/ci/build-harness-health.mjs`, `scripts/ci/validate-json.mjs`, `scripts/ci/validate-artifacts-ajv.mjs` |
 | `artifacts/e2e/summary.json` | `docs/schemas/artifacts-adapter-summary.schema.json` | `scripts/e2e/run-ui-e2e-semantic.mjs` | `scripts/ci/validate-artifacts-ajv.mjs`, future adapter-summary aggregators |
 
-### 5. Current gaps (next stage)
+### 5. Security Assurance Lane status semantics
+
+- `security-finding/v1` is candidate-first: `status=candidate` and `status=needs-human-review` are audit evidence, not confirmed vulnerabilities. Only `status=confirmed` represents a confirmed vulnerability.
+- `security-review/v1` applies three narrow gates: Dead Code, Trust Boundary, and Scope. Each gate records `pass | fail | unknown | not-applicable` plus a rationale.
+- `falsePositiveRootCause` uses `dead-code`, `trust-boundary-misunderstanding`, `out-of-scope`, `code-reading-error`, `spec-misinterpretation`, or `insufficient-evidence`; it remains `null` while the review is unresolved.
+- Policy-gate blocking behavior is intentionally out of scope for these schema contracts; downstream integration starts in report-only mode.
+
+### 6. Current gaps (next stage)
 
 - assurance contracts are still being introduced in phases; default operation stays report-only, and strict assurance enforcement is limited to Verify Lite when the `enforce-assurance` label is present.
 - `schemaVersion` still mixes semver and `*/v1` style identifiers. The staged unification plan lives in `docs/reference/SCHEMA-GOVERNANCE.md`.
@@ -174,7 +185,7 @@ The table below keeps the current producer/consumer baseline for representative 
   - `artifacts/*-retry-eligibility.json`
   - `artifacts/ci/*-summary.json` (risk and related summaries)
 
-### 6. References
+### 7. References
 
 - `docs/reference/SCHEMA-GOVERNANCE.md`
 - `docs/quality/ARTIFACTS-CONTRACT.md`
@@ -239,6 +250,7 @@ The table below keeps the current producer/consumer baseline for representative 
 - `schema/policy-decision-v1.schema.json`
 - `schema/pr-state-v1.schema.json`
 - `schema/policy-gate-summary-v1.schema.json`
+- `schema/security-review-v1.schema.json`
 - `schema/quality-report.schema.json`
 - `schema/trace-validation.schema.json`
 - `schema/verify-profile-summary.schema.json`
@@ -250,6 +262,7 @@ The table below keeps the current producer/consumer baseline for representative 
 - `schema/artifact-metadata.schema.json`
 - `schema/assurance-summary.schema.json`
 - `schema/claim-evidence-manifest.schema.json`
+- `schema/security-finding-v1.schema.json`
 - `schema/temporal-run-summary.schema.json`
 - `schema/bench-criteria.schema.json`
 - `schema/bench-compare.schema.json`
@@ -299,6 +312,8 @@ The table below keeps the current producer/consumer baseline for representative 
 | `artifacts/security/security-claims.json` | `schema/security-claim-v1.schema.json` | manual authoring、将来の `ae security extract-claims`、`fixtures/security-assurance/sample.security-claims.json`（schema contract fixture） | 将来の Security Assurance Lane producer、`scripts/ci/validate-json.mjs`、`tests/contracts/security-assurance-contract.test.ts`。後続 artifact は `claims[].id` を参照する |
 | `artifacts/security/security-threat-model.json` | `schema/security-threat-model-v1.schema.json` | manual authoring、将来の SPECA-compatible import、`fixtures/security-assurance/sample.security-threat-model.json`（schema contract fixture） | 将来の security audit / review producer、`scripts/ci/validate-json.mjs`、`tests/contracts/security-assurance-contract.test.ts`。`threats[].relatedClaimIds[]` で security claim id を参照する |
 | `artifacts/security/security-audit-scope.json` | `schema/security-audit-scope-v1.schema.json` | manual authoring、bug-bounty / audit scope translation、`fixtures/security-assurance/sample.security-audit-scope.json`（schema contract fixture） | 将来の security claim extraction、code-map、audit、review producer。MVP contract では glob-based scope に限定する |
+| `artifacts/security/security-findings.json` | `schema/security-finding-v1.schema.json` | 将来の proof-attempt audit producer、SPECA-compatible import、`fixtures/security-assurance/sample.security-findings.json`（schema contract fixture） | 将来の security review、assurance summary、claim-evidence manifest、policy-gate report-only consumer。`status=candidate` は confirmed vulnerability ではない |
+| `artifacts/security/security-review.json` | `schema/security-review-v1.schema.json` | 将来の three-gate security review producer、`fixtures/security-assurance/sample.security-review.json`（schema contract fixture） | 将来の assurance summary / PR summary consumer。Dead Code / Trust Boundary / Scope gate と false-positive root-cause classification を保持する |
 | `artifacts/temporal/*/temporal-run-summary.json` | `schema/temporal-run-summary.schema.json` | `examples/temporal-workflow-adapter`、`fixtures/temporal/sample.temporal-run-summary.json`（schema contract fixture） | `scripts/ci/validate-json.mjs`、`tests/contracts/temporal-run-summary-contract.test.ts`、operator review。Temporal 固有 metadata はこの adapter sidecar に閉じる |
 | `spec/assurance-profile/upstream-context-promotion-v1.json` | `schema/assurance-profile.schema.json` | manual authoring in `spec/assurance-profile/` | `scripts/assurance/aggregate-lanes.mjs`, `docs/guides/upstream-context-promotion.md`, `tests/fixtures/upstream-context-promotion-minimal.assurance.test.ts` |
 | `artifacts/report-envelope.json` | `schema/envelope.schema.json` | `scripts/trace/create-report-envelope.mjs` | `scripts/ci/validate-artifacts-ajv.mjs`, `scripts/trace/publish-envelope.mjs` |
@@ -335,7 +350,14 @@ The table below keeps the current producer/consumer baseline for representative 
 | `artifacts/e2e/ui-e2e-summary.json` | `schema/ui-e2e-summary.schema.json` | `scripts/e2e/run-ui-e2e-semantic.mjs`, `.github/workflows/parallel-test-execution.yml` | `scripts/ci/build-harness-health.mjs`, `scripts/ci/validate-json.mjs`, `scripts/ci/validate-artifacts-ajv.mjs` |
 | `artifacts/e2e/summary.json` | `docs/schemas/artifacts-adapter-summary.schema.json` | `scripts/e2e/run-ui-e2e-semantic.mjs` | `scripts/ci/validate-artifacts-ajv.mjs`, future adapter-summary aggregators |
 
-## 5. 現時点の未整備（次段階）
+## 5. Security Assurance Lane status semantics
+
+- `security-finding/v1` は candidate-first として扱う。`status=candidate` と `status=needs-human-review` は監査 evidence であり、confirmed vulnerability ではない。confirmed vulnerability を表すのは `status=confirmed` のみ。
+- `security-review/v1` は Dead Code / Trust Boundary / Scope の 3 gate を適用し、各 gate は `pass | fail | unknown | not-applicable` と rationale を保持する。
+- `falsePositiveRootCause` は `dead-code`, `trust-boundary-misunderstanding`, `out-of-scope`, `code-reading-error`, `spec-misinterpretation`, `insufficient-evidence` のいずれか。未解決 review では `null` のままにする。
+- これらの schema contract では policy-gate の block logic は扱わず、後続統合は report-only から開始する。
+
+## 6. 現時点の未整備（次段階）
 
 - assurance contract は段階導入中であり、既定運用は report-only、strict assurance enforcement は `enforce-assurance` ラベル時の Verify Lite に限定される。
 - `schemaVersion` は semver と `*/v1` 形式が混在している（統一規約は `docs/reference/SCHEMA-GOVERNANCE.md` で段階導入）。
@@ -348,7 +370,7 @@ The table below keeps the current producer/consumer baseline for representative 
   - `artifacts/*-retry-eligibility.json`
   - `artifacts/ci/*-summary.json`（risk など）
 
-## 6. 参照
+## 7. 参照
 
 - `docs/reference/SCHEMA-GOVERNANCE.md`
 - `docs/quality/ARTIFACTS-CONTRACT.md`

--- a/fixtures/security-assurance/sample.security-findings.json
+++ b/fixtures/security-assurance/sample.security-findings.json
@@ -1,0 +1,98 @@
+{
+  "schemaVersion": "security-finding/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "findings": [
+    {
+      "id": "SEC-FINDING-001",
+      "claimId": "SEC-CLAIM-001",
+      "status": "candidate",
+      "severity": "high",
+      "confidence": "medium",
+      "title": "Verification cache key may omit attacker-controlled input",
+      "summary": "The proof attempt cannot establish that all attacker-controlled fields are included in the cache key.",
+      "affectedLocations": [
+        {
+          "path": "src/cache.ts",
+          "startLine": 10,
+          "endLine": 42,
+          "symbol": "buildCacheKey",
+          "description": "Candidate key construction path from fixture audit."
+        }
+      ],
+      "proofAttempt": {
+        "claim": "SEC-CLAIM-001",
+        "map": "Relevant code paths include buildCacheKey and verification request parsing.",
+        "prove": "The implementation must show that every verification-affecting attacker-controlled field is included in the key material.",
+        "stressTest": "Counterexample candidate: two requests differ in an attacker-controlled field that affects verification but share the same cache key.",
+        "report": "Treat as a candidate until reviewed by the three-gate security review."
+      },
+      "scopeRefs": [
+        "TB-001"
+      ],
+      "evidenceRefs": [
+        {
+          "id": "SEC-EVIDENCE-001",
+          "kind": "security-claim",
+          "path": "fixtures/security-assurance/sample.security-claims.json",
+          "description": "Source claim fixture."
+        }
+      ],
+      "provenance": {
+        "origin": "fixture",
+        "generator": "security-proof-attempt-fixture"
+      },
+      "notes": [
+        "Candidate finding is not a confirmed vulnerability."
+      ]
+    },
+    {
+      "id": "SEC-FINDING-002",
+      "claimId": "SEC-CLAIM-001",
+      "status": "candidate",
+      "severity": "medium",
+      "confidence": "low",
+      "title": "Test-only cache helper resembles production key construction",
+      "summary": "The proof attempt found similar test helper code, but the path may be outside the audit scope.",
+      "affectedLocations": [
+        {
+          "path": "tests/fixtures/cache-helper.ts",
+          "startLine": 5,
+          "endLine": 20,
+          "symbol": "buildFixtureCacheKey"
+        }
+      ],
+      "proofAttempt": {
+        "claim": "SEC-CLAIM-001",
+        "map": "Candidate code path appears only in fixture helper files.",
+        "prove": "The implementation would need to show the helper is reachable from production entry points.",
+        "stressTest": "No production entry point reaches the fixture helper in the MVP scope.",
+        "report": "Candidate is expected to be rejected by the scope gate."
+      },
+      "scopeRefs": [
+        "tests/**"
+      ],
+      "evidenceRefs": [],
+      "provenance": {
+        "origin": "fixture",
+        "generator": "security-proof-attempt-fixture"
+      }
+    }
+  ],
+  "summary": {
+    "totalFindings": 2,
+    "byStatus": {
+      "candidate": 2,
+      "needsHumanReview": 0,
+      "confirmed": 0,
+      "rejected": 0,
+      "waived": 0,
+      "outOfScope": 0
+    },
+    "bySeverity": {
+      "low": 0,
+      "medium": 1,
+      "high": 1,
+      "critical": 0
+    }
+  }
+}

--- a/fixtures/security-assurance/sample.security-review.json
+++ b/fixtures/security-assurance/sample.security-review.json
@@ -1,0 +1,72 @@
+{
+  "schemaVersion": "security-review/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "reviews": [
+    {
+      "findingId": "SEC-FINDING-001",
+      "result": "needs-human-review",
+      "gates": {
+        "deadCode": {
+          "result": "pass",
+          "rationale": "The candidate path is reachable from the external verification entry point."
+        },
+        "trustBoundary": {
+          "result": "pass",
+          "rationale": "The relevant fields are attacker-controlled at boundary TB-001."
+        },
+        "scope": {
+          "result": "pass",
+          "rationale": "The affected source path is included by the audit scope."
+        }
+      },
+      "falsePositiveRootCause": null,
+      "reviewerNotes": [
+        "Human review is still required before confirming vulnerability status."
+      ],
+      "reviewedAt": "2026-05-07T00:00:00.000Z",
+      "reviewer": "security-review-fixture"
+    },
+    {
+      "findingId": "SEC-FINDING-002",
+      "result": "out-of-scope",
+      "gates": {
+        "deadCode": {
+          "result": "unknown",
+          "rationale": "Reachability was not analyzed in the schema-only fixture."
+        },
+        "trustBoundary": {
+          "result": "unknown",
+          "rationale": "No production trust boundary reaches this fixture helper."
+        },
+        "scope": {
+          "result": "fail",
+          "rationale": "The affected path is excluded by the audit scope outOfScope globs."
+        }
+      },
+      "falsePositiveRootCause": "out-of-scope",
+      "reviewerNotes": [
+        "Classified as out-of-scope rather than confirmed."
+      ],
+      "reviewedAt": "2026-05-07T00:00:00.000Z",
+      "reviewer": "security-review-fixture"
+    }
+  ],
+  "summary": {
+    "totalReviews": 2,
+    "byResult": {
+      "needsHumanReview": 1,
+      "confirmed": 0,
+      "rejected": 0,
+      "waived": 0,
+      "outOfScope": 1
+    },
+    "falsePositiveRootCauses": {
+      "deadCode": 0,
+      "trustBoundaryMisunderstanding": 0,
+      "outOfScope": 1,
+      "codeReadingError": 0,
+      "specMisinterpretation": 0,
+      "insufficientEvidence": 0
+    }
+  }
+}

--- a/schema/security-finding-v1.schema.json
+++ b/schema/security-finding-v1.schema.json
@@ -1,0 +1,337 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/security-finding-v1.schema.json",
+  "title": "Security Finding v1",
+  "description": "Candidate-first security finding contract. A finding is not a confirmed vulnerability unless status is explicitly confirmed.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "findings"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "security-finding/v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "findings": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/finding"
+      }
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "severity": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high",
+        "critical"
+      ]
+    },
+    "findingStatus": {
+      "type": "string",
+      "enum": [
+        "candidate",
+        "needs-human-review",
+        "confirmed",
+        "rejected",
+        "waived",
+        "out-of-scope"
+      ]
+    },
+    "confidence": {
+      "type": "string",
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "origin",
+        "generator"
+      ],
+      "properties": {
+        "origin": {
+          "type": "string",
+          "enum": [
+            "manual",
+            "llm-assisted",
+            "imported",
+            "deterministic",
+            "fixture"
+          ]
+        },
+        "generator": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "source": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "version": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "affectedLocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "startLine",
+        "endLine"
+      ],
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "startLine": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "endLine": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "symbol": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "proofAttempt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claim",
+        "map",
+        "prove",
+        "stressTest"
+      ],
+      "properties": {
+        "claim": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "map": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "prove": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "stressTest": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "report": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "path"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "security-claim",
+            "security-code-map",
+            "audit-task",
+            "source",
+            "trace",
+            "manual",
+            "other"
+          ]
+        },
+        "path": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "claimId",
+        "status",
+        "severity",
+        "confidence",
+        "title",
+        "summary",
+        "affectedLocations",
+        "proofAttempt",
+        "scopeRefs",
+        "evidenceRefs",
+        "provenance"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "claimId": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "$ref": "#/$defs/findingStatus"
+        },
+        "severity": {
+          "$ref": "#/$defs/severity"
+        },
+        "confidence": {
+          "$ref": "#/$defs/confidence"
+        },
+        "title": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "summary": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "affectedLocations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/affectedLocation"
+          }
+        },
+        "proofAttempt": {
+          "$ref": "#/$defs/proofAttempt"
+        },
+        "scopeRefs": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "evidenceRefs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidenceRef"
+          }
+        },
+        "provenance": {
+          "$ref": "#/$defs/provenance"
+        },
+        "notes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalFindings",
+        "byStatus",
+        "bySeverity"
+      ],
+      "properties": {
+        "totalFindings": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "byStatus": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "candidate",
+            "needsHumanReview",
+            "confirmed",
+            "rejected",
+            "waived",
+            "outOfScope"
+          ],
+          "properties": {
+            "candidate": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "needsHumanReview": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "confirmed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "rejected": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "waived": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "outOfScope": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "bySeverity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
+          "properties": {
+            "low": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "medium": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "high": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "critical": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/security-finding-v1.schema.json
+++ b/schema/security-finding-v1.schema.json
@@ -117,7 +117,8 @@
         "description": {
           "$ref": "#/$defs/nonEmptyString"
         }
-      }
+      },
+      "$comment": "Portable JSON Schema cannot compare sibling numeric values; ae-framework semantic validation enforces endLine >= startLine for affectedLocations."
     },
     "proofAttempt": {
       "type": "object",

--- a/schema/security-review-v1.schema.json
+++ b/schema/security-review-v1.schema.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/security-review-v1.schema.json",
+  "title": "Security Review v1",
+  "description": "Three-gate review contract for candidate security findings. Review results classify candidate findings without silently treating them as confirmed vulnerabilities.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "reviews"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "security-review/v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "reviews": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/review"
+      }
+    },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reviewResult": {
+      "type": "string",
+      "enum": [
+        "needs-human-review",
+        "confirmed",
+        "rejected",
+        "waived",
+        "out-of-scope"
+      ]
+    },
+    "gateResult": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail",
+        "unknown",
+        "not-applicable"
+      ]
+    },
+    "falsePositiveRootCause": {
+      "type": "string",
+      "enum": [
+        "dead-code",
+        "trust-boundary-misunderstanding",
+        "out-of-scope",
+        "code-reading-error",
+        "spec-misinterpretation",
+        "insufficient-evidence"
+      ]
+    },
+    "gateDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result",
+        "rationale"
+      ],
+      "properties": {
+        "result": {
+          "$ref": "#/$defs/gateResult"
+        },
+        "rationale": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "evidenceRefs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        }
+      }
+    },
+    "gates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "deadCode",
+        "trustBoundary",
+        "scope"
+      ],
+      "properties": {
+        "deadCode": {
+          "$ref": "#/$defs/gateDecision"
+        },
+        "trustBoundary": {
+          "$ref": "#/$defs/gateDecision"
+        },
+        "scope": {
+          "$ref": "#/$defs/gateDecision"
+        }
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "findingId",
+        "result",
+        "gates",
+        "falsePositiveRootCause",
+        "reviewerNotes"
+      ],
+      "properties": {
+        "findingId": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "result": {
+          "$ref": "#/$defs/reviewResult"
+        },
+        "gates": {
+          "$ref": "#/$defs/gates"
+        },
+        "falsePositiveRootCause": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/falsePositiveRootCause"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reviewerNotes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nonEmptyString"
+          }
+        },
+        "reviewedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "reviewer": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalReviews",
+        "byResult",
+        "falsePositiveRootCauses"
+      ],
+      "properties": {
+        "totalReviews": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "byResult": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "needsHumanReview",
+            "confirmed",
+            "rejected",
+            "waived",
+            "outOfScope"
+          ],
+          "properties": {
+            "needsHumanReview": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "confirmed": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "rejected": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "waived": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "outOfScope": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "falsePositiveRootCauses": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "deadCode",
+            "trustBoundaryMisunderstanding",
+            "outOfScope",
+            "codeReadingError",
+            "specMisinterpretation",
+            "insufficientEvidence"
+          ],
+          "properties": {
+            "deadCode": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "trustBoundaryMisunderstanding": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "outOfScope": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "codeReadingError": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "specMisinterpretation": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "insufficientEvidence": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/security-review-v1.schema.json
+++ b/schema/security-review-v1.schema.json
@@ -149,7 +149,54 @@
         "reviewer": {
           "$ref": "#/$defs/nonEmptyString"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "required": [
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "enum": [
+                  "needs-human-review",
+                  "confirmed",
+                  "waived"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "falsePositiveRootCause": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": [
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "enum": [
+                  "rejected",
+                  "out-of-scope"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "falsePositiveRootCause": {
+                "$ref": "#/$defs/falsePositiveRootCause"
+              }
+            }
+          }
+        }
+      ]
     },
     "summary": {
       "type": "object",

--- a/scripts/ci/lib/security-assurance-contract.mjs
+++ b/scripts/ci/lib/security-assurance-contract.mjs
@@ -1,0 +1,69 @@
+function createError(keyword, instancePath, message) {
+  return { keyword, instancePath, message };
+}
+
+function validateAffectedLocationRanges(findingsDocument, errors) {
+  const findings = Array.isArray(findingsDocument?.findings) ? findingsDocument.findings : [];
+  for (let findingIndex = 0; findingIndex < findings.length; findingIndex += 1) {
+    const finding = findings[findingIndex];
+    const locations = Array.isArray(finding?.affectedLocations) ? finding.affectedLocations : [];
+    for (let locationIndex = 0; locationIndex < locations.length; locationIndex += 1) {
+      const location = locations[locationIndex];
+      if (!Number.isInteger(location?.startLine) || !Number.isInteger(location?.endLine)) {
+        continue;
+      }
+      if (location.endLine < location.startLine) {
+        errors.push(createError(
+          'line_range_order',
+          `/findings/${findingIndex}/affectedLocations/${locationIndex}/endLine`,
+          `endLine must be greater than or equal to startLine (${location.startLine}), got ${location.endLine}`,
+        ));
+      }
+    }
+  }
+}
+
+function validateReviewRootCauseConsistency(reviewDocument, errors) {
+  const unresolvedOrNonFalsePositiveResults = new Set([
+    'needs-human-review',
+    'confirmed',
+    'waived',
+  ]);
+  const falsePositiveResults = new Set([
+    'rejected',
+    'out-of-scope',
+  ]);
+  const reviews = Array.isArray(reviewDocument?.reviews) ? reviewDocument.reviews : [];
+  for (let reviewIndex = 0; reviewIndex < reviews.length; reviewIndex += 1) {
+    const review = reviews[reviewIndex];
+    if (!review || typeof review !== 'object') {
+      continue;
+    }
+    if (unresolvedOrNonFalsePositiveResults.has(review.result) && review.falsePositiveRootCause !== null) {
+      errors.push(createError(
+        'false_positive_root_cause_result_mismatch',
+        `/reviews/${reviewIndex}/falsePositiveRootCause`,
+        `falsePositiveRootCause must be null when result is ${review.result}`,
+      ));
+    }
+    if (falsePositiveResults.has(review.result) && review.falsePositiveRootCause === null) {
+      errors.push(createError(
+        'false_positive_root_cause_missing',
+        `/reviews/${reviewIndex}/falsePositiveRootCause`,
+        `falsePositiveRootCause must be set when result is ${review.result}`,
+      ));
+    }
+  }
+}
+
+export function validateSecurityFindingSemantics(findingsDocument) {
+  const errors = [];
+  validateAffectedLocationRanges(findingsDocument, errors);
+  return errors;
+}
+
+export function validateSecurityReviewSemantics(reviewDocument) {
+  const errors = [];
+  validateReviewRootCauseConsistency(reviewDocument, errors);
+  return errors;
+}

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -142,6 +142,16 @@ const checks = [
     label: 'Security audit scope v1 schema validation'
   },
   {
+    schema: 'schema/security-finding-v1.schema.json',
+    fixtures: ['fixtures/security-assurance/sample.security-findings.json'],
+    label: 'Security finding v1 schema validation'
+  },
+  {
+    schema: 'schema/security-review-v1.schema.json',
+    fixtures: ['fixtures/security-assurance/sample.security-review.json'],
+    label: 'Security review v1 schema validation'
+  },
+  {
     schema: 'schema/temporal-run-summary.schema.json',
     fixtures: ['fixtures/temporal/sample.temporal-run-summary.json'],
     label: 'Temporal run summary schema validation'

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -7,6 +7,7 @@ import addFormats from 'ajv-formats';
 import yaml from 'yaml';
 import { runSchemaIdPolicyCheck } from './check-schema-id-policy.mjs';
 import { validateClaimEvidenceManifestSemantics } from './lib/claim-evidence-manifest-contract.mjs';
+import { validateSecurityFindingSemantics, validateSecurityReviewSemantics } from './lib/security-assurance-contract.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..', '..');
@@ -144,12 +145,14 @@ const checks = [
   {
     schema: 'schema/security-finding-v1.schema.json',
     fixtures: ['fixtures/security-assurance/sample.security-findings.json'],
-    label: 'Security finding v1 schema validation'
+    label: 'Security finding v1 schema validation',
+    semanticValidate: validateSecurityFindingSemantics
   },
   {
     schema: 'schema/security-review-v1.schema.json',
     fixtures: ['fixtures/security-assurance/sample.security-review.json'],
-    label: 'Security review v1 schema validation'
+    label: 'Security review v1 schema validation',
+    semanticValidate: validateSecurityReviewSemantics
   },
   {
     schema: 'schema/temporal-run-summary.schema.json',

--- a/tests/contracts/security-assurance-contract.test.ts
+++ b/tests/contracts/security-assurance-contract.test.ts
@@ -3,6 +3,10 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
+import {
+  validateSecurityFindingSemantics,
+  validateSecurityReviewSemantics,
+} from '../../scripts/ci/lib/security-assurance-contract.mjs';
 
 type JsonObject = Record<string, unknown>;
 
@@ -168,7 +172,7 @@ describe('security assurance contracts', () => {
     expect(validate.errors?.some((entry) => entry.instancePath === '/reviews/0/gates')).toBe(true);
   });
 
-  it('classifies false-positive root causes while allowing null for unresolved reviews', () => {
+  it('classifies false-positive root causes while keeping them consistent with review results', () => {
     const validate = buildValidator(schemas.review);
     const validFixture = structuredClone(fixtures.review) as {
       reviews: Array<Record<string, unknown>>;
@@ -183,6 +187,75 @@ describe('security assurance contracts', () => {
     expect(
       validate.errors?.some((entry) => entry.instancePath === '/reviews/1/falsePositiveRootCause'),
     ).toBe(true);
+
+    const unresolvedWithRootCause = structuredClone(fixtures.review) as {
+      reviews: Array<Record<string, unknown>>;
+    };
+    unresolvedWithRootCause.reviews[0].falsePositiveRootCause = 'insufficient-evidence';
+    expect(validate(unresolvedWithRootCause)).toBe(false);
+    expect(
+      validate.errors?.some((entry) => entry.instancePath === '/reviews/0/falsePositiveRootCause'),
+    ).toBe(true);
+
+    const confirmedWithRootCause = structuredClone(fixtures.review) as {
+      reviews: Array<Record<string, unknown>>;
+    };
+    confirmedWithRootCause.reviews[0].result = 'confirmed';
+    confirmedWithRootCause.reviews[0].falsePositiveRootCause = 'code-reading-error';
+    expect(validate(confirmedWithRootCause)).toBe(false);
+    expect(
+      validate.errors?.some((entry) => entry.instancePath === '/reviews/0/falsePositiveRootCause'),
+    ).toBe(true);
+
+    const rejectedWithoutRootCause = structuredClone(fixtures.review) as {
+      reviews: Array<Record<string, unknown>>;
+    };
+    rejectedWithoutRootCause.reviews[1].result = 'rejected';
+    rejectedWithoutRootCause.reviews[1].falsePositiveRootCause = null;
+    expect(validate(rejectedWithoutRootCause)).toBe(false);
+    expect(
+      validate.errors?.some((entry) => entry.instancePath === '/reviews/1/falsePositiveRootCause'),
+    ).toBe(true);
+  });
+
+  it('enforces security finding affected location line ranges semantically', () => {
+    const validFixture = structuredClone(fixtures.findings);
+    expect(validateSecurityFindingSemantics(validFixture)).toHaveLength(0);
+
+    const invalidFixture = structuredClone(fixtures.findings) as {
+      findings: Array<{ affectedLocations: Array<{ startLine: number; endLine: number }> }>;
+    };
+    invalidFixture.findings[0].affectedLocations[0].startLine = 42;
+    invalidFixture.findings[0].affectedLocations[0].endLine = 10;
+
+    expect(validateSecurityFindingSemantics(invalidFixture)).toEqual([
+      expect.objectContaining({
+        keyword: 'line_range_order',
+        instancePath: '/findings/0/affectedLocations/0/endLine',
+      }),
+    ]);
+  });
+
+  it('enforces security review root-cause consistency semantically', () => {
+    const validFixture = structuredClone(fixtures.review);
+    expect(validateSecurityReviewSemantics(validFixture)).toHaveLength(0);
+
+    const invalidFixture = structuredClone(fixtures.review) as {
+      reviews: Array<Record<string, unknown>>;
+    };
+    invalidFixture.reviews[0].falsePositiveRootCause = 'insufficient-evidence';
+    invalidFixture.reviews[1].falsePositiveRootCause = null;
+
+    expect(validateSecurityReviewSemantics(invalidFixture)).toEqual([
+      expect.objectContaining({
+        keyword: 'false_positive_root_cause_result_mismatch',
+        instancePath: '/reviews/0/falsePositiveRootCause',
+      }),
+      expect.objectContaining({
+        keyword: 'false_positive_root_cause_missing',
+        instancePath: '/reviews/1/falsePositiveRootCause',
+      }),
+    ]);
   });
 
   it('keeps security reviews connected to security finding ids', () => {

--- a/tests/contracts/security-assurance-contract.test.ts
+++ b/tests/contracts/security-assurance-contract.test.ts
@@ -13,12 +13,16 @@ const schemas = {
   claims: loadJson('schema/security-claim-v1.schema.json'),
   threatModel: loadJson('schema/security-threat-model-v1.schema.json'),
   auditScope: loadJson('schema/security-audit-scope-v1.schema.json'),
+  findings: loadJson('schema/security-finding-v1.schema.json'),
+  review: loadJson('schema/security-review-v1.schema.json'),
 };
 
 const fixtures = {
   claims: loadJson('fixtures/security-assurance/sample.security-claims.json'),
   threatModel: loadJson('fixtures/security-assurance/sample.security-threat-model.json'),
   auditScope: loadJson('fixtures/security-assurance/sample.security-audit-scope.json'),
+  findings: loadJson('fixtures/security-assurance/sample.security-findings.json'),
+  review: loadJson('fixtures/security-assurance/sample.security-review.json'),
 };
 
 const buildValidator = (schema: JsonObject) => {
@@ -28,7 +32,7 @@ const buildValidator = (schema: JsonObject) => {
 };
 
 describe('security assurance contracts', () => {
-  it('validates the sample security claim, threat model, and audit scope fixtures', () => {
+  it('validates the sample security assurance fixtures', () => {
     for (const [name, schema] of Object.entries(schemas)) {
       const validate = buildValidator(schema);
       const fixture = fixtures[name as keyof typeof fixtures];
@@ -98,7 +102,6 @@ describe('security assurance contracts', () => {
     }
   });
 
-
   it('constrains threat model frameworks to represented STRIDE and CWE taxonomies', () => {
     const validate = buildValidator(schemas.threatModel);
     const invalidFixture = structuredClone(fixtures.threatModel) as {
@@ -122,4 +125,76 @@ describe('security assurance contracts', () => {
     expect(validate(invalidFixture)).toBe(false);
     expect(validate.errors?.some((entry) => entry.instancePath === '/inScope')).toBe(true);
   });
+
+  it('keeps security findings connected to security claim ids', () => {
+    const claimIds = new Set(
+      (fixtures.claims.claims as Array<{ id: string }>).map((claim) => claim.id),
+    );
+    const findings = fixtures.findings.findings as Array<{ claimId: string }>;
+
+    expect(findings).not.toHaveLength(0);
+    for (const finding of findings) {
+      expect(claimIds.has(finding.claimId)).toBe(true);
+    }
+  });
+
+  it('distinguishes candidate findings from confirmed vulnerabilities', () => {
+    const validate = buildValidator(schemas.findings);
+    const validFixture = structuredClone(fixtures.findings) as {
+      findings: Array<Record<string, unknown>>;
+      summary: { byStatus: Record<string, number> };
+    };
+
+    validFixture.findings[0].status = 'confirmed';
+    validFixture.summary.byStatus.candidate = 1;
+    validFixture.summary.byStatus.confirmed = 1;
+
+    expect(validate(validFixture), JSON.stringify(validate.errors)).toBe(true);
+
+    validFixture.findings[0].status = 'vulnerable';
+    expect(validate(validFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/findings/0/status')).toBe(true);
+  });
+
+  it('requires three-gate review results for every security review', () => {
+    const validate = buildValidator(schemas.review);
+    const invalidFixture = structuredClone(fixtures.review) as {
+      reviews: Array<{ gates: Record<string, unknown> }>;
+    };
+
+    delete invalidFixture.reviews[0].gates.trustBoundary;
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/reviews/0/gates')).toBe(true);
+  });
+
+  it('classifies false-positive root causes while allowing null for unresolved reviews', () => {
+    const validate = buildValidator(schemas.review);
+    const validFixture = structuredClone(fixtures.review) as {
+      reviews: Array<Record<string, unknown>>;
+    };
+
+    expect(validFixture.reviews[0].falsePositiveRootCause).toBeNull();
+    expect(validFixture.reviews[1].falsePositiveRootCause).toBe('out-of-scope');
+    expect(validate(validFixture), JSON.stringify(validate.errors)).toBe(true);
+
+    validFixture.reviews[1].falsePositiveRootCause = 'maybe-false-positive';
+    expect(validate(validFixture)).toBe(false);
+    expect(
+      validate.errors?.some((entry) => entry.instancePath === '/reviews/1/falsePositiveRootCause'),
+    ).toBe(true);
+  });
+
+  it('keeps security reviews connected to security finding ids', () => {
+    const findingIds = new Set(
+      (fixtures.findings.findings as Array<{ id: string }>).map((finding) => finding.id),
+    );
+    const reviews = fixtures.review.reviews as Array<{ findingId: string }>;
+
+    expect(reviews).not.toHaveLength(0);
+    for (const review of reviews) {
+      expect(findingIds.has(review.findingId)).toBe(true);
+    }
+  });
+
 });


### PR DESCRIPTION
## Summary

- Add `security-finding/v1` and `security-review/v1` JSON schemas for candidate-first security findings and three-gate review results.
- Add sample security finding / review fixtures and wire them into JSON validation.
- Extend security assurance contract tests and Contract Catalog documentation, including status semantics that distinguish candidate findings from confirmed vulnerabilities.

## Acceptance

Closes #3260

- [x] `schema/security-finding-v1.schema.json` is added.
- [x] `schema/security-review-v1.schema.json` is added.
- [x] Sample fixtures validate against both schemas.
- [x] Candidate findings and confirmed vulnerabilities are distinct states.
- [x] Dead Code / Trust Boundary / Scope gate results are machine-readable.
- [x] False-positive root-cause classification is represented.
- [x] `claimId` connects findings to security claims.
- [x] Contract Catalog documents producer/consumer roles and status semantics.

## Validation

- `pnpm -s exec vitest run tests/contracts/security-assurance-contract.test.ts`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency` (passes with the pre-existing doc-governance warning for `docs/quality/quality-implementation-status.md:158`)
- `git diff --check`

## Rollback

Revert this PR to remove the new schema contracts, fixtures, validation wiring, tests, and Contract Catalog entries. The change is additive and does not alter existing runtime behavior.