### PR TITLE
test(cli): cover command boundary regressions

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -25,6 +25,7 @@ Use this index to choose the smallest test lane that gives adequate signal for t
 | Context | Primary command(s) | Cost class | Use when |
 | --- | --- | --- | --- |
 | Local edit loop | `pnpm run test:fast`, focused `vitest run <path>` | S | Validating a small source or test change before commit. |
+| CLI / command boundary | `pnpm run test:fast:batch:cli`, `pnpm run test:fast:batch:commands`, focused `vitest run tests/contracts/cli-artifacts-contracts.test.ts` | S-M | Updating CLI routing, command helpers, exit-code handling, JSON output, cwd/env behavior, or artifact path behavior. |
 | Local unit / contract confidence | `pnpm run test:unit`, `pnpm run test:contracts` | S-M | Updating core modules, schemas, CLI helpers, or contract fixtures. |
 | PR baseline | `pnpm run verify:lite` or `pnpm run test:ci:lite` | M | Preparing a PR that should match the default required-check posture. |
 | Coverage inspection | `pnpm run coverage` | M-L | Refreshing coverage evidence or validating `coverage-check` behavior. |
@@ -96,6 +97,7 @@ Run the same documentation and type-surface checks used by the planning issue:
 | 文脈 | 代表コマンド | Cost class | 利用場面 |
 | --- | --- | --- | --- |
 | Local edit loop | `pnpm run test:fast`, focused `vitest run <path>` | S | 小さい source / test 変更を commit 前に確認する場合。 |
+| CLI / command boundary | `pnpm run test:fast:batch:cli`, `pnpm run test:fast:batch:commands`, focused `vitest run tests/contracts/cli-artifacts-contracts.test.ts` | S-M | CLI routing、command helper、exit code、JSON output、cwd/env behavior、artifact path behavior を更新した場合。 |
 | Local unit / contract confidence | `pnpm run test:unit`, `pnpm run test:contracts` | S-M | core module、schema、CLI helper、contract fixture を更新した場合。 |
 | PR baseline | `pnpm run verify:lite` または `pnpm run test:ci:lite` | M | 既定の required-check posture に合わせて PR を準備する場合。 |
 | Coverage inspection | `pnpm run coverage` | M-L | coverage evidence や `coverage-check` の挙動を確認する場合。 |

--- a/tests/commands/core-exec-boundary.test.ts
+++ b/tests/commands/core-exec-boundary.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execaMock } = vi.hoisted(() => ({
+  execaMock: vi.fn(),
+}));
+
+vi.mock('execa', () => ({
+  execa: execaMock,
+}));
+
+import { run } from '../../src/core/exec.js';
+
+describe('core exec command boundary', () => {
+  beforeEach(() => {
+    execaMock.mockReset();
+  });
+
+  it('returns ok with normalized stdout for successful commands', async () => {
+    execaMock.mockResolvedValueOnce({ exitCode: 0, stdout: new Uint8Array(Buffer.from('ok\n')) });
+
+    const result = await run('unit-step', 'node', ['--version'], { cwd: process.cwd() });
+
+    expect(execaMock).toHaveBeenCalledWith('node', ['--version'], expect.objectContaining({
+      cwd: process.cwd(),
+      reject: false,
+    }));
+    expect(result).toEqual({ ok: true, value: { stdout: 'ok\n' } });
+  });
+
+  it('returns E_EXEC for non-zero exits without throwing', async () => {
+    execaMock.mockResolvedValueOnce({ exitCode: 2, stdout: 'bad input' });
+
+    const result = await run('input-check', 'ae', ['bad']);
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: 'E_EXEC',
+        step: 'input-check',
+        detail: 'exit 2',
+      },
+    });
+  });
+
+  it('returns E_EXEC with original message for spawn/internal errors', async () => {
+    execaMock.mockRejectedValueOnce(new Error('spawn ENOENT'));
+
+    const result = await run('internal-check', 'missing-bin', []);
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: 'E_EXEC',
+        step: 'internal-check',
+        detail: 'spawn ENOENT',
+      },
+    });
+  });
+});

--- a/tests/commands/qa-run-boundary.test.ts
+++ b/tests/commands/qa-run-boundary.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execaMock, loadConfigWithSourceMock, getThresholdMock, readFileMock, statMock } = vi.hoisted(() => ({
+  execaMock: vi.fn(),
+  loadConfigWithSourceMock: vi.fn(),
+  getThresholdMock: vi.fn(),
+  readFileMock: vi.fn(),
+  statMock: vi.fn(),
+}));
+
+vi.mock('execa', () => ({
+  execa: execaMock,
+}));
+
+vi.mock('../../src/core/config.js', () => ({
+  loadConfigWithSource: loadConfigWithSourceMock,
+}));
+
+vi.mock('../../src/utils/quality-policy-loader.js', () => ({
+  getThreshold: getThresholdMock,
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock,
+  stat: statMock,
+}));
+
+import { qaRun } from '../../src/commands/qa/run.js';
+
+const originalEnv = { ...process.env };
+let packageJson: Record<string, unknown>;
+
+function basePackageJson(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'qa-run-fixture',
+    private: true,
+    scripts: {
+      test: 'vitest run',
+      'test:fast': 'vitest run tests/unit',
+    },
+    devDependencies: {
+      vitest: '^2.1.9',
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  execaMock.mockReset();
+  loadConfigWithSourceMock.mockReset();
+  getThresholdMock.mockReset();
+  readFileMock.mockReset();
+  statMock.mockReset();
+  process.env = { ...originalEnv };
+  delete process.env['CI'];
+  delete process.env['AE_QA_LIGHT'];
+  delete process.env['AE_QUALITY_PROFILE'];
+  packageJson = basePackageJson();
+  loadConfigWithSourceMock.mockResolvedValue({
+    config: {
+      qa: {
+        coverageThreshold: {
+          branches: 70,
+          lines: 80,
+          functions: 80,
+          statements: 80,
+        },
+      },
+    },
+    source: { path: null, raw: {} },
+  });
+  getThresholdMock.mockReturnValue(null);
+  execaMock.mockResolvedValue({ exitCode: 0, stdout: '' });
+  statMock.mockImplementation(async (filePath: string) => {
+    if (filePath === 'pnpm-lock.yaml') {
+      return {};
+    }
+    throw new Error(`missing: ${filePath}`);
+  });
+  readFileMock.mockImplementation(async (filePath: string) => {
+    if (filePath === 'package.json') {
+      return `${JSON.stringify(packageJson, null, 2)}\n`;
+    }
+    throw new Error(`missing: ${filePath}`);
+  });
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('qaRun command boundary', () => {
+  it('routes vitest light mode through the package-manager fast script', async () => {
+    process.env['AE_QA_LIGHT'] = '1';
+
+    await qaRun();
+
+    expect(execaMock).toHaveBeenCalledWith('pnpm', ['run', 'test:fast'], { stdio: 'inherit' });
+  });
+
+  it('routes CI mode through the fast script even when light option is omitted', async () => {
+    process.env['CI'] = 'true';
+
+    await qaRun();
+
+    expect(execaMock).toHaveBeenCalledWith('pnpm', ['run', 'test:fast'], { stdio: 'inherit' });
+  });
+
+  it('routes jest full mode with policy coverage thresholds when available', async () => {
+    packageJson = basePackageJson({
+      scripts: {
+        test: 'jest',
+      },
+      devDependencies: {
+        jest: '^29.7.0',
+      },
+    });
+    getThresholdMock.mockImplementation((_gate: string, metric: string) => ({
+      branches: 61,
+      lines: 62,
+      functions: 63,
+      statements: 64,
+    }[metric]));
+
+    await qaRun({ light: false });
+
+    expect(execaMock).toHaveBeenCalledWith('pnpm', [
+      'run',
+      'test',
+      '--',
+      '--coverage',
+      '--coverageThreshold={"global":{"lines":62,"functions":63,"branches":61,"statements":64}}',
+    ], { stdio: 'inherit' });
+  });
+
+  it('propagates runner failures as command boundary errors', async () => {
+    execaMock.mockRejectedValueOnce(new Error('test command failed'));
+
+    await expect(qaRun({ light: true })).rejects.toThrow('test command failed');
+  });
+});


### PR DESCRIPTION
## Summary
- Add command-boundary regression tests for `src/core/exec.ts` covering success stdout normalization, non-zero exit mapping, and spawn/internal error mapping to `E_EXEC`.
- Add `qaRun` boundary tests for package-manager/test-runner routing, `AE_QA_LIGHT`, `CI`, Jest coverage threshold policy routing, and runner failure propagation.
- Document the focused CLI / command boundary test route in `docs/testing/README.md`.

## Acceptance
- Resolves #3282
- Part of #3279
- Latest coverage was inspected on current base `a866564d867a09ff96b68938ed9ebf6ee45c621d` with `CI=1 pnpm -s run coverage`.
  - Total snapshot: lines 31.95%, statements 31.95%, functions 60.76%, branches 67.91%.
  - `src/core/exec.ts` and `src/commands/qa/run.ts` were selected because the snapshot showed direct command-boundary coverage gaps while existing `tests/contracts/cli-artifacts-contracts.test.ts` already covers JSON-output artifact contracts for high-value CLI surfaces.
- Success, input/non-zero, and internal/spawn error boundaries are covered for `run()`.
- cwd/env-sensitive command routing is covered for `qaRun` through mocked package files and environment flags.
- Existing CLI artifact contract tests remain the source for `--format json` output shape and exit-code contracts.

## Verification
- `CI=1 pnpm -s run coverage`
- `pnpm -s exec vitest run tests/commands/core-exec-boundary.test.ts tests/commands/qa-run-boundary.test.ts --reporter dot`
- `pnpm -s exec vitest run tests/cli tests/commands tests/contracts/cli-artifacts-contracts.test.ts --reporter dot`
- `pnpm -s run test:contracts`
- `pnpm -s run test:unit`
- `pnpm -s run types:check`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:doc-todo-markers`
- `git diff --check`

## Rollback
- Revert this PR to remove the added tests and the docs/testing command-route row. No runtime command behavior or schema contract is changed.