### PR TITLE
feat(ci): add assurance-aware policy gate modes

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -30,6 +30,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'workflow_run' }}
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
   issues: write
@@ -97,6 +98,78 @@ jobs:
           fi
           printf '%s\n' "skip=false" >> "$GITHUB_OUTPUT"
           printf '%s\n' "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve assurance policy inputs
+        if: ${{ steps.pr.outputs.skip != 'true' }}
+        id: assurance-policy
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          AE_POLICY_ASSURANCE_MODE_CONFIG: ${{ vars.AE_POLICY_ASSURANCE_MODE || '' }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = Number(process.env.PR_NUMBER || 0);
+            const explicitMode = String(process.env.AE_POLICY_ASSURANCE_MODE_CONFIG || '').trim();
+
+            if (explicitMode) {
+              core.exportVariable('AE_POLICY_ASSURANCE_MODE', explicitMode);
+            }
+            core.setOutput('verify_lite_run_id', '');
+
+            if (!prNumber) {
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            const labels = new Set((pr.labels || []).map((label) => label.name));
+            const explicitStrict = ['strict', 'enforcement', 'enforced'].includes(explicitMode.toLowerCase());
+            const labelStrict = labels.has('enforce-assurance');
+            if (!explicitStrict && !labelStrict) {
+              return;
+            }
+
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: 'verify-lite.yml',
+              event: 'pull_request',
+              head_sha: pr.head.sha,
+              status: 'completed',
+              per_page: 10,
+            });
+            const run = (data.workflow_runs || []).find((candidate) =>
+              candidate.head_sha === pr.head.sha
+              && candidate.conclusion === 'success'
+            );
+            if (!run) {
+              if (labelStrict && !explicitStrict) {
+                core.notice('enforce-assurance label is present, but no successful Verify Lite artifact exists for this head yet; policy-gate remains report-only until workflow_run re-evaluation.');
+              } else {
+                core.warning('Strict assurance mode is configured, but no successful Verify Lite artifact exists for this head; policy-gate will fail closed if the assurance artifact is missing.');
+              }
+              return;
+            }
+
+            core.setOutput('verify_lite_run_id', String(run.id));
+            if (labelStrict && !explicitMode) {
+              core.exportVariable('AE_POLICY_ASSURANCE_MODE', 'strict');
+            }
+
+      - name: Download verify-lite assurance artifacts
+        if: ${{ steps.assurance-policy.outputs.verify_lite_run_id != '' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: verify-lite-report
+          path: .
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.assurance-policy.outputs.verify_lite_run_id }}
 
       - name: Run risk labeler
         if: ${{ steps.pr.outputs.skip != 'true' && github.event_name != 'workflow_run' }}

--- a/fixtures/assurance-e2e/inventory-waiver/expected/policy-gate-summary.md
+++ b/fixtures/assurance-e2e/inventory-waiver/expected/policy-gate-summary.md
@@ -8,7 +8,7 @@
 - required labels (by diff): enforce-assurance
 - missing required labels: enforce-assurance
 - assurance: waived (report-only)
-  - claim evidence manifest: present
+  - assurance artifact: present (claim-evidence-manifest/v1)
   - claims: pass=1, waived=1, report-only=1, block=0
   - waivers: active=1, expiringSoon=0, expired=0, orphan=0
     - id=change-package-v2:waiver:0:manual-fraud-review, claim=manual-fraud-review, status=active, owner=@team-risk, expires=2099-12-31, reason=Manual fraud review is active while automated model validation evidence is being collected.

--- a/scripts/ci/policy-gate.mjs
+++ b/scripts/ci/policy-gate.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import process from 'node:process';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import micromatch from 'micromatch';
@@ -32,12 +33,13 @@ const SUMMARY_CONTRACT_ID = 'policy-gate-summary.v1';
 const POLICY_INPUT_PATH = 'artifacts/ci/policy-input-v1.json';
 const POLICY_DECISION_PATH = 'artifacts/ci/policy-decision-js-v1.json';
 const CLAIM_EVIDENCE_MANIFEST_PATH = 'artifacts/assurance/claim-evidence-manifest.json';
+const CLAIM_LEVEL_SUMMARY_PATH = 'artifacts/assurance/claim-level-summary.json';
 const PLAN_ARTIFACT_PATH = 'artifacts/plan/plan-artifact.json';
 const PLAN_ARTIFACT_SCHEMA_PATH = 'schema/plan-artifact.schema.json';
 const PLAN_ARTIFACT_VALIDATION_JSON_PATH = 'artifacts/plan/plan-artifact-validation.json';
 const PLAN_ARTIFACT_VALIDATION_MD_PATH = 'artifacts/plan/plan-artifact-validation.md';
 const VALID_REVIEW_TOPOLOGIES = new Set(['team', 'solo']);
-const VALID_ASSURANCE_MODES = new Set(['report-only', 'strict']);
+const VALID_ASSURANCE_MODES = new Set(['report-only', 'strict', 'enforcement', 'enforced']);
 const EXPIRING_SOON_DAYS = 14;
 
 function parseArgs(argv) {
@@ -525,6 +527,9 @@ function normalizeAssuranceMode(value) {
   if (!raw) {
     return { value: 'report-only', warning: null };
   }
+  if (raw === 'enforcement' || raw === 'enforced') {
+    return { value: 'strict', warning: null };
+  }
   if (VALID_ASSURANCE_MODES.has(raw)) {
     return { value: raw, warning: null };
   }
@@ -532,6 +537,19 @@ function normalizeAssuranceMode(value) {
     value: 'report-only',
     warning: `invalid assurance mode: ${raw} (fallback to report-only)`,
   };
+}
+
+function resolveAssuranceMode(value, labels = []) {
+  const modeState = normalizeAssuranceMode(value);
+  const explicitMode = String(value ?? '').trim();
+  if (modeState.warning || explicitMode || modeState.value !== 'report-only') {
+    return modeState;
+  }
+  const labelSet = new Set(normalizeLabelNames(labels));
+  if (labelSet.has('enforce-assurance')) {
+    return { value: 'strict', warning: null };
+  }
+  return modeState;
 }
 
 function normalizeIdRefs(value) {
@@ -577,6 +595,11 @@ function normalizeWaiverStatus(waiver, nowDate) {
   return 'unknown';
 }
 
+function normalizeAssuranceResult(value, fallback = 'report-only') {
+  const raw = String(value ?? '').trim().toLowerCase();
+  return ['pass', 'waived', 'report-only', 'block'].includes(raw) ? raw : fallback;
+}
+
 
 function normalizeManifestSecuritySummary(value) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
@@ -615,6 +638,34 @@ function normalizeClaimWaivers(claim, nowDate) {
     .filter((waiver) => waiver.id);
 }
 
+function waiverValidationErrors(waiver, claim) {
+  const claimId = String(claim?.claimId || '').trim() || '(unknown claim)';
+  const errors = [];
+  if (waiver.status === 'expired') {
+    errors.push(`assurance waiver ${waiver.id} for ${claimId} is expired; next action: renew or remove the waiver and provide required evidence`);
+  } else if (waiver.status === 'orphan') {
+    errors.push(`assurance waiver ${waiver.id} for ${claimId} is orphaned; next action: link it to an active claim and evidence record`);
+  } else if (waiver.status === 'unknown') {
+    errors.push(`assurance waiver ${waiver.id} for ${claimId} has unknown status; next action: set status to active or expired`);
+  }
+  if (!waiver.owner) {
+    errors.push(`assurance waiver ${waiver.id} for ${claimId} is missing owner; next action: add waiver owner`);
+  }
+  if (!waiver.reason) {
+    errors.push(`assurance waiver ${waiver.id} for ${claimId} is missing reason; next action: add waiver rationale`);
+  }
+  if (!waiver.expires) {
+    errors.push(`assurance waiver ${waiver.id} for ${claimId} is missing expiry; next action: add waiver expiry date`);
+  }
+  if (!waiver.sourceArtifactId) {
+    errors.push(`assurance waiver ${waiver.id} for ${claimId} is missing source artifact; next action: link the waiver to its source artifact`);
+  }
+  if ((claim.evidenceRefs.length + claim.missingEvidenceRefs.length) === 0) {
+    errors.push(`assurance waiver ${waiver.id} for ${claimId} is missing related evidence link; next action: link evidence or missing-evidence refs`);
+  }
+  return errors;
+}
+
 function normalizeAssuranceClaim(claim, nowDate) {
   const id = String(claim?.id || claim?.claimId || '').trim();
   const status = String(claim?.status || 'unresolved').trim() || 'unresolved';
@@ -630,6 +681,38 @@ function normalizeAssuranceClaim(claim, nowDate) {
     result = 'waived';
   } else if (status === 'satisfied' && missingEvidenceRefs.length === 0) {
     result = 'pass';
+  }
+
+  return {
+    claimId: id,
+    result,
+    status,
+    evidenceRefs,
+    missingEvidenceRefs,
+    waiverRefs: waiverRefs.map((waiver) => waiver.id),
+    waivers: waiverRefs,
+  };
+}
+
+function normalizeClaimLevelSummaryClaim(claim, nowDate) {
+  const id = String(claim?.claimId || claim?.id || '').trim();
+  const status = String(claim?.state || claim?.status || 'unresolved').trim() || 'unresolved';
+  const evidenceRefs = normalizeIdRefs(claim?.evidenceRefs);
+  const missingEvidenceRefs = normalizeIdRefs(claim?.missingEvidenceRefs);
+  const waiverRefs = normalizeClaimWaivers(claim, nowDate);
+  const decisionResult = normalizeAssuranceResult(claim?.decision?.result, 'report-only');
+  let result = decisionResult;
+
+  if (status === 'failed' || status === 'unresolved') {
+    result = 'block';
+  } else if (missingEvidenceRefs.length > 0 && status !== 'waived' && status !== 'not-applicable') {
+    result = 'block';
+  } else if (status === 'waived' || waiverRefs.some((waiver) => waiver.status === 'active' || waiver.status === 'expiringSoon')) {
+    result = 'waived';
+  } else if (['satisfied', 'tested', 'model-checked', 'proved'].includes(status) && missingEvidenceRefs.length === 0) {
+    result = 'pass';
+  } else if (status === 'not-applicable') {
+    result = 'report-only';
   }
 
   return {
@@ -698,6 +781,67 @@ function inspectClaimEvidenceManifest(manifestPath = CLAIM_EVIDENCE_MANIFEST_PAT
   }
 }
 
+function inspectClaimLevelSummary(summaryPath = CLAIM_LEVEL_SUMMARY_PATH, now = new Date().toISOString()) {
+  const absolutePath = path.resolve(summaryPath);
+  const nowDate = toDateOnly(now);
+  const baseState = {
+    path: absolutePath,
+    present: false,
+    schemaVersion: null,
+    generatedAt: null,
+    summary: {
+      totalClaims: 0,
+      fullySupported: 0,
+      partiallySupported: 0,
+      waived: 0,
+      unresolved: 0,
+    },
+    claims: [],
+    warnings: [],
+    errors: [],
+  };
+
+  if (!fs.existsSync(absolutePath)) {
+    return baseState;
+  }
+
+  try {
+    const payload = JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+    const claims = (Array.isArray(payload?.claims) ? payload.claims : [])
+      .map((claim) => normalizeClaimLevelSummaryClaim(claim, nowDate))
+      .filter((claim) => claim.claimId);
+    return {
+      ...baseState,
+      present: true,
+      schemaVersion: String(payload?.schemaVersion || '').trim() || null,
+      generatedAt: String(payload?.generatedAt || '').trim() || null,
+      summary: {
+        totalClaims: Number(payload?.summary?.totalClaims ?? claims.length) || 0,
+        fullySupported: Number(payload?.summary?.satisfied ?? 0) + Number(payload?.summary?.tested ?? 0) + Number(payload?.summary?.modelChecked ?? 0) + Number(payload?.summary?.proved ?? 0) || 0,
+        partiallySupported: Number(payload?.summary?.runtimeMitigated ?? 0) || 0,
+        waived: Number(payload?.summary?.waived ?? 0) || 0,
+        unresolved: Number(payload?.summary?.unresolved ?? 0) + Number(payload?.summary?.failed ?? 0) || 0,
+      },
+      claims,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ...baseState,
+      present: true,
+      errors: [`failed to parse claim-level summary: ${message}`],
+    };
+  }
+}
+
+function inspectAssuranceEvidence(now = new Date().toISOString()) {
+  const claimLevelSummary = inspectClaimLevelSummary(CLAIM_LEVEL_SUMMARY_PATH, now);
+  if (claimLevelSummary.present) {
+    return claimLevelSummary;
+  }
+  return inspectClaimEvidenceManifest(CLAIM_EVIDENCE_MANIFEST_PATH, now);
+}
+
 function flattenAssuranceWaivers(claims) {
   return (Array.isArray(claims) ? claims : []).flatMap((claim) =>
     (Array.isArray(claim.waivers) ? claim.waivers : []).map((waiver) => ({
@@ -714,11 +858,28 @@ function buildAssuranceEvaluation(manifestState, options = {}) {
   if (modeState.warning) warnings.push(modeState.warning);
   if (!manifestState?.present) {
     warnings.push(`claim evidence manifest not found: ${manifestState?.path || path.resolve(CLAIM_EVIDENCE_MANIFEST_PATH)}`);
+    if (modeState.value === 'strict') {
+      errors.push(`required assurance artifact missing: ${manifestState?.path || path.resolve(CLAIM_LEVEL_SUMMARY_PATH)}; next action: generate claim-level summary or claim-evidence manifest`);
+    }
   }
 
   const claims = Array.isArray(manifestState?.claims) ? manifestState.claims : [];
   const waivers = flattenAssuranceWaivers(claims);
-  const hasBlockingWaiver = waivers.some((waiver) => waiver.status === 'expired' || waiver.status === 'orphan');
+  for (const claim of claims) {
+    for (const waiver of Array.isArray(claim.waivers) ? claim.waivers : []) {
+      errors.push(...waiverValidationErrors(waiver, claim));
+    }
+    if (claim.result === 'block') {
+      if (claim.status === 'failed') {
+        errors.push(`assurance claim ${claim.claimId} has failed evidence; next action: fix the failing evidence or provide a valid waiver`);
+      } else if (claim.missingEvidenceRefs.length > 0) {
+        errors.push(`assurance claim ${claim.claimId} is missing required evidence: ${claim.missingEvidenceRefs.join(', ')}; next action: add evidence or provide a valid waiver`);
+      } else {
+        errors.push(`assurance claim ${claim.claimId} is unresolved; next action: satisfy, waive, or mark the claim not applicable`);
+      }
+    }
+  }
+  const hasBlockingWaiver = waivers.some((waiver) => waiver.status === 'expired' || waiver.status === 'orphan' || waiver.status === 'unknown');
   const result = errors.length > 0 || hasBlockingWaiver || claims.some((claim) => claim.result === 'block')
     ? 'block'
     : (claims.some((claim) => claim.result === 'waived')
@@ -756,7 +917,11 @@ function buildAssuranceEvaluation(manifestState, options = {}) {
       generatedAt: manifestState?.generatedAt ?? null,
     },
     summary,
-    claims: claims.map(({ waivers: _waivers, ...claim }) => claim),
+    claims: claims.map((claim) => {
+      const normalizedClaim = { ...claim };
+      delete normalizedClaim.waivers;
+      return normalizedClaim;
+    }),
     waivers,
     warnings,
     errors,
@@ -844,14 +1009,16 @@ function evaluatePolicyGate({
   errors.push(...planArtifactEvaluation.errors);
   warnings.push(...planArtifactEvaluation.warnings);
 
+  const assuranceModeState = resolveAssuranceMode(assuranceMode, currentLabels);
+  if (assuranceModeState.warning) warnings.push(`assurance: ${assuranceModeState.warning}`);
   const assuranceEvaluation = buildAssuranceEvaluation(
-    assurance || inspectClaimEvidenceManifest(CLAIM_EVIDENCE_MANIFEST_PATH),
-    { assuranceMode },
+    assurance || inspectAssuranceEvidence(),
+    { assuranceMode: assuranceModeState.value },
   );
   warnings.push(...assuranceEvaluation.warnings.map((warning) => `assurance: ${warning}`));
   if (assuranceEvaluation.mode === 'strict' && assuranceEvaluation.result === 'block') {
     errors.push(...assuranceEvaluation.errors.map((error) => `assurance: ${error}`));
-    if (assuranceEvaluation.errors.length === 0) {
+    if (!errors.includes('assurance decision is block')) {
       errors.push('assurance decision is block');
     }
   } else if (assuranceEvaluation.errors.length > 0) {
@@ -976,7 +1143,7 @@ function buildMarkdownSummary(prNumber, evaluation) {
   }
   if (evaluation.assurance) {
     lines.push(`- assurance: ${evaluation.assurance.result} (${evaluation.assurance.mode})`);
-    lines.push(`  - claim evidence manifest: ${evaluation.assurance.manifest.present ? 'present' : 'missing'}`);
+    lines.push(`  - assurance artifact: ${evaluation.assurance.manifest.present ? 'present' : 'missing'} (${evaluation.assurance.manifest.schemaVersion ?? 'n/a'})`);
     lines.push(`  - claims: pass=${evaluation.assurance.summary.pass}, waived=${evaluation.assurance.summary.waived}, report-only=${evaluation.assurance.summary.reportOnly}, block=${evaluation.assurance.summary.block}`);
     if (evaluation.assurance.summary.security) {
       const security = evaluation.assurance.summary.security;
@@ -1186,7 +1353,7 @@ function buildPolicyInputV1({
   assurance,
   now = new Date().toISOString(),
 }) {
-  const normalizedAssuranceMode = normalizeAssuranceMode(assuranceMode).value;
+  const normalizedAssuranceMode = resolveAssuranceMode(assuranceMode, pullRequest?.labels || []).value;
   const input = {
     schemaVersion: '1.0.0',
     contractId: 'policy-input.v1',
@@ -1259,7 +1426,7 @@ async function run(options = parseArgs(process.argv)) {
   const statusRollup = fetchStatusRollup(repo, prNumber);
   const planArtifact = inspectPlanArtifact(options.policyPath);
   const now = new Date().toISOString();
-  const assurance = inspectClaimEvidenceManifest(CLAIM_EVIDENCE_MANIFEST_PATH, now);
+  const assurance = inspectAssuranceEvidence(now);
 
   const evaluation = evaluatePolicyGate({
     policy,
@@ -1285,7 +1452,7 @@ async function run(options = parseArgs(process.argv)) {
     statusRollup,
     reviewTopology: process.env.AE_REVIEW_TOPOLOGY,
     approvalOverride: process.env.AE_POLICY_MIN_HUMAN_APPROVALS,
-    assuranceMode: process.env.AE_POLICY_ASSURANCE_MODE,
+    assuranceMode: resolveAssuranceMode(process.env.AE_POLICY_ASSURANCE_MODE, pullRequest?.labels || []).value,
     assurance,
     now,
   });
@@ -1345,7 +1512,9 @@ export {
   evaluateCheckRequirement,
   evaluatePolicyGate,
   buildPolicyGateReport,
+  inspectAssuranceEvidence,
   inspectClaimEvidenceManifest,
+  inspectClaimLevelSummary,
   run,
   toCheckEntries,
 };

--- a/scripts/ci/policy-gate.mjs
+++ b/scripts/ci/policy-gate.mjs
@@ -539,16 +539,8 @@ function normalizeAssuranceMode(value) {
   };
 }
 
-function resolveAssuranceMode(value, labels = []) {
+function resolveAssuranceMode(value) {
   const modeState = normalizeAssuranceMode(value);
-  const explicitMode = String(value ?? '').trim();
-  if (modeState.warning || explicitMode || modeState.value !== 'report-only') {
-    return modeState;
-  }
-  const labelSet = new Set(normalizeLabelNames(labels));
-  if (labelSet.has('enforce-assurance')) {
-    return { value: 'strict', warning: null };
-  }
   return modeState;
 }
 
@@ -629,7 +621,7 @@ function normalizeClaimWaivers(claim, nowDate) {
     .filter((waiver) => waiver && typeof waiver === 'object')
     .map((waiver) => ({
       id: String(waiver.id || '').trim(),
-      sourceArtifactId: String(waiver.sourceArtifactId || '').trim(),
+      sourceArtifactId: String(waiver.sourceArtifactId || waiver.temporaryOverridePath || '').trim(),
       status: normalizeWaiverStatus(waiver, nowDate),
       owner: String(waiver.owner || '').trim() || null,
       expires: normalizeDateOnly(waiver.expires),
@@ -1009,7 +1001,7 @@ function evaluatePolicyGate({
   errors.push(...planArtifactEvaluation.errors);
   warnings.push(...planArtifactEvaluation.warnings);
 
-  const assuranceModeState = resolveAssuranceMode(assuranceMode, currentLabels);
+  const assuranceModeState = resolveAssuranceMode(assuranceMode);
   if (assuranceModeState.warning) warnings.push(`assurance: ${assuranceModeState.warning}`);
   const assuranceEvaluation = buildAssuranceEvaluation(
     assurance || inspectAssuranceEvidence(),
@@ -1353,7 +1345,7 @@ function buildPolicyInputV1({
   assurance,
   now = new Date().toISOString(),
 }) {
-  const normalizedAssuranceMode = resolveAssuranceMode(assuranceMode, pullRequest?.labels || []).value;
+  const normalizedAssuranceMode = resolveAssuranceMode(assuranceMode).value;
   const input = {
     schemaVersion: '1.0.0',
     contractId: 'policy-input.v1',
@@ -1452,7 +1444,7 @@ async function run(options = parseArgs(process.argv)) {
     statusRollup,
     reviewTopology: process.env.AE_REVIEW_TOPOLOGY,
     approvalOverride: process.env.AE_POLICY_MIN_HUMAN_APPROVALS,
-    assuranceMode: resolveAssuranceMode(process.env.AE_POLICY_ASSURANCE_MODE, pullRequest?.labels || []).value,
+    assuranceMode: resolveAssuranceMode(process.env.AE_POLICY_ASSURANCE_MODE).value,
     assurance,
     now,
   });

--- a/scripts/ci/policy-gate.mjs
+++ b/scripts/ci/policy-gate.mjs
@@ -849,7 +849,7 @@ function buildAssuranceEvaluation(manifestState, options = {}) {
   const errors = [...(Array.isArray(manifestState?.errors) ? manifestState.errors : [])];
   if (modeState.warning) warnings.push(modeState.warning);
   if (!manifestState?.present) {
-    warnings.push(`claim evidence manifest not found: ${manifestState?.path || path.resolve(CLAIM_EVIDENCE_MANIFEST_PATH)}`);
+    warnings.push(`assurance artifact not found: ${manifestState?.path || path.resolve(CLAIM_LEVEL_SUMMARY_PATH)}; expected claim-level summary or claim-evidence manifest`);
     if (modeState.value === 'strict') {
       errors.push(`required assurance artifact missing: ${manifestState?.path || path.resolve(CLAIM_LEVEL_SUMMARY_PATH)}; next action: generate claim-level summary or claim-evidence manifest`);
     }
@@ -861,7 +861,9 @@ function buildAssuranceEvaluation(manifestState, options = {}) {
     for (const waiver of Array.isArray(claim.waivers) ? claim.waivers : []) {
       errors.push(...waiverValidationErrors(waiver, claim));
     }
-    if (claim.result === 'block') {
+    const strictMissingEvidence = modeState.value === 'strict' && claim.result !== 'waived' && claim.missingEvidenceRefs.length > 0;
+    const strictFailedEvidence = modeState.value === 'strict' && claim.status === 'failed';
+    if (claim.result === 'block' || strictMissingEvidence || strictFailedEvidence) {
       if (claim.status === 'failed') {
         errors.push(`assurance claim ${claim.claimId} has failed evidence; next action: fix the failing evidence or provide a valid waiver`);
       } else if (claim.missingEvidenceRefs.length > 0) {

--- a/tests/unit/ci/policy-gate.test.ts
+++ b/tests/unit/ci/policy-gate.test.ts
@@ -7,6 +7,7 @@ import {
   buildPolicyInputV1,
   evaluatePolicyGate,
   inspectClaimEvidenceManifest,
+  inspectClaimLevelSummary,
 } from '../../../scripts/ci/policy-gate.mjs';
 import { loadRiskPolicy } from '../../../scripts/ci/lib/risk-policy.mjs';
 
@@ -508,6 +509,42 @@ describe('policy-gate', () => {
     ]);
   });
 
+  it('keeps report-only assurance blocks non-fatal while surfacing next actions', () => {
+    const result = evaluatePolicyGate({
+      policy,
+      pullRequest: {
+        labels: [{ name: 'risk:low' }],
+        body: '## Rollback\nnone\n\n## Acceptance\nok',
+      },
+      changedFiles: ['src/feature/example.ts'],
+      reviews: [],
+      statusRollup: [checkRun('verify-lite')],
+      assurance: assuranceState({
+        claims: [
+          {
+            claimId: 'proof-required',
+            result: 'block',
+            status: 'unresolved',
+            evidenceRefs: [],
+            missingEvidenceRefs: ['missing-proof:proof-required'],
+            waiverRefs: [],
+            waivers: [],
+          },
+        ],
+      }),
+      assuranceMode: 'report-only',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.assurance.result).toBe('block');
+    expect(result.assurance.summary.block).toBe(1);
+    expect(result.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('assurance claim proof-required is missing required evidence'),
+      expect.stringContaining('next action: add evidence or provide a valid waiver'),
+    ]));
+  });
+
   it('renders waiver ownership, expiry, and reason in the policy gate summary', () => {
     const result = evaluatePolicyGate({
       policy,
@@ -690,6 +727,41 @@ describe('policy-gate', () => {
     expect(result.errors).toContain('assurance decision is block');
     expect(result.assurance.result).toBe('block');
     expect(result.assurance.summary.expiredWaivers).toBe(1);
+  });
+
+  it('blocks strict assurance mode when claim evidence failed', () => {
+    const result = evaluatePolicyGate({
+      policy,
+      pullRequest: {
+        labels: [{ name: 'risk:low' }],
+        body: '## Rollback\nnone\n\n## Acceptance\nok',
+      },
+      changedFiles: ['src/feature/example.ts'],
+      reviews: [],
+      statusRollup: [checkRun('verify-lite')],
+      assurance: assuranceState({
+        claims: [
+          {
+            claimId: 'no-negative-stock',
+            result: 'block',
+            status: 'failed',
+            evidenceRefs: ['property-summary:no-negative-stock'],
+            missingEvidenceRefs: [],
+            waiverRefs: [],
+            waivers: [],
+          },
+        ],
+      }),
+      assuranceMode: 'strict',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.stringContaining('assurance claim no-negative-stock has failed evidence'),
+      expect.stringContaining('next action: fix the failing evidence or provide a valid waiver'),
+      'assurance decision is block',
+    ]));
+    expect(result.assurance.result).toBe('block');
   });
 
   it('keeps unresolved assurance claims blocking even when active waivers are present', () => {
@@ -883,10 +955,203 @@ describe('policy-gate', () => {
         },
       ],
       statusRollup: [checkRun('verify-lite')],
+      assurance: assuranceState(),
       planArtifact: planArtifactState(),
     });
     expect(result.ok).toBe(true);
     expect(result.errors).toHaveLength(0);
+  });
+
+  it('fails closed when assurance enforcement is selected but the required artifact is missing', () => {
+    const result = evaluatePolicyGate({
+      policy,
+      pullRequest: {
+        labels: [{ name: 'risk:low' }],
+        body: '## Rollback\nnone\n\n## Acceptance\nok',
+      },
+      changedFiles: ['src/feature/example.ts'],
+      reviews: [],
+      statusRollup: [checkRun('verify-lite')],
+      assuranceMode: 'enforcement',
+      assurance: {
+        path: '/workspace/artifacts/assurance/claim-level-summary.json',
+        present: false,
+        schemaVersion: null,
+        generatedAt: null,
+        summary: {
+          totalClaims: 0,
+          fullySupported: 0,
+          partiallySupported: 0,
+          waived: 0,
+          unresolved: 0,
+        },
+        claims: [],
+        warnings: [],
+        errors: [],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.assurance.mode).toBe('strict');
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.stringContaining('required assurance artifact missing'),
+      'assurance decision is block',
+    ]));
+  });
+
+  it('uses the enforce-assurance label as assurance enforcement mode', () => {
+    const result = evaluatePolicyGate({
+      policy,
+      pullRequest: {
+        labels: [{ name: 'risk:low' }, { name: 'enforce-assurance' }],
+        body: '## Rollback\nnone\n\n## Acceptance\nok',
+      },
+      changedFiles: ['src/feature/example.ts'],
+      reviews: [],
+      statusRollup: [checkRun('verify-lite')],
+      assurance: assuranceState({
+        claims: [
+          {
+            claimId: 'proof-required',
+            result: 'block',
+            status: 'unresolved',
+            evidenceRefs: [],
+            missingEvidenceRefs: ['missing-proof:proof-required'],
+            waiverRefs: [],
+            waivers: [],
+          },
+        ],
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.assurance.mode).toBe('strict');
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.stringContaining('assurance claim proof-required is missing required evidence'),
+      'assurance decision is block',
+    ]));
+  });
+
+  it('rejects invalid active waivers in assurance enforcement mode', () => {
+    const result = evaluatePolicyGate({
+      policy,
+      pullRequest: {
+        labels: [{ name: 'risk:low' }],
+        body: '## Rollback\nnone\n\n## Acceptance\nok',
+      },
+      changedFiles: ['src/feature/example.ts'],
+      reviews: [],
+      statusRollup: [checkRun('verify-lite')],
+      assuranceMode: 'strict',
+      assurance: assuranceState({
+        claims: [
+          {
+            claimId: 'manual-review',
+            result: 'waived',
+            status: 'waived',
+            evidenceRefs: [],
+            missingEvidenceRefs: [],
+            waiverRefs: ['waiver-invalid-001'],
+            waivers: [
+              {
+                id: 'waiver-invalid-001',
+                sourceArtifactId: '',
+                status: 'active',
+                owner: '',
+                expires: '',
+                reason: '',
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      expect.stringContaining('waiver-invalid-001 for manual-review is missing owner'),
+      expect.stringContaining('waiver-invalid-001 for manual-review is missing reason'),
+      expect.stringContaining('waiver-invalid-001 for manual-review is missing expiry'),
+      expect.stringContaining('waiver-invalid-001 for manual-review is missing source artifact'),
+      expect.stringContaining('waiver-invalid-001 for manual-review is missing related evidence link'),
+      'assurance decision is block',
+    ]));
+  });
+
+  it('consumes claim-level summary artifacts for assurance enforcement', () => {
+    mkdirSync(join(process.cwd(), 'artifacts'), { recursive: true });
+    const tempDir = mkdtempSync(join(process.cwd(), 'artifacts', 'policy-gate-claim-level-summary-'));
+    const summaryPath = join(tempDir, 'claim-level-summary.json');
+
+    try {
+      writeFileSync(
+        summaryPath,
+        JSON.stringify({
+          schemaVersion: 'claim-level-summary/v1',
+          generatedAt: '2026-05-08T00:00:00.000Z',
+          summary: {
+            totalClaims: 2,
+            satisfied: 0,
+            tested: 0,
+            modelChecked: 0,
+            proved: 1,
+            runtimeMitigated: 0,
+            waived: 1,
+            unresolved: 0,
+            failed: 0,
+            notApplicable: 0,
+          },
+          claims: [
+            {
+              claimId: 'balance-proved',
+              state: 'proved',
+              decision: { result: 'pass' },
+              evidenceRefs: [{ id: 'proof:balance' }],
+              missingEvidenceRefs: [],
+              waiverRefs: [],
+            },
+            {
+              claimId: 'manual-waiver',
+              state: 'waived',
+              decision: { result: 'waived' },
+              evidenceRefs: [{ id: 'manual-control:review' }],
+              missingEvidenceRefs: [{ id: 'missing-model:manual-waiver' }],
+              waiverRefs: [
+                {
+                  id: 'waiver-manual-001',
+                  sourceArtifactId: 'temporary-override',
+                  status: 'active',
+                  owner: '@team-risk',
+                  expires: '2026-06-30',
+                  reason: 'Manual review remains active while model validation is incomplete.',
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      const assurance = inspectClaimLevelSummary(summaryPath, '2026-05-08T00:00:00.000Z');
+      const result = evaluatePolicyGate({
+        policy,
+        pullRequest: {
+          labels: [{ name: 'risk:low' }],
+          body: '## Rollback\nnone\n\n## Acceptance\nok',
+        },
+        changedFiles: ['src/feature/example.ts'],
+        reviews: [],
+        statusRollup: [checkRun('verify-lite')],
+        assuranceMode: 'strict',
+        assurance,
+      });
+
+      expect(assurance.schemaVersion).toBe('claim-level-summary/v1');
+      expect(result.ok).toBe(true);
+      expect(result.assurance.result).toBe('waived');
+      expect(result.assurance.summary).toMatchObject({ pass: 1, waived: 1, block: 0 });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 
   it('fails high-risk PR when KvOnce trace validation check fails', () => {

--- a/tests/unit/ci/policy-gate.test.ts
+++ b/tests/unit/ci/policy-gate.test.ts
@@ -999,7 +999,7 @@ describe('policy-gate', () => {
     ]));
   });
 
-  it('uses the enforce-assurance label as assurance enforcement mode', () => {
+  it('keeps enforce-assurance label report-only until CI exports assurance enforcement mode', () => {
     const result = evaluatePolicyGate({
       policy,
       pullRequest: {
@@ -1024,11 +1024,11 @@ describe('policy-gate', () => {
       }),
     });
 
-    expect(result.ok).toBe(false);
-    expect(result.assurance.mode).toBe('strict');
-    expect(result.errors).toEqual(expect.arrayContaining([
+    expect(result.ok).toBe(true);
+    expect(result.assurance.mode).toBe('report-only');
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toEqual(expect.arrayContaining([
       expect.stringContaining('assurance claim proof-required is missing required evidence'),
-      'assurance decision is block',
     ]));
   });
 
@@ -1119,7 +1119,7 @@ describe('policy-gate', () => {
               waiverRefs: [
                 {
                   id: 'waiver-manual-001',
-                  sourceArtifactId: 'temporary-override',
+                  temporaryOverridePath: 'artifacts/assurance/temporary-overrides/waiver-manual-001.json',
                   status: 'active',
                   owner: '@team-risk',
                   expires: '2026-06-30',
@@ -1146,6 +1146,9 @@ describe('policy-gate', () => {
       });
 
       expect(assurance.schemaVersion).toBe('claim-level-summary/v1');
+      expect(assurance.claims[1]?.waivers[0]?.sourceArtifactId).toBe(
+        'artifacts/assurance/temporary-overrides/waiver-manual-001.json',
+      );
       expect(result.ok).toBe(true);
       expect(result.assurance.result).toBe('waived');
       expect(result.assurance.summary).toMatchObject({ pass: 1, waived: 1, block: 0 });

--- a/tests/unit/ci/policy-gate.test.ts
+++ b/tests/unit/ci/policy-gate.test.ts
@@ -764,6 +764,60 @@ describe('policy-gate', () => {
     expect(result.assurance.result).toBe('block');
   });
 
+  it('blocks strict manifest claims when partial status is missing evidence', () => {
+    mkdirSync(join(process.cwd(), 'artifacts'), { recursive: true });
+    const tempDir = mkdtempSync(join(process.cwd(), 'artifacts', 'policy-gate-manifest-partial-'));
+    const manifestPath = join(tempDir, 'claim-evidence-manifest.json');
+
+    try {
+      writeFileSync(
+        manifestPath,
+        JSON.stringify({
+          schemaVersion: 'claim-evidence-manifest/v1',
+          generatedAt: '2026-05-08T00:00:00.000Z',
+          summary: {
+            totalClaims: 1,
+            fullySupported: 0,
+            partiallySupported: 1,
+            waived: 0,
+            unresolved: 0,
+          },
+          claims: [
+            {
+              id: 'partial-proof',
+              status: 'partial',
+              evidenceRefs: [{ id: 'runtime-control:partial-proof' }],
+              missingEvidenceRefs: [{ id: 'missing-proof:partial-proof' }],
+              waiverRefs: [],
+            },
+          ],
+        }),
+      );
+      const assurance = inspectClaimEvidenceManifest(manifestPath, '2026-05-08T00:00:00.000Z');
+      const result = evaluatePolicyGate({
+        policy,
+        pullRequest: {
+          labels: [{ name: 'risk:low' }],
+          body: '## Rollback\nnone\n\n## Acceptance\nok',
+        },
+        changedFiles: ['src/feature/example.ts'],
+        reviews: [],
+        statusRollup: [checkRun('verify-lite')],
+        assurance,
+        assuranceMode: 'strict',
+      });
+
+      expect(assurance.claims[0]?.result).toBe('report-only');
+      expect(result.ok).toBe(false);
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.stringContaining('assurance claim partial-proof is missing required evidence'),
+        'assurance decision is block',
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps unresolved assurance claims blocking even when active waivers are present', () => {
     mkdirSync(join(process.cwd(), 'artifacts'), { recursive: true });
     const tempDir = mkdtempSync(join(process.cwd(), 'artifacts', 'policy-gate-test-'));
@@ -993,6 +1047,9 @@ describe('policy-gate', () => {
 
     expect(result.ok).toBe(false);
     expect(result.assurance.mode).toBe('strict');
+    expect(result.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('assurance artifact not found'),
+    ]));
     expect(result.errors).toEqual(expect.arrayContaining([
       expect.stringContaining('required assurance artifact missing'),
       'assurance decision is block',

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -86,4 +86,15 @@ describe('workflow permission boundaries', () => {
     expect(workflow.on?.workflow_run).toBeDefined();
     expect(workflow.on?.workflow_run?.workflows).toContain('Spec Generate & Model Tests');
   });
+
+  it('policy-gate downloads verify-lite assurance artifacts before label-derived strict mode', () => {
+    const workflow = readWorkflow('policy-gate.yml');
+    expect(workflow).toContain('actions: read');
+    expect(workflow).toContain('Resolve assurance policy inputs');
+    expect(workflow).toContain("labels.has('enforce-assurance')");
+    expect(workflow).toContain("core.exportVariable('AE_POLICY_ASSURANCE_MODE', 'strict')");
+    expect(workflow).toContain('Download verify-lite assurance artifacts');
+    expect(workflow).toContain('name: verify-lite-report');
+    expect(workflow).toContain('run-id: ${{ steps.assurance-policy.outputs.verify_lite_run_id }}');
+  });
 });


### PR DESCRIPTION
## Summary

- Teach `policy-gate` to prefer the generated claim-level summary artifact, with fallback to the existing claim-evidence manifest.
- Add assurance mode resolution for normal report-only behavior and fail-closed enforcement via `AE_POLICY_ASSURANCE_MODE` or the `enforce-assurance` label.
- Add waiver and blocked-claim validation that reports explicit blocked reasons plus next actions.
- Update policy-gate tests and the assurance E2E golden summary for the generalized assurance artifact wording.

## Acceptance

- Existing baseline policy-gate behavior remains compatible for normal report-only PRs.
- Report-only assurance blocks remain non-fatal while surfacing warnings and summary counts.
- Enforcement mode fails closed for missing assurance artifacts, missing evidence, failed evidence, invalid/expired waivers, and unresolved claims.
- Valid waivers are accepted and reported as `waived`, not satisfied/pass.
- OPA shadow/report behavior is preserved; focused policy-shadow tests still pass.

## Local verification

- `pnpm -s exec vitest run tests/scripts/assurance-e2e-scenario.test.ts tests/unit/ci/policy-gate.test.ts tests/unit/ci/policy-shadow-compare.test.ts tests/unit/ci/risk-policy.test.ts tests/unit/ci/risk-policy-gate-check-alignment.test.ts tests/unit/ci/validate-policy-gate-summary.test.ts --reporter dot` — 6 files / 74 tests passed.
- `pnpm -s exec eslint --no-ignore scripts/ci/policy-gate.mjs tests/unit/ci/policy-gate.test.ts` — passed.
- `node scripts/ci/validate-json.mjs` — passed.
- `pnpm -s run check:schemas` — passed.
- `pnpm -s run check:doc-consistency` — passed with 0 warnings.
- `pnpm -s run verify:lite` — passed locally; lint baseline warnings are existing warn-only debt.
- `git diff --check` — passed.

### Additional validation note

- `pnpm -s run test:fast` was attempted. The run exposed the expected local environment limitation in `tests/container/container-agent.test.ts` because Docker/Podman is unavailable (`No container engines available`). It also found the assurance E2E golden summary drift caused by this PR's wording change; that drift was fixed and the focused assurance E2E test now passes.

## Rollback

Revert this PR to restore the previous policy-gate behavior that only consumed the claim-evidence manifest and treated assurance as report-only/strict without claim-level-summary preference or label-derived enforcement.

Closes #3308
Part of #3302
