### PR TITLE
test(security): add assurance fixture golden scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ _apalache-out/
 
 # Local generated files (dev/test)
 artifacts/formal/
+artifacts/security-assurance/
 test-results/
 test-results-run/
 tmp-gh-event*.json

--- a/fixtures/security-assurance/cache-key/README.md
+++ b/fixtures/security-assurance/cache-key/README.md
@@ -1,0 +1,41 @@
+# Security Assurance Lane cache-key fixture
+
+この fixture は Issue #3266 の golden scenario です。小さな TypeScript 対象を使い、Security Assurance Lane の主要 artifact を外部 API / LLM / network なしで再生成します。
+
+## 実行方法
+
+```bash
+pnpm run test:security-assurance
+```
+
+個別 runner を直接実行する場合:
+
+```bash
+node scripts/security/run-security-assurance-fixture.mjs --scenario cache-key
+```
+
+意図した artifact 変更を承認する場合は、差分をレビューしたうえで次を実行します。
+
+```bash
+node scripts/security/run-security-assurance-fixture.mjs --scenario cache-key --update-expected
+```
+
+## シナリオの読み方
+
+- `SEC-CLAIM-001`: production `buildCacheKey` が `scope` を key material に含めないため、`security-findings.json` に candidate finding が出ます。`security-review.json` では `needs-human-review` に分類されます。
+- `SEC-CLAIM-002`: token freshness check は response fixture で `no-finding` として扱います。
+- `SEC-CLAIM-003`: `tests/fixtures/cache-helper.ts` は audit scope の `outOfScope` に該当するため、3-gate review で `out-of-scope` に分類されます。
+
+## Artifact map
+
+- `expected/security-claims.json`: `inputs/spec.md` から抽出された `security-claim/v1`。
+- `expected/security-threat-model.json`: fixture 固定の `security-threat-model/v1`。
+- `expected/security-code-map.json`: `inputs/target/src/**/*.ts` への deterministic pre-resolution map。
+- `expected/security-audit-tasks.json`: proof-attempt task bundle。
+- `expected/security-findings.json`: response fixture から生成された candidate findings。
+- `expected/security-review.json`: Dead Code / Trust Boundary / Scope の 3-gate review 結果。
+- `expected/assurance-summary.json`: security artifacts を assurance summary に接続した結果。
+- `expected/claim-evidence-manifest.json`: security counts を含む claim-evidence manifest。
+- `expected/security-summary.md`: golden scenario の人間向け要約。
+
+runner は `generatedAt` と artifact path を正規化してから expected/actual を比較します。これにより、ローカルの worktree 名や一時 output directory 名による drift は検出対象外になります。

--- a/fixtures/security-assurance/cache-key/expected/assurance-summary.json
+++ b/fixtures/security-assurance/cache-key/expected/assurance-summary.json
@@ -1,0 +1,284 @@
+{
+  "schemaVersion": "assurance-summary/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "metadata": {
+    "generatedAtUtc": "2026-05-07T00:00:00.000Z",
+    "generatedAtLocal": "2026-05-07T00:00:00.000Z",
+    "timezoneOffset": "+00:00",
+    "gitCommit": null,
+    "branch": null,
+    "runner": {
+      "name": "security-assurance-fixture",
+      "os": "normalized",
+      "arch": "normalized",
+      "ci": false
+    },
+    "toolVersions": {}
+  },
+  "inputs": {
+    "assuranceProfile": "fixtures/security-assurance/cache-key/inputs/assurance-profile.json",
+    "contextPacks": [],
+    "verifyLiteSummary": null,
+    "formalSummaries": [],
+    "conformanceReport": null,
+    "counterexamples": [],
+    "evidenceManifests": [],
+    "securityClaims": "artifacts/security-assurance/cache-key/security-claims.json",
+    "securityFindings": "artifacts/security-assurance/cache-key/security-findings.json",
+    "securityReview": "artifacts/security-assurance/cache-key/security-review.json"
+  },
+  "summary": {
+    "claimCount": 3,
+    "satisfiedClaims": 0,
+    "warningClaims": 3,
+    "claimsMissingRequiredLanes": 0,
+    "claimsMissingRequiredEvidenceKinds": 3,
+    "unlinkedCounterexamples": 0,
+    "warningCount": 2
+  },
+  "laneCoverage": {
+    "spec": {
+      "requiredClaims": 3,
+      "observedClaims": 3
+    },
+    "behavior": {
+      "requiredClaims": 0,
+      "observedClaims": 0
+    },
+    "adversarial": {
+      "requiredClaims": 2,
+      "observedClaims": 2
+    },
+    "model": {
+      "requiredClaims": 0,
+      "observedClaims": 0
+    },
+    "proof": {
+      "requiredClaims": 0,
+      "observedClaims": 0
+    },
+    "runtime": {
+      "requiredClaims": 0,
+      "observedClaims": 0
+    }
+  },
+  "claims": [
+    {
+      "claimId": "SEC-CLAIM-001",
+      "statement": "Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.",
+      "criticality": "high",
+      "targetLevel": "A2",
+      "minIndependentSources": 1,
+      "observedIndependentSources": 2,
+      "requiredLanes": [
+        "adversarial",
+        "spec"
+      ],
+      "observedLanes": [
+        "spec",
+        "adversarial"
+      ],
+      "missingLanes": [],
+      "requiredEvidenceKinds": [
+        "counterexample-closed"
+      ],
+      "observedEvidenceKinds": [
+        "security-claim",
+        "security-finding",
+        "security-review"
+      ],
+      "missingEvidenceKinds": [
+        "counterexample-closed"
+      ],
+      "counterexamples": {
+        "open": 1,
+        "resolved": 0,
+        "acceptedRisk": 0,
+        "total": 1
+      },
+      "independenceWarnings": [
+        "unresolved-critical-counterexample"
+      ],
+      "status": "warning",
+      "evidence": [
+        {
+          "lane": "spec",
+          "kind": "security-claim",
+          "sourceKind": "spec-derived",
+          "origin": "security-claim",
+          "status": "observed",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/0",
+          "detail": "Security claim imported from security-claim/v1 (type=invariant).",
+          "claimRefs": [
+            "SEC-CLAIM-001"
+          ],
+          "generatorLineage": "security-claim/security-claim-extractor"
+        },
+        {
+          "lane": "adversarial",
+          "kind": "security-finding",
+          "sourceKind": "source-derived",
+          "origin": "security-finding",
+          "status": "observed",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-findings.json#/findings/0",
+          "detail": "Security finding SEC-FINDING-001: status=candidate, severity=high, review=needs-human-review.",
+          "claimRefs": [
+            "SEC-CLAIM-001"
+          ],
+          "generatorLineage": "security-finding/security-proof-attempt-audit"
+        },
+        {
+          "lane": "adversarial",
+          "kind": "security-review",
+          "sourceKind": "source-derived",
+          "origin": "security-review",
+          "status": "observed",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-review.json#/reviews/0",
+          "detail": "Security review classified SEC-FINDING-001 as needs-human-review.",
+          "claimRefs": [
+            "SEC-CLAIM-001"
+          ],
+          "generatorLineage": "security-review/security-three-gate-review"
+        }
+      ]
+    },
+    {
+      "claimId": "SEC-CLAIM-002",
+      "statement": "Bearer token validation must reject expired tokens before cache lookup.",
+      "criticality": "medium",
+      "targetLevel": "A1",
+      "minIndependentSources": 1,
+      "observedIndependentSources": 1,
+      "requiredLanes": [
+        "spec"
+      ],
+      "observedLanes": [
+        "spec"
+      ],
+      "missingLanes": [],
+      "requiredEvidenceKinds": [
+        "schema"
+      ],
+      "observedEvidenceKinds": [
+        "security-claim"
+      ],
+      "missingEvidenceKinds": [
+        "schema"
+      ],
+      "counterexamples": {
+        "open": 0,
+        "resolved": 0,
+        "acceptedRisk": 0,
+        "total": 0
+      },
+      "independenceWarnings": [],
+      "status": "warning",
+      "evidence": [
+        {
+          "lane": "spec",
+          "kind": "security-claim",
+          "sourceKind": "spec-derived",
+          "origin": "security-claim",
+          "status": "observed",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/1",
+          "detail": "Security claim imported from security-claim/v1 (type=precondition).",
+          "claimRefs": [
+            "SEC-CLAIM-002"
+          ],
+          "generatorLineage": "security-claim/security-claim-extractor"
+        }
+      ]
+    },
+    {
+      "claimId": "SEC-CLAIM-003",
+      "statement": "Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.",
+      "criticality": "low",
+      "targetLevel": "A1",
+      "minIndependentSources": 1,
+      "observedIndependentSources": 2,
+      "requiredLanes": [
+        "adversarial",
+        "spec"
+      ],
+      "observedLanes": [
+        "spec",
+        "adversarial"
+      ],
+      "missingLanes": [],
+      "requiredEvidenceKinds": [
+        "counterexample-closed"
+      ],
+      "observedEvidenceKinds": [
+        "security-claim",
+        "security-finding",
+        "security-review"
+      ],
+      "missingEvidenceKinds": [
+        "counterexample-closed"
+      ],
+      "counterexamples": {
+        "open": 0,
+        "resolved": 1,
+        "acceptedRisk": 0,
+        "total": 1
+      },
+      "independenceWarnings": [],
+      "status": "warning",
+      "evidence": [
+        {
+          "lane": "spec",
+          "kind": "security-claim",
+          "sourceKind": "spec-derived",
+          "origin": "security-claim",
+          "status": "observed",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/2",
+          "detail": "Security claim imported from security-claim/v1 (type=assumption).",
+          "claimRefs": [
+            "SEC-CLAIM-003"
+          ],
+          "generatorLineage": "security-claim/security-claim-extractor"
+        },
+        {
+          "lane": "adversarial",
+          "kind": "security-finding",
+          "sourceKind": "source-derived",
+          "origin": "security-finding",
+          "status": "observed",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-findings.json#/findings/1",
+          "detail": "Security finding SEC-FINDING-002: status=candidate, severity=low, review=out-of-scope.",
+          "claimRefs": [
+            "SEC-CLAIM-003"
+          ],
+          "generatorLineage": "security-finding/security-proof-attempt-audit"
+        },
+        {
+          "lane": "adversarial",
+          "kind": "security-review",
+          "sourceKind": "source-derived",
+          "origin": "security-review",
+          "status": "observed",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-review.json#/reviews/1",
+          "detail": "Security review classified SEC-FINDING-002 as out-of-scope (out-of-scope).",
+          "claimRefs": [
+            "SEC-CLAIM-003"
+          ],
+          "generatorLineage": "security-review/security-three-gate-review"
+        }
+      ]
+    }
+  ],
+  "warnings": [
+    {
+      "code": "unresolved-critical-counterexample",
+      "message": "High/critical security finding SEC-FINDING-001 remains needsHumanReview.",
+      "claimId": "SEC-CLAIM-001",
+      "artifactPath": "artifacts/security-assurance/cache-key/security-findings.json"
+    },
+    {
+      "code": "unresolved-critical-counterexample",
+      "message": "Critical claim still has unresolved counterexamples.",
+      "claimId": "SEC-CLAIM-001",
+      "artifactPath": null
+    }
+  ]
+}

--- a/fixtures/security-assurance/cache-key/expected/assurance-summary.md
+++ b/fixtures/security-assurance/cache-key/expected/assurance-summary.md
@@ -1,0 +1,32 @@
+# Assurance Summary
+
+- generatedAt: 2026-05-07T00:00:00.000Z
+- claimCount: 3
+- satisfiedClaims: 0
+- warningClaims: 3
+- warningCount: 2
+- unlinkedCounterexamples: 0
+
+## Claim status
+
+| claim | status | required lanes | observed lanes | missing lanes | warnings |
+| --- | --- | --- | --- | --- | --- |
+| SEC-CLAIM-001 | warning | adversarial, spec | spec, adversarial |  | unresolved-critical-counterexample |
+| SEC-CLAIM-002 | warning | spec | spec |  |  |
+| SEC-CLAIM-003 | warning | adversarial, spec | spec, adversarial |  |  |
+
+## Lane coverage
+
+| lane | required claims | observed claims |
+| --- | --- | --- |
+| spec | 3 | 3 |
+| behavior | 0 | 0 |
+| adversarial | 2 | 2 |
+| model | 0 | 0 |
+| proof | 0 | 0 |
+| runtime | 0 | 0 |
+
+## Warnings
+
+- unresolved-critical-counterexample: claim=SEC-CLAIM-001 artifact=artifacts/security-assurance/cache-key/security-findings.json High/critical security finding SEC-FINDING-001 remains needsHumanReview.
+- unresolved-critical-counterexample: claim=SEC-CLAIM-001 Critical claim still has unresolved counterexamples.

--- a/fixtures/security-assurance/cache-key/expected/claim-evidence-manifest.json
+++ b/fixtures/security-assurance/cache-key/expected/claim-evidence-manifest.json
@@ -1,0 +1,280 @@
+{
+  "schemaVersion": "claim-evidence-manifest/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "sourceArtifacts": [
+    {
+      "id": "assurance-summary",
+      "kind": "assurance-summary",
+      "path": "artifacts/security-assurance/cache-key/assurance-summary.json",
+      "present": true,
+      "required": true,
+      "schemaVersion": "assurance-summary/v1",
+      "description": "Lane coverage and evidence summary input"
+    },
+    {
+      "id": "change-package-v2",
+      "kind": "change-package-v2",
+      "path": null,
+      "present": false,
+      "required": false,
+      "schemaVersion": null,
+      "description": "Optional proof-carrying change package input"
+    },
+    {
+      "id": "quality-scorecard",
+      "kind": "quality-scorecard",
+      "path": null,
+      "present": false,
+      "required": false,
+      "schemaVersion": null,
+      "description": "Quality gate evidence input"
+    },
+    {
+      "id": "verify-lite-run-summary",
+      "kind": "verify-lite-run-summary",
+      "path": null,
+      "present": false,
+      "required": false,
+      "schemaVersion": null,
+      "description": "Optional verify-lite run summary input"
+    },
+    {
+      "id": "trace-bundle",
+      "kind": "trace-bundle",
+      "path": null,
+      "present": false,
+      "required": false,
+      "schemaVersion": null,
+      "description": "Optional trace bundle input"
+    },
+    {
+      "id": "security-claims",
+      "kind": "security-claim",
+      "path": "artifacts/security-assurance/cache-key/security-claims.json",
+      "present": true,
+      "required": false,
+      "schemaVersion": "security-claim/v1",
+      "description": "Optional security-claim/v1 input"
+    },
+    {
+      "id": "security-findings",
+      "kind": "security-finding",
+      "path": "artifacts/security-assurance/cache-key/security-findings.json",
+      "present": true,
+      "required": false,
+      "schemaVersion": "security-finding/v1",
+      "description": "Optional security-finding/v1 input"
+    },
+    {
+      "id": "security-review",
+      "kind": "security-review",
+      "path": "artifacts/security-assurance/cache-key/security-review.json",
+      "present": true,
+      "required": false,
+      "schemaVersion": "security-review/v1",
+      "description": "Optional security-review/v1 input"
+    }
+  ],
+  "claims": [
+    {
+      "id": "sec-claim-001",
+      "statement": "Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.",
+      "criticality": "high",
+      "targetLevel": "A2",
+      "achievedLevel": "A1",
+      "status": "partial",
+      "evidenceRefs": [
+        {
+          "id": "assurance-summary:sec-claim-001:0:security-claim",
+          "kind": "spec",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/0",
+          "sourceArtifactId": "assurance-summary",
+          "description": "Security claim imported from security-claim/v1 (type=invariant)."
+        },
+        {
+          "id": "assurance-summary:sec-claim-001:1:security-finding",
+          "kind": "adversarial",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-findings.json#/findings/0",
+          "sourceArtifactId": "assurance-summary",
+          "description": "Security finding SEC-FINDING-001: status=candidate, severity=high, review=needs-human-review."
+        },
+        {
+          "id": "assurance-summary:sec-claim-001:2:security-review",
+          "kind": "adversarial",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-review.json#/reviews/0",
+          "sourceArtifactId": "assurance-summary",
+          "description": "Security review classified SEC-FINDING-001 as needs-human-review."
+        },
+        {
+          "id": "security-claims:sec-claim-001",
+          "kind": "spec",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/0",
+          "sourceArtifactId": "security-claims",
+          "description": "Security claim imported as assurance claim (type=invariant)."
+        },
+        {
+          "id": "security-findings:sec-finding-001",
+          "kind": "adversarial",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-findings.json#/findings/0",
+          "sourceArtifactId": "security-findings",
+          "description": "Security finding SEC-FINDING-001: status=candidate, severity=high, review=needs-human-review."
+        },
+        {
+          "id": "security-review:sec-finding-001:0",
+          "kind": "manual",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-review.json#/reviews/0",
+          "sourceArtifactId": "security-review",
+          "description": "Security review classified SEC-FINDING-001 as needs-human-review."
+        }
+      ],
+      "proofObligationRefs": [],
+      "missingEvidenceRefs": [
+        {
+          "id": "assurance-summary:sec-claim-001:missing-kind:counterexample-closed",
+          "expectedKind": "adversarial",
+          "reason": "Required evidence kind 'counterexample-closed' is not linked for this claim.",
+          "sourceArtifactId": "assurance-summary"
+        },
+        {
+          "id": "security-human-review:sec-finding-001",
+          "expectedKind": "manual",
+          "reason": "high severity security finding SEC-FINDING-001 is needs-human-review; human review or remediation evidence is required before treating it as supported.",
+          "sourceArtifactId": "security-findings"
+        }
+      ],
+      "waiverRefs": [],
+      "notes": [
+        "achievedLevel conservatively derived below targetLevel A2 because assurance-summary status=warning.",
+        "assurance-warning:unresolved-critical-counterexample Critical claim still has unresolved counterexamples.",
+        "assurance-warning:unresolved-critical-counterexample High/critical security finding SEC-FINDING-001 remains needsHumanReview.",
+        "security-attention:high SEC-FINDING-001 remains needs-human-review; keep report-only until reviewed/remediated.",
+        "security-claim:type=invariant provenance=manual-block",
+        "security-finding:SEC-FINDING-001 severity=high findingStatus=candidate reviewResult=needs-human-review falsePositiveRootCause=none"
+      ]
+    },
+    {
+      "id": "sec-claim-002",
+      "statement": "Bearer token validation must reject expired tokens before cache lookup.",
+      "criticality": "medium",
+      "targetLevel": "A1",
+      "achievedLevel": "A0",
+      "status": "partial",
+      "evidenceRefs": [
+        {
+          "id": "assurance-summary:sec-claim-002:0:security-claim",
+          "kind": "spec",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/1",
+          "sourceArtifactId": "assurance-summary",
+          "description": "Security claim imported from security-claim/v1 (type=precondition)."
+        },
+        {
+          "id": "security-claims:sec-claim-002",
+          "kind": "spec",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/1",
+          "sourceArtifactId": "security-claims",
+          "description": "Security claim imported as assurance claim (type=precondition)."
+        }
+      ],
+      "proofObligationRefs": [],
+      "missingEvidenceRefs": [
+        {
+          "id": "assurance-summary:sec-claim-002:missing-kind:schema",
+          "expectedKind": "spec",
+          "reason": "Required evidence kind 'schema' is not linked for this claim.",
+          "sourceArtifactId": "assurance-summary"
+        }
+      ],
+      "waiverRefs": [],
+      "notes": [
+        "achievedLevel conservatively derived below targetLevel A1 because assurance-summary status=warning.",
+        "security-claim:type=precondition provenance=manual-block"
+      ]
+    },
+    {
+      "id": "sec-claim-003",
+      "statement": "Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.",
+      "criticality": "low",
+      "targetLevel": "A2",
+      "achievedLevel": "A0",
+      "status": "partial",
+      "evidenceRefs": [
+        {
+          "id": "assurance-summary:sec-claim-003:0:security-claim",
+          "kind": "spec",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/2",
+          "sourceArtifactId": "assurance-summary",
+          "description": "Security claim imported from security-claim/v1 (type=assumption)."
+        },
+        {
+          "id": "assurance-summary:sec-claim-003:1:security-finding",
+          "kind": "adversarial",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-findings.json#/findings/1",
+          "sourceArtifactId": "assurance-summary",
+          "description": "Security finding SEC-FINDING-002: status=candidate, severity=low, review=out-of-scope."
+        },
+        {
+          "id": "assurance-summary:sec-claim-003:2:security-review",
+          "kind": "adversarial",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-review.json#/reviews/1",
+          "sourceArtifactId": "assurance-summary",
+          "description": "Security review classified SEC-FINDING-002 as out-of-scope (out-of-scope)."
+        },
+        {
+          "id": "security-claims:sec-claim-003",
+          "kind": "spec",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-claims.json#/claims/2",
+          "sourceArtifactId": "security-claims",
+          "description": "Security claim imported as assurance claim (type=assumption)."
+        },
+        {
+          "id": "security-findings:sec-finding-002",
+          "kind": "adversarial",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-findings.json#/findings/1",
+          "sourceArtifactId": "security-findings",
+          "description": "Security finding SEC-FINDING-002: status=candidate, severity=low, review=out-of-scope."
+        },
+        {
+          "id": "security-review:sec-finding-002:1",
+          "kind": "manual",
+          "artifactPath": "artifacts/security-assurance/cache-key/security-review.json#/reviews/1",
+          "sourceArtifactId": "security-review",
+          "description": "Security review classified SEC-FINDING-002 as out-of-scope (out-of-scope)."
+        }
+      ],
+      "proofObligationRefs": [],
+      "missingEvidenceRefs": [
+        {
+          "id": "assurance-summary:sec-claim-003:missing-kind:counterexample-closed",
+          "expectedKind": "adversarial",
+          "reason": "Required evidence kind 'counterexample-closed' is not linked for this claim.",
+          "sourceArtifactId": "assurance-summary"
+        }
+      ],
+      "waiverRefs": [],
+      "notes": [
+        "achievedLevel conservatively derived below targetLevel A1 because assurance-summary status=warning.",
+        "security-claim:type=assumption provenance=manual-block",
+        "security-finding:SEC-FINDING-002 severity=low findingStatus=candidate reviewResult=out-of-scope falsePositiveRootCause=out-of-scope"
+      ]
+    }
+  ],
+  "summary": {
+    "totalClaims": 3,
+    "fullySupported": 0,
+    "partiallySupported": 3,
+    "waived": 0,
+    "unresolved": 0,
+    "security": {
+      "claims": 3,
+      "findings": 2,
+      "reviews": 2,
+      "candidate": 0,
+      "needsHumanReview": 1,
+      "confirmed": 0,
+      "rejected": 0,
+      "waived": 0,
+      "outOfScope": 1,
+      "highOrCriticalOpen": 1
+    }
+  }
+}

--- a/fixtures/security-assurance/cache-key/expected/claim-evidence-manifest.md
+++ b/fixtures/security-assurance/cache-key/expected/claim-evidence-manifest.md
@@ -1,0 +1,51 @@
+# Claim Evidence Manifest
+
+- schemaVersion: claim-evidence-manifest/v1
+- generatedAt: 2026-05-07T00:00:00.000Z
+- sourceArtifacts: 4/8 present
+- claims: 3 total; 0 satisfied, 3 partial, 0 waived, 0 unresolved
+- securityFindings: 2 total; highOrCriticalOpen=1, needsHumanReview=1, outOfScope=1, rejected=0
+- missingEvidenceRefs: 4
+- waiverRefs: 0
+
+## Source artifacts
+
+| id | kind | present | required | path | schemaVersion |
+| --- | --- | --- | --- | --- | --- |
+| assurance-summary | assurance-summary | true | true | artifacts/security-assurance/cache-key/assurance-summary.json | assurance-summary/v1 |
+| change-package-v2 | change-package-v2 | false | false | n/a | n/a |
+| quality-scorecard | quality-scorecard | false | false | n/a | n/a |
+| verify-lite-run-summary | verify-lite-run-summary | false | false | n/a | n/a |
+| trace-bundle | trace-bundle | false | false | n/a | n/a |
+| security-claims | security-claim | true | false | artifacts/security-assurance/cache-key/security-claims.json | security-claim/v1 |
+| security-findings | security-finding | true | false | artifacts/security-assurance/cache-key/security-findings.json | security-finding/v1 |
+| security-review | security-review | true | false | artifacts/security-assurance/cache-key/security-review.json | security-review/v1 |
+
+## Claims
+
+| claim | criticality | target | achieved | status | evidence | missing | waivers |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| sec-claim-001 | high | A2 | A1 | partial | 6 | 2 | 0 |
+| sec-claim-002 | medium | A1 | A0 | partial | 2 | 1 | 0 |
+| sec-claim-003 | low | A2 | A0 | partial | 6 | 1 | 0 |
+
+## Missing evidence
+
+- sec-claim-001: assurance-summary:sec-claim-001:missing-kind:counterexample-closed (adversarial) — Required evidence kind 'counterexample-closed' is not linked for this claim.
+- sec-claim-001: security-human-review:sec-finding-001 (manual) — high severity security finding SEC-FINDING-001 is needs-human-review; human review or remediation evidence is required before treating it as supported.
+- sec-claim-002: assurance-summary:sec-claim-002:missing-kind:schema (spec) — Required evidence kind 'schema' is not linked for this claim.
+- sec-claim-003: assurance-summary:sec-claim-003:missing-kind:counterexample-closed (adversarial) — Required evidence kind 'counterexample-closed' is not linked for this claim.
+
+## Security findings
+
+- claims: 3
+- findings: 2
+- reviews: 2
+- needsHumanReview: 1
+- highOrCriticalOpen: 1
+- outOfScope: 1
+- rejected: 0
+
+## Waivers
+
+- none

--- a/fixtures/security-assurance/cache-key/expected/security-audit-scope.json
+++ b/fixtures/security-assurance/cache-key/expected/security-audit-scope.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "security-audit-scope/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "target": {
+    "repository": "itdojp/ae-framework-fixture",
+    "commit": "fixture-cache-key",
+    "defaultBranch": "main",
+    "description": "TypeScript-only cache-key fixture for Security Assurance Lane golden scenario."
+  },
+  "inScope": [
+    "src/**/*.ts"
+  ],
+  "outOfScope": [
+    "tests/**",
+    "**/*.test.ts"
+  ],
+  "trustBoundaries": [
+    {
+      "id": "TB-CACHE",
+      "name": "External authorization cache request",
+      "entryPoints": [
+        "api"
+      ],
+      "attackerControlled": true,
+      "description": "Tenant, subject, scope, and bearer token fields cross from an external request into cache lookup code.",
+      "dataClasses": [
+        "tenant",
+        "subject",
+        "scope",
+        "bearer-token",
+        "authorization-context"
+      ],
+      "scopeRefs": [
+        "src/**/*.ts"
+      ]
+    },
+    {
+      "id": "TB-TEST",
+      "name": "Test fixture helper boundary",
+      "entryPoints": [
+        "test-fixture"
+      ],
+      "attackerControlled": false,
+      "description": "Test-only helper code is intentionally outside production audit scope.",
+      "dataClasses": [
+        "fixture-input"
+      ],
+      "scopeRefs": [
+        "tests/**"
+      ]
+    }
+  ],
+  "notes": [
+    "Scope is intentionally small so golden comparisons remain deterministic."
+  ]
+}

--- a/fixtures/security-assurance/cache-key/expected/security-audit-summary.md
+++ b/fixtures/security-assurance/cache-key/expected/security-audit-summary.md
@@ -1,0 +1,73 @@
+# Security proof-attempt audit summary
+
+- Generated at: 2026-05-07T00:00:00.000Z
+- Audit tasks: 3
+- Ready tasks: 3
+- Blocked tasks: 0
+- Candidate locations: 7
+- Findings generated: 2
+- No-finding responses: 1
+- Warnings: 0
+
+## Audit tasks
+
+### SEC-AUDIT-TASK-001 / SEC-CLAIM-001
+
+- Status: ready
+- Candidate locations: 2
+
+Proof-attempt prompt:
+- Map: Map the security claim to these candidate code paths: - src/cache.ts:13-20 (buildCacheKey): Matched security claim terms in buildCacheKey: attacker, authorization, cache, controlled, key, scope, security, subject. - src/cache.ts:25-31 (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: cache, key, verification.
+- Prove: Prove whether the implementation satisfies claim SEC-CLAIM-001: Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.
+- Stress-Test: Stress-test attacker-controlled inputs, trust-boundary assumptions, cache/key equivalence classes, and edge cases that could break the proof. Do not generate exploit automation.
+- Report: Report a candidate finding only when the proof fails with concrete code evidence. Keep all findings as candidate status until three-gate review.
+
+Candidate locations:
+- `src/cache.ts:13-20 (buildCacheKey)`: Matched security claim terms in buildCacheKey: attacker, authorization, cache, controlled, key, scope, security, subject.
+- `src/cache.ts:25-31 (lookupVerificationCache)`: Matched security claim terms in lookupVerificationCache: cache, key, verification.
+
+### SEC-AUDIT-TASK-002 / SEC-CLAIM-002
+
+- Status: ready
+- Candidate locations: 3
+
+Proof-attempt prompt:
+- Map: Map the security claim to these candidate code paths: - src/cache.ts:25-31 (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: bearer, cache, key, lookup, token. - src/cache.ts:13-20 (buildCacheKey): Matched security claim terms in buildCacheKey: cache, key, security. - src/cache.ts:21-24 (isFreshToken): Matched security claim terms in isFreshToken: bearer, token.
+- Prove: Prove whether the implementation satisfies claim SEC-CLAIM-002: Bearer token validation must reject expired tokens before cache lookup.
+- Stress-Test: Stress-test attacker-controlled inputs, trust-boundary assumptions, cache/key equivalence classes, and edge cases that could break the proof. Do not generate exploit automation.
+- Report: Report a candidate finding only when the proof fails with concrete code evidence. Keep all findings as candidate status until three-gate review.
+
+Candidate locations:
+- `src/cache.ts:25-31 (lookupVerificationCache)`: Matched security claim terms in lookupVerificationCache: bearer, cache, key, lookup, token.
+- `src/cache.ts:13-20 (buildCacheKey)`: Matched security claim terms in buildCacheKey: cache, key, security.
+- `src/cache.ts:21-24 (isFreshToken)`: Matched security claim terms in isFreshToken: bearer, token.
+
+### SEC-AUDIT-TASK-003 / SEC-CLAIM-003
+
+- Status: ready
+- Candidate locations: 2
+
+Proof-attempt prompt:
+- Map: Map the security claim to these candidate code paths: - src/cache.ts:13-20 (buildCacheKey): Matched security claim terms in buildCacheKey: cache, fixture, input, key, scope, security. - src/cache.ts:25-31 (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: cache, input, key.
+- Prove: Prove whether the implementation satisfies claim SEC-CLAIM-003: Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.
+- Stress-Test: Stress-test attacker-controlled inputs, trust-boundary assumptions, cache/key equivalence classes, and edge cases that could break the proof. Do not generate exploit automation.
+- Report: Report a candidate finding only when the proof fails with concrete code evidence. Keep all findings as candidate status until three-gate review.
+
+Candidate locations:
+- `src/cache.ts:13-20 (buildCacheKey)`: Matched security claim terms in buildCacheKey: cache, fixture, input, key, scope, security.
+- `src/cache.ts:25-31 (lookupVerificationCache)`: Matched security claim terms in lookupVerificationCache: cache, input, key.
+
+## Claim audit statuses
+
+- SEC-AUDIT-TASK-001 / SEC-CLAIM-001: finding (SEC-FINDING-001) — The simulated proof attempt cannot establish that all attacker-controlled authorization fields participate in cache-key material.
+- SEC-AUDIT-TASK-002 / SEC-CLAIM-002: no-finding — isFreshToken rejects tokens whose expiresAtEpochMs is not greater than the current time before cache lookup.
+- SEC-AUDIT-TASK-003 / SEC-CLAIM-003: finding (SEC-FINDING-002) — The simulated proof attempt reports a test-only helper that resembles production cache-key construction.
+
+## Findings
+
+- SEC-FINDING-001 / SEC-CLAIM-001: Authorization cache key omits attacker-controlled scope (high, candidate)
+- SEC-FINDING-002 / SEC-CLAIM-003: Test fixture cache helper resembles production key construction (low, candidate)
+
+## Warnings
+
+- None

--- a/fixtures/security-assurance/cache-key/expected/security-audit-tasks.json
+++ b/fixtures/security-assurance/cache-key/expected/security-audit-tasks.json
@@ -1,0 +1,178 @@
+{
+  "schemaVersion": "security-audit-task-bundle/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "tasks": [
+    {
+      "id": "SEC-AUDIT-TASK-001",
+      "claimId": "SEC-CLAIM-001",
+      "claimStatement": "Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.",
+      "status": "ready",
+      "candidateLocations": [
+        {
+          "path": "src/cache.ts",
+          "startLine": 13,
+          "endLine": 20,
+          "reason": "Matched security claim terms in buildCacheKey: attacker, authorization, cache, controlled, key, scope, security, subject.",
+          "symbol": "buildCacheKey",
+          "matchedTerms": [
+            "attacker",
+            "authorization",
+            "cache",
+            "controlled",
+            "key",
+            "scope",
+            "security",
+            "subject",
+            "tenant",
+            "verification"
+          ]
+        },
+        {
+          "path": "src/cache.ts",
+          "startLine": 25,
+          "endLine": 31,
+          "reason": "Matched security claim terms in lookupVerificationCache: cache, key, verification.",
+          "symbol": "lookupVerificationCache",
+          "matchedTerms": [
+            "cache",
+            "key",
+            "verification"
+          ]
+        }
+      ],
+      "scopeRefs": [
+        "TB-CACHE",
+        "api"
+      ],
+      "proofAttemptPrompt": {
+        "map": "Map the security claim to these candidate code paths:\n- src/cache.ts:13-20 (buildCacheKey): Matched security claim terms in buildCacheKey: attacker, authorization, cache, controlled, key, scope, security, subject.\n- src/cache.ts:25-31 (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: cache, key, verification.",
+        "prove": "Prove whether the implementation satisfies claim SEC-CLAIM-001: Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.",
+        "stressTest": "Stress-test attacker-controlled inputs, trust-boundary assumptions, cache/key equivalence classes, and edge cases that could break the proof. Do not generate exploit automation.",
+        "report": "Report a candidate finding only when the proof fails with concrete code evidence. Keep all findings as candidate status until three-gate review."
+      },
+      "warnings": []
+    },
+    {
+      "id": "SEC-AUDIT-TASK-002",
+      "claimId": "SEC-CLAIM-002",
+      "claimStatement": "Bearer token validation must reject expired tokens before cache lookup.",
+      "status": "ready",
+      "candidateLocations": [
+        {
+          "path": "src/cache.ts",
+          "startLine": 25,
+          "endLine": 31,
+          "reason": "Matched security claim terms in lookupVerificationCache: bearer, cache, key, lookup, token.",
+          "symbol": "lookupVerificationCache",
+          "matchedTerms": [
+            "bearer",
+            "cache",
+            "key",
+            "lookup",
+            "token"
+          ]
+        },
+        {
+          "path": "src/cache.ts",
+          "startLine": 13,
+          "endLine": 20,
+          "reason": "Matched security claim terms in buildCacheKey: cache, key, security.",
+          "symbol": "buildCacheKey",
+          "matchedTerms": [
+            "cache",
+            "key",
+            "security"
+          ]
+        },
+        {
+          "path": "src/cache.ts",
+          "startLine": 21,
+          "endLine": 24,
+          "reason": "Matched security claim terms in isFreshToken: bearer, token.",
+          "symbol": "isFreshToken",
+          "matchedTerms": [
+            "bearer",
+            "token"
+          ]
+        }
+      ],
+      "scopeRefs": [
+        "TB-CACHE",
+        "api"
+      ],
+      "proofAttemptPrompt": {
+        "map": "Map the security claim to these candidate code paths:\n- src/cache.ts:25-31 (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: bearer, cache, key, lookup, token.\n- src/cache.ts:13-20 (buildCacheKey): Matched security claim terms in buildCacheKey: cache, key, security.\n- src/cache.ts:21-24 (isFreshToken): Matched security claim terms in isFreshToken: bearer, token.",
+        "prove": "Prove whether the implementation satisfies claim SEC-CLAIM-002: Bearer token validation must reject expired tokens before cache lookup.",
+        "stressTest": "Stress-test attacker-controlled inputs, trust-boundary assumptions, cache/key equivalence classes, and edge cases that could break the proof. Do not generate exploit automation.",
+        "report": "Report a candidate finding only when the proof fails with concrete code evidence. Keep all findings as candidate status until three-gate review."
+      },
+      "warnings": []
+    },
+    {
+      "id": "SEC-AUDIT-TASK-003",
+      "claimId": "SEC-CLAIM-003",
+      "claimStatement": "Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.",
+      "status": "ready",
+      "candidateLocations": [
+        {
+          "path": "src/cache.ts",
+          "startLine": 13,
+          "endLine": 20,
+          "reason": "Matched security claim terms in buildCacheKey: cache, fixture, input, key, scope, security.",
+          "symbol": "buildCacheKey",
+          "matchedTerms": [
+            "cache",
+            "fixture",
+            "input",
+            "key",
+            "scope",
+            "security"
+          ]
+        },
+        {
+          "path": "src/cache.ts",
+          "startLine": 25,
+          "endLine": 31,
+          "reason": "Matched security claim terms in lookupVerificationCache: cache, input, key.",
+          "symbol": "lookupVerificationCache",
+          "matchedTerms": [
+            "cache",
+            "input",
+            "key"
+          ]
+        }
+      ],
+      "scopeRefs": [
+        "TB-TEST",
+        "test-fixture"
+      ],
+      "proofAttemptPrompt": {
+        "map": "Map the security claim to these candidate code paths:\n- src/cache.ts:13-20 (buildCacheKey): Matched security claim terms in buildCacheKey: cache, fixture, input, key, scope, security.\n- src/cache.ts:25-31 (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: cache, input, key.",
+        "prove": "Prove whether the implementation satisfies claim SEC-CLAIM-003: Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.",
+        "stressTest": "Stress-test attacker-controlled inputs, trust-boundary assumptions, cache/key equivalence classes, and edge cases that could break the proof. Do not generate exploit automation.",
+        "report": "Report a candidate finding only when the proof fails with concrete code evidence. Keep all findings as candidate status until three-gate review."
+      },
+      "warnings": []
+    }
+  ],
+  "summary": {
+    "totalTasks": 3,
+    "readyTasks": 3,
+    "blockedTasks": 0,
+    "totalCandidateLocations": 7,
+    "totalWarnings": 0,
+    "byStatus": {
+      "ready": 3,
+      "blockedNoCandidateLocation": 0,
+      "blockedMissingCodeMap": 0
+    }
+  },
+  "provenance": {
+    "origin": "deterministic",
+    "generator": "security-proof-attempt-audit",
+    "claims": "artifacts/security-assurance/cache-key/security-claims.json",
+    "codeMap": "artifacts/security-assurance/cache-key/security-code-map.json",
+    "scope": "artifacts/security-assurance/cache-key/security-audit-scope.json"
+  },
+  "warnings": []
+}

--- a/fixtures/security-assurance/cache-key/expected/security-claims.json
+++ b/fixtures/security-assurance/cache-key/expected/security-claims.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": "security-claim/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "claims": [
+    {
+      "id": "SEC-CLAIM-001",
+      "type": "invariant",
+      "sourceRefs": [
+        {
+          "kind": "spec",
+          "uri": "fixtures/security-assurance/cache-key/inputs/spec.md",
+          "section": "Verification cache key"
+        }
+      ],
+      "criticality": "high",
+      "targetLevel": "A2",
+      "threatTags": {
+        "stride": [
+          "Tampering"
+        ],
+        "cwe": [
+          "CWE-20"
+        ]
+      },
+      "trustBoundary": {
+        "boundaryIds": [
+          "TB-CACHE"
+        ],
+        "entryPoints": [
+          "api"
+        ],
+        "attackerControlled": true,
+        "dataClasses": [
+          "tenant",
+          "subject",
+          "scope",
+          "authorization-context"
+        ]
+      },
+      "requiredLanes": [
+        "spec",
+        "adversarial"
+      ],
+      "provenance": {
+        "origin": "manual-block",
+        "generator": "security-claim-extractor",
+        "source": "fixtures/security-assurance/cache-key/inputs/spec.md"
+      },
+      "statement": "Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.",
+      "notes": [
+        "Fixture intentionally leaves scope out of buildCacheKey so the audit stage emits one candidate finding."
+      ]
+    },
+    {
+      "id": "SEC-CLAIM-002",
+      "type": "precondition",
+      "sourceRefs": [
+        {
+          "kind": "spec",
+          "uri": "fixtures/security-assurance/cache-key/inputs/spec.md",
+          "section": "Bearer token freshness"
+        }
+      ],
+      "criticality": "medium",
+      "targetLevel": "A1",
+      "threatTags": {
+        "stride": [
+          "Spoofing"
+        ],
+        "cwe": [
+          "CWE-613"
+        ]
+      },
+      "trustBoundary": {
+        "boundaryIds": [
+          "TB-CACHE"
+        ],
+        "entryPoints": [
+          "api"
+        ],
+        "attackerControlled": true,
+        "dataClasses": [
+          "bearer-token"
+        ]
+      },
+      "requiredLanes": [
+        "spec"
+      ],
+      "provenance": {
+        "origin": "manual-block",
+        "generator": "security-claim-extractor",
+        "source": "fixtures/security-assurance/cache-key/inputs/spec.md"
+      },
+      "statement": "Bearer token validation must reject expired tokens before cache lookup.",
+      "notes": [
+        "Fixture response marks this claim as no-finding."
+      ]
+    },
+    {
+      "id": "SEC-CLAIM-003",
+      "type": "assumption",
+      "sourceRefs": [
+        {
+          "kind": "spec",
+          "uri": "fixtures/security-assurance/cache-key/inputs/spec.md",
+          "section": "Test fixture isolation"
+        }
+      ],
+      "criticality": "low",
+      "targetLevel": "A1",
+      "threatTags": {
+        "stride": [
+          "Repudiation"
+        ],
+        "cwe": [
+          "CWE-693"
+        ]
+      },
+      "trustBoundary": {
+        "boundaryIds": [
+          "TB-TEST"
+        ],
+        "entryPoints": [
+          "test-fixture"
+        ],
+        "attackerControlled": false,
+        "dataClasses": [
+          "fixture-input"
+        ]
+      },
+      "requiredLanes": [
+        "spec",
+        "adversarial"
+      ],
+      "provenance": {
+        "origin": "manual-block",
+        "generator": "security-claim-extractor",
+        "source": "fixtures/security-assurance/cache-key/inputs/spec.md"
+      },
+      "statement": "Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.",
+      "notes": [
+        "Fixture response reports a test-only helper that the three-gate review must classify out-of-scope."
+      ]
+    }
+  ],
+  "summary": {
+    "totalClaims": 3,
+    "byCriticality": {
+      "low": 1,
+      "medium": 1,
+      "high": 1,
+      "critical": 0
+    }
+  }
+}

--- a/fixtures/security-assurance/cache-key/expected/security-claims.md
+++ b/fixtures/security-assurance/cache-key/expected/security-claims.md
@@ -1,0 +1,16 @@
+# Security claim extraction summary
+
+- Generated at: 2026-05-07T00:00:00.000Z
+- Source: fixtures/security-assurance/cache-key/inputs/spec.md
+- Claims: 3
+- Warnings: 0
+
+## Claims
+
+- `SEC-CLAIM-001` (high): Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.
+- `SEC-CLAIM-002` (medium): Bearer token validation must reject expired tokens before cache lookup.
+- `SEC-CLAIM-003` (low): Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.
+
+## Warnings
+
+- None

--- a/fixtures/security-assurance/cache-key/expected/security-code-map.json
+++ b/fixtures/security-assurance/cache-key/expected/security-code-map.json
@@ -1,0 +1,141 @@
+{
+  "schemaVersion": "security-code-map/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "mappings": [
+    {
+      "claimId": "SEC-CLAIM-001",
+      "candidateLocations": [
+        {
+          "path": "src/cache.ts",
+          "startLine": 13,
+          "endLine": 20,
+          "symbol": "buildCacheKey",
+          "reason": "Matched security claim terms in buildCacheKey: attacker, authorization, cache, controlled, key, scope, security, subject.",
+          "matchedTerms": [
+            "attacker",
+            "authorization",
+            "cache",
+            "controlled",
+            "key",
+            "scope",
+            "security",
+            "subject",
+            "tenant",
+            "verification"
+          ]
+        },
+        {
+          "path": "src/cache.ts",
+          "startLine": 25,
+          "endLine": 31,
+          "symbol": "lookupVerificationCache",
+          "reason": "Matched security claim terms in lookupVerificationCache: cache, key, verification.",
+          "matchedTerms": [
+            "cache",
+            "key",
+            "verification"
+          ]
+        }
+      ],
+      "coverage": "partial",
+      "warnings": []
+    },
+    {
+      "claimId": "SEC-CLAIM-002",
+      "candidateLocations": [
+        {
+          "path": "src/cache.ts",
+          "startLine": 25,
+          "endLine": 31,
+          "symbol": "lookupVerificationCache",
+          "reason": "Matched security claim terms in lookupVerificationCache: bearer, cache, key, lookup, token.",
+          "matchedTerms": [
+            "bearer",
+            "cache",
+            "key",
+            "lookup",
+            "token"
+          ]
+        },
+        {
+          "path": "src/cache.ts",
+          "startLine": 13,
+          "endLine": 20,
+          "symbol": "buildCacheKey",
+          "reason": "Matched security claim terms in buildCacheKey: cache, key, security.",
+          "matchedTerms": [
+            "cache",
+            "key",
+            "security"
+          ]
+        },
+        {
+          "path": "src/cache.ts",
+          "startLine": 21,
+          "endLine": 24,
+          "symbol": "isFreshToken",
+          "reason": "Matched security claim terms in isFreshToken: bearer, token.",
+          "matchedTerms": [
+            "bearer",
+            "token"
+          ]
+        }
+      ],
+      "coverage": "partial",
+      "warnings": []
+    },
+    {
+      "claimId": "SEC-CLAIM-003",
+      "candidateLocations": [
+        {
+          "path": "src/cache.ts",
+          "startLine": 13,
+          "endLine": 20,
+          "symbol": "buildCacheKey",
+          "reason": "Matched security claim terms in buildCacheKey: cache, fixture, input, key, scope, security.",
+          "matchedTerms": [
+            "cache",
+            "fixture",
+            "input",
+            "key",
+            "scope",
+            "security"
+          ]
+        },
+        {
+          "path": "src/cache.ts",
+          "startLine": 25,
+          "endLine": 31,
+          "symbol": "lookupVerificationCache",
+          "reason": "Matched security claim terms in lookupVerificationCache: cache, input, key.",
+          "matchedTerms": [
+            "cache",
+            "input",
+            "key"
+          ]
+        }
+      ],
+      "coverage": "partial",
+      "warnings": []
+    }
+  ],
+  "summary": {
+    "totalClaims": 3,
+    "mappedClaims": 3,
+    "totalCandidateLocations": 7,
+    "totalWarnings": 0,
+    "byCoverage": {
+      "none": 0,
+      "partial": 3,
+      "full": 0
+    }
+  },
+  "provenance": {
+    "origin": "deterministic",
+    "generator": "security-code-map-producer",
+    "claims": "artifacts/security-assurance/cache-key/security-claims.json",
+    "scope": "artifacts/security-assurance/cache-key/security-audit-scope.json",
+    "target": "fixtures/security-assurance/cache-key/inputs/target"
+  },
+  "warnings": []
+}

--- a/fixtures/security-assurance/cache-key/expected/security-code-map.md
+++ b/fixtures/security-assurance/cache-key/expected/security-code-map.md
@@ -1,0 +1,38 @@
+# Security code-map summary
+
+- Generated at: 2026-05-07T00:00:00.000Z
+- Claims: 3
+- Mapped claims: 3
+- Candidate locations: 7
+- Warnings: 0
+
+## Mappings
+
+### SEC-CLAIM-001
+
+- Coverage: partial
+- Candidate locations: 2
+
+- `src/cache.ts:13-20` (buildCacheKey): Matched security claim terms in buildCacheKey: attacker, authorization, cache, controlled, key, scope, security, subject.
+- `src/cache.ts:25-31` (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: cache, key, verification.
+
+### SEC-CLAIM-002
+
+- Coverage: partial
+- Candidate locations: 3
+
+- `src/cache.ts:25-31` (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: bearer, cache, key, lookup, token.
+- `src/cache.ts:13-20` (buildCacheKey): Matched security claim terms in buildCacheKey: cache, key, security.
+- `src/cache.ts:21-24` (isFreshToken): Matched security claim terms in isFreshToken: bearer, token.
+
+### SEC-CLAIM-003
+
+- Coverage: partial
+- Candidate locations: 2
+
+- `src/cache.ts:13-20` (buildCacheKey): Matched security claim terms in buildCacheKey: cache, fixture, input, key, scope, security.
+- `src/cache.ts:25-31` (lookupVerificationCache): Matched security claim terms in lookupVerificationCache: cache, input, key.
+
+## Document warnings
+
+- None

--- a/fixtures/security-assurance/cache-key/expected/security-findings.json
+++ b/fixtures/security-assurance/cache-key/expected/security-findings.json
@@ -1,0 +1,128 @@
+{
+  "schemaVersion": "security-finding/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "findings": [
+    {
+      "id": "SEC-FINDING-001",
+      "claimId": "SEC-CLAIM-001",
+      "status": "candidate",
+      "severity": "high",
+      "confidence": "medium",
+      "title": "Authorization cache key omits attacker-controlled scope",
+      "summary": "The cache key includes tenant and subject but omits scope, so two authorization contexts can share a key.",
+      "affectedLocations": [
+        {
+          "path": "src/cache.ts",
+          "startLine": 12,
+          "endLine": 17,
+          "symbol": "buildCacheKey",
+          "description": "buildCacheKey constructs key material from tenant and subject while the scope field is attacker-controlled and authorization-relevant."
+        }
+      ],
+      "proofAttempt": {
+        "claim": "SEC-CLAIM-001",
+        "map": "Relevant production path is src/cache.ts:12-17 (buildCacheKey).",
+        "prove": "The implementation must show tenant, subject, and scope are all included in the cache key before authorization cache reuse.",
+        "stressTest": "Counterexample candidate: two requests differ only by scope and produce the same cache key.",
+        "report": "Keep as candidate until human security review validates exploitability and intended cache semantics."
+      },
+      "scopeRefs": [
+        "TB-CACHE"
+      ],
+      "evidenceRefs": [
+        {
+          "id": "SEC-EVIDENCE-SEC-AUDIT-TASK-001",
+          "kind": "audit-task",
+          "path": "artifacts/security-assurance/cache-key/security-audit-tasks.json",
+          "description": "Proof-attempt audit task for SEC-CLAIM-001."
+        },
+        {
+          "id": "SEC-CODE-MAP-SEC-CLAIM-001",
+          "kind": "security-code-map",
+          "path": "artifacts/security-assurance/cache-key/security-code-map.json",
+          "description": "Candidate source locations for SEC-CLAIM-001."
+        }
+      ],
+      "provenance": {
+        "origin": "fixture",
+        "generator": "security-proof-attempt-audit",
+        "source": "security-audit-response-fixture/v1",
+        "version": "2026-05-07T00:00:00.000Z"
+      },
+      "notes": [
+        "Candidate finding is not a confirmed vulnerability.",
+        "Primary positive candidate for the golden scenario."
+      ]
+    },
+    {
+      "id": "SEC-FINDING-002",
+      "claimId": "SEC-CLAIM-003",
+      "status": "candidate",
+      "severity": "low",
+      "confidence": "low",
+      "title": "Test fixture cache helper resembles production key construction",
+      "summary": "The candidate path is under tests/fixtures and should be rejected by scope review rather than treated as production code.",
+      "affectedLocations": [
+        {
+          "path": "tests/fixtures/cache-helper.ts",
+          "startLine": 1,
+          "endLine": 3,
+          "symbol": "buildFixtureCacheKey",
+          "description": "Fixture-only helper path is intentionally excluded from production audit scope."
+        }
+      ],
+      "proofAttempt": {
+        "claim": "SEC-CLAIM-003",
+        "map": "Candidate code path appears only in tests/fixtures/cache-helper.ts.",
+        "prove": "A production entry point would need to reach the helper for this to be actionable.",
+        "stressTest": "No production entry point reaches this helper in the fixture scope.",
+        "report": "Expected to be classified out-of-scope by the three-gate review."
+      },
+      "scopeRefs": [
+        "TB-TEST",
+        "tests/**"
+      ],
+      "evidenceRefs": [
+        {
+          "id": "SEC-EVIDENCE-SEC-AUDIT-TASK-003",
+          "kind": "audit-task",
+          "path": "artifacts/security-assurance/cache-key/security-audit-tasks.json",
+          "description": "Proof-attempt audit task for SEC-CLAIM-003."
+        },
+        {
+          "id": "SEC-CODE-MAP-SEC-CLAIM-003",
+          "kind": "security-code-map",
+          "path": "artifacts/security-assurance/cache-key/security-code-map.json",
+          "description": "Candidate source locations for SEC-CLAIM-003."
+        }
+      ],
+      "provenance": {
+        "origin": "fixture",
+        "generator": "security-proof-attempt-audit",
+        "source": "security-audit-response-fixture/v1",
+        "version": "2026-05-07T00:00:00.000Z"
+      },
+      "notes": [
+        "Candidate finding is not a confirmed vulnerability.",
+        "Negative control for the golden scenario."
+      ]
+    }
+  ],
+  "summary": {
+    "totalFindings": 2,
+    "byStatus": {
+      "candidate": 2,
+      "needsHumanReview": 0,
+      "confirmed": 0,
+      "rejected": 0,
+      "waived": 0,
+      "outOfScope": 0
+    },
+    "bySeverity": {
+      "low": 1,
+      "medium": 0,
+      "high": 1,
+      "critical": 0
+    }
+  }
+}

--- a/fixtures/security-assurance/cache-key/expected/security-review.json
+++ b/fixtures/security-assurance/cache-key/expected/security-review.json
@@ -1,0 +1,91 @@
+{
+  "schemaVersion": "security-review/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "reviews": [
+    {
+      "findingId": "SEC-FINDING-001",
+      "severity": "high",
+      "result": "needs-human-review",
+      "gates": {
+        "deadCode": {
+          "result": "pass",
+          "rationale": "At least one affected location overlaps the security-code-map candidate locations for the same claim.",
+          "evidenceRefs": [
+            "src/cache.ts:12-17"
+          ]
+        },
+        "trustBoundary": {
+          "result": "pass",
+          "rationale": "Matched attacker-controlled trust boundary: TB-CACHE.",
+          "evidenceRefs": [
+            "TB-CACHE"
+          ]
+        },
+        "scope": {
+          "result": "pass",
+          "rationale": "All affected paths are covered by audit scope inScope globs (src/**/*.ts).",
+          "evidenceRefs": [
+            "src/**/*.ts"
+          ]
+        }
+      },
+      "falsePositiveRootCause": null,
+      "reviewerNotes": [
+        "Severity preserved from finding: high.",
+        "Rule-based MVP review only; exploitability confirmation and full reachability analysis are out of scope.",
+        "Candidate finding remains unresolved and requires human security review before confirmation."
+      ],
+      "reviewedAt": "2026-05-07T00:00:00.000Z",
+      "reviewer": "security-three-gate-review"
+    },
+    {
+      "findingId": "SEC-FINDING-002",
+      "severity": "low",
+      "result": "out-of-scope",
+      "gates": {
+        "deadCode": {
+          "result": "unknown",
+          "rationale": "Dead-code reachability was not evaluated because the scope gate failed first."
+        },
+        "trustBoundary": {
+          "result": "unknown",
+          "rationale": "Trust-boundary involvement was not evaluated because the scope gate failed first."
+        },
+        "scope": {
+          "result": "fail",
+          "rationale": "At least one affected path is excluded by audit scope outOfScope globs: tests/**.",
+          "evidenceRefs": [
+            "tests/**"
+          ]
+        }
+      },
+      "falsePositiveRootCause": "out-of-scope",
+      "reviewerNotes": [
+        "Severity preserved from finding: low.",
+        "Rule-based MVP review only; exploitability confirmation and full reachability analysis are out of scope.",
+        "Trust boundary involvement is unknown from available scope/code-map evidence.",
+        "Classified as out-of-scope based on audit scope glob rules."
+      ],
+      "reviewedAt": "2026-05-07T00:00:00.000Z",
+      "reviewer": "security-three-gate-review"
+    }
+  ],
+  "summary": {
+    "totalReviews": 2,
+    "byResult": {
+      "needsHumanReview": 1,
+      "confirmed": 0,
+      "rejected": 0,
+      "waived": 0,
+      "outOfScope": 1
+    },
+    "falsePositiveRootCauses": {
+      "deadCode": 0,
+      "trustBoundaryMisunderstanding": 0,
+      "outOfScope": 1,
+      "codeReadingError": 0,
+      "specMisinterpretation": 0,
+      "insufficientEvidence": 0
+    }
+  }
+}

--- a/fixtures/security-assurance/cache-key/expected/security-review.md
+++ b/fixtures/security-assurance/cache-key/expected/security-review.md
@@ -1,0 +1,49 @@
+# Security three-gate review summary
+
+- Generated at: 2026-05-07T00:00:00.000Z
+- Total reviews: 2
+- Needs human review: 1
+- Confirmed: 0
+- Rejected: 0
+- Waived: 0
+- Out of scope: 1
+- Dead-code root causes: 0
+- Trust-boundary root causes: 0
+- Out-of-scope root causes: 1
+- Warnings: 0
+
+## Reviews
+
+| Finding | Severity | Result | Dead Code | Trust Boundary | Scope | Root cause |
+| --- | --- | --- | --- | --- | --- | --- |
+| SEC-FINDING-001 | high | needs-human-review | pass | pass | pass | n/a |
+| SEC-FINDING-002 | low | out-of-scope | unknown | unknown | fail | out-of-scope |
+
+## Review detail
+
+### SEC-FINDING-001
+
+- Severity: high
+- Result: needs-human-review
+- False-positive root cause: n/a
+- Dead Code: pass — At least one affected location overlaps the security-code-map candidate locations for the same claim.
+- Trust Boundary: pass — Matched attacker-controlled trust boundary: TB-CACHE.
+- Scope: pass — All affected paths are covered by audit scope inScope globs (src/**/*.ts).
+- Reviewer notes:
+  - Severity preserved from finding: high.
+  - Rule-based MVP review only; exploitability confirmation and full reachability analysis are out of scope.
+  - Candidate finding remains unresolved and requires human security review before confirmation.
+
+### SEC-FINDING-002
+
+- Severity: low
+- Result: out-of-scope
+- False-positive root cause: out-of-scope
+- Dead Code: unknown — Dead-code reachability was not evaluated because the scope gate failed first.
+- Trust Boundary: unknown — Trust-boundary involvement was not evaluated because the scope gate failed first.
+- Scope: fail — At least one affected path is excluded by audit scope outOfScope globs: tests/**.
+- Reviewer notes:
+  - Severity preserved from finding: low.
+  - Rule-based MVP review only; exploitability confirmation and full reachability analysis are out of scope.
+  - Trust boundary involvement is unknown from available scope/code-map evidence.
+  - Classified as out-of-scope based on audit scope glob rules.

--- a/fixtures/security-assurance/cache-key/expected/security-summary.md
+++ b/fixtures/security-assurance/cache-key/expected/security-summary.md
@@ -1,0 +1,18 @@
+# Security Assurance fixture summary
+
+- Scenario: cache-key
+- Generated at: 2026-05-07T00:00:00.000Z
+- Claims: 3
+- Threats: 3
+- Code-map candidate locations: 7
+- Audit responses: finding=2, no-finding=1
+- Findings: 2
+- Review results: needs-human-review=1, rejected=0, out-of-scope=1
+- Assurance claims: 3
+- Manifest security: findings=2, highOrCriticalOpen=1, outOfScope=1, rejected=0
+
+## Expected lane behavior
+
+- `SEC-CLAIM-001` produces `SEC-FINDING-001` and remains `needs-human-review`.
+- `SEC-CLAIM-002` has a `no-finding` proof-attempt response.
+- `SEC-CLAIM-003` produces `SEC-FINDING-002`, which the Scope gate classifies as `out-of-scope`.

--- a/fixtures/security-assurance/cache-key/expected/security-threat-model.json
+++ b/fixtures/security-assurance/cache-key/expected/security-threat-model.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "security-threat-model/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "frameworks": [
+    "STRIDE",
+    "CWE_TOP_25"
+  ],
+  "threats": [
+    {
+      "id": "SEC-THREAT-001",
+      "stride": "Tampering",
+      "cwe": "CWE-20",
+      "description": "A caller changes authorization scope while reusing tenant and subject fields, causing two distinct authorization contexts to share a cache key.",
+      "relatedClaimIds": [
+        "SEC-CLAIM-001"
+      ],
+      "trustBoundaryIds": [
+        "TB-CACHE"
+      ],
+      "notes": [
+        "This is the intentional candidate finding in the fixture."
+      ]
+    },
+    {
+      "id": "SEC-THREAT-002",
+      "stride": "Spoofing",
+      "cwe": "CWE-613",
+      "description": "An expired bearer token is accepted before cache lookup.",
+      "relatedClaimIds": [
+        "SEC-CLAIM-002"
+      ],
+      "trustBoundaryIds": [
+        "TB-CACHE"
+      ],
+      "notes": [
+        "The response fixture records no finding for this threat."
+      ]
+    },
+    {
+      "id": "SEC-THREAT-003",
+      "stride": "Repudiation",
+      "cwe": "CWE-693",
+      "description": "A test-only helper is misread as production cache-key code.",
+      "relatedClaimIds": [
+        "SEC-CLAIM-003"
+      ],
+      "trustBoundaryIds": [
+        "TB-TEST"
+      ],
+      "notes": [
+        "The three-gate review must classify this as out-of-scope."
+      ]
+    }
+  ],
+  "summary": {
+    "totalThreats": 3
+  }
+}

--- a/fixtures/security-assurance/cache-key/inputs/assurance-profile.json
+++ b/fixtures/security-assurance/cache-key/inputs/assurance-profile.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "assurance-profile/v1",
+  "profileId": "security-cache-key-fixture-v1",
+  "scope": {
+    "contextPackSources": [
+      "fixtures/security-assurance/cache-key/inputs/spec.md"
+    ],
+    "componentGlobs": [
+      "fixtures/security-assurance/cache-key/inputs/target/src/**/*.ts"
+    ]
+  },
+  "claims": [
+    {
+      "id": "SEC-CLAIM-001",
+      "statement": "Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.",
+      "kind": "security",
+      "criticality": "high",
+      "targetLevel": "A2",
+      "minIndependentSources": 1,
+      "requiredLanes": [
+        "spec",
+        "adversarial"
+      ],
+      "requiredEvidenceKinds": [
+        "counterexample-closed"
+      ]
+    },
+    {
+      "id": "SEC-CLAIM-002",
+      "statement": "Bearer token validation must reject expired tokens before cache lookup.",
+      "kind": "security",
+      "criticality": "medium",
+      "targetLevel": "A1",
+      "minIndependentSources": 1,
+      "requiredLanes": [
+        "spec"
+      ],
+      "requiredEvidenceKinds": [
+        "schema"
+      ]
+    },
+    {
+      "id": "SEC-CLAIM-003",
+      "statement": "Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.",
+      "kind": "security",
+      "criticality": "low",
+      "targetLevel": "A1",
+      "minIndependentSources": 1,
+      "requiredLanes": [
+        "spec",
+        "adversarial"
+      ],
+      "requiredEvidenceKinds": [
+        "counterexample-closed"
+      ]
+    }
+  ]
+}

--- a/fixtures/security-assurance/cache-key/inputs/security-audit-responses.json
+++ b/fixtures/security-assurance/cache-key/inputs/security-audit-responses.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": "security-audit-response-fixture/v1",
+  "responses": [
+    {
+      "taskId": "SEC-AUDIT-TASK-001",
+      "claimId": "SEC-CLAIM-001",
+      "result": "finding",
+      "rationale": "The simulated proof attempt cannot establish that all attacker-controlled authorization fields participate in cache-key material.",
+      "finding": {
+        "id": "SEC-FINDING-001",
+        "status": "candidate",
+        "severity": "high",
+        "confidence": "medium",
+        "title": "Authorization cache key omits attacker-controlled scope",
+        "summary": "The cache key includes tenant and subject but omits scope, so two authorization contexts can share a key.",
+        "affectedLocations": [
+          {
+            "path": "src/cache.ts",
+            "startLine": 12,
+            "endLine": 17,
+            "symbol": "buildCacheKey",
+            "reason": "buildCacheKey constructs key material from tenant and subject while the scope field is attacker-controlled and authorization-relevant."
+          }
+        ],
+        "proofAttempt": {
+          "map": "Relevant production path is src/cache.ts:12-17 (buildCacheKey).",
+          "prove": "The implementation must show tenant, subject, and scope are all included in the cache key before authorization cache reuse.",
+          "stressTest": "Counterexample candidate: two requests differ only by scope and produce the same cache key.",
+          "report": "Keep as candidate until human security review validates exploitability and intended cache semantics."
+        },
+        "scopeRefs": [
+          "TB-CACHE"
+        ],
+        "notes": [
+          "Primary positive candidate for the golden scenario."
+        ]
+      }
+    },
+    {
+      "taskId": "SEC-AUDIT-TASK-002",
+      "claimId": "SEC-CLAIM-002",
+      "result": "no-finding",
+      "rationale": "isFreshToken rejects tokens whose expiresAtEpochMs is not greater than the current time before cache lookup."
+    },
+    {
+      "taskId": "SEC-AUDIT-TASK-003",
+      "claimId": "SEC-CLAIM-003",
+      "result": "finding",
+      "rationale": "The simulated proof attempt reports a test-only helper that resembles production cache-key construction.",
+      "finding": {
+        "id": "SEC-FINDING-002",
+        "status": "candidate",
+        "severity": "low",
+        "confidence": "low",
+        "title": "Test fixture cache helper resembles production key construction",
+        "summary": "The candidate path is under tests/fixtures and should be rejected by scope review rather than treated as production code.",
+        "affectedLocations": [
+          {
+            "path": "tests/fixtures/cache-helper.ts",
+            "startLine": 1,
+            "endLine": 3,
+            "symbol": "buildFixtureCacheKey",
+            "reason": "Fixture-only helper path is intentionally excluded from production audit scope."
+          }
+        ],
+        "proofAttempt": {
+          "map": "Candidate code path appears only in tests/fixtures/cache-helper.ts.",
+          "prove": "A production entry point would need to reach the helper for this to be actionable.",
+          "stressTest": "No production entry point reaches this helper in the fixture scope.",
+          "report": "Expected to be classified out-of-scope by the three-gate review."
+        },
+        "scopeRefs": [
+          "TB-TEST",
+          "tests/**"
+        ],
+        "notes": [
+          "Negative control for the golden scenario."
+        ]
+      }
+    }
+  ]
+}

--- a/fixtures/security-assurance/cache-key/inputs/security-audit-scope.json
+++ b/fixtures/security-assurance/cache-key/inputs/security-audit-scope.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "security-audit-scope/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "target": {
+    "repository": "itdojp/ae-framework-fixture",
+    "commit": "fixture-cache-key",
+    "defaultBranch": "main",
+    "description": "TypeScript-only cache-key fixture for Security Assurance Lane golden scenario."
+  },
+  "inScope": [
+    "src/**/*.ts"
+  ],
+  "outOfScope": [
+    "tests/**",
+    "**/*.test.ts"
+  ],
+  "trustBoundaries": [
+    {
+      "id": "TB-CACHE",
+      "name": "External authorization cache request",
+      "entryPoints": [
+        "api"
+      ],
+      "attackerControlled": true,
+      "description": "Tenant, subject, scope, and bearer token fields cross from an external request into cache lookup code.",
+      "dataClasses": [
+        "tenant",
+        "subject",
+        "scope",
+        "bearer-token",
+        "authorization-context"
+      ],
+      "scopeRefs": [
+        "src/**/*.ts"
+      ]
+    },
+    {
+      "id": "TB-TEST",
+      "name": "Test fixture helper boundary",
+      "entryPoints": [
+        "test-fixture"
+      ],
+      "attackerControlled": false,
+      "description": "Test-only helper code is intentionally outside production audit scope.",
+      "dataClasses": [
+        "fixture-input"
+      ],
+      "scopeRefs": [
+        "tests/**"
+      ]
+    }
+  ],
+  "notes": [
+    "Scope is intentionally small so golden comparisons remain deterministic."
+  ]
+}

--- a/fixtures/security-assurance/cache-key/inputs/security-threat-model.json
+++ b/fixtures/security-assurance/cache-key/inputs/security-threat-model.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": "security-threat-model/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "frameworks": [
+    "STRIDE",
+    "CWE_TOP_25"
+  ],
+  "threats": [
+    {
+      "id": "SEC-THREAT-001",
+      "stride": "Tampering",
+      "cwe": "CWE-20",
+      "description": "A caller changes authorization scope while reusing tenant and subject fields, causing two distinct authorization contexts to share a cache key.",
+      "relatedClaimIds": [
+        "SEC-CLAIM-001"
+      ],
+      "trustBoundaryIds": [
+        "TB-CACHE"
+      ],
+      "notes": [
+        "This is the intentional candidate finding in the fixture."
+      ]
+    },
+    {
+      "id": "SEC-THREAT-002",
+      "stride": "Spoofing",
+      "cwe": "CWE-613",
+      "description": "An expired bearer token is accepted before cache lookup.",
+      "relatedClaimIds": [
+        "SEC-CLAIM-002"
+      ],
+      "trustBoundaryIds": [
+        "TB-CACHE"
+      ],
+      "notes": [
+        "The response fixture records no finding for this threat."
+      ]
+    },
+    {
+      "id": "SEC-THREAT-003",
+      "stride": "Repudiation",
+      "cwe": "CWE-693",
+      "description": "A test-only helper is misread as production cache-key code.",
+      "relatedClaimIds": [
+        "SEC-CLAIM-003"
+      ],
+      "trustBoundaryIds": [
+        "TB-TEST"
+      ],
+      "notes": [
+        "The three-gate review must classify this as out-of-scope."
+      ]
+    }
+  ],
+  "summary": {
+    "totalThreats": 3
+  }
+}

--- a/fixtures/security-assurance/cache-key/inputs/spec.md
+++ b/fixtures/security-assurance/cache-key/inputs/spec.md
@@ -1,0 +1,60 @@
+# Cache key Security Assurance fixture
+
+この fixture は Security Assurance Lane の end-to-end golden scenario 用の小さな TypeScript 対象です。`SEC-CLAIM:` ブロックは extractor MVP が外部 LLM を使わず決定的に処理できる形式に固定しています。
+
+## Verification cache key
+
+SEC-CLAIM:
+id: SEC-CLAIM-001
+type: invariant
+criticality: high
+targetLevel: A2
+statement: Cache key must include tenant, subject, and attacker-controlled scope fields that affect authorization.
+stride: Tampering
+cwe: CWE-20
+sourceUri: fixtures/security-assurance/cache-key/inputs/spec.md
+sourceSection: Verification cache key
+boundaryIds: TB-CACHE
+entryPoints: api
+attackerControlled: true
+dataClasses: tenant, subject, scope, authorization-context
+requiredLanes: spec, adversarial
+notes: Fixture intentionally leaves scope out of buildCacheKey so the audit stage emits one candidate finding.
+
+## Bearer token freshness
+
+SEC-CLAIM:
+id: SEC-CLAIM-002
+type: precondition
+criticality: medium
+targetLevel: A1
+statement: Bearer token validation must reject expired tokens before cache lookup.
+stride: Spoofing
+cwe: CWE-613
+sourceUri: fixtures/security-assurance/cache-key/inputs/spec.md
+sourceSection: Bearer token freshness
+boundaryIds: TB-CACHE
+entryPoints: api
+attackerControlled: true
+dataClasses: bearer-token
+requiredLanes: spec
+notes: Fixture response marks this claim as no-finding.
+
+## Test fixture isolation
+
+SEC-CLAIM:
+id: SEC-CLAIM-003
+type: assumption
+criticality: low
+targetLevel: A1
+statement: Test-only fixture cache helpers must remain outside the production audit scope and trust boundary.
+stride: Repudiation
+cwe: CWE-693
+sourceUri: fixtures/security-assurance/cache-key/inputs/spec.md
+sourceSection: Test fixture isolation
+boundaryIds: TB-TEST
+entryPoints: test-fixture
+attackerControlled: false
+dataClasses: fixture-input
+requiredLanes: spec, adversarial
+notes: Fixture response reports a test-only helper that the three-gate review must classify out-of-scope.

--- a/fixtures/security-assurance/cache-key/inputs/target/src/cache.ts
+++ b/fixtures/security-assurance/cache-key/inputs/target/src/cache.ts
@@ -1,0 +1,30 @@
+export interface VerificationRequest {
+  tenantId: string;
+  subjectId: string;
+  scope: string;
+  tokenId: string;
+}
+
+export interface BearerToken {
+  tokenId: string;
+  expiresAtEpochMs: number;
+}
+
+export function buildCacheKey(input: VerificationRequest): string {
+  const attackerControlledTenant = input.tenantId.trim().toLowerCase();
+  const attackerControlledSubject = input.subjectId.trim().toLowerCase();
+
+  // SECURITY-FIXTURE: intentionally omits attacker-controlled authorization scope.
+  return `verification:${attackerControlledTenant}:${attackerControlledSubject}`;
+}
+
+export function isFreshToken(token: BearerToken, nowEpochMs: number): boolean {
+  return token.expiresAtEpochMs > nowEpochMs;
+}
+
+export function lookupVerificationCache(input: VerificationRequest, token: BearerToken, nowEpochMs: number): string | null {
+  if (!isFreshToken(token, nowEpochMs)) {
+    return null;
+  }
+  return buildCacheKey(input);
+}

--- a/fixtures/security-assurance/cache-key/inputs/target/tests/fixtures/cache-helper.ts
+++ b/fixtures/security-assurance/cache-key/inputs/target/tests/fixtures/cache-helper.ts
@@ -1,0 +1,3 @@
+export function buildFixtureCacheKey(tenantId: string, subjectId: string): string {
+  return `fixture:${tenantId}:${subjectId}`;
+}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "verify:lite": "node scripts/admin/run-script-alias.mjs verify:lite",
     "verify:assurance": "node scripts/assurance/aggregate-lanes.mjs",
     "assurance:e2e": "node scripts/assurance/run-e2e-scenario.mjs",
+    "test:security-assurance": "node scripts/security/run-security-assurance-fixture.mjs",
     "claim-evidence:generate": "node scripts/assurance/build-claim-evidence-manifest.mjs",
     "change-package:generate": "node scripts/change-package/generate.mjs",
     "change-package:generate:v2": "node scripts/change-package/generate.mjs --schema-version v2",

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -99,6 +99,7 @@ const checks = [
     schema: 'schema/assurance-profile.schema.json',
     fixtures: [
       'fixtures/assurance/sample.assurance-profile.json',
+      'fixtures/security-assurance/cache-key/inputs/assurance-profile.json',
       'spec/assurance-profile/upstream-context-promotion-v1.json',
     ],
     label: 'Assurance profile schema validation'
@@ -108,6 +109,7 @@ const checks = [
     fixtures: [
       'fixtures/assurance/sample.assurance-summary.json',
       'fixtures/assurance-e2e/inventory-waiver/expected/assurance-summary.json',
+      'fixtures/security-assurance/cache-key/expected/assurance-summary.json',
     ],
     label: 'Assurance summary schema validation'
   },
@@ -123,46 +125,68 @@ const checks = [
     fixtures: [
       'fixtures/assurance/sample.claim-evidence-manifest.json',
       'fixtures/assurance-e2e/inventory-waiver/expected/claim-evidence-manifest.json',
+      'fixtures/security-assurance/cache-key/expected/claim-evidence-manifest.json',
     ],
     label: 'Claim evidence manifest schema validation',
     semanticValidate: validateClaimEvidenceManifestSemantics
   },
   {
     schema: 'schema/security-claim-v1.schema.json',
-    fixtures: ['fixtures/security-assurance/sample.security-claims.json'],
+    fixtures: [
+      'fixtures/security-assurance/sample.security-claims.json',
+      'fixtures/security-assurance/cache-key/expected/security-claims.json',
+    ],
     label: 'Security claim v1 schema validation'
   },
   {
     schema: 'schema/security-threat-model-v1.schema.json',
-    fixtures: ['fixtures/security-assurance/sample.security-threat-model.json'],
+    fixtures: [
+      'fixtures/security-assurance/sample.security-threat-model.json',
+      'fixtures/security-assurance/cache-key/expected/security-threat-model.json',
+    ],
     label: 'Security threat model v1 schema validation'
   },
   {
     schema: 'schema/security-audit-scope-v1.schema.json',
-    fixtures: ['fixtures/security-assurance/sample.security-audit-scope.json'],
+    fixtures: [
+      'fixtures/security-assurance/sample.security-audit-scope.json',
+      'fixtures/security-assurance/cache-key/expected/security-audit-scope.json',
+    ],
     label: 'Security audit scope v1 schema validation'
   },
   {
     schema: 'schema/security-code-map-v1.schema.json',
-    fixtures: ['fixtures/security-assurance/sample.security-code-map.json'],
+    fixtures: [
+      'fixtures/security-assurance/sample.security-code-map.json',
+      'fixtures/security-assurance/cache-key/expected/security-code-map.json',
+    ],
     label: 'Security code map v1 schema validation',
     semanticValidate: validateSecurityCodeMapSemantics
   },
   {
     schema: 'schema/security-audit-task-bundle-v1.schema.json',
-    fixtures: ['fixtures/security-assurance/sample.security-audit-tasks.json'],
+    fixtures: [
+      'fixtures/security-assurance/sample.security-audit-tasks.json',
+      'fixtures/security-assurance/cache-key/expected/security-audit-tasks.json',
+    ],
     label: 'Security audit task bundle v1 schema validation',
     semanticValidate: validateSecurityAuditTaskBundleSemantics
   },
   {
     schema: 'schema/security-finding-v1.schema.json',
-    fixtures: ['fixtures/security-assurance/sample.security-findings.json'],
+    fixtures: [
+      'fixtures/security-assurance/sample.security-findings.json',
+      'fixtures/security-assurance/cache-key/expected/security-findings.json',
+    ],
     label: 'Security finding v1 schema validation',
     semanticValidate: validateSecurityFindingSemantics
   },
   {
     schema: 'schema/security-review-v1.schema.json',
-    fixtures: ['fixtures/security-assurance/sample.security-review.json'],
+    fixtures: [
+      'fixtures/security-assurance/sample.security-review.json',
+      'fixtures/security-assurance/cache-key/expected/security-review.json',
+    ],
     label: 'Security review v1 schema validation',
     semanticValidate: validateSecurityReviewSemantics
   },

--- a/scripts/security/run-security-assurance-fixture.mjs
+++ b/scripts/security/run-security-assurance-fixture.mjs
@@ -1,0 +1,620 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import { run as runAggregateLanes } from '../assurance/aggregate-lanes.mjs';
+import {
+  buildClaimEvidenceManifest,
+  renderClaimEvidenceManifestMarkdown,
+  validateManifest,
+} from '../assurance/build-claim-evidence-manifest.mjs';
+import { validateClaimEvidenceManifestSemantics } from '../ci/lib/claim-evidence-manifest-contract.mjs';
+import {
+  validateSecurityAuditTaskBundleSemantics,
+  validateSecurityCodeMapSemantics,
+  validateSecurityFindingSemantics,
+  validateSecurityReviewSemantics,
+} from '../ci/lib/security-assurance-contract.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DEFAULT_SCENARIO = 'cache-key';
+const DEFAULT_FIXTURE_ROOT = 'fixtures/security-assurance';
+const DEFAULT_GENERATED_AT = '2026-05-07T00:00:00.000Z';
+const SECURITY_CLI_TIMEOUT_MS = 120_000;
+
+const ARTIFACT_FILES = [
+  'security-audit-scope.json',
+  'security-threat-model.json',
+  'security-claims.json',
+  'security-claims.md',
+  'security-code-map.json',
+  'security-code-map.md',
+  'security-audit-tasks.json',
+  'security-audit-summary.md',
+  'security-findings.json',
+  'security-review.json',
+  'security-review.md',
+  'assurance-summary.json',
+  'assurance-summary.md',
+  'claim-evidence-manifest.json',
+  'claim-evidence-manifest.md',
+  'security-summary.md',
+];
+
+const JSON_ARTIFACT_SCHEMAS = {
+  'security-audit-scope.json': { schema: 'schema/security-audit-scope-v1.schema.json' },
+  'security-threat-model.json': { schema: 'schema/security-threat-model-v1.schema.json' },
+  'security-claims.json': { schema: 'schema/security-claim-v1.schema.json' },
+  'security-code-map.json': {
+    schema: 'schema/security-code-map-v1.schema.json',
+    semanticValidate: validateSecurityCodeMapSemantics,
+  },
+  'security-audit-tasks.json': {
+    schema: 'schema/security-audit-task-bundle-v1.schema.json',
+    semanticValidate: validateSecurityAuditTaskBundleSemantics,
+  },
+  'security-findings.json': {
+    schema: 'schema/security-finding-v1.schema.json',
+    semanticValidate: validateSecurityFindingSemantics,
+  },
+  'security-review.json': {
+    schema: 'schema/security-review-v1.schema.json',
+    semanticValidate: validateSecurityReviewSemantics,
+  },
+  'assurance-summary.json': { schema: 'schema/assurance-summary.schema.json' },
+  'claim-evidence-manifest.json': {
+    schema: 'schema/claim-evidence-manifest.schema.json',
+    semanticValidate: validateClaimEvidenceManifestSemantics,
+  },
+};
+
+function usage() {
+  process.stdout.write(`Usage: node scripts/security/run-security-assurance-fixture.mjs [options]\n\nOptions:\n  --scenario <name>          scenario under fixtures/security-assurance (default: ${DEFAULT_SCENARIO})\n  --scenario-dir <path>      explicit scenario directory\n  --output-dir <path>        actual artifact output directory\n  --generated-at <iso>       deterministic generatedAt value (default: ${DEFAULT_GENERATED_AT})\n  --update-expected          replace expected artifacts with current normalized actual artifacts\n  --no-compare               generate and validate only; skip expected-vs-actual comparison\n  --help                     show this help\n`);
+}
+
+function readRequiredValue(argv, index, option) {
+  const next = argv[index + 1];
+  if (!next || next.startsWith('--')) {
+    throw new Error(`${option} requires a value`);
+  }
+  return next;
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    scenario: DEFAULT_SCENARIO,
+    scenarioDir: null,
+    outputDir: null,
+    generatedAt: DEFAULT_GENERATED_AT,
+    updateExpected: false,
+    compare: true,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--') {
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (arg === '--scenario') {
+      options.scenario = readRequiredValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--scenario-dir') {
+      options.scenarioDir = readRequiredValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--output-dir') {
+      options.outputDir = readRequiredValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--generated-at') {
+      options.generatedAt = readRequiredValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+    if (arg === '--update-expected') {
+      options.updateExpected = true;
+      continue;
+    }
+    if (arg === '--no-compare') {
+      options.compare = false;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function ensureDateTime(value) {
+  const raw = String(value ?? '').trim();
+  if (!Number.isFinite(Date.parse(raw))) {
+    throw new Error(`generatedAt must be an ISO date-time: ${raw || '(empty)'}`);
+  }
+  return new Date(raw).toISOString();
+}
+
+function timestampSlug(value) {
+  return ensureDateTime(value)
+    .replace(/\.\d{3}Z$/u, 'Z')
+    .replace(/[:.]/gu, '-');
+}
+
+function toPosixPath(filePath) {
+  return String(filePath).split(path.sep).join('/');
+}
+
+function toRepoRelativePath(filePath) {
+  const relativePath = path.relative(REPO_ROOT, filePath);
+  return relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)
+    ? toPosixPath(relativePath)
+    : toPosixPath(filePath);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeText(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+function writeJson(filePath, payload) {
+  writeText(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function copyJsonWithGeneratedAt(inputPath, outputPath, generatedAt) {
+  const payload = readJson(inputPath);
+  if (Object.prototype.hasOwnProperty.call(payload, 'generatedAt')) {
+    payload.generatedAt = generatedAt;
+  }
+  writeJson(outputPath, payload);
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort((left, right) => left.localeCompare(right))
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeTextForComparison(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  return raw.replace(/\r\n/gu, '\n');
+}
+
+function compareArtifact(expectedPath, actualPath) {
+  if (!fs.existsSync(expectedPath)) {
+    return `expected artifact missing: ${expectedPath}`;
+  }
+  const expected = expectedPath.endsWith('.json')
+    ? stableStringify(readJson(expectedPath))
+    : normalizeTextForComparison(expectedPath);
+  const actual = actualPath.endsWith('.json')
+    ? stableStringify(readJson(actualPath))
+    : normalizeTextForComparison(actualPath);
+  return expected === actual ? null : `artifact differs: ${path.basename(actualPath)}`;
+}
+
+function scenarioPaths(options) {
+  const scenarioDir = path.resolve(REPO_ROOT, options.scenarioDir || path.join(DEFAULT_FIXTURE_ROOT, options.scenario));
+  const scenarioName = path.basename(scenarioDir);
+  const outputDir = path.resolve(
+    REPO_ROOT,
+    options.outputDir || path.join('artifacts/security-assurance', scenarioName, timestampSlug(options.generatedAt)),
+  );
+  return {
+    scenarioName,
+    scenarioDir,
+    inputsDir: path.join(scenarioDir, 'inputs'),
+    expectedDir: path.join(scenarioDir, 'expected'),
+    outputDir,
+  };
+}
+
+function canonicalRoots(scenarioName) {
+  return {
+    scenario: `fixtures/security-assurance/${scenarioName}`,
+    inputs: `fixtures/security-assurance/${scenarioName}/inputs`,
+    output: `artifacts/security-assurance/${scenarioName}`,
+  };
+}
+
+function normalizeReplacementEntries(paths) {
+  const canonical = canonicalRoots(paths.scenarioName);
+  const entries = [
+    [paths.outputDir, canonical.output],
+    [paths.inputsDir, canonical.inputs],
+    [paths.scenarioDir, canonical.scenario],
+  ];
+  const normalized = [];
+  for (const [fromPath, toPath] of entries) {
+    normalized.push([toPosixPath(path.resolve(fromPath)), toPath]);
+    normalized.push([toRepoRelativePath(path.resolve(fromPath)), toPath]);
+  }
+  return normalized
+    .filter(([fromPath]) => fromPath && fromPath !== '.')
+    .sort((left, right) => right[0].length - left[0].length);
+}
+
+function replaceAllLiteral(value, search, replacement) {
+  return value.split(search).join(replacement);
+}
+
+function normalizeString(value, replacements) {
+  let normalized = value.replace(/\\/gu, '/');
+  for (const [fromPath, toPath] of replacements) {
+    normalized = replaceAllLiteral(normalized, fromPath, toPath);
+  }
+  return normalized;
+}
+
+function deepNormalize(value, replacements) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => deepNormalize(entry, replacements));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, deepNormalize(entry, replacements)]),
+    );
+  }
+  return typeof value === 'string' ? normalizeString(value, replacements) : value;
+}
+
+function deterministicMetadata(generatedAt) {
+  return {
+    generatedAtUtc: generatedAt,
+    generatedAtLocal: generatedAt,
+    timezoneOffset: '+00:00',
+    gitCommit: null,
+    branch: null,
+    runner: {
+      name: 'security-assurance-fixture',
+      os: 'normalized',
+      arch: 'normalized',
+      ci: false,
+    },
+    toolVersions: {},
+  };
+}
+
+function normalizeAssuranceSummary(summary, generatedAt) {
+  return {
+    ...summary,
+    generatedAt,
+    metadata: deterministicMetadata(generatedAt),
+  };
+}
+
+function buildAjv() {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const metadataSchemaPath = path.join(REPO_ROOT, 'schema/artifact-metadata.schema.json');
+  if (fs.existsSync(metadataSchemaPath)) {
+    ajv.addSchema(readJson(metadataSchemaPath));
+  }
+  return ajv;
+}
+
+function validateWithSchema(label, payload, schemaPath, semanticValidate = null) {
+  const ajv = buildAjv();
+  const validate = ajv.compile(readJson(path.join(REPO_ROOT, schemaPath)));
+  if (!validate(payload)) {
+    throw new Error(`${label} schema validation failed: ${JSON.stringify(validate.errors ?? [], null, 2)}`);
+  }
+  if (typeof semanticValidate === 'function') {
+    const semanticErrors = semanticValidate(payload);
+    if (semanticErrors.length > 0) {
+      throw new Error(`${label} semantic validation failed: ${JSON.stringify(semanticErrors, null, 2)}`);
+    }
+  }
+}
+
+function validateJsonArtifact(fileName, payload) {
+  const check = JSON_ARTIFACT_SCHEMAS[fileName];
+  if (!check) return;
+  validateWithSchema(fileName, payload, check.schema, check.semanticValidate ?? null);
+}
+
+function rewriteNormalizedJsonArtifacts(paths, generatedAt) {
+  const replacements = normalizeReplacementEntries(paths);
+  for (const fileName of ARTIFACT_FILES.filter((entry) => entry.endsWith('.json'))) {
+    const filePath = path.join(paths.outputDir, fileName);
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`expected generated artifact was not written: ${filePath}`);
+    }
+    let payload = deepNormalize(readJson(filePath), replacements);
+    if (fileName === 'assurance-summary.json') {
+      payload = normalizeAssuranceSummary(payload, generatedAt);
+    }
+    validateJsonArtifact(fileName, payload);
+    writeJson(filePath, payload);
+  }
+}
+
+function rewriteNormalizedTextArtifacts(paths, generatedAt) {
+  const replacements = normalizeReplacementEntries(paths);
+  for (const fileName of ARTIFACT_FILES.filter((entry) => entry.endsWith('.md'))) {
+    const filePath = path.join(paths.outputDir, fileName);
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`expected generated artifact was not written: ${filePath}`);
+    }
+    let content = normalizeString(fs.readFileSync(filePath, 'utf8'), replacements).replace(/\r\n/gu, '\n');
+    if (fileName === 'assurance-summary.md') {
+      content = content.replace(/^- generatedAt: .+$/mu, `- generatedAt: ${generatedAt}`);
+    }
+    writeText(filePath, content.endsWith('\n') ? content : `${content}\n`);
+  }
+}
+
+function resolveTsxBinary() {
+  const binary = path.join(REPO_ROOT, 'node_modules', '.bin', process.platform === 'win32' ? 'tsx.cmd' : 'tsx');
+  return fs.existsSync(binary) ? binary : 'tsx';
+}
+
+function runSecurityCli(label, args) {
+  const result = spawnSync(resolveTsxBinary(), ['src/cli/index.ts', 'security', ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+    },
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: SECURITY_CLI_TIMEOUT_MS,
+  });
+  if (result.error) {
+    const timeoutSuffix = result.error.code === 'ETIMEDOUT' ? ` after ${SECURITY_CLI_TIMEOUT_MS}ms` : '';
+    throw new Error(`${label} failed${timeoutSuffix}: ${result.error.message}`);
+  }
+  if (result.status === null && result.signal) {
+    throw new Error(`${label} terminated by signal ${result.signal}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`${label} failed with exit code ${result.status ?? 'unknown'}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+  return result;
+}
+
+function runAggregate(paths) {
+  runAggregateLanes([
+    '--assurance-profile', path.join(paths.inputsDir, 'assurance-profile.json'),
+    '--security-claims', path.join(paths.outputDir, 'security-claims.json'),
+    '--security-findings', path.join(paths.outputDir, 'security-findings.json'),
+    '--security-review', path.join(paths.outputDir, 'security-review.json'),
+    '--output-json', path.join(paths.outputDir, 'assurance-summary.json'),
+    '--output-md', path.join(paths.outputDir, 'assurance-summary.md'),
+  ]);
+}
+
+function writeClaimEvidenceManifest(paths, generatedAt) {
+  const missingChangePackage = path.join(paths.outputDir, '__missing-change-package-v2.json');
+  const missingTraceBundle = path.join(paths.outputDir, '__missing-trace-bundle.json');
+  const manifest = buildClaimEvidenceManifest({
+    assuranceSummary: path.join(paths.outputDir, 'assurance-summary.json'),
+    changePackages: [missingChangePackage],
+    qualityScorecard: null,
+    verifyLiteSummary: null,
+    traceBundles: [missingTraceBundle],
+    securityClaims: path.join(paths.outputDir, 'security-claims.json'),
+    securityFindings: path.join(paths.outputDir, 'security-findings.json'),
+    securityReview: path.join(paths.outputDir, 'security-review.json'),
+    generatedAt,
+  });
+  const normalized = deepNormalize(manifest, normalizeReplacementEntries(paths));
+  validateManifest(normalized, path.join(REPO_ROOT, 'schema/claim-evidence-manifest.schema.json'));
+  writeJson(path.join(paths.outputDir, 'claim-evidence-manifest.json'), normalized);
+  writeText(path.join(paths.outputDir, 'claim-evidence-manifest.md'), renderClaimEvidenceManifestMarkdown(normalized));
+}
+
+function countResponsesByResult(responsesPath) {
+  const payload = readJson(responsesPath);
+  const responses = Array.isArray(payload.responses) ? payload.responses : [];
+  return responses.reduce((counts, response) => {
+    const result = String(response?.result ?? 'unknown');
+    counts[result] = (counts[result] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+function writeSecuritySummary(paths, generatedAt) {
+  const claims = readJson(path.join(paths.outputDir, 'security-claims.json'));
+  const threatModel = readJson(path.join(paths.outputDir, 'security-threat-model.json'));
+  const codeMap = readJson(path.join(paths.outputDir, 'security-code-map.json'));
+  const findings = readJson(path.join(paths.outputDir, 'security-findings.json'));
+  const review = readJson(path.join(paths.outputDir, 'security-review.json'));
+  const assuranceSummary = readJson(path.join(paths.outputDir, 'assurance-summary.json'));
+  const manifest = readJson(path.join(paths.outputDir, 'claim-evidence-manifest.json'));
+  const responseCounts = countResponsesByResult(path.join(paths.inputsDir, 'security-audit-responses.json'));
+
+  const lines = [
+    '# Security Assurance fixture summary',
+    '',
+    `- Scenario: ${paths.scenarioName}`,
+    `- Generated at: ${generatedAt}`,
+    `- Claims: ${claims.summary?.totalClaims ?? claims.claims?.length ?? 0}`,
+    `- Threats: ${threatModel.summary?.totalThreats ?? threatModel.threats?.length ?? 0}`,
+    `- Code-map candidate locations: ${codeMap.summary?.totalCandidateLocations ?? 0}`,
+    `- Audit responses: finding=${responseCounts.finding ?? 0}, no-finding=${responseCounts['no-finding'] ?? 0}`,
+    `- Findings: ${findings.summary?.totalFindings ?? 0}`,
+    `- Review results: needs-human-review=${review.summary?.byResult?.needsHumanReview ?? 0}, rejected=${review.summary?.byResult?.rejected ?? 0}, out-of-scope=${review.summary?.byResult?.outOfScope ?? 0}`,
+    `- Assurance claims: ${assuranceSummary.summary?.claimCount ?? 0}`,
+    `- Manifest security: findings=${manifest.summary?.security?.findings ?? 0}, highOrCriticalOpen=${manifest.summary?.security?.highOrCriticalOpen ?? 0}, outOfScope=${manifest.summary?.security?.outOfScope ?? 0}, rejected=${manifest.summary?.security?.rejected ?? 0}`,
+    '',
+    '## Expected lane behavior',
+    '',
+    '- `SEC-CLAIM-001` produces `SEC-FINDING-001` and remains `needs-human-review`.',
+    '- `SEC-CLAIM-002` has a `no-finding` proof-attempt response.',
+    '- `SEC-CLAIM-003` produces `SEC-FINDING-002`, which the Scope gate classifies as `out-of-scope`.',
+    '',
+  ];
+  writeText(path.join(paths.outputDir, 'security-summary.md'), lines.join('\n'));
+}
+
+function requiredInputs(paths) {
+  return {
+    spec: path.join(paths.inputsDir, 'spec.md'),
+    target: path.join(paths.inputsDir, 'target'),
+    scope: path.join(paths.inputsDir, 'security-audit-scope.json'),
+    threatModel: path.join(paths.inputsDir, 'security-threat-model.json'),
+    responses: path.join(paths.inputsDir, 'security-audit-responses.json'),
+    assuranceProfile: path.join(paths.inputsDir, 'assurance-profile.json'),
+  };
+}
+
+function ensureScenarioInputs(paths) {
+  for (const [label, filePath] of Object.entries(requiredInputs(paths))) {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`${label} input not found: ${filePath}`);
+    }
+  }
+}
+
+function generateSecurityArtifacts(paths, generatedAt) {
+  const inputs = requiredInputs(paths);
+  fs.mkdirSync(paths.outputDir, { recursive: true });
+  copyJsonWithGeneratedAt(inputs.scope, path.join(paths.outputDir, 'security-audit-scope.json'), generatedAt);
+  copyJsonWithGeneratedAt(inputs.threatModel, path.join(paths.outputDir, 'security-threat-model.json'), generatedAt);
+
+  runSecurityCli('security claims extraction', [
+    'extract-claims',
+    '--spec', inputs.spec,
+    '--out', paths.outputDir,
+    '--generated-at', generatedAt,
+  ]);
+  runSecurityCli('security code-map generation', [
+    'map-code',
+    '--claims', path.join(paths.outputDir, 'security-claims.json'),
+    '--scope', path.join(paths.outputDir, 'security-audit-scope.json'),
+    '--target', inputs.target,
+    '--out', paths.outputDir,
+    '--generated-at', generatedAt,
+  ]);
+  runSecurityCli('security proof-attempt audit', [
+    'audit',
+    '--claims', path.join(paths.outputDir, 'security-claims.json'),
+    '--code-map', path.join(paths.outputDir, 'security-code-map.json'),
+    '--scope', path.join(paths.outputDir, 'security-audit-scope.json'),
+    '--out', paths.outputDir,
+    '--response-fixture', inputs.responses,
+    '--generated-at', generatedAt,
+  ]);
+  runSecurityCli('security three-gate review', [
+    'review',
+    '--findings', path.join(paths.outputDir, 'security-findings.json'),
+    '--scope', path.join(paths.outputDir, 'security-audit-scope.json'),
+    '--code-map', path.join(paths.outputDir, 'security-code-map.json'),
+    '--out', paths.outputDir,
+    '--generated-at', generatedAt,
+  ]);
+}
+
+function updateExpected(paths) {
+  fs.mkdirSync(paths.expectedDir, { recursive: true });
+  for (const fileName of ARTIFACT_FILES) {
+    fs.copyFileSync(path.join(paths.outputDir, fileName), path.join(paths.expectedDir, fileName));
+  }
+}
+
+function compareExpected(paths) {
+  const comparisonErrors = [];
+  for (const fileName of ARTIFACT_FILES) {
+    const error = compareArtifact(path.join(paths.expectedDir, fileName), path.join(paths.outputDir, fileName));
+    if (error) comparisonErrors.push(error);
+  }
+  if (comparisonErrors.length > 0) {
+    throw new Error(`security assurance fixture drift detected:\n- ${comparisonErrors.join('\n- ')}\nRun with --update-expected after reviewing intentional changes.`);
+  }
+}
+
+export function runScenario(options) {
+  const generatedAt = ensureDateTime(options.generatedAt);
+  const paths = scenarioPaths(options);
+  ensureScenarioInputs(paths);
+
+  const previousCwd = process.cwd();
+  process.chdir(REPO_ROOT);
+  try {
+    generateSecurityArtifacts(paths, generatedAt);
+    runAggregate(paths);
+    writeClaimEvidenceManifest(paths, generatedAt);
+    rewriteNormalizedJsonArtifacts(paths, generatedAt);
+    writeSecuritySummary(paths, generatedAt);
+    rewriteNormalizedTextArtifacts(paths, generatedAt);
+
+    if (options.updateExpected) {
+      updateExpected(paths);
+    }
+    if (options.compare) {
+      compareExpected(paths);
+    }
+
+    const findings = readJson(path.join(paths.outputDir, 'security-findings.json'));
+    const review = readJson(path.join(paths.outputDir, 'security-review.json'));
+    const manifest = readJson(path.join(paths.outputDir, 'claim-evidence-manifest.json'));
+    return {
+      scenario: paths.scenarioName,
+      outputDir: paths.outputDir,
+      expectedDir: paths.expectedDir,
+      summary: {
+        claims: readJson(path.join(paths.outputDir, 'security-claims.json')).summary.totalClaims,
+        findings: findings.summary.totalFindings,
+        needsHumanReview: review.summary.byResult.needsHumanReview,
+        rejected: review.summary.byResult.rejected,
+        outOfScope: review.summary.byResult.outOfScope,
+        highOrCriticalOpen: manifest.summary.security?.highOrCriticalOpen ?? 0,
+        compared: options.compare,
+      },
+    };
+  } finally {
+    process.chdir(previousCwd);
+  }
+}
+
+export function run(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    usage();
+    return 0;
+  }
+  const result = runScenario(options);
+  process.stdout.write('### Security Assurance Fixture\n');
+  process.stdout.write(`- scenario: ${result.scenario}\n`);
+  process.stdout.write(`- output: ${result.outputDir}\n`);
+  process.stdout.write(`- claims: ${result.summary.claims}\n`);
+  process.stdout.write(`- findings: ${result.summary.findings}\n`);
+  process.stdout.write(`- needs-human-review: ${result.summary.needsHumanReview}\n`);
+  process.stdout.write(`- rejected: ${result.summary.rejected}\n`);
+  process.stdout.write(`- out-of-scope: ${result.summary.outOfScope}\n`);
+  process.stdout.write(`- high/critical open: ${result.summary.highOrCriticalOpen}\n`);
+  process.stdout.write(`- comparison: ${result.summary.compared ? 'ok' : 'skipped'}\n`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exitCode = run();
+  } catch (error) {
+    process.stderr.write(`[security-assurance-fixture] ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tests/scripts/security-assurance-fixture.test.ts
+++ b/tests/scripts/security-assurance-fixture.test.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve('.');
+const scriptPath = resolve(repoRoot, 'scripts/security/run-security-assurance-fixture.mjs');
+
+const runScript = (args: string[]) =>
+  spawnSync('node', [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    timeout: 180_000,
+  });
+
+describe('security assurance fixture runner', () => {
+  it('reproduces the cache-key golden artifacts', () => {
+    mkdirSync(resolve(repoRoot, 'artifacts'), { recursive: true });
+    const outputDir = mkdtempSync(join(resolve(repoRoot, 'artifacts'), 'security-assurance-fixture-test-'));
+
+    try {
+      const result = runScript([
+        '--scenario',
+        'cache-key',
+        '--output-dir',
+        outputDir,
+      ]);
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stdout).toContain('comparison: ok');
+      for (const fileName of [
+        'security-claims.json',
+        'security-code-map.json',
+        'security-audit-tasks.json',
+        'security-findings.json',
+        'security-review.json',
+        'assurance-summary.json',
+        'claim-evidence-manifest.json',
+        'security-summary.md',
+      ]) {
+        expect(existsSync(join(outputDir, fileName)), `${fileName} should be generated`).toBe(true);
+      }
+
+      const claims = JSON.parse(readFileSync(join(outputDir, 'security-claims.json'), 'utf8'));
+      expect(claims.summary).toMatchObject({ totalClaims: 3 });
+
+      const findings = JSON.parse(readFileSync(join(outputDir, 'security-findings.json'), 'utf8'));
+      expect(findings.summary).toMatchObject({
+        totalFindings: 2,
+        byStatus: { candidate: 2 },
+        bySeverity: { high: 1, low: 1 },
+      });
+
+      const review = JSON.parse(readFileSync(join(outputDir, 'security-review.json'), 'utf8'));
+      expect(review.summary.byResult).toMatchObject({
+        needsHumanReview: 1,
+        outOfScope: 1,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(outputDir, 'claim-evidence-manifest.json'), 'utf8'));
+      expect(manifest.summary.security).toMatchObject({
+        claims: 3,
+        findings: 2,
+        reviews: 2,
+        needsHumanReview: 1,
+        outOfScope: 1,
+        highOrCriticalOpen: 1,
+      });
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+
+  it('reports when expected comparison is intentionally skipped', () => {
+    mkdirSync(resolve(repoRoot, 'artifacts'), { recursive: true });
+    const outputDir = mkdtempSync(join(resolve(repoRoot, 'artifacts'), 'security-assurance-fixture-no-compare-test-'));
+
+    try {
+      const result = runScript([
+        '--scenario',
+        'cache-key',
+        '--output-dir',
+        outputDir,
+        '--no-compare',
+      ]);
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stdout).toContain('comparison: skipped');
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports drift when deterministic timestamp changes', () => {
+    mkdirSync(resolve(repoRoot, 'artifacts'), { recursive: true });
+    const outputDir = mkdtempSync(join(resolve(repoRoot, 'artifacts'), 'security-assurance-fixture-drift-test-'));
+
+    try {
+      const result = runScript([
+        '--scenario',
+        'cache-key',
+        '--generated-at',
+        '2026-05-08T00:00:00.000Z',
+        '--output-dir',
+        outputDir,
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('security assurance fixture drift detected');
+      expect(result.stderr).toContain('security-claims.json');
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a deterministic `fixtures/security-assurance/cache-key` golden scenario for the Security Assurance Lane.
- Adds `scripts/security/run-security-assurance-fixture.mjs` and `pnpm run test:security-assurance` to regenerate, normalize, validate, and compare expected artifacts.
- Wires the new expected security/assurance artifacts into `scripts/ci/validate-json.mjs` so schema and semantic validation cover the scenario in CI.

## Acceptance

- The fixture produces three security claims, one no-finding audit response, one candidate finding that remains `needs-human-review`, and one out-of-scope review classification.
- Generated artifacts include `security-claims`, threat model, audit scope, code map, audit tasks, findings, review, assurance summary, claim-evidence manifest, and a human-readable summary.
- The runner normalizes `generatedAt` and artifact paths before expected/actual comparison.

## Validation

- `pnpm -s run test:security-assurance`
- `pnpm -s exec vitest run tests/contracts/security-assurance-contract.test.ts tests/scripts/security-assurance-fixture.test.ts --reporter dot`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency` (known pre-existing doc governance warning only)
- `node --check scripts/security/run-security-assurance-fixture.mjs`
- `git diff --check`

## Rollback

Revert this PR to remove the fixture, runner, npm script, validation wiring, and expected artifacts. Existing Security Assurance Lane producers remain unchanged.

Closes #3266