### PR TITLE
feat(assurance): stabilize preview claim summary schemas

### DIFF
--- a/docs/architecture/ASSURANCE-CONTROL-PLANE-DETAILED-DESIGN.md
+++ b/docs/architecture/ASSURANCE-CONTROL-PLANE-DETAILED-DESIGN.md
@@ -34,6 +34,8 @@ Baseline assumptions (as of `lastVerified: 2026-05-08`):
 - Canonical current lane summary: `schema/assurance-summary.schema.json` with `schemaVersion: assurance-summary/v1`.
 - Canonical current policy-gate summary: `schema/policy-gate-summary-v1.schema.json` with `schemaVersion: policy-gate-summary/v1`.
 - Canonical current proof-carrying package preview: `schema/change-package-v2.schema.json` with `schemaVersion: change-package/v2`.
+- Preview per-claim PR/release projection: `schema/claim-level-summary-v1.schema.json` with `schemaVersion: claim-level-summary/v1`.
+- Preview temporary override record: `schema/temporary-override-v1.schema.json` with `schemaVersion: temporary-override/v1`.
 
 ### 2. Design goals and non-goals
 
@@ -140,7 +142,7 @@ Current emitted evidence states for change-package claims are:
 | `waived` | Human exception exists and is traceable. | `claim-evidence-manifest/v1.status=waived` plus `waiverRefs`; `change-package/v2.claims[].status=waived`. |
 | `unresolved` | Evidence is missing, failed, stale, insufficient, out of scope, or not accepted. | `claim-evidence-manifest/v1.status=unresolved`/`partial`, `missingEvidenceRefs`, policy result `block` or `report-only`. |
 
-`not-applicable` is intentionally not part of the current emitted state set. Until a schema migration exists, a producer should either omit a non-claim or record the unresolved/out-of-scope rationale in notes, missing evidence, waiver/residual risk, or PR summary text.
+`not-applicable` is intentionally not part of the current `claim-evidence-manifest/v1` or `change-package/v2` emitted state set. The preview `claim-level-summary/v1` schema can represent `not-applicable` for PR/release projection and migration testing, but producers should not emit it into current primary contracts until promotion is explicit.
 
 #### 4.6 Evidence manifest
 
@@ -166,7 +168,7 @@ Assumptions must remain visible in PR/release summaries. A formal or model-check
 
 #### 4.8 Waiver / override
 
-A waiver is a time-bounded human exception. The current compatible contract requires or derives:
+A waiver is a time-bounded human exception. The current compatible representation is `schema/temporary-override-v1.schema.json` for preview override records plus waiver references in claim-evidence, policy, and change-package artifacts. It requires or derives:
 
 - owner
 - reason
@@ -214,7 +216,7 @@ The v2 package consumes claim-evidence and policy artifacts; it is not the sourc
 
 #### 4.12 PR/release summary
 
-A PR or release summary is a human-facing projection of the contracts above. It should surface:
+A PR or release summary is a human-facing projection of the contracts above. The preview schema is `schema/claim-level-summary-v1.schema.json`. It should surface:
 
 - target and achieved assurance level
 - satisfied, partial, waived, and unresolved claim counts
@@ -256,7 +258,7 @@ Summaries must avoid wording that claims proof beyond the linked evidence scope.
 7. If a claim is waived, keep waiver details and do not count it as satisfied.
 8. If a claim is runtime-mitigated, record runtime control evidence and residual risk; do not treat it as proof/model-checking evidence.
 9. When multiple sources disagree, choose the more conservative claim status in this order: `unresolved` > `waived` > `partial` > `satisfied`, while preserving all evidence and notes.
-10. When a current schema lacks a precise state, represent it as `unresolved` or `partial` with a note/missing-evidence reference rather than introducing an undeclared enum value.
+10. When a current primary schema lacks a precise state, represent it as `unresolved` or `partial` with a note/missing-evidence reference rather than introducing an undeclared enum value. Use `claim-level-summary/v1` only as a preview projection until producers and consumers are promoted together.
 
 ### 6. Failure-mode representation
 

--- a/docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
+++ b/docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
@@ -52,7 +52,7 @@ Use this document with:
 | Risk-based verification | Heavy verification is conditional and risk-based, not universal. |
 | Claim-based assurance | Assurance is evaluated per claim, not by repository-wide green status alone. |
 | Summary-first evidence | Summary artifacts are primary judgment inputs; raw logs are supporting evidence. |
-| Distinct evidence states | Current emitted evidence states are `proved`, `model-checked`, `tested`, `runtime-mitigated`, `waived`, and `unresolved`. A future `not-applicable` state requires schema and docs migration before producers emit it. |
+| Distinct evidence states | Current primary emitted evidence states are `proved`, `model-checked`, `tested`, `runtime-mitigated`, `waived`, and `unresolved`. Preview `claim-level-summary/v1` can represent `not-applicable` for PR/release projection, but current primary producers must not emit it until promotion is explicit. |
 | Human override | Human override requires owner, reason, expiry, related claim IDs, and evidence link. |
 | Contract evolution | Contract changes use compatibility windows, dual-write/dual-validate behavior, or explicit migration notes. |
 | Enforcement default | New assurance evaluation should start report-only unless an explicit policy, label, or risk profile selects enforcement. |
@@ -84,7 +84,8 @@ A claim state must not be upgraded beyond the supporting evidence.
 | `tested` | Unit, integration, property, MBT, or similar behavior evidence exists. | Formal proof. |
 | `runtime-mitigated` | Runtime control reduces operational risk. | Proof or model checking. |
 | `waived` | An owner accepted a time-bounded exception with evidence link. | Satisfied claim. |
-| `unresolved` | Required evidence is absent, stale, failed, insufficient, or intentionally out of current scope. | Passing build. |
+| `unresolved` | Required evidence is absent, stale, failed, insufficient, or intentionally out of current primary-contract scope. | Passing build. |
+| `not-applicable` | Preview-only claim-level summary projection for an explicitly out-of-scope/non-applicable claim. | A current `claim-evidence-manifest/v1` or `change-package/v2` emitted state. |
 
 ### 6. Valid and invalid wording examples
 

--- a/docs/reference/CONTRACT-CATALOG.md
+++ b/docs/reference/CONTRACT-CATALOG.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-05-07'
+lastVerified: '2026-05-08'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -25,7 +25,7 @@ This document is the baseline inventory created for Issue #2406. It classifies t
 
 Some schemas are dual-role. This catalog records the primary role used in the current implementation.
 
-### 3. Schema inventory (snapshot: 2026-05-07)
+### 3. Schema inventory (snapshot: 2026-05-08)
 
 #### 3.1 input
 
@@ -62,6 +62,7 @@ Some schemas are dual-role. This catalog records the primary role used in the cu
 - `schema/policy-decision-v1.schema.json`
 - `schema/pr-state-v1.schema.json`
 - `schema/policy-gate-summary-v1.schema.json`
+- `schema/temporary-override-v1.schema.json`
 - `schema/security-review-v1.schema.json`
 - `schema/quality-report.schema.json`
 - `schema/trace-validation.schema.json`
@@ -74,6 +75,7 @@ Some schemas are dual-role. This catalog records the primary role used in the cu
 - `schema/artifact-metadata.schema.json`
 - `schema/assurance-summary.schema.json`
 - `schema/claim-evidence-manifest.schema.json`
+- `schema/claim-level-summary-v1.schema.json`
 - `schema/security-code-map-v1.schema.json`
 - `schema/symbol-index-v1.schema.json`
 - `schema/security-entrypoint-map-v1.schema.json`
@@ -129,6 +131,8 @@ The table below keeps the current producer/consumer baseline for representative 
 | `artifacts/discovery-pack/context-pack-scaffold.yaml` | `schema/context-pack-v1.schema.json` (scaffold-compatible, non-authoritative) | `scripts/discovery-pack/compile.mjs` (`--target context-pack-scaffold`), `src/cli/discovery-cli.ts` | manual editing before Context Pack SSOT promotion, future Context Pack validation |
 | `artifacts/assurance/assurance-summary.json` | `schema/assurance-summary.schema.json` | `scripts/assurance/aggregate-lanes.mjs`, `.github/workflows/verify-lite.yml`; optional `security-claim/v1`, `security-finding/v1`, and `security-review/v1` inputs surface Security Assurance Lane evidence, including claim-type and assumption-handling summaries | `scripts/ci/validate-assurance-summary.mjs`, `scripts/ci/validate-artifacts-ajv.mjs`, `scripts/ci/validate-json.mjs`, `scripts/ci/enforce-assurance-summary.mjs`, `scripts/quality/build-quality-scorecard.mjs`, `scripts/agents/build-hook-feedback.mjs`, `scripts/agents/create-handoff.mjs`, `scripts/summary/render-pr-summary.mjs`, `.github/workflows/pr-ci-status-comment.yml` |
 | `artifacts/assurance/claim-evidence-manifest.json` | `schema/claim-evidence-manifest.schema.json` | `scripts/assurance/build-claim-evidence-manifest.mjs`, `.github/workflows/verify-lite.yml`, `fixtures/assurance/sample.claim-evidence-manifest.json` (schema contract fixture); optional `security-claim/v1`, `security-finding/v1`, and `security-review/v1` inputs are summarized under `summary.security`, preserve original security IDs in claim/evidence `externalIds`, and expose assumption handling through `securityClaimType` / `assumptionHandlingRefs` | `scripts/ci/validate-json.mjs`, `scripts/ci/validate-artifacts-ajv.mjs`, `tests/contracts/claim-evidence-manifest-contract.test.ts`, `scripts/summary/render-pr-summary.mjs`, `scripts/ci/policy-gate.mjs`, `.github/workflows/pr-ci-status-comment.yml` |
+| `artifacts/assurance/claim-level-summary.json` | `schema/claim-level-summary-v1.schema.json` | Preview/manual or future `claim-evidence-manifest/v1` projection; `fixtures/assurance/sample.claim-level-summary-v1.json` covers satisfied, tested, model-checked, proved, runtime-mitigated, waived, unresolved, failed, and not-applicable states | `scripts/ci/validate-json.mjs`, `tests/contracts/assurance-control-plane-schema-contract.test.ts`, future PR/release summary renderers; this preview does not change current `claim-evidence-manifest/v1` or `change-package/v2` emitted state sets |
+| `artifacts/assurance/temporary-overrides/*.json` | `schema/temporary-override-v1.schema.json` | Manual or policy-owner waiver records; `fixtures/assurance/sample.temporary-override-v1.json` is the schema contract fixture | `scripts/ci/validate-json.mjs`, `tests/contracts/assurance-control-plane-schema-contract.test.ts`, future claim-level summaries and policy-gate waiver projections; requires owner, reason, expiry, related claim IDs, and evidence link |
 | `artifacts/security/security-claims.json` | `schema/security-claim-v1.schema.json` | manual authoring, `ae security import-speca`, `ae security extract-claims`, `fixtures/security-assurance/sample.security-claims.json` (schema contract fixture) | `ae security map-code`, future Security Assurance Lane producers, `scripts/ci/validate-json.mjs`, `tests/contracts/security-assurance-contract.test.ts`; downstream artifacts reference `claims[].id` |
 | `artifacts/security/security-threat-model.json` | `schema/security-threat-model-v1.schema.json` | manual authoring, `ae security import-speca`, `fixtures/security-assurance/sample.security-threat-model.json` (schema contract fixture) | future security audit and review producers, `scripts/ci/validate-json.mjs`, `tests/contracts/security-assurance-contract.test.ts`; references security claim ids through `threats[].relatedClaimIds[]` |
 | `artifacts/security/security-audit-scope.json` | `schema/security-audit-scope-v1.schema.json` | manual authoring, bug-bounty/audit scope translation, `fixtures/security-assurance/sample.security-audit-scope.json` (schema contract fixture) | future security claim extraction, code-map, audit, and review producers; scope remains glob-based in the MVP contract |
@@ -185,7 +189,7 @@ The table below keeps the current producer/consumer baseline for representative 
 
 ### 6. Current gaps (next stage)
 
-- assurance contracts are still being introduced in phases; default operation stays report-only, and strict assurance enforcement is limited to Verify Lite when the `enforce-assurance` label is present.
+- assurance contracts are still being introduced in phases; default operation stays report-only, and strict assurance enforcement is limited to Verify Lite when the `enforce-assurance` label is present. `claim-level-summary/v1` and `temporary-override/v1` are preview contracts and are not mandatory producer outputs yet.
 - `schemaVersion` still mixes semver and `*/v1` style identifiers. The staged unification plan lives in `docs/reference/SCHEMA-GOVERNANCE.md`.
 - `change-package` still runs with `v1` as the production contract while `v2` remains the proof-carrying preview contract.
 - Formal Summary still operates in a dual-write + dual-validate period (`v2`: `schemaVersion=formal-summary/v2`, `contractId=formal-summary.v2`).
@@ -261,6 +265,7 @@ The table below keeps the current producer/consumer baseline for representative 
 - `schema/policy-decision-v1.schema.json`
 - `schema/pr-state-v1.schema.json`
 - `schema/policy-gate-summary-v1.schema.json`
+- `schema/temporary-override-v1.schema.json`
 - `schema/security-review-v1.schema.json`
 - `schema/quality-report.schema.json`
 - `schema/trace-validation.schema.json`
@@ -273,6 +278,7 @@ The table below keeps the current producer/consumer baseline for representative 
 - `schema/artifact-metadata.schema.json`
 - `schema/assurance-summary.schema.json`
 - `schema/claim-evidence-manifest.schema.json`
+- `schema/claim-level-summary-v1.schema.json`
 - `schema/security-code-map-v1.schema.json`
 - `schema/symbol-index-v1.schema.json`
 - `schema/security-entrypoint-map-v1.schema.json`

--- a/fixtures/assurance/invalid.claim-level-summary-v1.missing-enforced-reason.json
+++ b/fixtures/assurance/invalid.claim-level-summary-v1.missing-enforced-reason.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": "claim-level-summary/v1",
+  "generatedAt": "2026-05-08T00:00:00.000Z",
+  "source": {
+    "repository": "itdojp/ae-framework",
+    "prNumber": 3306,
+    "baseRef": "main",
+    "headRef": "feat/3306-assurance-schemas"
+  },
+  "inputs": {
+    "claimEvidenceManifest": {
+      "path": "artifacts/assurance/claim-evidence-manifest.json",
+      "schemaVersion": "claim-evidence-manifest/v1",
+      "present": true,
+      "required": true
+    },
+    "policyGateSummary": {
+      "path": "artifacts/ci/policy-gate-summary.json",
+      "schemaVersion": "policy-gate-summary/v1",
+      "present": true,
+      "required": true
+    },
+    "temporaryOverrides": [],
+    "changePackageV2": null
+  },
+  "summary": {
+    "totalClaims": 1,
+    "satisfied": 0,
+    "tested": 0,
+    "modelChecked": 0,
+    "proved": 0,
+    "runtimeMitigated": 0,
+    "waived": 0,
+    "unresolved": 0,
+    "failed": 1,
+    "notApplicable": 0,
+    "enforcedDecisions": 1,
+    "reportOnlyDecisions": 0
+  },
+  "claims": [
+    {
+      "claimId": "claim-failed-strict-proof",
+      "statement": "Strict proof requirement failed and blocks enforcement.",
+      "criticality": "critical",
+      "targetLevel": "A4",
+      "achievedLevel": "A1",
+      "state": "failed",
+      "stateRationale": "Required proof evidence failed under strict policy.",
+      "decision": {
+        "mode": "strict",
+        "result": "block",
+        "enforced": true,
+        "sourceArtifactId": "policy-gate-summary",
+        "evidenceRefs": ["ev-failed-proof"],
+        "missingEvidenceRefs": ["missing-discharged-proof"],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [],
+      "missingEvidenceRefs": [
+        {
+          "id": "missing-discharged-proof",
+          "expectedKind": "proof",
+          "reason": "A discharged proof obligation is required for strict enforcement.",
+          "sourceArtifactId": "claim-evidence-manifest"
+        }
+      ],
+      "waiverRefs": [],
+      "assumptions": [],
+      "runtimeControls": [],
+      "notes": []
+    }
+  ]
+}

--- a/fixtures/assurance/invalid.temporary-override-v1.missing-evidence-link.json
+++ b/fixtures/assurance/invalid.temporary-override-v1.missing-evidence-link.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "temporary-override/v1",
+  "id": "override-missing-evidence-link",
+  "status": "active",
+  "owner": "@team-platform",
+  "reason": "Missing evidence link should be rejected.",
+  "expires": "2026-06-30",
+  "relatedClaimIds": ["claim-waived-audit-trail"]
+}

--- a/fixtures/assurance/sample.claim-level-summary-v1.json
+++ b/fixtures/assurance/sample.claim-level-summary-v1.json
@@ -1,0 +1,392 @@
+{
+  "schemaVersion": "claim-level-summary/v1",
+  "generatedAt": "2026-05-08T00:00:00.000Z",
+  "source": {
+    "repository": "itdojp/ae-framework",
+    "prNumber": 3306,
+    "baseRef": "main",
+    "headRef": "feat/3306-assurance-schemas",
+    "headSha": "0000000000000000000000000000000000000000"
+  },
+  "inputs": {
+    "claimEvidenceManifest": {
+      "path": "artifacts/assurance/claim-evidence-manifest.json",
+      "schemaVersion": "claim-evidence-manifest/v1",
+      "present": true,
+      "required": true
+    },
+    "policyGateSummary": {
+      "path": "artifacts/ci/policy-gate-summary.json",
+      "schemaVersion": "policy-gate-summary/v1",
+      "present": true,
+      "required": true
+    },
+    "temporaryOverrides": [
+      {
+        "path": "artifacts/assurance/temporary-overrides/override-inventory-waiver-2026-06.json",
+        "schemaVersion": "temporary-override/v1",
+        "present": true,
+        "required": false
+      }
+    ],
+    "changePackageV2": {
+      "path": "artifacts/change-package/change-package-v2.json",
+      "schemaVersion": "change-package/v2",
+      "present": true,
+      "required": false
+    }
+  },
+  "summary": {
+    "totalClaims": 9,
+    "satisfied": 1,
+    "tested": 1,
+    "modelChecked": 1,
+    "proved": 1,
+    "runtimeMitigated": 1,
+    "waived": 1,
+    "unresolved": 1,
+    "failed": 1,
+    "notApplicable": 1,
+    "enforcedDecisions": 1,
+    "reportOnlyDecisions": 2
+  },
+  "claims": [
+    {
+      "claimId": "claim-satisfied-inventory-reservation",
+      "statement": "Inventory reservations do not produce negative available stock.",
+      "criticality": "high",
+      "targetLevel": "A2",
+      "achievedLevel": "A2",
+      "state": "satisfied",
+      "stateRationale": "Required behavior and policy evidence are linked and no missing evidence remains.",
+      "decision": {
+        "mode": "report-only",
+        "result": "pass",
+        "enforced": false,
+        "reason": "Claim is satisfied at target level.",
+        "sourceArtifactId": "policy-gate-summary",
+        "evidenceRefs": ["ev-policy-pass"],
+        "missingEvidenceRefs": [],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [
+        {
+          "id": "ev-policy-pass",
+          "kind": "policy",
+          "status": "observed",
+          "artifactPath": "artifacts/ci/policy-gate-summary.json#/evaluation/assurance/claims/0",
+          "sourceArtifactId": "policy-gate-summary",
+          "description": "Policy gate summarized claim as pass."
+        }
+      ],
+      "missingEvidenceRefs": [],
+      "waiverRefs": [],
+      "assumptions": [],
+      "runtimeControls": [],
+      "notes": []
+    },
+    {
+      "claimId": "claim-tested-reservation-flow",
+      "statement": "Reservation flow has behavior test coverage.",
+      "criticality": "medium",
+      "targetLevel": "A2",
+      "achievedLevel": "A2",
+      "state": "tested",
+      "stateRationale": "Behavior evidence is present but no model/proof evidence is claimed.",
+      "decision": {
+        "mode": "report-only",
+        "result": "pass",
+        "enforced": false,
+        "reason": "Behavior evidence is linked.",
+        "sourceArtifactId": "claim-evidence-manifest",
+        "evidenceRefs": ["ev-behavior-test"],
+        "missingEvidenceRefs": [],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [
+        {
+          "id": "ev-behavior-test",
+          "kind": "behavior",
+          "status": "observed",
+          "artifactPath": "artifacts/verify-lite/verify-lite-run-summary.json",
+          "sourceArtifactId": "verify-lite-run-summary",
+          "description": "Verify Lite behavior tests passed."
+        }
+      ],
+      "missingEvidenceRefs": [],
+      "waiverRefs": [],
+      "assumptions": [],
+      "runtimeControls": [],
+      "notes": []
+    },
+    {
+      "claimId": "claim-model-checked-inventory-state",
+      "statement": "Inventory state transition model has been checked for the stated scope.",
+      "criticality": "high",
+      "targetLevel": "A3",
+      "achievedLevel": "A3",
+      "state": "model-checked",
+      "stateRationale": "Formal summary contains model checking evidence for the modeled scope.",
+      "decision": {
+        "mode": "report-only",
+        "result": "pass",
+        "enforced": false,
+        "reason": "Model-checking evidence is linked.",
+        "sourceArtifactId": "claim-evidence-manifest",
+        "evidenceRefs": ["ev-model-check"],
+        "missingEvidenceRefs": [],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [
+        {
+          "id": "ev-model-check",
+          "kind": "model",
+          "status": "observed",
+          "artifactPath": "artifacts/formal/formal-summary-v2.json",
+          "sourceArtifactId": "formal-summary-v2",
+          "description": "Model checking completed under stated assumptions."
+        }
+      ],
+      "missingEvidenceRefs": [],
+      "waiverRefs": [],
+      "assumptions": [
+        {
+          "id": "assumption-model-scope",
+          "statement": "The model covers reservation state transitions only.",
+          "status": "accepted",
+          "artifactPath": "artifacts/formal/formal-summary-v2.json#/assumptions/0"
+        }
+      ],
+      "runtimeControls": [],
+      "notes": []
+    },
+    {
+      "claimId": "claim-proved-balance-invariant",
+      "statement": "The balance invariant is discharged by proof-level evidence for the stated module.",
+      "criticality": "critical",
+      "targetLevel": "A4",
+      "achievedLevel": "A4",
+      "state": "proved",
+      "stateRationale": "Proof obligation is discharged and linked.",
+      "decision": {
+        "mode": "report-only",
+        "result": "pass",
+        "enforced": false,
+        "reason": "Proof-level evidence is linked.",
+        "sourceArtifactId": "claim-evidence-manifest",
+        "evidenceRefs": ["ev-proof"],
+        "missingEvidenceRefs": [],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [
+        {
+          "id": "ev-proof",
+          "kind": "proof",
+          "status": "observed",
+          "artifactPath": "artifacts/formal/proof-summary.json",
+          "sourceArtifactId": "claim-evidence-manifest",
+          "description": "Proof obligation status is discharged."
+        }
+      ],
+      "missingEvidenceRefs": [],
+      "waiverRefs": [],
+      "assumptions": [],
+      "runtimeControls": [],
+      "notes": []
+    },
+    {
+      "claimId": "claim-runtime-mitigated-rollout",
+      "statement": "Rollout risk is mitigated by runtime controls.",
+      "criticality": "medium",
+      "targetLevel": "A3",
+      "achievedLevel": "A2",
+      "state": "runtime-mitigated",
+      "stateRationale": "Runtime control evidence exists, but proof/model evidence is not claimed.",
+      "decision": {
+        "mode": "report-only",
+        "result": "report-only",
+        "enforced": false,
+        "reason": "Runtime mitigation remains distinct from proof.",
+        "sourceArtifactId": "claim-evidence-manifest",
+        "evidenceRefs": ["ev-runtime-control"],
+        "missingEvidenceRefs": ["missing-proof-for-runtime-claim"],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [
+        {
+          "id": "ev-runtime-control",
+          "kind": "runtime",
+          "status": "observed",
+          "artifactPath": "artifacts/change-package/change-package-v2.json#/runtimeControls/featureFlags/0",
+          "sourceArtifactId": "change-package-v2",
+          "description": "Feature flag limits blast radius."
+        }
+      ],
+      "missingEvidenceRefs": [
+        {
+          "id": "missing-proof-for-runtime-claim",
+          "expectedKind": "proof",
+          "reason": "Runtime mitigation does not satisfy proof evidence requirements.",
+          "sourceArtifactId": "claim-evidence-manifest"
+        }
+      ],
+      "waiverRefs": [],
+      "assumptions": [],
+      "runtimeControls": [
+        {
+          "id": "runtime-control-inventory-flag",
+          "kind": "feature-flag",
+          "description": "Inventory rollout flag remains enabled for staged deployment.",
+          "artifactPath": "artifacts/change-package/change-package-v2.json#/runtimeControls/featureFlags/0"
+        }
+      ],
+      "notes": ["Runtime control is not proof."]
+    },
+    {
+      "claimId": "claim-waived-audit-trail",
+      "statement": "Audit trail completeness is temporarily waived.",
+      "criticality": "high",
+      "targetLevel": "A3",
+      "achievedLevel": "A2",
+      "state": "waived",
+      "stateRationale": "A linked time-bounded temporary override exists.",
+      "decision": {
+        "mode": "report-only",
+        "result": "waived",
+        "enforced": false,
+        "reason": "Active waiver is linked and not counted as satisfied.",
+        "sourceArtifactId": "policy-gate-summary",
+        "evidenceRefs": ["ev-waiver-record"],
+        "missingEvidenceRefs": [],
+        "waiverRefs": ["override-inventory-waiver-2026-06"]
+      },
+      "evidenceRefs": [
+        {
+          "id": "ev-waiver-record",
+          "kind": "manual",
+          "status": "observed",
+          "artifactPath": "artifacts/assurance/temporary-overrides/override-inventory-waiver-2026-06.json",
+          "sourceArtifactId": "temporary-override",
+          "description": "Temporary override record is present."
+        }
+      ],
+      "missingEvidenceRefs": [],
+      "waiverRefs": [
+        {
+          "id": "override-inventory-waiver-2026-06",
+          "temporaryOverridePath": "artifacts/assurance/temporary-overrides/override-inventory-waiver-2026-06.json",
+          "status": "active",
+          "owner": "@team-platform",
+          "expires": "2026-06-30",
+          "reason": "Temporary exception while inventory audit trail migration is completed."
+        }
+      ],
+      "assumptions": [],
+      "runtimeControls": [],
+      "notes": ["Waived is distinct from satisfied."]
+    },
+    {
+      "claimId": "claim-unresolved-missing-model",
+      "statement": "Model evidence for inventory reconciliation is required but missing.",
+      "criticality": "high",
+      "targetLevel": "A3",
+      "achievedLevel": "A1",
+      "state": "unresolved",
+      "stateRationale": "Required model evidence is absent.",
+      "decision": {
+        "mode": "report-only",
+        "result": "report-only",
+        "enforced": false,
+        "reason": "Missing model evidence is report-only in default mode.",
+        "sourceArtifactId": "policy-gate-summary",
+        "evidenceRefs": [],
+        "missingEvidenceRefs": ["missing-model-reconciliation"],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [],
+      "missingEvidenceRefs": [
+        {
+          "id": "missing-model-reconciliation",
+          "expectedKind": "model",
+          "reason": "No model summary is linked for this claim.",
+          "sourceArtifactId": "claim-evidence-manifest"
+        }
+      ],
+      "waiverRefs": [],
+      "assumptions": [],
+      "runtimeControls": [],
+      "notes": []
+    },
+    {
+      "claimId": "claim-failed-strict-proof",
+      "statement": "Strict proof requirement failed and blocks enforcement.",
+      "criticality": "critical",
+      "targetLevel": "A4",
+      "achievedLevel": "A1",
+      "state": "failed",
+      "stateRationale": "Required proof evidence failed under strict policy.",
+      "decision": {
+        "mode": "strict",
+        "result": "block",
+        "enforced": true,
+        "reason": "Strict proof evidence failed.",
+        "sourceArtifactId": "policy-gate-summary",
+        "evidenceRefs": ["ev-failed-proof"],
+        "missingEvidenceRefs": ["missing-discharged-proof"],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [
+        {
+          "id": "ev-failed-proof",
+          "kind": "proof",
+          "status": "failed",
+          "artifactPath": "artifacts/formal/proof-summary.json#/proofObligations/0",
+          "sourceArtifactId": "formal-summary-v2",
+          "description": "Proof obligation failed."
+        }
+      ],
+      "missingEvidenceRefs": [
+        {
+          "id": "missing-discharged-proof",
+          "expectedKind": "proof",
+          "reason": "A discharged proof obligation is required for strict enforcement.",
+          "sourceArtifactId": "claim-evidence-manifest"
+        }
+      ],
+      "waiverRefs": [],
+      "assumptions": [],
+      "runtimeControls": [],
+      "notes": []
+    },
+    {
+      "claimId": "claim-not-applicable-ui-flow",
+      "statement": "UI-only assurance is not applicable to this docs-only change.",
+      "criticality": "low",
+      "targetLevel": "A1",
+      "achievedLevel": "A0",
+      "state": "not-applicable",
+      "stateRationale": "The claim is explicitly outside the changed scope in this preview summary.",
+      "decision": {
+        "mode": "report-only",
+        "result": "report-only",
+        "enforced": false,
+        "reason": "Applicability record documents why this claim is outside scope.",
+        "sourceArtifactId": "claim-level-summary",
+        "evidenceRefs": [],
+        "missingEvidenceRefs": [],
+        "waiverRefs": []
+      },
+      "evidenceRefs": [],
+      "missingEvidenceRefs": [],
+      "waiverRefs": [],
+      "assumptions": [],
+      "runtimeControls": [],
+      "applicability": {
+        "reason": "Docs-only change does not alter UI runtime behavior.",
+        "scope": "docs/architecture/**",
+        "artifactPath": "artifacts/change-package/change-package-v2.json#/scope"
+      },
+      "notes": ["Preview-only state; current producers must not emit this into claim-evidence-manifest/v1 or change-package/v2."]
+    }
+  ]
+}

--- a/fixtures/assurance/sample.temporary-override-v1.json
+++ b/fixtures/assurance/sample.temporary-override-v1.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "temporary-override/v1",
+  "id": "override-inventory-waiver-2026-06",
+  "status": "active",
+  "owner": "@team-platform",
+  "reason": "Temporary exception while inventory audit trail migration is completed.",
+  "expires": "2026-06-30",
+  "relatedClaimIds": ["claim-waived-audit-trail"],
+  "evidenceLink": {
+    "artifactPath": "artifacts/assurance/temporary-overrides/override-inventory-waiver-2026-06.md",
+    "sourceArtifactId": "manual-waiver-record",
+    "description": "Human-approved waiver record linked to follow-up migration issue."
+  },
+  "approvedBy": ["@security-reviewer"],
+  "createdAt": "2026-05-08T00:00:00.000Z",
+  "notes": ["Does not mark the related claim as satisfied."]
+}

--- a/schema/claim-level-summary-v1.schema.json
+++ b/schema/claim-level-summary-v1.schema.json
@@ -1,0 +1,459 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/claim-level-summary-v1.schema.json",
+  "title": "Claim Level Summary v1",
+  "description": "Preview per-claim assurance summary contract that projects claim-evidence, policy-gate, temporary overrides, runtime controls, and residual-risk state into a compact PR/release review artifact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "source",
+    "inputs",
+    "summary",
+    "claims"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "claim-level-summary/v1"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "baseRef",
+        "headRef"
+      ],
+      "properties": {
+        "repository": {
+          "type": ["string", "null"],
+          "pattern": "^[^/\\s]+/[^/\\s]+$"
+        },
+        "prNumber": {
+          "type": ["integer", "null"],
+          "minimum": 1
+        },
+        "baseRef": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "headRef": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "headSha": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claimEvidenceManifest",
+        "policyGateSummary",
+        "temporaryOverrides",
+        "changePackageV2"
+      ],
+      "properties": {
+        "claimEvidenceManifest": {
+          "$ref": "#/$defs/inputArtifact"
+        },
+        "policyGateSummary": {
+          "$ref": "#/$defs/inputArtifact"
+        },
+        "temporaryOverrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/inputArtifact"
+          }
+        },
+        "changePackageV2": {
+          "$ref": "#/$defs/nullableInputArtifact"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "totalClaims",
+        "satisfied",
+        "tested",
+        "modelChecked",
+        "proved",
+        "runtimeMitigated",
+        "waived",
+        "unresolved",
+        "failed",
+        "notApplicable",
+        "enforcedDecisions",
+        "reportOnlyDecisions"
+      ],
+      "properties": {
+        "totalClaims": { "$ref": "#/$defs/nonNegativeInteger" },
+        "satisfied": { "$ref": "#/$defs/nonNegativeInteger" },
+        "tested": { "$ref": "#/$defs/nonNegativeInteger" },
+        "modelChecked": { "$ref": "#/$defs/nonNegativeInteger" },
+        "proved": { "$ref": "#/$defs/nonNegativeInteger" },
+        "runtimeMitigated": { "$ref": "#/$defs/nonNegativeInteger" },
+        "waived": { "$ref": "#/$defs/nonNegativeInteger" },
+        "unresolved": { "$ref": "#/$defs/nonNegativeInteger" },
+        "failed": { "$ref": "#/$defs/nonNegativeInteger" },
+        "notApplicable": { "$ref": "#/$defs/nonNegativeInteger" },
+        "enforcedDecisions": { "$ref": "#/$defs/nonNegativeInteger" },
+        "reportOnlyDecisions": { "$ref": "#/$defs/nonNegativeInteger" }
+      }
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/claimSummary"
+      },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "artifactPath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\.\\.)(?!.*//).+"
+    },
+    "assuranceLevel": {
+      "type": "string",
+      "enum": ["A0", "A1", "A2", "A3", "A4"]
+    },
+    "criticality": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"]
+    },
+    "claimState": {
+      "type": "string",
+      "enum": [
+        "satisfied",
+        "tested",
+        "model-checked",
+        "proved",
+        "runtime-mitigated",
+        "waived",
+        "unresolved",
+        "failed",
+        "not-applicable"
+      ]
+    },
+    "evidenceKind": {
+      "type": "string",
+      "enum": [
+        "spec",
+        "behavior",
+        "adversarial",
+        "model",
+        "proof",
+        "runtime",
+        "quality",
+        "trace",
+        "policy",
+        "manual",
+        "other"
+      ]
+    },
+    "evidenceStatus": {
+      "type": "string",
+      "enum": ["observed", "failed", "stale", "missing"]
+    },
+    "inputArtifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "present", "required"],
+      "properties": {
+        "path": {
+          "oneOf": [
+            { "$ref": "#/$defs/artifactPath" },
+            { "type": "null" }
+          ]
+        },
+        "schemaVersion": {
+          "type": ["string", "null"],
+          "minLength": 1
+        },
+        "present": {
+          "type": "boolean"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "nullableInputArtifact": {
+      "oneOf": [
+        { "$ref": "#/$defs/inputArtifact" },
+        { "type": "null" }
+      ]
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "status",
+        "artifactPath",
+        "sourceArtifactId",
+        "description"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "kind": { "$ref": "#/$defs/evidenceKind" },
+        "status": { "$ref": "#/$defs/evidenceStatus" },
+        "artifactPath": { "$ref": "#/$defs/artifactPath" },
+        "sourceArtifactId": { "$ref": "#/$defs/nonEmptyString" },
+        "description": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "missingEvidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "expectedKind",
+        "reason",
+        "sourceArtifactId"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "expectedKind": { "$ref": "#/$defs/evidenceKind" },
+        "reason": { "$ref": "#/$defs/nonEmptyString" },
+        "sourceArtifactId": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "waiverRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "temporaryOverridePath",
+        "status",
+        "owner",
+        "expires",
+        "reason"
+      ],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "temporaryOverridePath": { "$ref": "#/$defs/artifactPath" },
+        "status": {
+          "type": "string",
+          "enum": ["active", "expiringSoon", "expired", "orphan", "unknown"]
+        },
+        "owner": { "$ref": "#/$defs/nonEmptyString" },
+        "expires": {
+          "type": "string",
+          "format": "date"
+        },
+        "reason": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "assumption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "statement", "status"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "statement": { "$ref": "#/$defs/nonEmptyString" },
+        "status": {
+          "type": "string",
+          "enum": ["accepted", "needs-validation", "residual-risk"]
+        },
+        "artifactPath": { "$ref": "#/$defs/artifactPath" }
+      }
+    },
+    "runtimeControl": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "description"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "kind": {
+          "type": "string",
+          "enum": ["alert", "feature-flag", "rollout-guard", "monitor", "runtime-conformance", "other"]
+        },
+        "description": { "$ref": "#/$defs/nonEmptyString" },
+        "artifactPath": { "$ref": "#/$defs/artifactPath" }
+      }
+    },
+    "gateDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "mode",
+        "result",
+        "enforced",
+        "reason",
+        "sourceArtifactId",
+        "evidenceRefs",
+        "missingEvidenceRefs",
+        "waiverRefs"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["report-only", "strict"]
+        },
+        "result": {
+          "type": "string",
+          "enum": ["pass", "waived", "report-only", "block"]
+        },
+        "enforced": {
+          "type": "boolean"
+        },
+        "reason": { "$ref": "#/$defs/nonEmptyString" },
+        "sourceArtifactId": { "$ref": "#/$defs/nonEmptyString" },
+        "evidenceRefs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "missingEvidenceRefs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "waiverRefs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enforced": { "const": true }
+            },
+            "required": ["enforced"]
+          },
+          "then": {
+            "properties": {
+              "mode": { "const": "strict" },
+              "result": { "const": "block" },
+              "missingEvidenceRefs": { "minItems": 1 }
+            }
+          }
+        }
+      ]
+    },
+    "applicability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reason", "scope"],
+      "properties": {
+        "reason": { "$ref": "#/$defs/nonEmptyString" },
+        "scope": { "$ref": "#/$defs/nonEmptyString" },
+        "artifactPath": { "$ref": "#/$defs/artifactPath" }
+      }
+    },
+    "claimSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claimId",
+        "statement",
+        "criticality",
+        "targetLevel",
+        "achievedLevel",
+        "state",
+        "stateRationale",
+        "decision",
+        "evidenceRefs",
+        "missingEvidenceRefs",
+        "waiverRefs",
+        "assumptions",
+        "runtimeControls",
+        "notes"
+      ],
+      "properties": {
+        "claimId": { "$ref": "#/$defs/nonEmptyString" },
+        "statement": { "$ref": "#/$defs/nonEmptyString" },
+        "criticality": { "$ref": "#/$defs/criticality" },
+        "targetLevel": { "$ref": "#/$defs/assuranceLevel" },
+        "achievedLevel": { "$ref": "#/$defs/assuranceLevel" },
+        "state": { "$ref": "#/$defs/claimState" },
+        "stateRationale": { "$ref": "#/$defs/nonEmptyString" },
+        "decision": { "$ref": "#/$defs/gateDecision" },
+        "evidenceRefs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/evidenceRef" }
+        },
+        "missingEvidenceRefs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/missingEvidenceRef" }
+        },
+        "waiverRefs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/waiverRef" }
+        },
+        "assumptions": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/assumption" }
+        },
+        "runtimeControls": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/runtimeControl" }
+        },
+        "applicability": { "$ref": "#/$defs/applicability" },
+        "notes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "state": { "const": "waived" }
+            },
+            "required": ["state"]
+          },
+          "then": {
+            "properties": {
+              "waiverRefs": { "minItems": 1 }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": { "const": "not-applicable" }
+            },
+            "required": ["state"]
+          },
+          "then": {
+            "required": ["applicability"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "state": { "const": "runtime-mitigated" }
+            },
+            "required": ["state"]
+          },
+          "then": {
+            "properties": {
+              "runtimeControls": { "minItems": 1 }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schema/claim-level-summary-v1.schema.json
+++ b/schema/claim-level-summary-v1.schema.json
@@ -342,9 +342,7 @@
           },
           "then": {
             "properties": {
-              "mode": { "const": "strict" },
-              "result": { "const": "block" },
-              "missingEvidenceRefs": { "minItems": 1 }
+              "mode": { "const": "strict" }
             }
           }
         }

--- a/schema/claim-level-summary-v1.schema.json
+++ b/schema/claim-level-summary-v1.schema.json
@@ -336,6 +336,32 @@
         {
           "if": {
             "properties": {
+              "mode": { "const": "report-only" }
+            },
+            "required": ["mode"]
+          },
+          "then": {
+            "properties": {
+              "enforced": { "const": false }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "mode": { "const": "strict" }
+            },
+            "required": ["mode"]
+          },
+          "then": {
+            "properties": {
+              "enforced": { "const": true }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
               "enforced": { "const": true }
             },
             "required": ["enforced"]
@@ -343,6 +369,33 @@
           "then": {
             "properties": {
               "mode": { "const": "strict" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "enforced": { "const": false }
+            },
+            "required": ["enforced"]
+          },
+          "then": {
+            "properties": {
+              "mode": { "const": "report-only" }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "result": { "const": "block" }
+            },
+            "required": ["result"]
+          },
+          "then": {
+            "properties": {
+              "mode": { "const": "strict" },
+              "enforced": { "const": true }
             }
           }
         }

--- a/schema/temporary-override-v1.schema.json
+++ b/schema/temporary-override-v1.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ae-framework/schema/temporary-override-v1.schema.json",
+  "title": "Temporary Override v1",
+  "description": "Preview contract for a time-bounded human waiver or override that can be linked from assurance claim summaries and policy-gate decisions.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "status",
+    "owner",
+    "reason",
+    "expires",
+    "relatedClaimIds",
+    "evidenceLink"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "temporary-override/v1"
+    },
+    "id": {
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "expiringSoon",
+        "expired",
+        "orphan",
+        "unknown"
+      ]
+    },
+    "owner": {
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "reason": {
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "expires": {
+      "type": "string",
+      "format": "date"
+    },
+    "relatedClaimIds": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "evidenceLink": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifactPath",
+        "description"
+      ],
+      "properties": {
+        "artifactPath": {
+          "$ref": "#/$defs/artifactPath"
+        },
+        "sourceArtifactId": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "url": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "approvedBy": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      },
+      "uniqueItems": true
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifactPath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\.\\.)(?!.*//).+"
+    }
+  }
+}

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -139,6 +139,20 @@ const checks = [
     semanticValidate: validateClaimEvidenceManifestSemantics
   },
   {
+    schema: 'schema/claim-level-summary-v1.schema.json',
+    fixtures: [
+      'fixtures/assurance/sample.claim-level-summary-v1.json',
+    ],
+    label: 'Claim level summary v1 schema validation'
+  },
+  {
+    schema: 'schema/temporary-override-v1.schema.json',
+    fixtures: [
+      'fixtures/assurance/sample.temporary-override-v1.json',
+    ],
+    label: 'Temporary override v1 schema validation'
+  },
+  {
     schema: 'schema/security-claim-v1.schema.json',
     fixtures: [
       'fixtures/security-assurance/sample.security-claims.json',

--- a/tests/contracts/assurance-control-plane-schema-contract.test.ts
+++ b/tests/contracts/assurance-control-plane-schema-contract.test.ts
@@ -41,6 +41,29 @@ describe('assurance control plane preview schema contracts', () => {
     expect(validate.errors?.some((entry) => entry.instancePath === '/claims/0/decision')).toBe(true);
   });
 
+  it('allows enforced strict decisions to pass when evidence is present', () => {
+    const validate = buildValidator('schema/claim-level-summary-v1.schema.json');
+    const fixture = structuredClone(loadJson('fixtures/assurance/sample.claim-level-summary-v1.json')) as {
+      claims: Array<{
+        state: string;
+        decision: Record<string, unknown>;
+      }>;
+    };
+    const satisfiedClaim = fixture.claims.find((claim) => claim.state === 'satisfied');
+    if (!satisfiedClaim) {
+      throw new Error('sample fixture must include a satisfied claim');
+    }
+    satisfiedClaim.decision = {
+      ...satisfiedClaim.decision,
+      mode: 'strict',
+      result: 'pass',
+      enforced: true,
+      missingEvidenceRefs: [],
+    };
+
+    expect(validate(fixture), JSON.stringify(validate.errors)).toBe(true);
+  });
+
   it('rejects waived claim-level summaries without waiver references', () => {
     const validate = buildValidator('schema/claim-level-summary-v1.schema.json');
     const invalidFixture = structuredClone(loadJson('fixtures/assurance/sample.claim-level-summary-v1.json')) as {

--- a/tests/contracts/assurance-control-plane-schema-contract.test.ts
+++ b/tests/contracts/assurance-control-plane-schema-contract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const loadJson = (path: string) => JSON.parse(readFileSync(resolve(path), 'utf8')) as Record<string, unknown>;
+
+const buildValidator = (schemaPath: string) => {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  return ajv.compile(loadJson(schemaPath));
+};
+
+describe('assurance control plane preview schema contracts', () => {
+  it('validates the claim-level summary fixture with all preview states', () => {
+    const validate = buildValidator('schema/claim-level-summary-v1.schema.json');
+    const fixture = loadJson('fixtures/assurance/sample.claim-level-summary-v1.json') as {
+      claims: Array<{ state: string }>;
+    };
+
+    expect(validate(fixture), JSON.stringify(validate.errors)).toBe(true);
+    expect(fixture.claims.map((claim) => claim.state)).toEqual([
+      'satisfied',
+      'tested',
+      'model-checked',
+      'proved',
+      'runtime-mitigated',
+      'waived',
+      'unresolved',
+      'failed',
+      'not-applicable',
+    ]);
+  });
+
+  it('rejects an enforced claim-level decision without a reason', () => {
+    const validate = buildValidator('schema/claim-level-summary-v1.schema.json');
+    const invalidFixture = loadJson('fixtures/assurance/invalid.claim-level-summary-v1.missing-enforced-reason.json');
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/claims/0/decision')).toBe(true);
+  });
+
+  it('rejects waived claim-level summaries without waiver references', () => {
+    const validate = buildValidator('schema/claim-level-summary-v1.schema.json');
+    const invalidFixture = structuredClone(loadJson('fixtures/assurance/sample.claim-level-summary-v1.json')) as {
+      claims: Array<Record<string, unknown>>;
+    };
+    const waivedClaim = invalidFixture.claims.find((claim) => claim.state === 'waived');
+    if (!waivedClaim) {
+      throw new Error('sample fixture must include a waived claim');
+    }
+    waivedClaim.waiverRefs = [];
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath.endsWith('/waiverRefs'))).toBe(true);
+  });
+
+  it('requires applicability metadata for not-applicable claim-level summaries', () => {
+    const validate = buildValidator('schema/claim-level-summary-v1.schema.json');
+    const invalidFixture = structuredClone(loadJson('fixtures/assurance/sample.claim-level-summary-v1.json')) as {
+      claims: Array<Record<string, unknown>>;
+    };
+    const notApplicableClaim = invalidFixture.claims.find((claim) => claim.state === 'not-applicable');
+    if (!notApplicableClaim) {
+      throw new Error('sample fixture must include a not-applicable claim');
+    }
+    delete notApplicableClaim.applicability;
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/claims/8')).toBe(true);
+  });
+
+  it('validates the temporary override fixture', () => {
+    const validate = buildValidator('schema/temporary-override-v1.schema.json');
+    const fixture = loadJson('fixtures/assurance/sample.temporary-override-v1.json');
+
+    expect(validate(fixture), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it('rejects temporary overrides without evidence links', () => {
+    const validate = buildValidator('schema/temporary-override-v1.schema.json');
+    const invalidFixture = loadJson('fixtures/assurance/invalid.temporary-override-v1.missing-evidence-link.json');
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '')).toBe(true);
+  });
+
+  it('rejects temporary overrides without related claim ids', () => {
+    const validate = buildValidator('schema/temporary-override-v1.schema.json');
+    const invalidFixture = structuredClone(loadJson('fixtures/assurance/sample.temporary-override-v1.json')) as {
+      relatedClaimIds: string[];
+    };
+    invalidFixture.relatedClaimIds = [];
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/relatedClaimIds')).toBe(true);
+  });
+});

--- a/tests/contracts/assurance-control-plane-schema-contract.test.ts
+++ b/tests/contracts/assurance-control-plane-schema-contract.test.ts
@@ -20,7 +20,7 @@ describe('assurance control plane preview schema contracts', () => {
     };
 
     expect(validate(fixture), JSON.stringify(validate.errors)).toBe(true);
-    expect(fixture.claims.map((claim) => claim.state)).toEqual([
+    const expectedStates = [
       'satisfied',
       'tested',
       'model-checked',
@@ -30,7 +30,10 @@ describe('assurance control plane preview schema contracts', () => {
       'unresolved',
       'failed',
       'not-applicable',
-    ]);
+    ];
+    const observedStates = fixture.claims.map((claim) => claim.state);
+    expect(observedStates).toHaveLength(expectedStates.length);
+    expect(new Set(observedStates)).toEqual(new Set(expectedStates));
   });
 
   it('rejects an enforced claim-level decision without a reason', () => {
@@ -62,6 +65,52 @@ describe('assurance control plane preview schema contracts', () => {
     };
 
     expect(validate(fixture), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it('rejects strict decisions that are not marked as enforced', () => {
+    const validate = buildValidator('schema/claim-level-summary-v1.schema.json');
+    const fixture = structuredClone(loadJson('fixtures/assurance/sample.claim-level-summary-v1.json')) as {
+      claims: Array<{
+        state: string;
+        decision: Record<string, unknown>;
+      }>;
+    };
+    const failedClaim = fixture.claims.find((claim) => claim.state === 'failed');
+    if (!failedClaim) {
+      throw new Error('sample fixture must include a failed claim');
+    }
+    failedClaim.decision = {
+      ...failedClaim.decision,
+      mode: 'strict',
+      result: 'block',
+      enforced: false,
+    };
+
+    expect(validate(fixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath.endsWith('/decision/enforced'))).toBe(true);
+  });
+
+  it('rejects report-only decisions that try to block', () => {
+    const validate = buildValidator('schema/claim-level-summary-v1.schema.json');
+    const fixture = structuredClone(loadJson('fixtures/assurance/sample.claim-level-summary-v1.json')) as {
+      claims: Array<{
+        state: string;
+        decision: Record<string, unknown>;
+      }>;
+    };
+    const unresolvedClaim = fixture.claims.find((claim) => claim.state === 'unresolved');
+    if (!unresolvedClaim) {
+      throw new Error('sample fixture must include an unresolved claim');
+    }
+    unresolvedClaim.decision = {
+      ...unresolvedClaim.decision,
+      mode: 'report-only',
+      result: 'block',
+      enforced: false,
+    };
+
+    expect(validate(fixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath.endsWith('/decision/mode'))).toBe(true);
   });
 
   it('rejects waived claim-level summaries without waiver references', () => {


### PR DESCRIPTION
## Summary

- Add preview `claim-level-summary/v1` and `temporary-override/v1` schemas for the assurance control plane.
- Add positive and negative fixtures plus contract tests covering enforced decisions, waiver references, not-applicable applicability metadata, and temporary override evidence links.
- Wire the new positive fixtures into `scripts/ci/validate-json.mjs` and update canonical docs/catalog references.

## Acceptance

- Schema names follow the current `schema/*-v1.schema.json` convention.
- Positive fixtures validate via `node scripts/ci/validate-json.mjs`.
- Negative fixtures reject missing enforced-decision fields and missing waiver evidence links.
- `temporary-override/v1` requires owner, reason, expiry, related claim IDs, and evidence link.
- `claim-level-summary/v1` distinguishes `satisfied`, `tested`, `model-checked`, `proved`, `runtime-mitigated`, `waived`, `unresolved`, `failed`, and preview `not-applicable` states without changing current primary producer state sets.
- Existing schema and doc consistency checks pass.

## Validation

- `node scripts/ci/validate-json.mjs`
- `pnpm -s exec vitest run tests/contracts/assurance-control-plane-schema-contract.test.ts --reporter dot`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`
- `pnpm -s run test:fast` attempted; it failed only in `tests/container/container-agent.test.ts` because no Docker or Podman engine is available in this local environment (`No container engines available. Please install Docker or Podman.`). Non-container targeted checks above passed.

## Rollback

- Revert this schema/docs/test-only change. No runtime producer or policy-gate enforcement behavior is changed.

Closes #3306. Part of #3302.
