### PR TITLE
docs(testing): document test portfolio baseline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 docRole: narrative
-lastVerified: '2026-03-24'
+lastVerified: '2026-05-08'
 ---
 
 # 📚 ae-framework Documentation / ドキュメント
@@ -59,6 +59,7 @@ See `reference/DOC-GOVERNANCE.md` for the front matter fields and lint rules.
 - `integrations/CODEX-CONTINUATION-CONTRACT.md`
 
 **Quality / CI operators**
+- `testing/README.md`
 - `quality/ARTIFACTS-CONTRACT.md`
 - `quality/formal-runbook.md`
 - `ci/ci-operations-handbook.md`
@@ -215,6 +216,7 @@ Current verification baseline, assurance model, artifact contracts, automation p
 - Verify-first implementation runbook: `quality/verify-first-implementation-runbook.md`
 - Assurance profile / level: `quality/assurance-profile.md`
 - Assurance operations runbook: `quality/assurance-operations-runbook.md`
+- Testing portfolio and coverage baseline: `testing/README.md`
 - Security Assurance Lane: `security/security-assurance-lane.md`
 - Quality scorecard: `quality/quality-scorecard.md`
 - Automation observability: `ci/automation-observability.md`
@@ -381,6 +383,7 @@ Claude CodeやMCPとの統合
 ### ✅ [quality/](./quality/) - 品質ゲート・検証
 フォーマル検証や品質基準
 
+- [testing/README.md](./testing/README.md) - テスト体系、実行コマンド、CI label、coverage baseline 運用の入口
 - [ASSURANCE-MODEL.md](./quality/ASSURANCE-MODEL.md) - claim / level / lane / evidence kind の共通モデル
 - **[formal-gates.md](./quality/formal-gates.md)** ⭐ フォーマル品質ゲート（v0.2 DoD）
 - **[formal-csp.md](./quality/formal-csp.md)** ⭐ CSP 検証（cspx 連携・summary/result 契約）
@@ -481,11 +484,12 @@ Claude CodeやMCPとの統合
 3. **[architecture/NEW_FEATURES.md](./architecture/NEW_FEATURES.md)** - 機能概要
 
 ### 🧪 品質保証・テストエンジニア
-1. **🆕 [phases/PHASE-2-2-RUNTIME-CONFORMANCE.md](./phases/PHASE-2-2-RUNTIME-CONFORMANCE.md)** - リアルタイム適合性検証
-2. **🆕 [phases/PHASE-2-3-INTEGRATION-TESTING.md](./phases/PHASE-2-3-INTEGRATION-TESTING.md)** - 統合テスト・E2Eテスト
-3. **🆕 [architecture/CEGIS-DESIGN.md](./architecture/CEGIS-DESIGN.md)** - 自動修復システム
-4. **🆕 [guides/ADVANCED-TROUBLESHOOTING-GUIDE.md](./guides/ADVANCED-TROUBLESHOOTING-GUIDE.md)** - 問題解決ガイド
-5. **[quality/type-coverage-policy.md](./quality/type-coverage-policy.md)** - 型カバレッジポリシー（運用ルール）
+1. **[testing/README.md](./testing/README.md)** - テスト体系、代表コマンド、CI label、coverage baseline 運用
+2. **🆕 [phases/PHASE-2-2-RUNTIME-CONFORMANCE.md](./phases/PHASE-2-2-RUNTIME-CONFORMANCE.md)** - リアルタイム適合性検証
+3. **🆕 [phases/PHASE-2-3-INTEGRATION-TESTING.md](./phases/PHASE-2-3-INTEGRATION-TESTING.md)** - 統合テスト・E2Eテスト
+4. **🆕 [architecture/CEGIS-DESIGN.md](./architecture/CEGIS-DESIGN.md)** - 自動修復システム
+5. **🆕 [guides/ADVANCED-TROUBLESHOOTING-GUIDE.md](./guides/ADVANCED-TROUBLESHOOTING-GUIDE.md)** - 問題解決ガイド
+6. **[quality/type-coverage-policy.md](./quality/type-coverage-policy.md)** - 型カバレッジポリシー（運用ルール）
 
 ## 🔄 更新履歴
 

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -2,7 +2,7 @@
 docRole: derived
 canonicalSource:
   - .github/workflows/agent-commands.yml
-lastVerified: '2026-05-07'
+lastVerified: '2026-05-08'
 ---
 
 # Agent Commands Catalog

--- a/docs/quality/coverage-policy.md
+++ b/docs/quality/coverage-policy.md
@@ -3,7 +3,7 @@ docRole: derived
 canonicalSource:
 - policy/quality.json
 - docs/quality/verification-gates.md
-lastVerified: '2026-04-08'
+lastVerified: '2026-05-08'
 ---
 # Coverage Policy — Proposal and Operations
 
@@ -38,6 +38,21 @@ Blocking enforcement is enabled when:
 Reporting behavior:
 - `.github/workflows/coverage-check.yml` posts a non-blocking PR comment that records effective coverage, effective threshold, threshold source, and current policy state
 - Verify Lite logs note the current `COVERAGE_ENFORCE_MAIN` setting and the configured default threshold; they do not compute or print the effective threshold
+
+### Baseline Freshness and Generated Artifacts
+- `pnpm run coverage` is the canonical project command for generating local coverage evidence.
+- The command writes `coverage/coverage-summary.json` and `coverage/lcov.info`; `coverage/` is ignored by `.gitignore` and is treated as generated evidence, not as a manually maintained tracked baseline.
+- When documenting a baseline, record the target commit, command, date, and relevant environment flags. Do not infer freshness from an old local `coverage/` directory alone.
+- On hosts without a detectable Docker or Podman engine, non-CI coverage runs can fail in `tests/container/container-agent.test.ts`. Use `CI=1 pnpm run coverage` when the intent is to emulate CI degraded-mode behavior locally, and record that condition with the evidence.
+
+Latest observed `origin/main` baseline as of 2026-05-08 on commit `944fc818dd89a9d51cb72f1c2ee6e1b5cfa3e7e1` using `CI=1 pnpm -s run coverage`:
+
+| Metric | Percent | Covered / Total |
+| --- | ---: | ---: |
+| Lines | 31.96% | 53,302 / 166,738 |
+| Statements | 31.96% | 53,302 / 166,738 |
+| Functions | 60.76% | 3,132 / 5,154 |
+| Branches | 67.89% | 10,708 / 15,771 |
 
 ### Recommended Operations
 - On PRs, use `/coverage <pct>` for ad-hoc threshold overrides.
@@ -155,6 +170,21 @@ Source: label
 報告時の挙動:
 - `.github/workflows/coverage-check.yml` は非ブロッキングの PR コメントを投稿し、effective coverage、effective threshold、threshold source、現在の policy state を記録する
 - Verify Lite のログは現在の `COVERAGE_ENFORCE_MAIN` 設定と設定済み既定しきい値を記録するが、effective threshold 自体は計算・出力しない
+
+### Baseline freshness と generated artifact
+- `pnpm run coverage` は local coverage evidence を生成する project の標準コマンドです。
+- このコマンドは `coverage/coverage-summary.json` と `coverage/lcov.info` を出力します。`coverage/` は `.gitignore` で除外されており、手動管理する tracked baseline ではなく generated evidence として扱います。
+- baseline を文書に記録する場合は、対象 commit、command、date、関連する environment flag を併記します。古い local `coverage/` directory だけから鮮度を判断しないでください。
+- Docker / Podman engine を検出できない host では、non-CI の coverage run が `tests/container/container-agent.test.ts` で失敗する場合があります。CI degraded-mode を local で再現したい場合は `CI=1 pnpm run coverage` を使い、その条件を evidence として記録します。
+
+2026-05-08 時点で `origin/main` commit `944fc818dd89a9d51cb72f1c2ee6e1b5cfa3e7e1` に対して `CI=1 pnpm -s run coverage` で確認した latest observed baseline:
+
+| Metric | Percent | Covered / Total |
+| --- | ---: | ---: |
+| Lines | 31.96% | 53,302 / 166,738 |
+| Statements | 31.96% | 53,302 / 166,738 |
+| Functions | 60.76% | 3,132 / 5,154 |
+| Branches | 67.89% | 10,708 / 15,771 |
 
 ### 推奨運用
 - PR では `/coverage <pct>` で一時的なしきい値 override を行う

--- a/docs/quality/quality-implementation-status.md
+++ b/docs/quality/quality-implementation-status.md
@@ -181,7 +181,7 @@ This report documents that the AE Framework quality system protects against regr
 
 #### このレポートで記録している品質 gate
 - Accessibility: critical violation 0 件、minor violation は最大 2 件
-- TypeScript: 対象範囲で compilation 成功、かつ `any` 禁止ポリシー
+- TypeScript: 対象範囲で compilation 成功、かつ `any` 0 件として記録
 - Performance: CLI command が設定済み timeout threshold 内で完了
 - Security: command injection 試行を遮断
 

--- a/docs/quality/quality-implementation-status.md
+++ b/docs/quality/quality-implementation-status.md
@@ -181,7 +181,7 @@ This report documents that the AE Framework quality system protects against regr
 
 #### このレポートで記録している品質 gate
 - Accessibility: critical violation 0 件、minor violation は最大 2 件
-- TypeScript: 対象範囲で compilation 成功、かつ `any` 0 件として記録
+- TypeScript: 対象範囲で compilation 成功、`no-explicit-any` は warn として追跡（baseline に既存違反あり）
 - Performance: CLI command が設定済み timeout threshold 内で完了
 - Security: command injection 試行を遮断
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,157 @@
+---
+docRole: derived
+canonicalSource:
+- package.json
+- docs/testing/test-categorization.md
+- docs/testing/parallel-execution-strategy.md
+- docs/ci/label-gating.md
+- docs/quality/coverage-policy.md
+lastVerified: '2026-05-08'
+---
+# Testing Portfolio and Coverage Baseline Operations
+
+> Language / 言語: English | 日本語
+
+---
+
+## English
+
+### Purpose
+
+Use this index to choose the smallest test lane that gives adequate signal for the change under review. The canonical script names remain in `package.json`; this document routes contributors to those scripts and to the CI labels that opt into heavier lanes.
+
+### Recommended command routes
+
+| Context | Primary command(s) | Cost class | Use when |
+| --- | --- | --- | --- |
+| Local edit loop | `pnpm run test:fast`, focused `vitest run <path>` | S | Validating a small source or test change before commit. |
+| Local unit / contract confidence | `pnpm run test:unit`, `pnpm run test:contracts` | S-M | Updating core modules, schemas, CLI helpers, or contract fixtures. |
+| PR baseline | `pnpm run verify:lite` or `pnpm run test:ci:lite` | M | Preparing a PR that should match the default required-check posture. |
+| Coverage inspection | `pnpm run coverage` | M-L | Refreshing coverage evidence or validating `coverage-check` behavior. |
+| Extended PR signal | `pnpm run test:ci:extended` | L | High-risk changes, integration-sensitive edits, or label-gated PR runs. |
+| Nightly / scheduled heavy signal | `pnpm run test:mbt:ci`, `pnpm run pipelines:mutation:quick`, `pnpm run verify:formal` | XL | Regression discovery, assurance refresh, or scheduled quality reporting. |
+| Release readiness | `pnpm run verify:lite`, `pnpm run test:ci:extended`, selected heavy lanes | L-XL | Confirming the release candidate across default and opt-in lanes. |
+
+Cost classes are approximate: S is usually suitable for the local edit loop, M for pre-PR checks, L for extended CI or pre-release runs, and XL for scheduled or explicitly requested assurance lanes.
+
+### Category selection criteria
+
+| Category | Representative command(s) | Choose this when | CI label / control |
+| --- | --- | --- | --- |
+| Unit | `pnpm run test:fast`, `pnpm run test:unit` | The change is isolated to functions, adapters, utilities, or small command helpers. | Default `verify-lite` path; no special label. |
+| Contract | `pnpm run test:contracts` | JSON schema, artifact shape, CLI output, or compatibility contracts changed. | `enforce-artifacts` for blocking artifact validation when appropriate. |
+| Property | `pnpm run test:property`, `pnpm run pbt` | Invariants, parsers, normalizers, generators, or boundary-heavy logic changed. | `run-property`; `enforce-testing` can make related checks blocking. |
+| Model-based (MBT) | `pnpm run test:mbt`, `pnpm run test:mbt:ci` | Stateful flows, trace transitions, or workflow behavior changed. | `run-mbt`. |
+| Mutation | `pnpm run mutation`, `pnpm run pipelines:mutation:quick` | The risk is weak assertions or insufficient negative-path coverage. | `run-mutation`. |
+| Formal | `pnpm run verify:formal` | A formal spec, model, trace contract, or high-assurance invariant changed. | Usually scheduled/manual; pair with high-risk review labels as needed. |
+| Security | `pnpm run test:security-assurance`, `pnpm run security:integrated:quick`, `pnpm run security:integrated:full` | Security findings, SBOM, dependency, claim extraction, or assurance-lane evidence changed. | `run-security` for security/SBOM workflows. |
+| Coverage | `pnpm run coverage` | The change affects the coverage baseline or coverage reporting path. | `enforce-coverage`; `coverage:<pct>` for threshold override. |
+| Extended CI | `pnpm run test:ci:extended` | The PR needs integration, property, MBT, or mutation lanes beyond the default baseline. | `run-ci-extended`, plus narrower labels such as `run-property`, `run-mbt`, `run-mutation`. |
+
+### CI label map
+
+| Label | Effect | Typical use |
+| --- | --- | --- |
+| `run-ci-extended` | Starts the heavy CI Extended lane. | Broad high-risk PRs or release-candidate validation. |
+| `run-mbt` | Starts the MBT smoke portion of CI Extended. | Stateful workflow or trace-transition changes. |
+| `run-mutation` | Starts mutation auto-diff / scoped mutation work. | Assertion-strength or negative-path validation. |
+| `run-property` | Starts the property-harness portion of CI Extended. | Parser, normalizer, generator, or invariant-heavy changes. |
+| `enforce-coverage` | Makes coverage threshold enforcement blocking. | Coverage-sensitive PRs after the report-only baseline is understood. |
+
+See `docs/ci/label-gating.md` for the broader label policy.
+
+### Coverage baseline and artifact treatment
+
+- The project coverage command is `pnpm run coverage`; it emits `coverage/coverage-summary.json` and `coverage/lcov.info` through Vitest reporters.
+- `coverage/` is ignored by `.gitignore`, so coverage output is treated as a generated artifact, not as a manually maintained tracked baseline.
+- Documentation may record the latest observed baseline for operational context, but the current baseline is established by rerunning the command on the target commit.
+- On hosts without a detectable Docker or Podman engine, the non-CI command can fail in `tests/container/container-agent.test.ts`. For local baseline emulation of CI degraded-mode behavior, use `CI=1 pnpm run coverage` and record that environment in the evidence.
+
+Latest observed baseline on `origin/main` `944fc818dd89a9d51cb72f1c2ee6e1b5cfa3e7e1` (2026-05-08, `CI=1 pnpm -s run coverage`):
+
+| Metric | Percent | Covered / Total |
+| --- | ---: | ---: |
+| Lines | 31.96% | 53,302 / 166,738 |
+| Statements | 31.96% | 53,302 / 166,738 |
+| Functions | 60.76% | 3,132 / 5,154 |
+| Branches | 67.89% | 10,708 / 15,771 |
+
+### Verification for docs-only updates
+
+Run the same documentation and type-surface checks used by the planning issue:
+
+- `pnpm -s run check:doc-consistency`
+- `pnpm -s run check:doc-todo-markers`
+- `pnpm -s run check:runbook-command-blocks`
+- `pnpm -s run types:check`
+
+## 日本語
+
+### 目的
+
+この index は、変更内容に対して十分な signal を得られる最小の test lane を選ぶための入口です。script 名の一次情報は `package.json` に置き、この文書では各 script と heavy lane を起動する CI label への導線を整理します。
+
+### 推奨コマンド経路
+
+| 文脈 | 代表コマンド | Cost class | 利用場面 |
+| --- | --- | --- | --- |
+| Local edit loop | `pnpm run test:fast`, focused `vitest run <path>` | S | 小さい source / test 変更を commit 前に確認する場合。 |
+| Local unit / contract confidence | `pnpm run test:unit`, `pnpm run test:contracts` | S-M | core module、schema、CLI helper、contract fixture を更新した場合。 |
+| PR baseline | `pnpm run verify:lite` または `pnpm run test:ci:lite` | M | 既定の required-check posture に合わせて PR を準備する場合。 |
+| Coverage inspection | `pnpm run coverage` | M-L | coverage evidence や `coverage-check` の挙動を確認する場合。 |
+| Extended PR signal | `pnpm run test:ci:extended` | L | high-risk 変更、integration-sensitive な変更、label-gated PR run が必要な場合。 |
+| Nightly / scheduled heavy signal | `pnpm run test:mbt:ci`, `pnpm run pipelines:mutation:quick`, `pnpm run verify:formal` | XL | regression discovery、assurance refresh、scheduled quality reporting。 |
+| Release readiness | `pnpm run verify:lite`, `pnpm run test:ci:extended`, selected heavy lanes | L-XL | release candidate を default lane と opt-in lane の両方で確認する場合。 |
+
+Cost class は目安です。S は local edit loop、M は pre-PR、L は extended CI / pre-release、XL は scheduled run または明示依頼された assurance lane を想定します。
+
+### カテゴリ選択基準
+
+| Category | 代表コマンド | 選択する場面 | CI label / control |
+| --- | --- | --- | --- |
+| Unit | `pnpm run test:fast`, `pnpm run test:unit` | 関数、adapter、utility、小さい command helper の変更。 | 既定の `verify-lite` 経路。特別な label は不要。 |
+| Contract | `pnpm run test:contracts` | JSON schema、artifact shape、CLI output、compatibility contract の変更。 | 必要に応じて `enforce-artifacts` で artifact validation を blocking 化。 |
+| Property | `pnpm run test:property`, `pnpm run pbt` | invariant、parser、normalizer、generator、境界値の多い logic の変更。 | `run-property`; 関連 check の blocking 化は `enforce-testing`。 |
+| Model-based (MBT) | `pnpm run test:mbt`, `pnpm run test:mbt:ci` | stateful flow、trace transition、workflow behavior の変更。 | `run-mbt`. |
+| Mutation | `pnpm run mutation`, `pnpm run pipelines:mutation:quick` | assertion の弱さや negative path coverage を確認したい場合。 | `run-mutation`. |
+| Formal | `pnpm run verify:formal` | formal spec、model、trace contract、high-assurance invariant の変更。 | 通常は scheduled / manual。必要に応じて high-risk review label と組み合わせる。 |
+| Security | `pnpm run test:security-assurance`, `pnpm run security:integrated:quick`, `pnpm run security:integrated:full` | security finding、SBOM、dependency、claim extraction、assurance-lane evidence の変更。 | Security / SBOM workflow は `run-security`。 |
+| Coverage | `pnpm run coverage` | coverage baseline または coverage reporting path に影響する変更。 | `enforce-coverage`; しきい値 override は `coverage:<pct>`。 |
+| Extended CI | `pnpm run test:ci:extended` | 既定 baseline を超えて integration、property、MBT、mutation lane の signal が必要な PR。 | `run-ci-extended`, 追加で `run-property`, `run-mbt`, `run-mutation`。 |
+
+### CI label map
+
+| Label | 効果 | 典型的な利用場面 |
+| --- | --- | --- |
+| `run-ci-extended` | heavy CI Extended lane を起動する。 | 広範な high-risk PR または release-candidate validation。 |
+| `run-mbt` | CI Extended の MBT smoke 部分を起動する。 | stateful workflow または trace-transition 変更。 |
+| `run-mutation` | mutation auto-diff / scoped mutation を起動する。 | assertion strength または negative-path validation。 |
+| `run-property` | CI Extended の property-harness 部分を起動する。 | parser、normalizer、generator、invariant-heavy な変更。 |
+| `enforce-coverage` | coverage threshold enforcement を blocking にする。 | report-only baseline を把握した後の coverage-sensitive PR。 |
+
+より広い label 方針は `docs/ci/label-gating.md` を参照してください。
+
+### Coverage baseline と artifact の扱い
+
+- project の coverage command は `pnpm run coverage` です。Vitest reporter により `coverage/coverage-summary.json` と `coverage/lcov.info` を出力します。
+- `coverage/` は `.gitignore` で除外されているため、coverage 出力は手動管理する tracked baseline ではなく generated artifact として扱います。
+- 文書には運用上の参考として latest observed baseline を記録できますが、現在の baseline は対象 commit でコマンドを再実行して確認します。
+- Docker / Podman engine を検出できない host では、non-CI の `pnpm run coverage` が `tests/container/container-agent.test.ts` で失敗する場合があります。CI degraded-mode に合わせた local baseline emulation では `CI=1 pnpm run coverage` を使い、その環境条件を evidence に記録します。
+
+`origin/main` `944fc818dd89a9d51cb72f1c2ee6e1b5cfa3e7e1` で確認した最新 baseline（2026-05-08, `CI=1 pnpm -s run coverage`）:
+
+| Metric | Percent | Covered / Total |
+| --- | ---: | ---: |
+| Lines | 31.96% | 53,302 / 166,738 |
+| Statements | 31.96% | 53,302 / 166,738 |
+| Functions | 60.76% | 3,132 / 5,154 |
+| Branches | 67.89% | 10,708 / 15,771 |
+
+### docs-only 更新時の検証
+
+planning issue と同じ documentation / type-surface check を実行します。
+
+- `pnpm -s run check:doc-consistency`
+- `pnpm -s run check:doc-todo-markers`
+- `pnpm -s run check:runbook-command-blocks`
+- `pnpm -s run types:check`

--- a/docs/testing/test-categorization.md
+++ b/docs/testing/test-categorization.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: 2026-03-11
+lastVerified: '2026-05-08'
 owner: testing-docs
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -10,34 +10,40 @@ verificationCommand: pnpm -s run check:doc-consistency
 
 ## Overview
 
-This document summarizes how tests are grouped in ae-framework so contributors can select the right suite for local runs, CI, and investigation.
+This document summarizes how tests are grouped in ae-framework so contributors can select the right suite for local runs, CI, and investigation. For the route-by-context index, coverage baseline treatment, and label map, start with `docs/testing/README.md`.
 
 ## Categories
 
-| Category | Primary purpose | Typical scripts | Notes |
-| -------- | --------------- | -------------- | ----- |
-| **Fast / Unit** | Quick feedback on core logic | `pnpm run test:fast`, `pnpm run test:unit` | Use for local iteration and pre-commit checks. |
-| **Integration** | Validate cross-module behavior | `pnpm run test:int`, `pnpm run test:integration:webapi` | Higher cost; usually run in CI or before release. |
-| **Property-based** | Explore edge cases via generators | `pnpm run test:property`, `pnpm run pbt` | Prefer for invariants and fuzz-friendly logic. |
-| **Model-based (MBT)** | Stateful behavior verification | `pnpm run test:mbt`, `pnpm run test:mbt:ci` | Uses model traces; keep deterministic inputs. |
-| **Mutation** | Detect weak tests | `pnpm run mutation`, `pnpm run pipelines:mutation:quick` | Run selectively or in scheduled CI. |
-| **Formal / Model Check** | Spec-level guarantees | `pnpm run verify:formal`, `pnpm run verify:tla`, `pnpm run verify:alloy` | Requires formal specs and external tools. |
-| **Quality Gates** | Policy/threshold enforcement | `pnpm run quality:gates`, `pnpm run quality:gates:dev` | Centralized quality policy (lint/coverage/security/etc). |
-| **Security** | Dependency and SBOM checks | `pnpm run security:integrated:quick`, `pnpm run security:integrated:full` | Use quick mode for PRs, full for scheduled runs. |
-| **Extended CI** | Full integration pipeline | `pnpm run test:ci:lite`, `pnpm run test:ci:extended` | Used by CI workflows for gating. |
+| Category | Primary purpose | Typical scripts | Cost | CI label / control | Notes |
+| -------- | --------------- | -------------- | ---- | ------------------ | ----- |
+| **Fast / Unit** | Quick feedback on core logic | `pnpm run test:fast`, `pnpm run test:unit` | S | default `verify-lite` path | Use for local iteration and pre-commit checks. |
+| **Contract** | Validate schema, artifact, and output compatibility | `pnpm run test:contracts` | S-M | `enforce-artifacts` when artifact validation should block | Pair with schema and fixture updates. |
+| **Integration** | Validate cross-module behavior | `pnpm run test:int`, `pnpm run test:integration:webapi` | M-L | `run-ci-extended`, `run-integration` | Higher cost; usually run in CI or before release. |
+| **Property-based** | Explore edge cases via generators | `pnpm run test:property`, `pnpm run pbt` | M-L | `run-property`, optional `enforce-testing` | Prefer for invariants and fuzz-friendly logic. |
+| **Model-based (MBT)** | Stateful behavior verification | `pnpm run test:mbt`, `pnpm run test:mbt:ci` | L-XL | `run-mbt` | Uses model traces; keep deterministic inputs. |
+| **Mutation** | Detect weak tests | `pnpm run mutation`, `pnpm run pipelines:mutation:quick` | XL | `run-mutation` | Run selectively or in scheduled CI. |
+| **Formal / Model Check** | Spec-level guarantees | `pnpm run verify:formal`, `pnpm run verify:tla`, `pnpm run verify:alloy` | XL | scheduled/manual, plus risk labels when needed | Requires formal specs and external tools. |
+| **Quality Gates** | Policy/threshold enforcement | `pnpm run quality:gates`, `pnpm run quality:gates:dev` | M | policy labels such as `risk:high` | Centralized quality policy for lint, coverage, security, and evidence gates. |
+| **Security** | Dependency, SBOM, and security-assurance evidence | `pnpm run test:security-assurance`, `pnpm run security:integrated:quick`, `pnpm run security:integrated:full` | M-XL | `run-security` | Use quick mode for PRs, full mode or fixtures for scheduled assurance refreshes. |
+| **Coverage** | Coverage summary and coverage-gate evidence | `pnpm run coverage` | M-L | `enforce-coverage`, `coverage:<pct>` | `coverage/` output is generated evidence, not a manually maintained tracked baseline. |
+| **Extended CI** | Full integration pipeline | `pnpm run test:ci:lite`, `pnpm run test:ci:extended` | M-L | `run-ci-extended` and narrower heavy-lane labels | Used by CI workflows for gating and opt-in assurance. |
 
 ## Guidance
 
 - **Local dev**: start with `test:fast` and narrow to the suite you are editing.
-- **Before PR**: `test:ci:lite` (verify-lite) for a balanced signal.
-- **Nightly / heavy**: run mutation, MBT, and full formal checks for regression coverage.
+- **Before PR**: use `verify:lite` or `test:ci:lite` for the default required-check signal.
+- **Contract-sensitive changes**: add `test:contracts` and focused schema or artifact fixture checks.
+- **High-risk / nightly / heavy**: run property, MBT, mutation, and formal checks based on the risk surface and labels documented in `docs/testing/README.md`.
+- **Coverage-sensitive changes**: run `pnpm run coverage` and treat `coverage/` as generated evidence. Record the commit, command, and environment when quoting a baseline.
 
 ## CI gating notes
 
 - Heavy suites are **label-gated** to avoid unstable or expensive runs on every PR.
-- Use `docs/ci/label-gating.md` for labels (`run-ci-extended`, `run-mbt`, `run-mutation`, `run-property`).
+- Use `docs/ci/label-gating.md` for labels (`run-ci-extended`, `run-mbt`, `run-mutation`, `run-property`, `enforce-coverage`).
 - Prefer the stable profile for CI baselines: `docs/ci/stable-profile.md`.
 
 ## Related
 
+- `docs/testing/README.md`
 - `docs/testing/parallel-execution-strategy.md`
+- `docs/quality/coverage-policy.md`


### PR DESCRIPTION
## Summary
- Add `docs/testing/README.md` as the test portfolio entrypoint with local / PR / nightly / release command routes, cost classes, and CI label mapping.
- Clarify coverage baseline handling as generated evidence rather than a tracked manual baseline, and record the 2026-05-08 `origin/main` observed baseline.
- Update testing categorization, coverage policy, docs index links, and remove the known doc governance warning in `quality-implementation-status`.

## Acceptance
- Resolves #3280
- Part of #3279
- `docs/testing/README.md` exists and covers unit / contract / property / MBT / mutation / formal / security / coverage lanes.
- Coverage freshness and regeneration handling are documented.
- CI labels `run-ci-extended`, `run-mbt`, `run-mutation`, `run-property`, and `enforce-coverage` are mapped.
- `docs/quality/quality-implementation-status.md` no longer emits the known narrative wording warning.
- `docs/README.md` links to the testing entrypoint.

## Coverage evidence
- `pnpm run coverage` on this local host without CI failed because no Docker/Podman engine was detectable by `tests/container/container-agent.test.ts`.
- `CI=1 pnpm -s run coverage` passed on `origin/main` `944fc818dd89a9d51cb72f1c2ee6e1b5cfa3e7e1` and produced:
  - lines: 31.96% (53,302 / 166,738)
  - statements: 31.96% (53,302 / 166,738)
  - functions: 60.76% (3,132 / 5,154)
  - branches: 67.89% (10,708 / 15,771)

## Verification
- `CI=1 pnpm -s run coverage`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:doc-todo-markers`
- `pnpm -s run check:runbook-command-blocks`
- `pnpm -s run types:check`
- `git diff --check`

## Rollback
- Revert this PR to remove the documentation entrypoint and restore previous testing / coverage policy wording. No runtime code or generated coverage artifacts are tracked in this change.