### PR TITLE
test(security): cover assurance CLI boundaries

### DIFF
--- a/fixtures/security-assurance/boundary-cases/README.md
+++ b/fixtures/security-assurance/boundary-cases/README.md
@@ -1,0 +1,7 @@
+# Security assurance boundary-case fixtures
+
+These fixtures keep Security Assurance Lane edge cases reproducible at the CLI and contract boundary.
+
+- `zero-finding.security-audit-responses.json`: proof-attempt fixture where every matched task reports `no-finding`; no `security-findings.json` is emitted.
+- `multiple-review-records.security-review.json`: two review records for the same candidate finding, used to preserve review-history semantics.
+- `trust-boundary-unknown.security-review.json`: review outcome where the trust-boundary gate remains `unknown`, keeping the candidate-first posture explicit.

--- a/fixtures/security-assurance/boundary-cases/multiple-review-records.security-review.json
+++ b/fixtures/security-assurance/boundary-cases/multiple-review-records.security-review.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": "security-review/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "reviews": [
+    {
+      "findingId": "SEC-FINDING-001",
+      "severity": "high",
+      "result": "needs-human-review",
+      "gates": {
+        "deadCode": {
+          "result": "pass",
+          "rationale": "Primary review found production code evidence.",
+          "evidenceRefs": [
+            "src/cache.ts"
+          ]
+        },
+        "trustBoundary": {
+          "result": "pass",
+          "rationale": "The candidate crosses TB-001.",
+          "evidenceRefs": [
+            "TB-001"
+          ]
+        },
+        "scope": {
+          "result": "pass",
+          "rationale": "The source path is in scope.",
+          "evidenceRefs": [
+            "src/**/*.ts"
+          ]
+        }
+      },
+      "falsePositiveRootCause": null,
+      "reviewerNotes": [
+        "First deterministic review record for the same finding."
+      ],
+      "reviewedAt": "2026-05-07T00:00:00.000Z",
+      "reviewer": "security-review-fixture"
+    },
+    {
+      "findingId": "SEC-FINDING-001",
+      "severity": "high",
+      "result": "confirmed",
+      "gates": {
+        "deadCode": {
+          "result": "pass",
+          "rationale": "Follow-up review confirmed the code is reachable.",
+          "evidenceRefs": [
+            "src/cache.ts"
+          ]
+        },
+        "trustBoundary": {
+          "result": "pass",
+          "rationale": "Follow-up review confirmed attacker-controlled input crosses TB-001.",
+          "evidenceRefs": [
+            "TB-001"
+          ]
+        },
+        "scope": {
+          "result": "pass",
+          "rationale": "The finding remains in the audit scope.",
+          "evidenceRefs": [
+            "src/**/*.ts"
+          ]
+        }
+      },
+      "falsePositiveRootCause": null,
+      "reviewerNotes": [
+        "Second deterministic review record for the same finding."
+      ],
+      "reviewedAt": "2026-05-07T00:01:00.000Z",
+      "reviewer": "security-review-fixture"
+    }
+  ],
+  "summary": {
+    "totalReviews": 2,
+    "byResult": {
+      "needsHumanReview": 1,
+      "confirmed": 1,
+      "rejected": 0,
+      "waived": 0,
+      "outOfScope": 0
+    },
+    "falsePositiveRootCauses": {
+      "deadCode": 0,
+      "trustBoundaryMisunderstanding": 0,
+      "outOfScope": 0,
+      "codeReadingError": 0,
+      "specMisinterpretation": 0,
+      "insufficientEvidence": 0
+    }
+  }
+}

--- a/fixtures/security-assurance/boundary-cases/trust-boundary-unknown.security-review.json
+++ b/fixtures/security-assurance/boundary-cases/trust-boundary-unknown.security-review.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": "security-review/v1",
+  "generatedAt": "2026-05-07T00:00:00.000Z",
+  "reviews": [
+    {
+      "findingId": "SEC-FINDING-001",
+      "severity": "high",
+      "result": "needs-human-review",
+      "gates": {
+        "deadCode": {
+          "result": "pass",
+          "rationale": "The candidate location appears reachable.",
+          "evidenceRefs": [
+            "src/cache.ts"
+          ]
+        },
+        "trustBoundary": {
+          "result": "unknown",
+          "rationale": "The fixture intentionally omits explicit trust-boundary evidence.",
+          "evidenceRefs": []
+        },
+        "scope": {
+          "result": "pass",
+          "rationale": "The source path is in scope.",
+          "evidenceRefs": [
+            "src/**/*.ts"
+          ]
+        }
+      },
+      "falsePositiveRootCause": null,
+      "reviewerNotes": [
+        "Trust-boundary unknown remains a candidate-first review outcome."
+      ],
+      "reviewedAt": "2026-05-07T00:00:00.000Z",
+      "reviewer": "security-review-fixture"
+    }
+  ],
+  "summary": {
+    "totalReviews": 1,
+    "byResult": {
+      "needsHumanReview": 1,
+      "confirmed": 0,
+      "rejected": 0,
+      "waived": 0,
+      "outOfScope": 0
+    },
+    "falsePositiveRootCauses": {
+      "deadCode": 0,
+      "trustBoundaryMisunderstanding": 0,
+      "outOfScope": 0,
+      "codeReadingError": 0,
+      "specMisinterpretation": 0,
+      "insufficientEvidence": 0
+    }
+  }
+}

--- a/fixtures/security-assurance/boundary-cases/zero-finding.security-audit-responses.json
+++ b/fixtures/security-assurance/boundary-cases/zero-finding.security-audit-responses.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "security-audit-response-fixture/v1",
+  "responses": [
+    {
+      "taskId": "SEC-AUDIT-TASK-001",
+      "claimId": "SEC-CLAIM-001",
+      "result": "no-finding",
+      "rationale": "Boundary fixture: deterministic proof attempt found no candidate vulnerability for the mapped claim."
+    }
+  ]
+}

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -5,6 +5,7 @@
 
 import path from 'node:path';
 import { tmpdir } from 'node:os';
+import { existsSync, realpathSync } from 'node:fs';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { createServer } from '../api/server.js';
@@ -31,6 +32,25 @@ function isInsideDirectory(parentDir: string, candidatePath: string): boolean {
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
+function nearestExistingPath(candidatePath: string): string {
+  let current = candidatePath;
+  while (!existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return current;
+    }
+    current = parent;
+  }
+  return current;
+}
+
+function resolveThroughExistingParent(candidatePath: string): string {
+  const nearestExisting = nearestExistingPath(candidatePath);
+  const nearestRealPath = realpathSync.native(nearestExisting);
+  const unresolvedSuffix = path.relative(nearestExisting, candidatePath);
+  return unresolvedSuffix ? path.resolve(nearestRealPath, unresolvedSuffix) : nearestRealPath;
+}
+
 function assertSafeSecurityOutputPath(value: string, optionName = '--out'): string {
   const raw = String(value || '').trim();
   if (!raw) {
@@ -44,6 +64,11 @@ function assertSafeSecurityOutputPath(value: string, optionName = '--out'): stri
   const allowedRoots = [process.cwd(), tmpdir()].map((entry) => path.resolve(entry));
   if (!allowedRoots.some((root) => isInsideDirectory(root, resolved))) {
     throw new Error(`Unsafe ${optionName} path: absolute output paths must stay under the current working directory or the OS temp directory.`);
+  }
+  const realResolved = resolveThroughExistingParent(resolved);
+  const realAllowedRoots = allowedRoots.map((root) => realpathSync.native(root));
+  if (!realAllowedRoots.some((root) => isInsideDirectory(root, realResolved))) {
+    throw new Error(`Unsafe ${optionName} path: existing symlink segments must not resolve outside the current working directory or the OS temp directory.`);
   }
   return raw;
 }

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -3,6 +3,8 @@
  * Provides commands to test and manage security headers
  */
 
+import path from 'node:path';
+import { tmpdir } from 'node:os';
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { createServer } from '../api/server.js';
@@ -14,6 +16,41 @@ import { extractSecurityClaimsFromSpec } from '../security/assurance/claim-extra
 import { importSpecaLikeSecurityArtifacts } from '../security/assurance/speca-import.js';
 import { generateSecurityProofAudit } from '../security/assurance/proof-audit.js';
 import { generateSecurityThreeGateReview } from '../security/assurance/three-gate-review.js';
+import { normalizeArtifactPath } from '../utils/path-normalization.js';
+
+
+function pathHasTraversalSegment(value: string): boolean {
+  return value
+    .replace(/\\/g, '/')
+    .split('/')
+    .some((segment) => segment === '..');
+}
+
+function isInsideDirectory(parentDir: string, candidatePath: string): boolean {
+  const relative = path.relative(parentDir, candidatePath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function assertSafeSecurityOutputPath(value: string, optionName = '--out'): string {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    throw new Error(`Unsafe ${optionName} path: output path must not be empty.`);
+  }
+  if (pathHasTraversalSegment(raw)) {
+    throw new Error(`Unsafe ${optionName} path: path traversal segments are not allowed.`);
+  }
+
+  const resolved = path.resolve(raw);
+  const allowedRoots = [process.cwd(), tmpdir()].map((entry) => path.resolve(entry));
+  if (!allowedRoots.some((root) => isInsideDirectory(root, resolved))) {
+    throw new Error(`Unsafe ${optionName} path: absolute output paths must stay under the current working directory or the OS temp directory.`);
+  }
+  return raw;
+}
+
+function displayArtifactPath(value: string): string {
+  return normalizeArtifactPath(value, { repoRoot: process.cwd() }) ?? value.replace(/\\/g, '/');
+}
 
 export function createSecurityCommand(): Command {
   const security = new Command('security');
@@ -30,7 +67,8 @@ export function createSecurityCommand(): Command {
     .option('--no-validate', 'Skip schema validation for input and generated artifacts')
     .action(async (options) => {
       try {
-        const result = await generateSecurityThreeGateReview(options.findings, options.scope, options.codeMap, options.out, {
+        const outPath = assertSafeSecurityOutputPath(options.out);
+        const result = await generateSecurityThreeGateReview(options.findings, options.scope, options.codeMap, outPath, {
           generatedAt: options.generatedAt,
           validate: options.validate,
         });
@@ -41,8 +79,8 @@ export function createSecurityCommand(): Command {
         console.log(`Rejected: ${result.review.summary.byResult.rejected}`);
         console.log(`Out of scope: ${result.review.summary.byResult.outOfScope}`);
         console.log(`Warnings: ${result.warnings.length}`);
-        console.log(`Output: ${result.outputPaths.review}`);
-        console.log(`Summary: ${result.outputPaths.summaryMarkdown}`);
+        console.log(`Output: ${displayArtifactPath(result.outputPaths.review)}`);
+        console.log(`Summary: ${displayArtifactPath(result.outputPaths.summaryMarkdown)}`);
       } catch (error: unknown) {
         console.error(chalk.red(`❌ Security three-gate review failed: ${toMessage(error)}`));
         safeExit(1);
@@ -61,7 +99,8 @@ export function createSecurityCommand(): Command {
     .option('--no-validate', 'Skip schema validation for input and generated artifacts')
     .action(async (options) => {
       try {
-        const result = await generateSecurityProofAudit(options.claims, options.codeMap, options.scope, options.out, {
+        const outPath = assertSafeSecurityOutputPath(options.out);
+        const result = await generateSecurityProofAudit(options.claims, options.codeMap, options.scope, outPath, {
           generatedAt: options.generatedAt,
           validate: options.validate,
           responseFixture: options.responseFixture,
@@ -74,13 +113,13 @@ export function createSecurityCommand(): Command {
         console.log(`Findings: ${result.findings?.summary.totalFindings ?? 0}`);
         console.log(`No-finding responses: ${result.responseSummary.noFindingResponses}`);
         console.log(`Warnings: ${result.warnings.length}`);
-        console.log(`Tasks: ${result.outputPaths.tasks}`);
+        console.log(`Tasks: ${displayArtifactPath(result.outputPaths.tasks)}`);
         if (result.findings && result.outputPaths.findings) {
-          console.log(`Findings output: ${result.outputPaths.findings}`);
+          console.log(`Findings output: ${displayArtifactPath(result.outputPaths.findings)}`);
         } else {
           console.log('Findings output: not generated (dry-run or all responses were no-finding)');
         }
-        console.log(`Summary: ${result.outputPaths.summaryMarkdown}`);
+        console.log(`Summary: ${displayArtifactPath(result.outputPaths.summaryMarkdown)}`);
       } catch (error: unknown) {
         console.error(chalk.red(`❌ Security proof-attempt audit failed: ${toMessage(error)}`));
         safeExit(1);
@@ -98,7 +137,8 @@ export function createSecurityCommand(): Command {
     .option('--no-validate', 'Skip schema validation for input and generated artifacts')
     .action(async (options) => {
       try {
-        const result = await generateSecurityCodeMap(options.claims, options.scope, options.target, options.out, {
+        const outPath = assertSafeSecurityOutputPath(options.out);
+        const result = await generateSecurityCodeMap(options.claims, options.scope, options.target, outPath, {
           generatedAt: options.generatedAt,
           validate: options.validate,
         });
@@ -108,8 +148,8 @@ export function createSecurityCommand(): Command {
         console.log(`Mapped claims: ${result.codeMap.summary.mappedClaims}`);
         console.log(`Candidate locations: ${result.codeMap.summary.totalCandidateLocations}`);
         console.log(`Warnings: ${result.warnings.length}`);
-        console.log(`Output: ${result.outputPaths.codeMap}`);
-        console.log(`Summary: ${result.outputPaths.summaryMarkdown}`);
+        console.log(`Output: ${displayArtifactPath(result.outputPaths.codeMap)}`);
+        console.log(`Summary: ${displayArtifactPath(result.outputPaths.summaryMarkdown)}`);
       } catch (error: unknown) {
         console.error(chalk.red(`❌ Security code-map generation failed: ${toMessage(error)}`));
         safeExit(1);
@@ -125,7 +165,8 @@ export function createSecurityCommand(): Command {
     .option('--no-validate', 'Skip schema validation for generated artifacts')
     .action(async (options) => {
       try {
-        const result = await extractSecurityClaimsFromSpec(options.spec, options.out, {
+        const outPath = assertSafeSecurityOutputPath(options.out);
+        const result = await extractSecurityClaimsFromSpec(options.spec, outPath, {
           generatedAt: options.generatedAt,
           validate: options.validate,
         });
@@ -133,8 +174,8 @@ export function createSecurityCommand(): Command {
         console.log(chalk.green('✅ Security claims extraction completed'));
         console.log(`Claims: ${result.claims.claims.length}`);
         console.log(`Warnings: ${result.warnings.length}`);
-        console.log(`Output: ${result.outputPaths.claims}`);
-        console.log(`Summary: ${result.outputPaths.summaryMarkdown}`);
+        console.log(`Output: ${displayArtifactPath(result.outputPaths.claims)}`);
+        console.log(`Summary: ${displayArtifactPath(result.outputPaths.summaryMarkdown)}`);
       } catch (error: unknown) {
         console.error(chalk.red(`❌ Security claims extraction failed: ${toMessage(error)}`));
         safeExit(1);
@@ -150,7 +191,8 @@ export function createSecurityCommand(): Command {
     .option('--no-validate', 'Skip schema validation for generated artifacts')
     .action(async (options) => {
       try {
-        const result = await importSpecaLikeSecurityArtifacts(options.input, options.out, {
+        const outPath = assertSafeSecurityOutputPath(options.out);
+        const result = await importSpecaLikeSecurityArtifacts(options.input, outPath, {
           generatedAt: options.generatedAt,
           validate: options.validate,
         });
@@ -161,7 +203,7 @@ export function createSecurityCommand(): Command {
         console.log(`Findings: ${result.artifacts.findings.findings.length}`);
         console.log(`Reviews: ${result.artifacts.review.reviews.length}`);
         console.log(`Warnings: ${result.warnings.length}`);
-        console.log(`Summary: ${result.outputPaths.summaryMarkdown}`);
+        console.log(`Summary: ${displayArtifactPath(result.outputPaths.summaryMarkdown)}`);
       } catch (error: unknown) {
         console.error(chalk.red(`❌ SPECA-compatible security import failed: ${toMessage(error)}`));
         safeExit(1);

--- a/src/security/assurance/code-map.ts
+++ b/src/security/assurance/code-map.ts
@@ -208,7 +208,17 @@ function warning(code: string, pathRef: string, message: string, source?: string
 }
 
 async function loadJson(filePath: string): Promise<unknown> {
-  return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+  } catch (error: unknown) {
+    if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+      throw new Error(`Input file not found: ${filePath}`);
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error(`Malformed JSON input: ${filePath}`);
+    }
+    throw error;
+  }
 }
 
 async function validateWithSchema(repoRoot: string, schemaName: string, document: unknown, label: string): Promise<void> {

--- a/src/security/assurance/code-map.ts
+++ b/src/security/assurance/code-map.ts
@@ -212,10 +212,11 @@ async function loadJson(filePath: string): Promise<unknown> {
     return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
   } catch (error: unknown) {
     if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
-      throw new Error(`Input file not found: ${filePath}`);
+      const detail = error instanceof Error ? `: ${error.message}` : '';
+      throw new Error(`Input file not found: ${filePath}${detail}`, { cause: error });
     }
     if (error instanceof SyntaxError) {
-      throw new Error(`Malformed JSON input: ${filePath}`);
+      throw new Error(`Malformed JSON input: ${filePath}: ${error.message}`, { cause: error });
     }
     throw error;
   }

--- a/src/security/assurance/proof-audit.ts
+++ b/src/security/assurance/proof-audit.ts
@@ -256,7 +256,17 @@ function outputPathsFor(outPath: string, includeFindings: boolean): SecurityAudi
 }
 
 async function loadJson(filePath: string): Promise<unknown> {
-  return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+  } catch (error: unknown) {
+    if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+      throw new Error(`Input file not found: ${filePath}`);
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error(`Malformed JSON input: ${filePath}`);
+    }
+    throw error;
+  }
 }
 
 async function validateWithSchema(repoRoot: string, schemaName: string, document: unknown, label: string): Promise<void> {

--- a/src/security/assurance/proof-audit.ts
+++ b/src/security/assurance/proof-audit.ts
@@ -260,10 +260,11 @@ async function loadJson(filePath: string): Promise<unknown> {
     return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
   } catch (error: unknown) {
     if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
-      throw new Error(`Input file not found: ${filePath}`);
+      const detail = error instanceof Error ? `: ${error.message}` : '';
+      throw new Error(`Input file not found: ${filePath}${detail}`, { cause: error });
     }
     if (error instanceof SyntaxError) {
-      throw new Error(`Malformed JSON input: ${filePath}`);
+      throw new Error(`Malformed JSON input: ${filePath}: ${error.message}`, { cause: error });
     }
     throw error;
   }

--- a/src/security/assurance/speca-import.ts
+++ b/src/security/assurance/speca-import.ts
@@ -835,10 +835,11 @@ async function readJson(filePath: string): Promise<JsonRecord> {
     parsed = JSON.parse(content) as unknown;
   } catch (error: unknown) {
     if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
-      throw new Error(`Input file not found: ${filePath}`);
+      const detail = error instanceof Error ? `: ${error.message}` : '';
+      throw new Error(`Input file not found: ${filePath}${detail}`, { cause: error });
     }
     if (error instanceof SyntaxError) {
-      throw new Error(`Malformed JSON input: ${filePath}`);
+      throw new Error(`Malformed JSON input: ${filePath}: ${error.message}`, { cause: error });
     }
     throw error;
   }

--- a/src/security/assurance/speca-import.ts
+++ b/src/security/assurance/speca-import.ts
@@ -829,8 +829,19 @@ export function convertSpecaLikeSecurityArtifacts(bundle: SpecaLikeBundle, optio
 }
 
 async function readJson(filePath: string): Promise<JsonRecord> {
-  const content = await fs.readFile(filePath, 'utf8');
-  const parsed = JSON.parse(content) as unknown;
+  let parsed: unknown;
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    parsed = JSON.parse(content) as unknown;
+  } catch (error: unknown) {
+    if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+      throw new Error(`Input file not found: ${filePath}`);
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error(`Malformed JSON input: ${filePath}`);
+    }
+    throw error;
+  }
   if (!isRecord(parsed)) {
     throw new Error(`JSON root must be an object: ${filePath}`);
   }

--- a/src/security/assurance/three-gate-review.ts
+++ b/src/security/assurance/three-gate-review.ts
@@ -245,10 +245,11 @@ async function loadJson(filePath: string): Promise<unknown> {
     return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
   } catch (error: unknown) {
     if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
-      throw new Error(`Input file not found: ${filePath}`);
+      const detail = error instanceof Error ? `: ${error.message}` : '';
+      throw new Error(`Input file not found: ${filePath}${detail}`, { cause: error });
     }
     if (error instanceof SyntaxError) {
-      throw new Error(`Malformed JSON input: ${filePath}`);
+      throw new Error(`Malformed JSON input: ${filePath}: ${error.message}`, { cause: error });
     }
     throw error;
   }

--- a/src/security/assurance/three-gate-review.ts
+++ b/src/security/assurance/three-gate-review.ts
@@ -241,7 +241,17 @@ function outputPathsFor(outPath: string): SecurityReviewOutputPaths {
 }
 
 async function loadJson(filePath: string): Promise<unknown> {
-  return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+  try {
+    return JSON.parse(await fs.readFile(filePath, 'utf8')) as unknown;
+  } catch (error: unknown) {
+    if (typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+      throw new Error(`Input file not found: ${filePath}`);
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error(`Malformed JSON input: ${filePath}`);
+    }
+    throw error;
+  }
 }
 
 async function validateWithSchema(repoRoot: string, schemaName: string, document: unknown, label: string): Promise<void> {

--- a/tests/contracts/security-assurance-contract.test.ts
+++ b/tests/contracts/security-assurance-contract.test.ts
@@ -35,6 +35,11 @@ const fixtures = {
   review: loadJson('fixtures/security-assurance/sample.security-review.json'),
 };
 
+const boundaryFixtures = {
+  multipleReviewRecords: loadJson('fixtures/security-assurance/boundary-cases/multiple-review-records.security-review.json'),
+  trustBoundaryUnknown: loadJson('fixtures/security-assurance/boundary-cases/trust-boundary-unknown.security-review.json'),
+};
+
 const buildValidator = (schema: JsonObject) => {
   const ajv = new Ajv2020({ allErrors: true, strict: false });
   addFormats(ajv);
@@ -378,6 +383,33 @@ describe('security assurance contracts', () => {
         instancePath: '/reviews/1/falsePositiveRootCause',
       }),
     ]);
+  });
+
+
+  it('keeps boundary security review fixtures schema-valid', () => {
+    const validate = buildValidator(schemas.review);
+
+    expect(validate(boundaryFixtures.multipleReviewRecords), JSON.stringify(validate.errors)).toBe(true);
+    expect(validateSecurityReviewSemantics(boundaryFixtures.multipleReviewRecords)).toHaveLength(0);
+    expect(validate(boundaryFixtures.trustBoundaryUnknown), JSON.stringify(validate.errors)).toBe(true);
+    expect(validateSecurityReviewSemantics(boundaryFixtures.trustBoundaryUnknown)).toHaveLength(0);
+  });
+
+  it('allows multiple review records for a single candidate finding', () => {
+    const reviews = boundaryFixtures.multipleReviewRecords.reviews as Array<{ findingId: string; result: string }>;
+
+    expect(reviews.filter((review) => review.findingId === 'SEC-FINDING-001')).toHaveLength(2);
+    expect(reviews.map((review) => review.result)).toEqual(['needs-human-review', 'confirmed']);
+  });
+
+  it('preserves trust-boundary unknown as a candidate-first review scenario', () => {
+    const reviews = boundaryFixtures.trustBoundaryUnknown.reviews as Array<{
+      result: string;
+      gates: { trustBoundary: { result: string } };
+    }>;
+
+    expect(reviews[0]?.result).toBe('needs-human-review');
+    expect(reviews[0]?.gates.trustBoundary.result).toBe('unknown');
   });
 
   it('keeps security reviews connected to security finding ids', () => {

--- a/tests/unit/security-assurance/proof-audit.test.ts
+++ b/tests/unit/security-assurance/proof-audit.test.ts
@@ -9,6 +9,7 @@ const claimsPath = 'fixtures/security-assurance/sample.security-claims.json';
 const codeMapPath = 'fixtures/security-assurance/sample.security-code-map.json';
 const scopePath = 'fixtures/security-assurance/sample.security-audit-scope.json';
 const responseFixturePath = 'fixtures/security-assurance/sample.security-audit-responses.json';
+const zeroFindingResponseFixturePath = 'fixtures/security-assurance/boundary-cases/zero-finding.security-audit-responses.json';
 const generatedAt = '2026-05-07T00:00:00.000Z';
 const tsxBin = resolve('node_modules/.bin/tsx');
 
@@ -188,21 +189,12 @@ describe('security proof-attempt audit producer', () => {
   });
 
 
-  it('allows response fixtures where every task has no finding', async () => {
-    const fixtureDir = mkdtempSync(join(tmpdir(), 'ae-proof-audit-all-clean-'));
+  it('allows the zero-finding boundary fixture where every task has no finding', async () => {
     const outDir = mkdtempSync(join(tmpdir(), 'ae-proof-audit-all-clean-out-'));
     try {
-      const localResponsesPath = join(fixtureDir, 'responses.json');
-      writeJson(localResponsesPath, {
-        schemaVersion: 'security-audit-response-fixture/v1',
-        responses: [
-          { taskId: 'SEC-AUDIT-TASK-001', result: 'no-finding', rationale: 'The fixture proof established the claim for the mapped code path.' },
-        ],
-      });
-
       const result = await generateSecurityProofAudit(claimsPath, codeMapPath, scopePath, outDir, {
         generatedAt,
-        responseFixture: localResponsesPath,
+        responseFixture: zeroFindingResponseFixturePath,
       });
 
       expect(result.findings).toBeUndefined();
@@ -210,7 +202,6 @@ describe('security proof-attempt audit producer', () => {
       expect(result.responseSummary).toEqual({ totalResponses: 1, findingResponses: 0, noFindingResponses: 1, missingResponses: 0 });
       expect(readFileSync(join(outDir, 'security-audit-summary.md'), 'utf8')).toContain('SEC-AUDIT-TASK-001 / SEC-CLAIM-001: no-finding');
     } finally {
-      rmSync(fixtureDir, { recursive: true, force: true });
       rmSync(outDir, { recursive: true, force: true });
     }
   });

--- a/tests/unit/security-assurance/security-cli-boundary.test.ts
+++ b/tests/unit/security-assurance/security-cli-boundary.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path, { join, resolve } from 'node:path';
+
+const tsxBin = resolve('node_modules/.bin/tsx');
+const inputSpec = 'fixtures/security-assurance/extract-claims/spec.md';
+const scopePath = 'fixtures/security-assurance/sample.security-audit-scope.json';
+const targetPath = 'fixtures/security-assurance/code-map-target';
+const generatedAt = '2026-05-07T00:00:00.000Z';
+
+const cliEnv = {
+  ...process.env,
+  VITEST: '',
+  NODE_ENV: 'production',
+  AE_TEST_NO_EXIT: '0',
+  DISABLE_TELEMETRY: 'true',
+};
+
+function runSecurity(args: string[], options: { cwd?: string } = {}) {
+  return spawnSync(tsxBin, ['src/cli/index.ts', 'security', ...args], {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    timeout: 60_000,
+    env: cliEnv,
+  });
+}
+
+describe('Security Assurance Lane CLI boundary', () => {
+  it('prints repo-relative POSIX artifact paths for generated outputs', () => {
+    mkdirSync('artifacts', { recursive: true });
+    const outDir = mkdtempSync(join(resolve('artifacts'), 'security-cli-boundary-'));
+    try {
+      const result = runSecurity([
+        'extract-claims',
+        '--spec',
+        inputSpec,
+        '--out',
+        outDir,
+        '--generated-at',
+        generatedAt,
+      ]);
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      const outputLine = result.stdout.split(/\r?\n/).find((line) => line.startsWith('Output: '));
+      const summaryLine = result.stdout.split(/\r?\n/).find((line) => line.startsWith('Summary: '));
+      expect(outputLine).toMatch(/^Output: artifacts\/security-cli-boundary-[^\\]+\/security-claims\.json$/);
+      expect(summaryLine).toMatch(/^Summary: artifacts\/security-cli-boundary-[^\\]+\/security-claims\.md$/);
+      expect(outputLine).not.toContain(process.cwd());
+      expect(readFileSync(join(outDir, 'security-claims.json'), 'utf8')).toContain('security-claim/v1');
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --out path traversal before writing artifacts', () => {
+    const result = runSecurity([
+      'extract-claims',
+      '--spec',
+      inputSpec,
+      '--out',
+      '../security-escape',
+      '--generated-at',
+      generatedAt,
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Unsafe --out path');
+    expect(result.stderr).toContain('path traversal');
+  });
+
+  it('rejects unsafe absolute --out paths outside the working and temp roots', () => {
+    const deniedPath = path.join(path.parse(process.cwd()).root, `ae-security-denied-output-${Date.now()}.json`);
+    const result = runSecurity([
+      'extract-claims',
+      '--spec',
+      inputSpec,
+      '--out',
+      deniedPath,
+      '--generated-at',
+      generatedAt,
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Unsafe --out path');
+    expect(result.stderr).toContain('absolute output paths must stay under');
+    expect(existsSync(deniedPath)).toBe(false);
+  });
+
+  it('reports malformed JSON input with a stable error prefix', () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'ae-security-cli-malformed-'));
+    const malformedClaims = join(fixtureDir, 'malformed-claims.json');
+    try {
+      writeFileSync(malformedClaims, '{not json', 'utf8');
+      const result = runSecurity([
+        'map-code',
+        '--claims',
+        malformedClaims,
+        '--scope',
+        scopePath,
+        '--target',
+        targetPath,
+        '--out',
+        join(fixtureDir, 'out'),
+        '--generated-at',
+        generatedAt,
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Security code-map generation failed');
+      expect(result.stderr).toContain('Malformed JSON input:');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports schema mismatches at the CLI boundary', () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'ae-security-cli-schema-'));
+    const invalidClaims = join(fixtureDir, 'invalid-claims.json');
+    try {
+      writeFileSync(
+        invalidClaims,
+        `${JSON.stringify({ schemaVersion: 'security-claim/v1', generatedAt, claims: [{ id: 'SEC-CLAIM-BAD' }] }, null, 2)}\n`,
+        'utf8',
+      );
+      const result = runSecurity([
+        'map-code',
+        '--claims',
+        invalidClaims,
+        '--scope',
+        scopePath,
+        '--target',
+        targetPath,
+        '--out',
+        join(fixtureDir, 'out'),
+        '--generated-at',
+        generatedAt,
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Input security claims failed schema validation');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports missing input files with a stable error prefix', () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'ae-security-cli-missing-'));
+    try {
+      const result = runSecurity([
+        'map-code',
+        '--claims',
+        join(fixtureDir, 'missing-claims.json'),
+        '--scope',
+        scopePath,
+        '--target',
+        targetPath,
+        '--out',
+        join(fixtureDir, 'out'),
+        '--generated-at',
+        generatedAt,
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Security code-map generation failed');
+      expect(result.stderr).toContain('Input file not found:');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/security-assurance/security-cli-boundary.test.ts
+++ b/tests/unit/security-assurance/security-cli-boundary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path, { join, resolve } from 'node:path';
 
@@ -45,6 +45,8 @@ describe('Security Assurance Lane CLI boundary', () => {
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
       const outputLine = result.stdout.split(/\r?\n/).find((line) => line.startsWith('Output: '));
       const summaryLine = result.stdout.split(/\r?\n/).find((line) => line.startsWith('Summary: '));
+      expect(outputLine, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBeDefined();
+      expect(summaryLine, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBeDefined();
       expect(outputLine).toMatch(/^Output: artifacts\/security-cli-boundary-[^\\]+\/security-claims\.json$/);
       expect(summaryLine).toMatch(/^Summary: artifacts\/security-cli-boundary-[^\\]+\/security-claims\.md$/);
       expect(outputLine).not.toContain(process.cwd());
@@ -86,6 +88,41 @@ describe('Security Assurance Lane CLI boundary', () => {
     expect(result.stderr).toContain('Unsafe --out path');
     expect(result.stderr).toContain('absolute output paths must stay under');
     expect(existsSync(deniedPath)).toBe(false);
+  });
+
+  it('rejects --out paths that escape through existing symlink directories', () => {
+    mkdirSync('artifacts', { recursive: true });
+    const outDir = mkdtempSync(join(resolve('artifacts'), 'security-cli-symlink-boundary-'));
+    const linkPath = join(outDir, 'link-to-root');
+    const escapedFileName = `ae-security-symlink-escape-${Date.now()}.json`;
+    const escapedOutputPath = join(linkPath, escapedFileName);
+    try {
+      try {
+        symlinkSync(path.parse(process.cwd()).root, linkPath, 'dir');
+      } catch (error: unknown) {
+        if (process.platform === 'win32') {
+          return;
+        }
+        throw error;
+      }
+
+      const result = runSecurity([
+        'extract-claims',
+        '--spec',
+        inputSpec,
+        '--out',
+        escapedOutputPath,
+        '--generated-at',
+        generatedAt,
+      ]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Unsafe --out path');
+      expect(result.stderr).toContain('existing symlink segments');
+      expect(existsSync(escapedOutputPath)).toBe(false);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
   });
 
   it('reports malformed JSON input with a stable error prefix', () => {


### PR DESCRIPTION
## Summary
- Add Security Assurance Lane CLI boundary regression tests for output path safety, malformed JSON, schema mismatch, missing input files, and repo-relative POSIX artifact-path output.
- Harden `ae security ...` assurance subcommands so `--out` rejects path traversal and unsafe absolute paths before writing artifacts.
- Stabilize JSON input error prefixes across security assurance producers.
- Add boundary-case fixtures for zero-finding proof-audit responses, multiple review records per finding, and trust-boundary unknown review outcomes.

## Acceptance
- Resolves #3281
- Part of #3279
- CLI smoke coverage remains present for `extract-claims`, `map-code`, `audit`, `review`, and `import-speca`.
- CLI input failures now have stable regression coverage for malformed JSON, schema mismatch, and missing input files.
- Unsafe `--out` traversal / absolute output paths are rejected before artifact writes.
- Candidate-first semantics remain fixed through existing candidate-vs-confirmed tests and new review-boundary fixtures.
- Existing golden scenario still reports `comparison: ok`.

## Verification
- `pnpm -s run test:security-assurance`
- `pnpm -s exec vitest run tests/unit/security-assurance tests/contracts/security-assurance-contract.test.ts --reporter dot`
- `pnpm -s run types:check`
- `pnpm -s run check:schemas`
- `git diff --check`

## Notes
- Security CLI does not currently expose a separate `--output-md` option; Markdown output remains derived from `--out` / JSON output path conventions and is covered through repo-relative POSIX artifact output assertions.

## Rollback
- Revert this PR to restore prior CLI output-path behavior and remove the added boundary fixtures/tests. No schema contract version is changed.