### PR TITLE
test(agents): add agent MCP smoke lane

### DIFF
--- a/docs/integrations/CODEX-INTEGRATION.md
+++ b/docs/integrations/CODEX-INTEGRATION.md
@@ -78,6 +78,26 @@ pnpm run codex:mcp:code
 pnpm run codex:mcp:spec
 ```
 
+### Agent / MCP boundary smoke test
+
+Use the focused smoke lane when changing agent entrypoints, MCP stdio servers, or provider fallback behavior:
+
+```bash
+pnpm run test:agents:smoke
+```
+
+This lane starts the Intent MCP server over stdio, verifies the client initialize handshake, lists tools, performs a basic tool call, and confirms that missing external provider API keys fall back to the local echo provider without network access.
+
+### Agent / MCP 境界 smoke test
+
+agent entrypoint、MCP stdio server、provider fallback を変更した場合は、次の focused smoke lane を使います。
+
+```bash
+pnpm run test:agents:smoke
+```
+
+この lane は Intent MCP server を stdio で起動し、client initialize handshake、tool list、basic tool call、外部 provider API key 未設定時の local echo provider fallback を確認します。
+
 ### Client setup (example)
 Configure CodeX to connect to the servers via stdio on Node 20.11+. Ensure the working directory is the ae-framework repo (or set `cwd`).
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -27,6 +27,7 @@ Use this index to choose the smallest test lane that gives adequate signal for t
 | Local edit loop | `pnpm run test:fast`, focused `vitest run <path>` | S | Validating a small source or test change before commit. |
 | CLI / command boundary | `pnpm run test:fast:batch:cli`, `pnpm run test:fast:batch:commands`, focused `vitest run tests/contracts/cli-artifacts-contracts.test.ts` | S-M | Updating CLI routing, command helpers, exit-code handling, JSON output, cwd/env behavior, or artifact path behavior. |
 | Workspace package / app smoke | `pnpm run test:workspace:smoke`, `pnpm run build:tokens`, `pnpm run build:ui`, `pnpm run type-check:frontend` | S-M | Updating `packages/*`, `apps/web`, `apps/storybook`, package exports, design tokens, UI source, or frontend/story inventory. |
+| Agent / MCP boundary smoke | `pnpm run test:agents:smoke`, `pnpm run test:fast:batch:agents` | S-M | Updating `src/agents/*`, `src/mcp-server/*`, provider fallback behavior, or Codex MCP stdio integration. |
 | Local unit / contract confidence | `pnpm run test:unit`, `pnpm run test:contracts` | S-M | Updating core modules, schemas, CLI helpers, or contract fixtures. |
 | PR baseline | `pnpm run verify:lite` or `pnpm run test:ci:lite` | M | Preparing a PR that should match the default required-check posture. |
 | Coverage inspection | `pnpm run coverage` | M-L | Refreshing coverage evidence or validating `coverage-check` behavior. |
@@ -100,6 +101,7 @@ Run the same documentation and type-surface checks used by the planning issue:
 | Local edit loop | `pnpm run test:fast`, focused `vitest run <path>` | S | 小さい source / test 変更を commit 前に確認する場合。 |
 | CLI / command boundary | `pnpm run test:fast:batch:cli`, `pnpm run test:fast:batch:commands`, focused `vitest run tests/contracts/cli-artifacts-contracts.test.ts` | S-M | CLI routing、command helper、exit code、JSON output、cwd/env behavior、artifact path behavior を更新した場合。 |
 | Workspace package / app smoke | `pnpm run test:workspace:smoke`, `pnpm run build:tokens`, `pnpm run build:ui`, `pnpm run type-check:frontend` | S-M | `packages/*`、`apps/web`、`apps/storybook`、package export、design tokens、UI source、frontend/story inventory を更新した場合。 |
+| Agent / MCP boundary smoke | `pnpm run test:agents:smoke`, `pnpm run test:fast:batch:agents` | S-M | `src/agents/*`、`src/mcp-server/*`、provider fallback、Codex MCP stdio integration を更新した場合。 |
 | Local unit / contract confidence | `pnpm run test:unit`, `pnpm run test:contracts` | S-M | core module、schema、CLI helper、contract fixture を更新した場合。 |
 | PR baseline | `pnpm run verify:lite` または `pnpm run test:ci:lite` | M | 既定の required-check posture に合わせて PR を準備する場合。 |
 | Coverage inspection | `pnpm run coverage` | M-L | coverage evidence や `coverage-check` の挙動を確認する場合。 |

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "test:fast:batch:cli": "vitest run tests/cli/**",
     "test:fast:batch:property": "vitest run tests/property/**",
     "test:fast:batch:agents": "vitest run tests/agents/**",
+    "test:agents:smoke": "vitest run tests/agents/agent-mcp-boundary-smoke.test.ts",
     "test:workspace:smoke": "vitest run tests/workspace",
     "test:a11y": "jest --config configs/jest.a11y.config.cjs",
     "test:a11y:report": "node scripts/generate-a11y-report.cjs",

--- a/tests/agents/agent-mcp-boundary-smoke.test.ts
+++ b/tests/agents/agent-mcp-boundary-smoke.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { LLM } from '../../src/providers/index.js';
+import { FormalAgent } from '../../src/agents/formal-agent.js';
+import { IntentAgent } from '../../src/agents/intent-agent.js';
+import { VerifyAgent } from '../../src/agents/verify-agent.js';
+import { loadLLM } from '../../src/providers/index.js';
+
+const repoRoot = process.cwd();
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+
+const withoutProviderKeys = (): Record<string, string> => {
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  );
+
+  env['ANTHROPIC_API_KEY'] = '';
+  env['OPENAI_API_KEY'] = '';
+  env['GEMINI_API_KEY'] = '';
+  return env;
+};
+
+describe('Agent / MCP boundary smoke', () => {
+  test('intent, formal, and verify agents expose stable minimal input/output shapes', async () => {
+    const intentAgent = new IntentAgent();
+    const intentRequest = IntentAgent.createSimpleRequest(
+      'Users must reserve inventory without making on-hand stock negative.',
+      {
+        domain: 'inventory',
+        analysisDepth: 'basic',
+        outputFormat: 'structured',
+      },
+    );
+
+    const intentResult = await intentAgent.analyzeIntent(intentRequest);
+
+    expect(intentResult.requirements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.stringMatching(/^REQ-/),
+          description: expect.stringContaining('reserve inventory'),
+        }),
+      ]),
+    );
+    expect(intentResult.primaryIntent).toContain('reserve inventory');
+    expect(intentResult.traceability.length).toBeGreaterThan(0);
+
+    const formalAgent = new FormalAgent({
+      generateDiagrams: false,
+      enableModelChecking: false,
+    });
+
+    const formalSpec = await formalAgent.generateFormalSpecification(
+      'Inventory reservation must never make onHand negative.',
+      'tla+',
+      { includeDiagrams: false, generateProperties: true },
+    );
+
+    expect(formalSpec).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(/^spec_/),
+        type: 'tla+',
+        title: expect.any(String),
+        validation: expect.objectContaining({ status: 'valid' }),
+      }),
+    );
+    expect(formalSpec.title.length).toBeGreaterThan(0);
+    expect(formalSpec.content).toContain('MODULE');
+    expect(formalSpec.metadata.properties).toEqual(expect.any(Array));
+
+    const verifyAgent = new VerifyAgent({ enableContainers: false });
+    const verificationResult = await verifyAgent.runFullVerification({
+      codeFiles: [
+        {
+          path: 'src/sample.ts',
+          content: 'export const reserved: number = 1;',
+          language: 'typescript',
+        },
+      ],
+      testFiles: [],
+      verificationTypes: ['typechecking'],
+      strictMode: true,
+    });
+
+    expect(verificationResult.passed).toBe(true);
+    expect(verificationResult.results).toEqual([
+      expect.objectContaining({
+        type: 'typechecking',
+        passed: true,
+        details: { errors: [] },
+      }),
+    ]);
+    expect(verificationResult.traceability.code).toEqual([
+      expect.objectContaining({
+        id: 'src/sample.ts',
+        covered: true,
+      }),
+    ]);
+  });
+
+  test('provider loading falls back to the local echo provider when external API keys are unset', async () => {
+    const previousEnv = {
+      ANTHROPIC_API_KEY: process.env['ANTHROPIC_API_KEY'],
+      OPENAI_API_KEY: process.env['OPENAI_API_KEY'],
+      GEMINI_API_KEY: process.env['GEMINI_API_KEY'],
+    };
+
+    try {
+      delete process.env['ANTHROPIC_API_KEY'];
+      delete process.env['OPENAI_API_KEY'];
+      delete process.env['GEMINI_API_KEY'];
+
+      const llm: LLM = await loadLLM();
+      const completion = await llm.complete({
+        system: 'agent-smoke',
+        prompt: 'Summarize local fallback behavior.',
+      });
+
+      expect(llm.name).toBe('echo');
+      expect(completion).toBe('[echo] [system: agent-smoke] Summarize local fallback behavior.');
+    } finally {
+      for (const [key, value] of Object.entries(previousEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
+
+  test(
+    'intent MCP stdio server supports initialize, tool listing, and a basic tool call',
+    async () => {
+      const transport = new StdioClientTransport({
+        command: pnpmCommand,
+        args: ['exec', 'tsx', 'src/mcp-server/intent-server.ts'],
+        cwd: repoRoot,
+        env: withoutProviderKeys(),
+        stderr: 'pipe',
+      });
+      const client = new Client(
+        { name: 'agent-mcp-smoke-client', version: '1.0.0' },
+        { capabilities: {} },
+      );
+
+      try {
+        await client.connect(transport);
+
+        expect(client.getServerVersion()).toEqual(
+          expect.objectContaining({
+            name: 'intent-agent-server',
+            version: '1.0.0',
+          }),
+        );
+        expect(client.getServerCapabilities()).toEqual(
+          expect.objectContaining({
+            tools: expect.any(Object),
+          }),
+        );
+
+        const tools = await client.listTools();
+        expect(tools.tools.map((tool) => tool.name)).toEqual(
+          expect.arrayContaining([
+            'analyze_intent',
+            'extract_from_natural_language',
+            'create_user_stories',
+          ]),
+        );
+
+        const result = await client.callTool({
+          name: 'extract_from_natural_language',
+          arguments: {
+            text: 'Users must reserve inventory without making on-hand stock negative.',
+          },
+        });
+        const firstContent = result.content[0];
+
+        expect(firstContent?.type).toBe('text');
+        const payload = JSON.parse(firstContent?.type === 'text' ? firstContent.text : '{}') as {
+          extracted_requirements?: Array<{ id: string; description: string }>;
+          count?: number;
+        };
+
+        expect(payload.count).toBeGreaterThan(0);
+        expect(payload.extracted_requirements).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: expect.stringMatching(/^REQ-/),
+              description: expect.stringContaining('reserve inventory'),
+            }),
+          ]),
+        );
+      } finally {
+        await client.close().catch(() => undefined);
+        await transport.close().catch(() => undefined);
+      }
+    },
+    20_000,
+  );
+});


### PR DESCRIPTION
## Summary
- Add a focused `test:agents:smoke` Vitest lane for Agent / MCP boundary regression coverage.
- Cover minimal `IntentAgent`, `FormalAgent`, and `VerifyAgent` input/output contracts without external services.
- Exercise the Intent MCP stdio server with an MCP client initialize handshake, tool listing, and basic tool call, and document the lane in testing and CodeX integration docs.

## Acceptance
- Resolves #3284
- Part of #3279
- Agent / MCP boundary smoke coverage is runnable from the repository root.
- Provider API keys unset path falls back to the local echo provider without network access.
- External LLM provider E2E, long-running MCP soak tests, and full agent-pipeline E2E remain out of scope for this slice.

## Verification
- `pnpm -s run test:agents:smoke -- --reporter dot` — 1 file / 3 tests passed.
- `pnpm -s exec vitest run tests/agents tests/unit/agents tests/codex tests/providers/provider-utils.test.ts tests/commands/mcp-command.test.ts --reporter dot` — 23 files / 150 tests passed.
- `pnpm -s run types:check` — passed.
- `pnpm -s run check:doc-consistency` — passed; doc governance warnings 0.
- `pnpm -s run check:doc-todo-markers` — passed.
- `git diff --check` — passed.
- `pnpm -s run lint -- tests/agents/agent-mcp-boundary-smoke.test.ts` — exited 0; command linted the repo with existing warnings and reported the new test file is ignored by the current lint config.

## Rollback
- Revert this PR to remove the focused agent/MCP smoke test lane, the smoke test file, and the documentation route updates. No production runtime behavior or schema contract is changed.