### PR TITLE
feat(assurance): stabilize proof-carrying change package

### DIFF
--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -328,6 +328,12 @@ jobs:
           if [ -f artifacts/assurance/assurance-summary.json ]; then
             args+=(--assurance-summary artifacts/assurance/assurance-summary.json)
           fi
+          if [ -f artifacts/assurance/claim-level-summary.json ]; then
+            args+=(--claim-level-summary artifacts/assurance/claim-level-summary.json)
+          fi
+          if [ -f artifacts/release/post-deploy-verify.json ]; then
+            args+=(--post-deploy-verify artifacts/release/post-deploy-verify.json)
+          fi
           node scripts/change-package/generate.mjs "${args[@]}"
       - name: Validate Change Package
         run: |

--- a/docs/ci/change-package.md
+++ b/docs/ci/change-package.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-03-22'
+lastVerified: '2026-05-08'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -46,16 +46,21 @@ Responsibility split:
 - schema: `schema/change-package-v2.schema.json`
 - sample fixture: `fixtures/change-package/sample.change-package-v2.json`
 - added sections:
+  - `requirements`
+  - `validationLanes`
+  - `policyDecision`
   - `assurance`
   - `claims`
   - `assumptions`
   - `proofObligations`
   - `counterexamples`
+  - `releaseControls`
+  - `residualRisks`
   - `trustBoundary`
   - `runtimeControls`
   - `waivers`
 
-The default path remains `change-package/v1`. v2 is available through opt-in generation, strict validation, and dual-write / dual-validate commands so migration can proceed without breaking existing consumers.
+The default path remains `change-package/v1`. v2 is available through opt-in generation, strict validation, and dual-write / dual-validate commands so migration can proceed without breaking existing consumers. The v2 package is the proof-carrying PR/release package: it preserves evidence-backed, waived, runtime-mitigated, unresolved, failed, and not-applicable claim states and points summaries to `artifacts/change-package/change-package-v2.json`.
 
 ### 3. Generation and validation commands
 ```bash
@@ -70,7 +75,8 @@ node scripts/change-package/generate.mjs \
   --schema-version v2 \
   --claim-evidence-manifest artifacts/assurance/claim-evidence-manifest.json \
   --policy-decision artifacts/ci/policy-decision-js-v1.json \
-  --assurance-summary artifacts/assurance/assurance-summary.json
+  --assurance-summary artifacts/assurance/assurance-summary.json \
+  --claim-level-summary artifacts/assurance/claim-level-summary.json
 
 # Dual-write v1 + v2
 node scripts/change-package/generate.mjs --dual-write
@@ -104,7 +110,8 @@ node scripts/change-package/validate.mjs \
 - `--mode digest|detailed`: markdown output detail level
 - `--schema-version v1|v2`: switch the generated contract; default is `v1`
 - `--dual-write`: write v1 to `change-package.json|md` and v2 to `change-package-v2.json|md`
-- `--claim-evidence-manifest`, `--policy-decision`, `--assurance-summary`: optional v2 integration inputs
+- `--claim-evidence-manifest`, `--policy-decision`, `--assurance-summary`, `--claim-level-summary`: optional v2 integration inputs
+- `--post-deploy-verify <path>`: optional release/post-deploy verification input for v2 `releaseControls`
 
 #### `validate.mjs`
 - `--required-evidence <csv>`: explicit required evidence IDs
@@ -123,7 +130,7 @@ node scripts/change-package/validate.mjs \
 This means:
 - `pr-summary:detailed` shows richer evidence and reproducibility commands
 - digest mode shows a shorter summary
-- when `artifacts/change-package/change-package-v2.json` exists, PR summary rendering includes v2 claim / proof obligation / waiver counts
+- when `artifacts/change-package/change-package-v2.json` exists, PR summary rendering includes v2 claim / proof obligation / waiver counts, claim-state counts, and the evidence package path
 - `AE_CHANGE_PACKAGE_DUAL_WRITE=1` enables opt-in v1 + v2 generation in the PR summary workflow; `AE_CHANGE_PACKAGE_V2_STRICT=1` makes its v2 validation strict
 
 When tied to auto-merge:
@@ -136,6 +143,8 @@ When tied to auto-merge:
 - When `policy/risk-policy.yml` changes, verify Change Package outcomes with fixtures and tests
 - When the schema changes, update `fixtures/change-package/sample.change-package.json` and `scripts/ci/validate-json.mjs` together
 - Keep `change-package/v1` as the default until downstream consumers explicitly migrate to v2
+- Review `failed`, `not-applicable`, `runtime-mitigated`, and `waived` claim states explicitly; do not treat them as satisfied claims.
+- For release decisions, review `releaseControls` and `residualRisks` in the v2 Markdown before relying on post-deploy mitigation.
 
 ---
 
@@ -171,16 +180,21 @@ PR の安全性判断を diff 中心ではなく、証跡（evidence）中心で
 - スキーマ: `schema/change-package-v2.schema.json`
 - sample fixture: `fixtures/change-package/sample.change-package-v2.json`
 - 追加セクション:
+  - `requirements`
+  - `validationLanes`
+  - `policyDecision`
   - `assurance`
   - `claims`
   - `assumptions`
   - `proofObligations`
   - `counterexamples`
+  - `releaseControls`
+  - `residualRisks`
   - `trustBoundary`
   - `runtimeControls`
   - `waivers`
 
-既定経路は引き続き `change-package/v1` です。v2 は opt-in 生成、strict validation、dual-write / dual-validate による段階移行として利用できます。
+既定経路は引き続き `change-package/v1` です。v2 は opt-in 生成、strict validation、dual-write / dual-validate による段階移行として利用できます。v2 は proof-carrying PR/release package であり、evidence-backed / waived / runtime-mitigated / unresolved / failed / not-applicable の claim state を区別し、summary から `artifacts/change-package/change-package-v2.json` を参照できるようにします。
 
 ## 3. 生成・検証コマンド
 
@@ -196,7 +210,8 @@ node scripts/change-package/generate.mjs \
   --schema-version v2 \
   --claim-evidence-manifest artifacts/assurance/claim-evidence-manifest.json \
   --policy-decision artifacts/ci/policy-decision-js-v1.json \
-  --assurance-summary artifacts/assurance/assurance-summary.json
+  --assurance-summary artifacts/assurance/assurance-summary.json \
+  --claim-level-summary artifacts/assurance/claim-level-summary.json
 
 # v1 + v2 dual-write
 node scripts/change-package/generate.mjs --dual-write
@@ -231,7 +246,8 @@ node scripts/change-package/validate.mjs \
 - `--mode digest|detailed`: Markdown 出力粒度
 - `--schema-version v1|v2`: 生成する contract を切り替える。既定は `v1`
 - `--dual-write`: v1 を `change-package.json|md`、v2 を `change-package-v2.json|md` に同時出力する
-- `--claim-evidence-manifest`, `--policy-decision`, `--assurance-summary`: v2 生成用の任意入力
+- `--claim-evidence-manifest`, `--policy-decision`, `--assurance-summary`, `--claim-level-summary`: v2 生成用の任意入力
+- `--post-deploy-verify <path>`: v2 `releaseControls` に使う任意の release/post-deploy verification 入力
 
 ### `validate.mjs`
 - `--required-evidence <csv>`: required evidence ID を明示
@@ -250,7 +266,7 @@ node scripts/change-package/validate.mjs \
 5. artifact としてアップロード
 
 これにより、`pr-summary:detailed` の場合は証跡と再現コマンドを詳細表示し、digest の場合は短い要約を表示します。
-`artifacts/change-package/change-package-v2.json` が存在する場合、PR summary は v2 の claims / proofObligations / waivers 件数も表示します。
+`artifacts/change-package/change-package-v2.json` が存在する場合、PR summary は v2 の claims / proofObligations / waivers 件数、claim-state counts、evidence package path も表示します。
 PR summary workflow では `AE_CHANGE_PACKAGE_DUAL_WRITE=1` で v1 + v2 生成を opt-in でき、`AE_CHANGE_PACKAGE_V2_STRICT=1` で v2 validation を strict にできます。
 
 auto-merge 運用と連携する場合:
@@ -264,3 +280,5 @@ auto-merge 運用と連携する場合:
 - `policy/risk-policy.yml` の更新時は、Change Package の判定結果が意図どおりかを fixture とテストで確認する。  
 - schema 変更時は `fixtures/change-package/sample.change-package.json` と `scripts/ci/validate-json.mjs` の検証対象を同時更新する。  
 - downstream consumer が明示移行するまでは `change-package/v1` を既定運用として維持する。
+- `failed`、`not-applicable`、`runtime-mitigated`、`waived` は satisfied claim として扱わず、明示的に確認する。
+- release 判断では v2 Markdown の `releaseControls` と `residualRisks` を確認してから post-deploy mitigation に依存する。

--- a/docs/reference/change-package-v2.md
+++ b/docs/reference/change-package-v2.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-03-21'
+lastVerified: '2026-05-08'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -14,21 +14,30 @@ verificationCommand: pnpm -s run check:doc-consistency
 
 ### 1. Purpose
 
-`change-package/v2` extends `change-package/v1` so that safety reasoning can be recorded in terms of claims, assumptions, proof obligations, counterexamples, trust boundaries, and runtime controls.
+`change-package/v2` extends `change-package/v1` so that a PR or release can carry a reviewable assurance package. It records requirement references, touched files, validation lanes, evidence links, per-claim achieved levels, assumptions, waivers, runtime controls, residual risks, policy decisions, and release/post-deploy controls.
 
-The default production contract remains `change-package/v1`, but v2 is now connected through opt-in generation, dual-write, strict validation, and PR summary rendering when the v2 artifact is present.
+The default compatibility contract remains `change-package/v1`. v2 is the stabilized proof-carrying extension used through opt-in generation, dual-write, strict validation, and PR summary rendering when the v2 artifact is present.
 
 ### 2. Schema and Fixture
 
 - Schema: `schema/change-package-v2.schema.json`
 - Sample fixture: `fixtures/change-package/sample.change-package-v2.json`
-- Current production contract: `schema/change-package.schema.json` (`change-package/v1`)
+- Current default contract: `schema/change-package.schema.json` (`change-package/v1`)
 
 Minimal excerpt:
 
 ```json
 {
   "schemaVersion": "change-package/v2",
+  "requirements": {
+    "changedRefs": ["docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md"],
+    "claimRefs": [
+      {
+        "claimId": "no-negative-balance",
+        "refs": ["docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md"]
+      }
+    ]
+  },
   "assurance": {
     "targetLevel": "A3",
     "achievedLevel": "A2",
@@ -39,90 +48,73 @@ Minimal excerpt:
       "id": "no-negative-balance",
       "statement": "The change must not allow a negative balance.",
       "criticality": "high",
+      "targetLevel": "A3",
+      "achievedLevel": "A3",
       "status": "model-checked",
-      "artifactRefs": [
-        "artifacts/assurance/assurance-summary.json"
-      ]
-    }
-  ],
-  "proofObligations": [
-    {
-      "id": "obl-1",
-      "claimId": "no-negative-balance",
-      "method": "tla",
-      "status": "discharged",
-      "artifactRefs": [
-        "artifacts/hermetic-reports/formal/tla-summary.json"
-      ]
+      "requirementRefs": ["docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md"],
+      "artifactRefs": ["artifacts/assurance/claim-level-summary.json"]
     }
   ]
 }
 ```
 
-This excerpt focuses on the `assurance`, `claims`, and `proofObligations` structure while keeping the shown entries schema-valid. Use `fixtures/change-package/sample.change-package-v2.json` for the complete sample.
+Use the fixture for a complete schema-valid sample, including `validationLanes`, `policyDecision`, `releaseControls`, and `residualRisks`.
 
 ### 3. Differences from v1
 
 | Field | v1 | v2 |
 | --- | --- | --- |
-| Primary purpose | aggregate PR risk, evidence, rollout | record assurance package claim by claim |
-| assurance level | absent | `assurance.targetLevel` / `achievedLevel` / `status` |
-| claim | absent | `claims[]` |
-| assumption | absent | `assumptions[]` |
-| proof obligation | absent | `proofObligations[]` |
-| counterexample | absent | `counterexamples[]` |
-| trust boundary | implicit | `trustBoundary.outsideModel` |
-| runtime control | spread across rollout / monitoring | explicit `runtimeControls.alerts[]` / `runtimeControls.featureFlags[]` |
-| waiver | only `exceptions[]` | adds `waivers[]` linked to claims |
+| Primary purpose | aggregate PR risk, evidence, rollout | proof-carrying PR/release assurance package |
+| Requirement refs | implicit in docs/diff | explicit `requirements` and `claims[].requirementRefs[]` |
+| Touched files | `scope.changedFiles[]` | preserved in `scope.changedFiles[]` |
+| Validation lanes | inferred from CI artifacts | explicit `validationLanes[]` with `pass` / `warn` / `fail` / `missing` |
+| Evidence manifest link | evidence catalog only | explicit `claimEvidenceManifest` / `claimLevelSummary` evidence items |
+| Achieved level | absent | package-level and per-claim `targetLevel` / `achievedLevel` |
+| Claims | absent | `claims[]` with first-class status |
+| Policy decision | external artifact only | summarized as `policyDecision` |
+| Residual risks | notes or exceptions | explicit `residualRisks[]` |
+| Release controls | rollout / monitoring only | explicit `releaseControls` for pre-deploy, post-deploy, rollback |
+| Waivers | only `exceptions[]` | `waivers[]` linked to claims and evidence refs |
 
-### 4. Meaning of Additional Sections
+### 4. Claim states
 
-#### 4.1 `assurance`
-Records the target assurance level and the currently achieved level for the entire change package.
+`claims[].status` distinguishes review-relevant outcomes instead of collapsing them into a generic pass/fail result:
 
-#### 4.2 `claims`
-Declares what the change is intended to guarantee. Current status values distinguish at least:
-
-- `proved`
-- `model-checked`
+- `satisfied`
 - `tested`
+- `model-checked`
+- `proved`
 - `runtime-mitigated`
 - `waived`
 - `unresolved`
+- `failed`
+- `not-applicable`
 
-#### 4.3 `assumptions`
-Records the assumptions on which the assurance depends, including external systems and operational dependencies.
+`runtime-mitigated` is not proof. `waived` is not satisfied. `failed` and `not-applicable` are first-class states, not comments.
 
-#### 4.4 `proofObligations`
-Records which verification obligation exists for which claim, and whether it has been discharged.
+### 5. Core sections
 
-#### 4.5 `counterexamples`
-Preserves references to counterexample artifacts, whether still open or already resolved.
+- `requirements`: changed requirement references plus claim-to-requirement links. Empty arrays mean no requirement reference was found, not that the field was skipped.
+- `validationLanes`: validation lanes and their status with evidence refs.
+- `policyDecision`: policy-gate result, mode, enforcement flag, reason, warnings, and errors.
+- `claims`: claim statements, criticality, target/achieved levels, status, requirement refs, artifact refs, and optional per-claim decision.
+- `assumptions`: assumptions on which assurance depends.
+- `proofObligations`: claim-specific verification obligations and their discharge state.
+- `counterexamples`: open, resolved, or accepted-risk counterexample artifacts.
+- `runtimeControls`: runtime alerts and feature flags that mitigate but do not prove a claim.
+- `releaseControls`: pre-deploy checks, post-deploy checks, and rollback signals.
+- `residualRisks`: unresolved, failed, waived, runtime-mitigated, or assumption-driven risks requiring human review.
+- `waivers`: owner, expiry, reason, related claim IDs, and evidence refs.
 
-#### 4.6 `trustBoundary` / `runtimeControls` / `waivers`
-Separates what is not closed by proof alone from what is controlled operationally or intentionally waived.
-
-### 5. Staged Migration Policy
-
-1. Phase 1: add schema, fixture, and docs
-2. Phase 2: add opt-in v2 generation and Markdown renderer support
-3. Phase 3: use v1 + v2 dual-write / dual-validate in selected CI lanes before considering a default switch
-
-Current state:
-- default generator stays on `scripts/change-package/generate.mjs` for v1
-- `--schema-version v2` writes `artifacts/change-package/change-package-v2.json|md`
-- `--dual-write` writes v1 and v2 in one command
-- validator auto-detects v2 when the input has `schemaVersion: "change-package/v2"` and no explicit `--schema` override
-- strict v2 validation checks schema, evidence counts, `artifactRefs` existence, proof-obligation claim references, waiver claim references, counterexample claim references, and optional policy-decision consistency
-
-### 6. Manual Validation Example
+### 6. Generation and validation
 
 ```bash
 node scripts/change-package/generate.mjs \
   --schema-version v2 \
   --claim-evidence-manifest artifacts/assurance/claim-evidence-manifest.json \
   --policy-decision artifacts/ci/policy-decision-js-v1.json \
-  --assurance-summary artifacts/assurance/assurance-summary.json
+  --assurance-summary artifacts/assurance/assurance-summary.json \
+  --claim-level-summary artifacts/assurance/claim-level-summary.json
 
 node scripts/change-package/validate.mjs \
   --file artifacts/change-package/change-package-v2.json \
@@ -132,13 +124,11 @@ node scripts/change-package/validate.mjs \
   --strict
 ```
 
-This validates schema shape, required evidence IDs, present/missing count consistency, v2 claim references, artifact reference existence, and policy-decision alignment. Use `pnpm run change-package:generate:dual` and `pnpm run change-package:validate:dual` for opt-in dual-write / dual-validate migration checks.
+Use `pnpm run change-package:generate:dual` and `pnpm run change-package:validate:dual` for v1/v2 compatibility checks. The v1 default is preserved; consumers should migrate by dual-write and dual-validate before relying on v2-only fields.
 
-### 7. Design Notes
+### 7. PR / release summary behavior
 
-- Do not collapse `proved`, `tested`, and `runtime-mitigated` into one category.
-- Every waiver should retain `owner`, `expires`, `reason`, and `relatedClaimIds`.
-- Treat v2 as an additive migration contract, not as an in-place overwrite of v1.
+The generated Markdown points to the evidence package path, lists claim-state counts, and includes policy decision, validation lanes, release controls, residual risks, proof obligations, and waivers. `scripts/summary/render-pr-summary.mjs` also adds a digest line when `artifacts/change-package/change-package-v2.json` is present.
 
 ---
 
@@ -146,115 +136,73 @@ This validates schema shape, required evidence IDs, present/missing count consis
 
 ## 1. 目的
 
-`change-package/v2` は、現行の `change-package/v1` に対して、変更の安全性説明を claim / assumption / proof obligation / counterexample / runtime control 単位で残すための拡張契約です。
+`change-package/v2` は、PR または release の受入判断に使う proof-carrying assurance package です。requirement reference、変更ファイル、validation lane、evidence link、claim 単位の achieved level、assumption、waiver、runtime control、residual risk、policy decision、release/post-deploy control を記録します。
 
-既定契約は引き続き `change-package/v1` ですが、v2 は opt-in 生成、dual-write、strict validation、v2 artifact が存在する場合の PR summary 表示に接続済みです。
+互換性のため、既定 contract は引き続き `change-package/v1` です。v2 は opt-in 生成、dual-write、strict validation、v2 artifact が存在する場合の PR summary rendering に接続された安定化済み拡張 contract として扱います。
 
 ## 2. スキーマと fixture
 
 - スキーマ: `schema/change-package-v2.schema.json`
 - sample fixture: `fixtures/change-package/sample.change-package-v2.json`
-- 現行 production contract: `schema/change-package.schema.json`（`change-package/v1`）
+- 既定 contract: `schema/change-package.schema.json`（`change-package/v1`）
 
-最小例（抜粋）:
-
-```json
-{
-  "schemaVersion": "change-package/v2",
-  "assurance": {
-    "targetLevel": "A3",
-    "achievedLevel": "A2",
-    "status": "partial"
-  },
-  "claims": [
-    {
-      "id": "no-negative-balance",
-      "statement": "The change must not allow a negative balance.",
-      "criticality": "high",
-      "status": "model-checked",
-      "artifactRefs": [
-        "artifacts/assurance/assurance-summary.json"
-      ]
-    }
-  ],
-  "proofObligations": [
-    {
-      "id": "obl-1",
-      "claimId": "no-negative-balance",
-      "method": "tla",
-      "status": "discharged",
-      "artifactRefs": [
-        "artifacts/hermetic-reports/formal/tla-summary.json"
-      ]
-    }
-  ]
-}
-```
-
-上記は `assurance` / `claims` / `proofObligations` の shape を示す**抜粋**です。`schema/change-package-v2.schema.json` を満たす完全なサンプルは `fixtures/change-package/sample.change-package-v2.json` を参照してください。
+完全な schema-valid sample は fixture を参照してください。fixture には `validationLanes`、`policyDecision`、`releaseControls`、`residualRisks` も含まれます。
 
 ## 3. v1 との差分
 
 | 項目 | v1 | v2 |
 | --- | --- | --- |
-| 主要目的 | PR リスク・evidence・rollout の集約 | 変更の assurance package を claim 単位で記録 |
-| assurance level | なし | `assurance.targetLevel` / `achievedLevel` / `status` |
-| claim | なし | `claims[]` |
-| assumption | なし | `assumptions[]` |
-| proof obligation | なし | `proofObligations[]` |
-| counterexample | なし | `counterexamples[]` |
-| trust boundary | 暗黙 | `trustBoundary.outsideModel` |
-| runtime control | rollout/monitoring に分散 | `runtimeControls` に明示 |
-| waiver | `exceptions[]` のみ | `waivers[]` を追加し claim とひも付け |
+| 主要目的 | PR リスク・evidence・rollout の集約 | PR/release 向け proof-carrying assurance package |
+| requirement refs | docs/diff に暗黙 | `requirements` と `claims[].requirementRefs[]` に明示 |
+| touched files | `scope.changedFiles[]` | `scope.changedFiles[]` として維持 |
+| validation lanes | CI artifact から推測 | `validationLanes[]` に `pass` / `warn` / `fail` / `missing` として明示 |
+| evidence manifest link | evidence catalog のみ | `claimEvidenceManifest` / `claimLevelSummary` evidence item として明示 |
+| achieved level | なし | package-level と claim-level の `targetLevel` / `achievedLevel` |
+| claims | なし | first-class status 付きの `claims[]` |
+| policy decision | 外部 artifact のみ | `policyDecision` として要約 |
+| residual risks | notes / exceptions に分散 | `residualRisks[]` に明示 |
+| release controls | rollout / monitoring のみ | pre-deploy / post-deploy / rollback を `releaseControls` に明示 |
+| waivers | `exceptions[]` のみ | claim と evidence refs に紐づく `waivers[]` |
 
-## 4. 追加セクションの意味
+## 4. claim state
 
-### 4.1 `assurance`
-変更全体として要求した level と、現時点で達成した level を記録します。
+`claims[].status` は次を区別します。
 
-### 4.2 `claims`
-変更で何を保証したいのかを明示します。`status` は少なくとも次を区別します。
-
-- `proved`
-- `model-checked`
+- `satisfied`
 - `tested`
+- `model-checked`
+- `proved`
 - `runtime-mitigated`
 - `waived`
 - `unresolved`
+- `failed`
+- `not-applicable`
 
-### 4.3 `assumptions`
-保証の前提条件です。システム外部や運用上の依存もここに記録します。
+`runtime-mitigated` は proof ではありません。`waived` は satisfied ではありません。`failed` と `not-applicable` はコメントではなく first-class state です。
 
-### 4.4 `proofObligations`
-どの claim に対して、どの検証 obligation があり、どこまで discharge されたかを記録します。
+## 5. 主要セクション
 
-### 4.5 `counterexamples`
-未解決・解消済みを問わず、反例 artifact への参照を change package に残します。
+- `requirements`: 変更された requirement reference と claim-to-requirement link。空配列は「対象なし」を意味し、「未評価」と区別します。
+- `validationLanes`: 検証レーン、状態、evidence refs。
+- `policyDecision`: policy-gate の result / mode / enforcement / reason / warnings / errors。
+- `claims`: claim statement、criticality、target/achieved level、status、requirement refs、artifact refs、任意の per-claim decision。
+- `assumptions`: assurance の前提。
+- `proofObligations`: claim 単位の検証 obligation と discharge 状態。
+- `counterexamples`: open / resolved / accepted-risk の counterexample artifact。
+- `runtimeControls`: claim を緩和する runtime alert / feature flag。proof には昇格しません。
+- `releaseControls`: pre-deploy check、post-deploy check、rollback signal。
+- `residualRisks`: human review が必要な unresolved / failed / waived / runtime-mitigated / assumption 起因のリスク。
+- `waivers`: owner、expiry、reason、related claim IDs、evidence refs。
 
-### 4.6 `trustBoundary` / `runtimeControls` / `waivers`
-proof だけで閉じない範囲を分離して記述します。
-
-## 5. 段階移行方針
-
-1. Phase 1: schema/fixture/docs を追加する
-2. Phase 2: opt-in v2 生成と Markdown renderer を追加する
-3. Phase 3: 既定切替の前に、選択した CI lane で v1 + v2 dual-write / dual-validate を運用する
-
-現時点では、次を維持します。
-- 既定 generator: `scripts/change-package/generate.mjs` は v1 のまま
-- `--schema-version v2` で `artifacts/change-package/change-package-v2.json|md` を出力する
-- `--dual-write` で v1 と v2 を同時出力する
-- validator は入力の `schemaVersion: "change-package/v2"` を自動検出し、明示 `--schema` がない場合は v2 schema を使う
-- v2 strict validation は schema、evidence 件数、`artifactRefs` 実在、proof-obligation / waiver / counterexample の claim 参照、任意の policy-decision 整合性を確認する
-
-## 6. 手動検証例
+## 6. 生成・検証
 
 ```bash
 node scripts/change-package/generate.mjs \
   --schema-version v2 \
   --claim-evidence-manifest artifacts/assurance/claim-evidence-manifest.json \
   --policy-decision artifacts/ci/policy-decision-js-v1.json \
-  --assurance-summary artifacts/assurance/assurance-summary.json
+  --assurance-summary artifacts/assurance/assurance-summary.json \
+  --claim-level-summary artifacts/assurance/claim-level-summary.json
 
 node scripts/change-package/validate.mjs \
   --file artifacts/change-package/change-package-v2.json \
@@ -264,10 +212,8 @@ node scripts/change-package/validate.mjs \
   --strict
 ```
 
-このコマンドは schema validation、required evidence、present/missing 件数、v2 の claim 参照、artifact ref 実在、policy-decision 整合性を確認します。段階移行確認には `pnpm run change-package:generate:dual` と `pnpm run change-package:validate:dual` を使用します。
+v1/v2 互換性確認には `pnpm run change-package:generate:dual` と `pnpm run change-package:validate:dual` を使います。v1 default は維持し、v2-only field に依存する consumer は dual-write / dual-validate 期間を置いて移行します。
 
-## 7. 設計上の注意
+## 7. PR / release summary
 
-- `proved` と `tested` と `runtime-mitigated` を混同しない
-- `waivers` は必ず owner / expires / reason / relatedClaimIds を持たせる
-- v2 は v1 の完全置換ではなく、段階移行前提の追加契約として扱う
+生成 Markdown は evidence package path を示し、claim-state counts、policy decision、validation lanes、release controls、residual risks、proof obligations、waivers を表示します。`artifacts/change-package/change-package-v2.json` が存在する場合、`scripts/summary/render-pr-summary.mjs` も PR summary digest に v2 情報を追加します。

--- a/fixtures/assurance-e2e/inventory-waiver/inputs/change-package-v2.json
+++ b/fixtures/assurance-e2e/inventory-waiver/inputs/change-package-v2.json
@@ -92,7 +92,10 @@
       "artifactRefs": [
         "artifacts/assurance/assurance-summary.json",
         "artifacts/formal/tla/no-negative-balance-summary.json"
-      ]
+      ],
+      "targetLevel": "A3",
+      "achievedLevel": "A3",
+      "requirementRefs": []
     },
     {
       "id": "manual-fraud-review",
@@ -101,7 +104,10 @@
       "criticality": "medium",
       "artifactRefs": [
         "artifacts/runtime/manual-fraud-review-control.json"
-      ]
+      ],
+      "targetLevel": "A3",
+      "achievedLevel": "A2",
+      "requirementRefs": []
     }
   ],
   "assumptions": [
@@ -154,6 +160,63 @@
       "expires": "2099-12-31",
       "reason": "Manual fraud review is active while automated model validation evidence is being collected.",
       "relatedClaimIds": [
+        "manual-fraud-review"
+      ],
+      "evidenceRefs": [
+        "fixtures/assurance/sample.temporary-override-v1.json"
+      ]
+    }
+  ],
+  "requirements": {
+    "changedRefs": [],
+    "claimRefs": []
+  },
+  "validationLanes": [
+    {
+      "id": "verifyLiteSummary",
+      "status": "pass",
+      "evidenceRefs": [
+        "artifacts/verify-lite/verify-lite-run-summary.json"
+      ]
+    },
+    {
+      "id": "policyGateSummary",
+      "status": "pass",
+      "evidenceRefs": [
+        "artifacts/ci/policy-gate-summary.json"
+      ]
+    }
+  ],
+  "policyDecision": {
+    "present": false,
+    "sourceArtifactPath": null,
+    "result": "unassessed",
+    "mode": "unknown",
+    "enforced": false,
+    "reason": "No policy-decision/v1 artifact is linked in this fixture.",
+    "warnings": [],
+    "errors": []
+  },
+  "releaseControls": {
+    "preDeployChecks": [
+      "pnpm -s run assurance:e2e -- --scenario inventory-waiver",
+      "node scripts/ci/validate-json.mjs"
+    ],
+    "postDeployChecks": [
+      "post-deploy-verify workflow or release verification artifact required before production rollout"
+    ],
+    "rollbackSignals": [
+      "golden-artifact-drift",
+      "post-deploy-verify.status=fail"
+    ]
+  },
+  "residualRisks": [
+    {
+      "id": "claim:manual-fraud-review:waived",
+      "statement": "waived claim requires human review: High-risk reservations receive manual fraud review until model validation is complete.",
+      "severity": "medium",
+      "source": "change-package/v2 fixture claim status",
+      "claimIds": [
         "manual-fraud-review"
       ]
     }

--- a/fixtures/assurance/claim-level-summary/inputs/change-package-v2.json
+++ b/fixtures/assurance/claim-level-summary/inputs/change-package-v2.json
@@ -91,7 +91,10 @@
       "criticality": "medium",
       "artifactRefs": [
         "artifacts/verify-lite/verify-lite-run-summary.json"
-      ]
+      ],
+      "targetLevel": "A4",
+      "achievedLevel": "A4",
+      "requirementRefs": []
     },
     {
       "id": "inventory-model",
@@ -100,7 +103,10 @@
       "criticality": "high",
       "artifactRefs": [
         "artifacts/formal/inventory-model-summary.json"
-      ]
+      ],
+      "targetLevel": "A4",
+      "achievedLevel": "A4",
+      "requirementRefs": []
     },
     {
       "id": "balance-proved",
@@ -109,7 +115,10 @@
       "criticality": "critical",
       "artifactRefs": [
         "artifacts/formal/proof/balance-invariant.json"
-      ]
+      ],
+      "targetLevel": "A4",
+      "achievedLevel": "A4",
+      "requirementRefs": []
     },
     {
       "id": "rollout-runtime",
@@ -118,7 +127,10 @@
       "criticality": "high",
       "artifactRefs": [
         "artifacts/runtime/rollout-guard.json"
-      ]
+      ],
+      "targetLevel": "A4",
+      "achievedLevel": "A3",
+      "requirementRefs": []
     },
     {
       "id": "manual-waiver",
@@ -127,7 +139,10 @@
       "criticality": "medium",
       "artifactRefs": [
         "docs/operate/release-engineering.md#manual-fraud-review"
-      ]
+      ],
+      "targetLevel": "A4",
+      "achievedLevel": "A3",
+      "requirementRefs": []
     },
     {
       "id": "strict-proof-failure",
@@ -136,7 +151,10 @@
       "criticality": "critical",
       "artifactRefs": [
         "artifacts/formal/proof/strict-proof-failure.json"
-      ]
+      ],
+      "targetLevel": "A4",
+      "achievedLevel": "A3",
+      "requirementRefs": []
     },
     {
       "id": "unresolved-model",
@@ -145,7 +163,10 @@
       "criticality": "high",
       "artifactRefs": [
         "artifacts/formal/model-reconciliation.json"
-      ]
+      ],
+      "targetLevel": "A4",
+      "achievedLevel": "A3",
+      "requirementRefs": []
     }
   ],
   "assumptions": [
@@ -208,6 +229,90 @@
       "reason": "Manual fraud review is active while model validation is incomplete.",
       "relatedClaimIds": [
         "manual-waiver"
+      ],
+      "evidenceRefs": [
+        "fixtures/assurance/sample.temporary-override-v1.json"
+      ]
+    }
+  ],
+  "requirements": {
+    "changedRefs": [],
+    "claimRefs": []
+  },
+  "validationLanes": [
+    {
+      "id": "verifyLiteSummary",
+      "status": "pass",
+      "evidenceRefs": [
+        "artifacts/verify-lite/verify-lite-run-summary.json"
+      ]
+    },
+    {
+      "id": "policyGateSummary",
+      "status": "pass",
+      "evidenceRefs": [
+        "artifacts/ci/policy-gate-summary.json"
+      ]
+    }
+  ],
+  "policyDecision": {
+    "present": false,
+    "sourceArtifactPath": null,
+    "result": "unassessed",
+    "mode": "unknown",
+    "enforced": false,
+    "reason": "No policy-decision/v1 artifact is linked in this fixture.",
+    "warnings": [],
+    "errors": []
+  },
+  "releaseControls": {
+    "preDeployChecks": [
+      "pnpm -s run assurance:e2e -- --scenario inventory-waiver",
+      "node scripts/ci/validate-json.mjs"
+    ],
+    "postDeployChecks": [
+      "post-deploy-verify workflow or release verification artifact required before production rollout"
+    ],
+    "rollbackSignals": [
+      "golden-artifact-drift",
+      "post-deploy-verify.status=fail"
+    ]
+  },
+  "residualRisks": [
+    {
+      "id": "claim:rollout-runtime:runtime-mitigated",
+      "statement": "runtime-mitigated claim requires human review: Rollout guard mitigates incomplete proof for staged deployment.",
+      "severity": "high",
+      "source": "change-package/v2 fixture claim status",
+      "claimIds": [
+        "rollout-runtime"
+      ]
+    },
+    {
+      "id": "claim:manual-waiver:waived",
+      "statement": "waived claim requires human review: Manual fraud review remains in place until model validation is complete.",
+      "severity": "medium",
+      "source": "change-package/v2 fixture claim status",
+      "claimIds": [
+        "manual-waiver"
+      ]
+    },
+    {
+      "id": "claim:strict-proof-failure:unresolved",
+      "statement": "unresolved claim requires human review: Strict proof evidence must pass before enforced release.",
+      "severity": "critical",
+      "source": "change-package/v2 fixture claim status",
+      "claimIds": [
+        "strict-proof-failure"
+      ]
+    },
+    {
+      "id": "claim:unresolved-model:unresolved",
+      "statement": "unresolved claim requires human review: Model reconciliation evidence is required but absent.",
+      "severity": "high",
+      "source": "change-package/v2 fixture claim status",
+      "claimIds": [
+        "unresolved-model"
       ]
     }
   ]

--- a/fixtures/change-package/sample.change-package-v2.json
+++ b/fixtures/change-package/sample.change-package-v2.json
@@ -116,6 +116,37 @@
       "artifactRefs": [
         "artifacts/assurance/assurance-summary.json",
         "artifacts/hermetic-reports/formal/summary.json"
+      ],
+      "targetLevel": "A3",
+      "achievedLevel": "A3",
+      "requirementRefs": []
+    },
+    {
+      "id": "strict-proof-failure",
+      "statement": "Strict proof obligation produced a counterexample that remains decision-relevant.",
+      "status": "failed",
+      "criticality": "high",
+      "targetLevel": "A4",
+      "achievedLevel": "A1",
+      "requirementRefs": [
+        "docs/quality/ARTIFACTS-CONTRACT.md"
+      ],
+      "artifactRefs": [
+        "artifacts/formal/counterexamples/cex-001.json"
+      ]
+    },
+    {
+      "id": "ui-out-of-scope",
+      "statement": "UI-only assurance is not applicable to this change-package contract update.",
+      "status": "not-applicable",
+      "criticality": "low",
+      "targetLevel": "A1",
+      "achievedLevel": "A0",
+      "requirementRefs": [
+        "docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md"
+      ],
+      "artifactRefs": [
+        "docs/ci/change-package.md"
       ]
     }
   ],
@@ -137,6 +168,15 @@
       "status": "discharged",
       "artifactRefs": [
         "artifacts/hermetic-reports/formal/tla-summary.json"
+      ]
+    },
+    {
+      "id": "obl-strict-proof-failure",
+      "claimId": "strict-proof-failure",
+      "method": "tla",
+      "status": "open",
+      "artifactRefs": [
+        "artifacts/formal/counterexamples/cex-001.json"
       ]
     }
   ],
@@ -164,5 +204,74 @@
       "ledger_v2_shadow_write"
     ]
   },
-  "waivers": []
+  "waivers": [],
+  "requirements": {
+    "changedRefs": [],
+    "claimRefs": [
+      {
+        "claimId": "strict-proof-failure",
+        "refs": [
+          "docs/quality/ARTIFACTS-CONTRACT.md"
+        ]
+      },
+      {
+        "claimId": "ui-out-of-scope",
+        "refs": [
+          "docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md"
+        ]
+      }
+    ]
+  },
+  "validationLanes": [
+    {
+      "id": "verifyLiteSummary",
+      "status": "pass",
+      "evidenceRefs": [
+        "artifacts/verify-lite/verify-lite-run-summary.json"
+      ]
+    },
+    {
+      "id": "policyGateSummary",
+      "status": "missing",
+      "evidenceRefs": [
+        "artifacts/ci/policy-gate-summary.json"
+      ]
+    }
+  ],
+  "policyDecision": {
+    "present": false,
+    "sourceArtifactPath": null,
+    "result": "unassessed",
+    "mode": "unknown",
+    "enforced": false,
+    "reason": "No policy-decision/v1 artifact is linked in this fixture.",
+    "warnings": [],
+    "errors": []
+  },
+  "releaseControls": {
+    "preDeployChecks": [
+      "pnpm run verify:lite",
+      "pnpm run artifacts:validate -- --strict=true",
+      "pnpm run test:ci:extended"
+    ],
+    "postDeployChecks": [
+      "post-deploy-verify workflow or release verification artifact required before production rollout"
+    ],
+    "rollbackSignals": [
+      "human-approval-required",
+      "missing-required-labels",
+      "post-deploy-verify.status=fail"
+    ]
+  },
+  "residualRisks": [
+    {
+      "id": "claim:strict-proof-failure:failed",
+      "statement": "failed claim requires human review: Strict proof obligation produced a counterexample that remains decision-relevant.",
+      "severity": "high",
+      "source": "change-package/v2 fixture claim status",
+      "claimIds": [
+        "strict-proof-failure"
+      ]
+    }
+  ]
 }

--- a/schema/change-package-v2.schema.json
+++ b/schema/change-package-v2.schema.json
@@ -24,7 +24,12 @@
     "counterexamples",
     "trustBoundary",
     "runtimeControls",
-    "waivers"
+    "waivers",
+    "requirements",
+    "validationLanes",
+    "policyDecision",
+    "releaseControls",
+    "residualRisks"
   ],
   "properties": {
     "schemaVersion": {
@@ -106,6 +111,27 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/waiver"
+      }
+    },
+    "requirements": {
+      "$ref": "#/$defs/requirements"
+    },
+    "validationLanes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/validationLane"
+      }
+    },
+    "policyDecision": {
+      "$ref": "#/$defs/policyDecision"
+    },
+    "releaseControls": {
+      "$ref": "#/$defs/releaseControls"
+    },
+    "residualRisks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/residualRisk"
       }
     }
   },
@@ -465,7 +491,9 @@
             "partial",
             "satisfied",
             "waived",
-            "unresolved"
+            "unresolved",
+            "failed",
+            "not-applicable"
           ]
         }
       }
@@ -487,7 +515,10 @@
         "statement",
         "status",
         "criticality",
-        "artifactRefs"
+        "artifactRefs",
+        "targetLevel",
+        "achievedLevel",
+        "requirementRefs"
       ],
       "properties": {
         "id": {
@@ -506,7 +537,10 @@
             "tested",
             "runtime-mitigated",
             "waived",
-            "unresolved"
+            "unresolved",
+            "satisfied",
+            "failed",
+            "not-applicable"
           ]
         },
         "criticality": {
@@ -520,6 +554,37 @@
         },
         "artifactRefs": {
           "$ref": "#/$defs/artifactRefs"
+        },
+        "targetLevel": {
+          "type": "string",
+          "enum": [
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4"
+          ]
+        },
+        "achievedLevel": {
+          "type": "string",
+          "enum": [
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4"
+          ]
+        },
+        "requirementRefs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "decision": {
+          "$ref": "#/$defs/claimDecision"
         }
       }
     },
@@ -675,7 +740,8 @@
         "owner",
         "expires",
         "reason",
-        "relatedClaimIds"
+        "relatedClaimIds",
+        "evidenceRefs"
       ],
       "properties": {
         "owner": {
@@ -693,6 +759,270 @@
         "relatedClaimIds": {
           "type": "array",
           "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "evidenceRefs": {
+          "$ref": "#/$defs/artifactRefs"
+        }
+      }
+    },
+    "requirementClaimRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "claimId",
+        "refs"
+      ],
+      "properties": {
+        "claimId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "changedRefs",
+        "claimRefs"
+      ],
+      "properties": {
+        "changedRefs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "claimRefs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requirementClaimRef"
+          }
+        }
+      }
+    },
+    "claimDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "result",
+        "mode",
+        "enforced",
+        "reason"
+      ],
+      "properties": {
+        "result": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "waived",
+            "report-only",
+            "block",
+            "unassessed"
+          ]
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "report-only",
+            "strict",
+            "unknown"
+          ]
+        },
+        "enforced": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "validationLane": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "status",
+        "evidenceRefs"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "warn",
+            "fail",
+            "missing"
+          ]
+        },
+        "evidenceRefs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "policyDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "present",
+        "sourceArtifactPath",
+        "result",
+        "mode",
+        "enforced",
+        "reason",
+        "warnings",
+        "errors"
+      ],
+      "properties": {
+        "present": {
+          "type": "boolean"
+        },
+        "sourceArtifactPath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "result": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "waived",
+            "report-only",
+            "block",
+            "unassessed"
+          ]
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "report-only",
+            "strict",
+            "unknown"
+          ]
+        },
+        "enforced": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "releaseControls": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "preDeployChecks",
+        "postDeployChecks",
+        "rollbackSignals"
+      ],
+      "properties": {
+        "preDeployChecks": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "postDeployChecks": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "rollbackSignals": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "residualRisk": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "statement",
+        "severity",
+        "source",
+        "claimIds"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "statement": {
+          "type": "string",
+          "minLength": 1
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "claimIds": {
+          "type": "array",
           "items": {
             "type": "string",
             "minLength": 1

--- a/scripts/assurance/aggregate-claim-levels.mjs
+++ b/scripts/assurance/aggregate-claim-levels.mjs
@@ -27,7 +27,17 @@ const CLAIM_STATES = new Set([
   'failed',
   'not-applicable',
 ]);
-const CHANGE_PACKAGE_STATES = new Set(['proved', 'model-checked', 'tested', 'runtime-mitigated', 'waived', 'unresolved']);
+const CHANGE_PACKAGE_STATES = new Set([
+  'satisfied',
+  'proved',
+  'model-checked',
+  'tested',
+  'runtime-mitigated',
+  'waived',
+  'unresolved',
+  'failed',
+  'not-applicable',
+]);
 const DECISION_RESULTS = new Set(['pass', 'waived', 'report-only', 'block']);
 const DECISION_MODES = new Set(['report-only', 'strict']);
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');

--- a/scripts/change-package/generate.mjs
+++ b/scripts/change-package/generate.mjs
@@ -670,7 +670,6 @@ function ingestClaimLevelSummaryForV2(claimsById, proofObligations, waivers, ass
     if (!claimId) continue;
     const artifactRefs = [
       ...ensureArray(rawClaim?.evidenceRefs).map((entry) => entry?.artifactPath),
-      ...ensureArray(rawClaim?.missingEvidenceRefs).map((entry) => `${source.path}#/claims/${claimId}/missingEvidenceRefs/${entry?.id || 'missing'}`),
       source.path,
     ];
     const claim = upsertClaim(claimsById, {
@@ -962,7 +961,7 @@ function buildValidationLanes(claimLevelSummarySource, baseEvidence) {
       const laneStatus = mapEvidenceStatusToLaneStatus(evidence?.status);
       const existing = lanesById.get(laneId) || { id: laneId, status: 'pass', evidenceRefs: [] };
       existing.status = mergeLaneStatus(existing.status, laneStatus);
-      existing.evidenceRefs = uniqueStrings([...existing.evidenceRefs, evidence?.artifactPath, evidence?.id]);
+      existing.evidenceRefs = uniqueStrings([...existing.evidenceRefs, evidence?.artifactPath]);
       lanesById.set(laneId, existing);
     }
   }

--- a/scripts/change-package/generate.mjs
+++ b/scripts/change-package/generate.mjs
@@ -24,15 +24,20 @@ const DEFAULT_MODE = 'detailed';
 const DEFAULT_CLAIM_EVIDENCE_MANIFEST_PATH = 'artifacts/assurance/claim-evidence-manifest.json';
 const DEFAULT_POLICY_DECISION_PATH = 'artifacts/ci/policy-decision-js-v1.json';
 const DEFAULT_ASSURANCE_SUMMARY_PATH = 'artifacts/assurance/assurance-summary.json';
+const DEFAULT_CLAIM_LEVEL_SUMMARY_PATH = 'artifacts/assurance/claim-level-summary.json';
+const DEFAULT_POST_DEPLOY_VERIFY_PATH = 'artifacts/release/post-deploy-verify.json';
 
 const ASSURANCE_LEVELS = ['A0', 'A1', 'A2', 'A3', 'A4'];
 const V2_CLAIM_STATUSES = new Set([
+  'satisfied',
   'proved',
   'model-checked',
   'tested',
   'runtime-mitigated',
   'waived',
   'unresolved',
+  'failed',
+  'not-applicable',
 ]);
 const V2_PROOF_METHODS = new Set([
   'spec',
@@ -130,6 +135,8 @@ function parseArgs(argv = process.argv) {
     claimEvidenceManifestPath: DEFAULT_CLAIM_EVIDENCE_MANIFEST_PATH,
     policyDecisionPath: DEFAULT_POLICY_DECISION_PATH,
     assuranceSummaryPath: DEFAULT_ASSURANCE_SUMMARY_PATH,
+    claimLevelSummaryPath: DEFAULT_CLAIM_LEVEL_SUMMARY_PATH,
+    postDeployVerifyPath: DEFAULT_POST_DEPLOY_VERIFY_PATH,
     repository: '',
     prNumber: null,
     baseRef: '',
@@ -262,6 +269,22 @@ function parseArgs(argv = process.argv) {
       options.assuranceSummaryPath = arg.slice('--assurance-summary='.length);
       continue;
     }
+    if (arg === '--claim-level-summary') {
+      options.claimLevelSummaryPath = readValue('--claim-level-summary');
+      continue;
+    }
+    if (arg.startsWith('--claim-level-summary=')) {
+      options.claimLevelSummaryPath = arg.slice('--claim-level-summary='.length);
+      continue;
+    }
+    if (arg === '--post-deploy-verify') {
+      options.postDeployVerifyPath = readValue('--post-deploy-verify');
+      continue;
+    }
+    if (arg.startsWith('--post-deploy-verify=')) {
+      options.postDeployVerifyPath = arg.slice('--post-deploy-verify='.length);
+      continue;
+    }
     if (arg === '--repo') {
       options.repository = readValue('--repo');
       continue;
@@ -351,6 +374,8 @@ function printHelp() {
     + `  --claim-evidence-manifest <path> claim-evidence-manifest/v1 input for v2 (default: ${DEFAULT_CLAIM_EVIDENCE_MANIFEST_PATH})\n`
     + `  --policy-decision <path>      policy-decision/v1 input for v2 (default: ${DEFAULT_POLICY_DECISION_PATH})\n`
     + `  --assurance-summary <path>    assurance-summary/v1 input for v2 (default: ${DEFAULT_ASSURANCE_SUMMARY_PATH})\n`
+    + `  --claim-level-summary <path>  claim-level-summary/v1 input for v2 (default: ${DEFAULT_CLAIM_LEVEL_SUMMARY_PATH})\n`
+    + `  --post-deploy-verify <path>   post-deploy verification input for v2 release controls (default: ${DEFAULT_POST_DEPLOY_VERIFY_PATH})\n`
     + `  --changed-files-file <path>   newline-separated changed files input\n`
     + `  --artifact-root <path>        root path for evidence existence checks (default: ${DEFAULT_ARTIFACT_ROOT})\n`
     + `  --mode <digest|detailed>      markdown detail level (default: ${DEFAULT_MODE})\n`
@@ -429,8 +454,19 @@ function normalizeCriticality(value) {
 }
 
 function normalizeV2ClaimStatus(value, fallback = 'unresolved') {
-  const candidate = String(value || '').trim();
+  const candidate = String(value || '').trim().toLowerCase();
   return V2_CLAIM_STATUSES.has(candidate) ? candidate : fallback;
+}
+
+function normalizeDecisionResult(value, fallback = 'unassessed') {
+  const candidate = String(value || '').trim().toLowerCase();
+  return ['pass', 'waived', 'report-only', 'block', 'unassessed'].includes(candidate) ? candidate : fallback;
+}
+
+function normalizeDecisionMode(value, enforced = false) {
+  const candidate = String(value || '').trim().toLowerCase();
+  if (candidate === 'strict' || candidate === 'report-only') return candidate;
+  return enforced ? 'strict' : 'unknown';
 }
 
 function normalizeV2ProofMethod(value) {
@@ -461,6 +497,30 @@ function normalizeArtifactRefs(values, fallback) {
     .map(stripJsonPointer)
     .filter(Boolean);
   return refs.length > 0 ? refs : [fallback].filter(Boolean);
+}
+
+function collectRequirementRefs(rawClaim) {
+  const directRefs = [
+    ...ensureArray(rawClaim?.requirementRefs),
+    ...ensureArray(rawClaim?.requirements),
+    ...ensureArray(rawClaim?.requirementIds),
+  ];
+  const specEvidenceRefs = ensureArray(rawClaim?.evidenceRefs)
+    .filter((entry) => String(entry?.kind || '').trim().toLowerCase() === 'spec')
+    .map((entry) => entry?.artifactPath || entry?.id);
+  return uniqueStrings([...directRefs, ...specEvidenceRefs]);
+}
+
+function normalizeClaimDecision(rawDecision) {
+  const decision = ensureObject(rawDecision);
+  const result = normalizeDecisionResult(decision.result);
+  const enforced = Boolean(decision.enforced);
+  return {
+    result,
+    mode: normalizeDecisionMode(decision.mode, enforced),
+    enforced,
+    reason: String(decision.reason || 'No policy decision was linked for this claim.'),
+  };
 }
 
 function loadOptionalJsonSource(id, filePath, description) {
@@ -495,11 +555,13 @@ function inferV2StatusFromManifestClaim(claim) {
 function mapPolicyClaimResultToV2Status(result, status) {
   const normalizedResult = String(result || '').trim().toLowerCase();
   if (normalizedResult === 'waived') return 'waived';
-  if (normalizedResult === 'block' || normalizedResult === 'report-only') return 'unresolved';
+  if (normalizedResult === 'block') return 'failed';
+  if (normalizedResult === 'report-only') return 'unresolved';
   const normalizedStatus = String(status || '').trim().toLowerCase();
   if (normalizedStatus === 'waived') return 'waived';
   if (normalizedStatus === 'partial' || normalizedStatus === 'unresolved') return 'unresolved';
-  return 'tested';
+  if (V2_CLAIM_STATUSES.has(normalizedStatus)) return normalizedStatus;
+  return 'satisfied';
 }
 
 function upsertClaim(claimsById, rawClaim) {
@@ -510,6 +572,10 @@ function upsertClaim(claimsById, rawClaim) {
     statement: `Assurance claim ${id}`,
     status: 'unresolved',
     criticality: 'medium',
+    targetLevel: 'A0',
+    achievedLevel: 'A0',
+    requirementRefs: [],
+    decision: normalizeClaimDecision(null),
     artifactRefs: [],
   };
   const merged = {
@@ -517,6 +583,13 @@ function upsertClaim(claimsById, rawClaim) {
     statement: String(rawClaim?.statement || existing.statement || `Assurance claim ${id}`),
     status: normalizeV2ClaimStatus(rawClaim?.status, existing.status),
     criticality: normalizeCriticality(rawClaim?.criticality || existing.criticality),
+    targetLevel: normalizeAssuranceLevel(rawClaim?.targetLevel, existing.targetLevel),
+    achievedLevel: normalizeAssuranceLevel(rawClaim?.achievedLevel, existing.achievedLevel),
+    requirementRefs: uniqueStrings([
+      ...ensureArray(existing.requirementRefs),
+      ...collectRequirementRefs(rawClaim),
+    ]),
+    decision: rawClaim?.decision ? normalizeClaimDecision(rawClaim.decision) : existing.decision,
     artifactRefs: normalizeArtifactRefs([
       ...ensureArray(existing.artifactRefs),
       ...ensureArray(rawClaim?.artifactRefs),
@@ -541,6 +614,9 @@ function ingestManifestForV2(claimsById, proofObligations, waivers, source) {
       statement: rawClaim?.statement,
       criticality: rawClaim?.criticality,
       status: inferV2StatusFromManifestClaim(rawClaim),
+      targetLevel: rawClaim?.targetLevel,
+      achievedLevel: rawClaim?.achievedLevel,
+      requirementRefs: rawClaim?.requirementRefs,
       artifactRefs: collectManifestArtifactRefs(rawClaim, source.path),
     });
     if (!claim) continue;
@@ -563,6 +639,7 @@ function ingestManifestForV2(claimsById, proofObligations, waivers, source) {
         expires: normalizeDate(rawWaiver?.expires),
         reason: String(rawWaiver?.reason || `Waiver recorded for claim ${claim.id}`),
         relatedClaimIds: [claim.id],
+        evidenceRefs: normalizeArtifactRefs([rawWaiver?.artifactPath, rawWaiver?.temporaryOverridePath, source.path], source.path),
       });
     }
   }
@@ -578,8 +655,81 @@ function ingestAssuranceSummaryForV2(claimsById, source) {
       statement: rawClaim?.statement,
       criticality: rawClaim?.criticality,
       status: String(rawClaim?.status || '').trim() === 'satisfied' ? 'tested' : 'unresolved',
+      targetLevel: rawClaim?.targetLevel,
+      achievedLevel: inferAssuranceSummaryAchievedLevel(rawClaim),
+      requirementRefs: rawClaim?.requirementRefs,
       artifactRefs: ensureArray(rawClaim?.evidence).map((entry) => entry?.artifactPath),
     });
+  }
+}
+
+function ingestClaimLevelSummaryForV2(claimsById, proofObligations, waivers, assumptions, runtimeControls, source) {
+  const summary = ensureObject(source.payload);
+  for (const rawClaim of ensureArray(summary.claims)) {
+    const claimId = String(rawClaim?.claimId || rawClaim?.id || '').trim();
+    if (!claimId) continue;
+    const artifactRefs = [
+      ...ensureArray(rawClaim?.evidenceRefs).map((entry) => entry?.artifactPath),
+      ...ensureArray(rawClaim?.missingEvidenceRefs).map((entry) => `${source.path}#/claims/${claimId}/missingEvidenceRefs/${entry?.id || 'missing'}`),
+      source.path,
+    ];
+    const claim = upsertClaim(claimsById, {
+      id: claimId,
+      statement: rawClaim?.statement,
+      criticality: rawClaim?.criticality,
+      status: rawClaim?.state,
+      targetLevel: rawClaim?.targetLevel,
+      achievedLevel: rawClaim?.achievedLevel,
+      requirementRefs: collectRequirementRefs(rawClaim),
+      decision: rawClaim?.decision,
+      artifactRefs,
+    });
+    if (!claim) continue;
+
+    for (const rawEvidence of ensureArray(rawClaim?.evidenceRefs)) {
+      const kind = String(rawEvidence?.kind || '').trim().toLowerCase();
+      if (!['proof', 'model', 'runtime'].includes(kind)) continue;
+      const evidenceId = String(rawEvidence?.id || `${claim.id}:${kind}:${proofObligations.length}`).trim();
+      if (!evidenceId) continue;
+      proofObligations.push({
+        id: `${evidenceId}:obligation`,
+        claimId: claim.id,
+        method: normalizeV2ProofMethod(kind),
+        status: String(rawEvidence?.status || '').trim().toLowerCase() === 'observed' ? 'discharged' : 'open',
+        artifactRefs: normalizeArtifactRefs([rawEvidence?.artifactPath], source.path),
+      });
+    }
+
+    for (const rawWaiver of ensureArray(rawClaim?.waiverRefs)) {
+      waivers.push({
+        owner: String(rawWaiver?.owner || 'unknown'),
+        expires: normalizeDate(rawWaiver?.expires),
+        reason: String(rawWaiver?.reason || `Waiver recorded for claim ${claim.id}`),
+        relatedClaimIds: [claim.id],
+        evidenceRefs: normalizeArtifactRefs([rawWaiver?.temporaryOverridePath, rawWaiver?.artifactPath, source.path], source.path),
+      });
+    }
+
+    for (const rawAssumption of ensureArray(rawClaim?.assumptions)) {
+      assumptions.push({
+        id: String(rawAssumption?.id || `${claim.id}:assumption:${assumptions.length}`),
+        statement: String(rawAssumption?.statement || `Assumption linked to ${claim.id}.`),
+        owner: String(rawAssumption?.owner || 'unknown'),
+        evidenceRefs: normalizeArtifactRefs([rawAssumption?.artifactPath, source.path], source.path),
+        status: String(rawAssumption?.status || ''),
+        claimId: claim.id,
+      });
+    }
+
+    for (const rawControl of ensureArray(rawClaim?.runtimeControls)) {
+      runtimeControls.push({
+        id: String(rawControl?.id || `${claim.id}:runtime-control:${runtimeControls.length}`),
+        kind: String(rawControl?.kind || 'other'),
+        description: String(rawControl?.description || `Runtime control linked to ${claim.id}.`),
+        artifactPath: rawControl?.artifactPath,
+        claimId: claim.id,
+      });
+    }
   }
 }
 
@@ -635,6 +785,7 @@ function ingestPolicyDecisionForV2(claimsById, waivers, source) {
       expires: normalizeDate(rawWaiver?.expires),
       reason: String(rawWaiver?.reason || `Policy decision waiver for claim ${claimId}`),
       relatedClaimIds: [claimId],
+      evidenceRefs: normalizeArtifactRefs([source.path], source.path),
     });
   }
 }
@@ -662,6 +813,7 @@ function dedupeWaivers(entries) {
       expires: normalizeDate(entry.expires),
       reason: String(entry.reason || 'Change-package v2 waiver'),
       relatedClaimIds,
+      evidenceRefs: normalizeArtifactRefs(entry.evidenceRefs, DEFAULT_CLAIM_LEVEL_SUMMARY_PATH),
     };
     const key = `${normalized.owner}::${normalized.expires}::${normalized.reason}::${normalized.relatedClaimIds.join(',')}`;
     if (seen.has(key)) continue;
@@ -691,16 +843,29 @@ function buildV2Evidence(baseEvidence, sources) {
   };
 }
 
-function buildV2Assurance(claims, manifestSource, policyDecisionSource, assuranceSummarySource) {
+function summarizeClaimStatuses(claims) {
+  const summary = new Map();
+  for (const claim of claims) {
+    summary.set(claim.status, (summary.get(claim.status) || 0) + 1);
+  }
+  return summary;
+}
+
+function buildV2Assurance(claims, manifestSource, policyDecisionSource, assuranceSummarySource, claimLevelSummarySource) {
   const manifestClaims = ensureArray(manifestSource.payload?.claims);
   const assuranceClaims = ensureArray(assuranceSummarySource.payload?.claims);
+  const claimLevelClaims = ensureArray(claimLevelSummarySource.payload?.claims);
   const targetLevel = maxAssuranceLevel([
     ...manifestClaims.map((claim) => claim?.targetLevel),
     ...assuranceClaims.map((claim) => claim?.targetLevel),
+    ...claimLevelClaims.map((claim) => claim?.targetLevel),
+    ...claims.map((claim) => claim?.targetLevel),
   ]);
   const achievedLevel = minAssuranceLevel([
     ...manifestClaims.map((claim) => claim?.achievedLevel),
     ...assuranceClaims.map(inferAssuranceSummaryAchievedLevel),
+    ...claimLevelClaims.map((claim) => claim?.achievedLevel),
+    ...claims.map((claim) => claim?.achievedLevel),
   ], targetLevel);
   const policyAssurance = ensureObject(policyDecisionSource.payload?.evaluation?.assurance);
   const policyResult = String(policyAssurance.result || '').trim().toLowerCase();
@@ -712,7 +877,12 @@ function buildV2Assurance(claims, manifestSource, policyDecisionSource, assuranc
     .filter((claim) => sourceStatusesByClaimId.get(claim.id) !== 'partial');
 
   let status = 'unassessed';
-  if (policyResult === 'block' || sourceStatuses.includes('unresolved') || generatedUnresolvedClaims.length > 0) {
+  const claimStatusSummary = summarizeClaimStatuses(claims);
+  if (claimStatusSummary.get('failed') > 0 || policyResult === 'block') {
+    status = 'failed';
+  } else if (claims.length > 0 && claims.every((claim) => claim.status === 'not-applicable')) {
+    status = 'not-applicable';
+  } else if (sourceStatuses.includes('unresolved') || generatedUnresolvedClaims.length > 0) {
     status = 'unresolved';
   } else if (policyResult === 'report-only' || manifestStatuses.includes('partial') || sourceStatuses.includes('partial')) {
     status = 'partial';
@@ -729,6 +899,137 @@ function buildV2Assurance(claims, manifestSource, policyDecisionSource, assuranc
     achievedLevel,
     status,
   };
+}
+
+function inferChangedRequirementRefs(changedFiles) {
+  return uniqueStrings(changedFiles.filter((filePath) => {
+    const normalized = String(filePath || '').trim().toLowerCase();
+    return normalized.startsWith('requirements/')
+      || normalized.startsWith('reqs/')
+      || normalized.includes('/requirements/')
+      || normalized.startsWith('spec/')
+      || normalized.startsWith('docs/product/')
+      || normalized.startsWith('docs/requirements/');
+  }));
+}
+
+function buildV2Requirements(changedFiles, claims) {
+  return {
+    changedRefs: inferChangedRequirementRefs(changedFiles),
+    claimRefs: claims
+      .filter((claim) => ensureArray(claim.requirementRefs).length > 0)
+      .map((claim) => ({
+        claimId: claim.id,
+        refs: uniqueStrings(claim.requirementRefs),
+      }))
+      .sort((left, right) => left.claimId.localeCompare(right.claimId)),
+  };
+}
+
+function mapEvidenceStatusToLaneStatus(status) {
+  const normalized = String(status || '').trim().toLowerCase();
+  if (normalized === 'failed') return 'fail';
+  if (normalized === 'missing' || normalized === 'stale') return 'warn';
+  return 'pass';
+}
+
+function mergeLaneStatus(current, next) {
+  const rank = { missing: 0, pass: 1, warn: 2, fail: 3 };
+  return rank[next] > rank[current] ? next : current;
+}
+
+function buildValidationLanes(claimLevelSummarySource, baseEvidence) {
+  const lanesById = new Map();
+  for (const item of ensureArray(baseEvidence.items)) {
+    const status = item.present ? 'pass' : 'missing';
+    lanesById.set(item.id, {
+      id: item.id,
+      status,
+      evidenceRefs: [item.path],
+    });
+  }
+  for (const claim of ensureArray(claimLevelSummarySource.payload?.claims)) {
+    for (const evidence of [
+      ...ensureArray(claim?.evidenceRefs),
+      ...ensureArray(claim?.missingEvidenceRefs).map((entry) => ({
+        ...entry,
+        kind: entry?.expectedKind,
+        status: 'missing',
+        artifactPath: claimLevelSummarySource.path,
+      })),
+    ]) {
+      const laneId = String(evidence?.kind || evidence?.expectedKind || 'other').trim().toLowerCase() || 'other';
+      const laneStatus = mapEvidenceStatusToLaneStatus(evidence?.status);
+      const existing = lanesById.get(laneId) || { id: laneId, status: 'pass', evidenceRefs: [] };
+      existing.status = mergeLaneStatus(existing.status, laneStatus);
+      existing.evidenceRefs = uniqueStrings([...existing.evidenceRefs, evidence?.artifactPath, evidence?.id]);
+      lanesById.set(laneId, existing);
+    }
+  }
+  return [...lanesById.values()].sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function buildPolicyDecisionSummary(policyDecisionSource) {
+  const assurance = ensureObject(policyDecisionSource.payload?.evaluation?.assurance);
+  const result = normalizeDecisionResult(assurance.result);
+  const enforced = String(assurance.mode || '').trim().toLowerCase() === 'strict' || result === 'block';
+  return {
+    present: policyDecisionSource.present,
+    sourceArtifactPath: policyDecisionSource.present ? policyDecisionSource.path : null,
+    result,
+    mode: policyDecisionSource.present ? normalizeDecisionMode(assurance.mode, enforced) : 'unknown',
+    enforced,
+    reason: policyDecisionSource.present
+      ? `Policy decision assurance result is ${result}.`
+      : 'No policy-decision/v1 artifact was available when the change package was generated.',
+    warnings: ensureArray(assurance.warnings).map(String),
+    errors: ensureArray(assurance.errors).map(String),
+  };
+}
+
+function buildReleaseControls(baseChangePackage, postDeploySource) {
+  const postDeployChecks = postDeploySource.present
+    ? [postDeploySource.path]
+    : ['post-deploy-verify workflow or release verification artifact required before production rollout'];
+  return {
+    preDeployChecks: uniqueStrings(baseChangePackage.reproducibility.commands),
+    postDeployChecks,
+    rollbackSignals: uniqueStrings([
+      ...ensureArray(baseChangePackage.monitoringPlan.alerts),
+      'post-deploy-verify.status=fail',
+    ]),
+  };
+}
+
+function buildResidualRisks(claims, assumptions) {
+  const risks = [];
+  for (const claim of claims) {
+    if (!['failed', 'unresolved', 'runtime-mitigated', 'waived'].includes(claim.status)) continue;
+    risks.push({
+      id: `claim:${claim.id}:${claim.status}`,
+      statement: `${claim.status} claim requires human review: ${claim.statement}`,
+      severity: normalizeCriticality(claim.criticality),
+      source: 'change-package/v2 claim status',
+      claimIds: [claim.id],
+    });
+  }
+  for (const assumption of assumptions) {
+    if (!['needs-validation', 'residual-risk'].includes(String(assumption.status || ''))) continue;
+    risks.push({
+      id: `assumption:${assumption.id}`,
+      statement: assumption.statement,
+      severity: 'medium',
+      source: 'claim-level-summary/v1 assumption',
+      owner: assumption.owner,
+      claimIds: [assumption.claimId].filter(Boolean),
+    });
+  }
+  const seen = new Set();
+  return risks.filter((risk) => {
+    if (seen.has(risk.id)) return false;
+    seen.add(risk.id);
+    return true;
+  }).sort((left, right) => left.id.localeCompare(right.id));
 }
 
 function toPositiveInt(value) {
@@ -1038,24 +1339,39 @@ function renderTable(headers, rows) {
   ].join('\n');
 }
 
-function renderV2DetailedSections(changePackage) {
+function renderStatusCounts(claims) {
+  const counts = summarizeClaimStatuses(claims);
+  return ['satisfied', 'tested', 'model-checked', 'proved', 'runtime-mitigated', 'waived', 'unresolved', 'failed', 'not-applicable']
+    .map((status) => `${status}=${counts.get(status) || 0}`)
+    .join(', ');
+}
+
+function renderV2DetailedSections(changePackage, outputJsonPath) {
   if (changePackage.schemaVersion !== 'change-package/v2') {
     return [];
   }
   const claims = ensureArray(changePackage.claims);
   const proofObligations = ensureArray(changePackage.proofObligations);
   const waivers = ensureArray(changePackage.waivers);
+  const residualRisks = ensureArray(changePackage.residualRisks);
   return [
-    '### Assurance',
+    '### Proof-carrying Assurance',
+    `- evidence package: \`${outputJsonPath || DEFAULT_V2_OUTPUT_JSON_PATH}\``,
     `- target/achieved/status: ${changePackage.assurance.targetLevel}/${changePackage.assurance.achievedLevel}/${changePackage.assurance.status}`,
+    `- claim states: ${renderStatusCounts(claims)}`,
+    `- policy decision: ${changePackage.policyDecision.result} (${changePackage.policyDecision.mode}, enforced=${changePackage.policyDecision.enforced})`,
+    `- changed requirement refs: ${ensureArray(changePackage.requirements.changedRefs).length > 0 ? changePackage.requirements.changedRefs.join(', ') : '(none)'}`,
     '',
     '### Claims',
     renderTable(
-      ['id', 'status', 'criticality', 'artifactRefs', 'statement'],
+      ['id', 'status', 'target', 'achieved', 'criticality', 'requirements', 'artifactRefs', 'statement'],
       claims.map((claim) => [
         claim.id,
         claim.status,
+        claim.targetLevel,
+        claim.achievedLevel,
         claim.criticality,
+        ensureArray(claim.requirementRefs).join(', ') || '(none)',
         String(ensureArray(claim.artifactRefs).length),
         claim.statement,
       ]),
@@ -1073,13 +1389,40 @@ function renderV2DetailedSections(changePackage) {
       ]),
     ),
     '',
+    '### Validation Lanes',
+    renderTable(
+      ['id', 'status', 'evidenceRefs'],
+      ensureArray(changePackage.validationLanes).map((lane) => [
+        lane.id,
+        lane.status,
+        String(ensureArray(lane.evidenceRefs).length),
+      ]),
+    ),
+    '',
+    '### Release / Post-deploy Controls',
+    `- pre-deploy checks: ${ensureArray(changePackage.releaseControls.preDeployChecks).length}`,
+    `- post-deploy checks: ${ensureArray(changePackage.releaseControls.postDeployChecks).join(', ') || '(none)'}`,
+    `- rollback signals: ${ensureArray(changePackage.releaseControls.rollbackSignals).join(', ') || '(none)'}`,
+    '',
+    '### Residual Risks',
+    renderTable(
+      ['id', 'severity', 'claimIds', 'statement'],
+      residualRisks.map((risk) => [
+        risk.id,
+        risk.severity,
+        ensureArray(risk.claimIds).join(', '),
+        risk.statement,
+      ]),
+    ),
+    '',
     '### Waivers',
     renderTable(
-      ['owner', 'expires', 'relatedClaimIds', 'reason'],
+      ['owner', 'expires', 'relatedClaimIds', 'evidenceRefs', 'reason'],
       waivers.map((waiver) => [
         waiver.owner,
         waiver.expires,
         ensureArray(waiver.relatedClaimIds).join(', '),
+        String(ensureArray(waiver.evidenceRefs).length),
         waiver.reason,
       ]),
     ),
@@ -1087,17 +1430,19 @@ function renderV2DetailedSections(changePackage) {
   ];
 }
 
-function renderV2DigestSuffix(changePackage) {
+function renderV2DigestSuffix(changePackage, outputJsonPath) {
   if (changePackage.schemaVersion !== 'change-package/v2') {
     return '';
   }
   return ` | assurance=${changePackage.assurance.targetLevel}/${changePackage.assurance.achievedLevel}/${changePackage.assurance.status}`
     + ` | claims=${ensureArray(changePackage.claims).length}`
+    + ` | states(${renderStatusCounts(ensureArray(changePackage.claims))})`
     + ` | proofObligations=${ensureArray(changePackage.proofObligations).length}`
-    + ` | waivers=${ensureArray(changePackage.waivers).length}`;
+    + ` | waivers=${ensureArray(changePackage.waivers).length}`
+    + ` | evidencePackage=${outputJsonPath || DEFAULT_V2_OUTPUT_JSON_PATH}`;
 }
 
-function renderDetailedMarkdown(changePackage) {
+function renderDetailedMarkdown(changePackage, outputJsonPath) {
   const risk = changePackage.risk;
   const evidenceRows = changePackage.evidence.items
     .map((item) => `| ${item.id} | \`${item.path}\` | ${item.present ? 'yes' : 'no'} |`)
@@ -1140,7 +1485,7 @@ function renderDetailedMarkdown(changePackage) {
     '| --- | --- | --- |',
     evidenceRows,
     '',
-    ...renderV2DetailedSections(changePackage),
+    ...renderV2DetailedSections(changePackage, outputJsonPath),
     '### Reproducibility',
     ...changePackage.reproducibility.commands.map((command) => `- \`${command}\``),
     '',
@@ -1158,22 +1503,22 @@ function renderDetailedMarkdown(changePackage) {
   ].join('\n');
 }
 
-function renderDigestMarkdown(changePackage) {
+function renderDigestMarkdown(changePackage, outputJsonPath) {
   const risk = changePackage.risk;
   return [
     '### Change Package',
-    `- risk=${risk.selected} (inferred=${risk.inferred}) | files=${changePackage.scope.changedFileCount} | areas=${changePackage.scope.areas.join(', ')} | evidence=${changePackage.evidence.presentCount}/${changePackage.evidence.missingCount} present/missing${renderV2DigestSuffix(changePackage)}`,
+    `- risk=${risk.selected} (inferred=${risk.inferred}) | files=${changePackage.scope.changedFileCount} | areas=${changePackage.scope.areas.join(', ')} | evidence=${changePackage.evidence.presentCount}/${changePackage.evidence.missingCount} present/missing${renderV2DigestSuffix(changePackage, outputJsonPath)}`,
     `- required labels: ${risk.requiredLabels.length > 0 ? risk.requiredLabels.join(', ') : '(none)'} | missing: ${risk.missingRequiredLabels.length > 0 ? risk.missingRequiredLabels.join(', ') : '(none)'}`,
     `- reproducibility: ${changePackage.reproducibility.commands.map((command) => `\`${command}\``).join(', ')}`,
     '',
   ].join('\n');
 }
 
-function renderMarkdown(changePackage, mode) {
+function renderMarkdown(changePackage, mode, outputJsonPath) {
   if (mode === 'digest') {
-    return renderDigestMarkdown(changePackage);
+    return renderDigestMarkdown(changePackage, outputJsonPath);
   }
-  return renderDetailedMarkdown(changePackage);
+  return renderDetailedMarkdown(changePackage, outputJsonPath);
 }
 
 function isModeDigest(mode) {
@@ -1285,9 +1630,21 @@ function buildChangePackageV2(options, eventPayload, baseChangePackage = buildCh
     options.assuranceSummaryPath,
     'assurance-summary/v1 lane coverage summary',
   );
+  const claimLevelSummary = loadOptionalJsonSource(
+    'claimLevelSummary',
+    options.claimLevelSummaryPath,
+    'claim-level-summary/v1 per-claim achieved-level summary',
+  );
+  const postDeployVerify = loadOptionalJsonSource(
+    'postDeployVerify',
+    options.postDeployVerifyPath,
+    'post-deploy verification result',
+  );
   const claimsById = new Map();
   const proofObligations = [];
   const waivers = [];
+  const assumptions = [];
+  const runtimeControls = [];
 
   if (assuranceSummary.present) {
     ingestAssuranceSummaryForV2(claimsById, assuranceSummary);
@@ -1297,6 +1654,9 @@ function buildChangePackageV2(options, eventPayload, baseChangePackage = buildCh
   }
   if (policyDecision.present) {
     ingestPolicyDecisionForV2(claimsById, waivers, policyDecision);
+  }
+  if (claimLevelSummary.present) {
+    ingestClaimLevelSummaryForV2(claimsById, proofObligations, waivers, assumptions, runtimeControls, claimLevelSummary);
   }
 
   const claims = Array.from(claimsById.values())
@@ -1314,6 +1674,16 @@ function buildChangePackageV2(options, eventPayload, baseChangePackage = buildCh
       relatedClaimIds: waiver.relatedClaimIds.filter((claimId) => claimIds.has(claimId)),
     }))
     .filter((waiver) => waiver.relatedClaimIds.length > 0);
+  const releaseControls = buildReleaseControls(baseChangePackage, postDeployVerify);
+  const normalizedRuntimeControls = {
+    alerts: uniqueStrings([
+      ...baseChangePackage.monitoringPlan.alerts,
+      ...runtimeControls.filter((control) => control.kind === 'alert').map((control) => control.id),
+    ]),
+    featureFlags: uniqueStrings([
+      ...runtimeControls.filter((control) => control.kind === 'feature-flag').map((control) => control.id),
+    ]),
+  };
 
   return {
     ...baseChangePackage,
@@ -1322,25 +1692,34 @@ function buildChangePackageV2(options, eventPayload, baseChangePackage = buildCh
       claimEvidenceManifest,
       policyDecision,
       assuranceSummary,
+      claimLevelSummary,
+      postDeployVerify,
     ]),
-    assurance: buildV2Assurance(claims, claimEvidenceManifest, policyDecision, assuranceSummary),
+    requirements: buildV2Requirements(baseChangePackage.scope.changedFiles, claims),
+    validationLanes: buildValidationLanes(claimLevelSummary, baseChangePackage.evidence),
+    policyDecision: buildPolicyDecisionSummary(policyDecision),
+    releaseControls,
+    residualRisks: buildResidualRisks(claims, assumptions),
+    assurance: buildV2Assurance(claims, claimEvidenceManifest, policyDecision, assuranceSummary, claimLevelSummary),
     claims,
-    assumptions: [],
+    assumptions: assumptions.map((assumption) => ({
+      id: assumption.id,
+      statement: assumption.statement,
+      owner: assumption.owner,
+      evidenceRefs: normalizeArtifactRefs(assumption.evidenceRefs, claimLevelSummary.path),
+    })).sort((left, right) => left.id.localeCompare(right.id)),
     proofObligations: filteredProofObligations,
     counterexamples: [],
     trustBoundary: {
       outsideModel: [],
     },
-    runtimeControls: {
-      alerts: baseChangePackage.monitoringPlan.alerts,
-      featureFlags: [],
-    },
+    runtimeControls: normalizedRuntimeControls,
     waivers: filteredWaivers,
   };
 }
 
 function writeChangePackageOutputs(changePackage, outputJsonPath, outputMarkdownPath, mode) {
-  const markdown = renderMarkdown(changePackage, mode);
+  const markdown = renderMarkdown(changePackage, mode, outputJsonPath);
 
   ensureDirectory(outputJsonPath);
   fs.writeFileSync(outputJsonPath, `${JSON.stringify(changePackage, null, 2)}\n`);

--- a/scripts/change-package/validate.mjs
+++ b/scripts/change-package/validate.mjs
@@ -310,6 +310,11 @@ function collectArtifactRefs(payload) {
       refs.push({ path: `/assumptions/${index}/evidenceRefs`, artifactRef });
     }
   }
+  for (const [index, waiver] of ensureArray(payload?.waivers).entries()) {
+    for (const artifactRef of ensureArray(waiver?.evidenceRefs)) {
+      refs.push({ path: `/waivers/${index}/evidenceRefs`, artifactRef });
+    }
+  }
   for (const [index, obligation] of ensureArray(payload?.proofObligations).entries()) {
     for (const artifactRef of ensureArray(obligation?.artifactRefs)) {
       refs.push({ path: `/proofObligations/${index}/artifactRefs`, artifactRef });
@@ -366,10 +371,10 @@ function evaluatePolicyDecisionConsistency(payload, policyDecision) {
     if (result === 'waived' && status !== 'waived') {
       errors.push(`policy decision marks ${claimId} waived but change-package status is ${status}`);
     }
-    if (result === 'pass' && ['waived', 'unresolved'].includes(status)) {
+    if (result === 'pass' && ['waived', 'unresolved', 'failed'].includes(status)) {
       errors.push(`policy decision marks ${claimId} pass but change-package status is ${status}`);
     }
-    if (result === 'block' && status !== 'unresolved') {
+    if (result === 'block' && !['failed', 'unresolved'].includes(status)) {
       errors.push(`policy decision marks ${claimId} block but change-package status is ${status}`);
     }
     if (result === 'report-only' && status === 'waived') {

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+/* global process, console */
+/* eslint-disable no-empty */
 import fs from 'node:fs';
 function r(p){ try { return JSON.parse(fs.readFileSync(p,'utf-8')); } catch { return undefined; } }
 const lang = (process.env.SUMMARY_LANG||'en').toLowerCase();
@@ -52,6 +54,7 @@ if (Array.isArray(props) && props.length) {
     }
   }
 }
+void propsCount;
 const ltlLine = ltlSug && typeof ltlSug.count === 'number'
   ? t(`LTL sugg: ${ltlSug.count}`, `LTL候補: ${ltlSug.count}`)
   : t('LTL sugg: n/a', 'LTL候補: なし');
@@ -152,14 +155,28 @@ const changePackageV2Waivers = Array.isArray(changePackageV2?.waivers) ? changeP
 const changePackageV2Assurance = changePackageV2?.assurance && typeof changePackageV2.assurance === 'object'
   ? changePackageV2.assurance
   : null;
+const changePackageV2StateCounts = changePackageV2Claims.reduce((counts, claim) => {
+  const status = String(claim?.status || 'unknown');
+  counts.set(status, (counts.get(status) || 0) + 1);
+  return counts;
+}, new Map());
+const changePackageV2StateLine = ['satisfied', 'tested', 'model-checked', 'proved', 'runtime-mitigated', 'waived', 'unresolved', 'failed', 'not-applicable']
+  .map((status) => `${status}=${changePackageV2StateCounts.get(status) || 0}`)
+  .join(', ');
+const changePackageV2PolicyDecision = changePackageV2?.policyDecision && typeof changePackageV2.policyDecision === 'object'
+  ? changePackageV2.policyDecision
+  : null;
+const changePackageV2ReleaseControls = changePackageV2?.releaseControls && typeof changePackageV2.releaseControls === 'object'
+  ? changePackageV2.releaseControls
+  : null;
 const changePackageV2Line = changePackageV2?.schemaVersion === 'change-package/v2'
   ? t(
-      `Change Package v2: claims=${changePackageV2Claims.length}, proofObligations=${changePackageV2ProofObligations.length}, waivers=${changePackageV2Waivers.length}, assurance=${changePackageV2Assurance?.targetLevel ?? 'n/a'}/${changePackageV2Assurance?.achievedLevel ?? 'n/a'}/${changePackageV2Assurance?.status ?? 'n/a'}`,
-      `Change Package v2: claims=${changePackageV2Claims.length}, proofObligations=${changePackageV2ProofObligations.length}, waivers=${changePackageV2Waivers.length}, assurance=${changePackageV2Assurance?.targetLevel ?? 'n/a'}/${changePackageV2Assurance?.achievedLevel ?? 'n/a'}/${changePackageV2Assurance?.status ?? 'n/a'}`,
+      `Change Package v2: claims=${changePackageV2Claims.length}, proofObligations=${changePackageV2ProofObligations.length}, waivers=${changePackageV2Waivers.length}, assurance=${changePackageV2Assurance?.targetLevel ?? 'n/a'}/${changePackageV2Assurance?.achievedLevel ?? 'n/a'}/${changePackageV2Assurance?.status ?? 'n/a'}, claimStates=${changePackageV2StateLine}, evidencePackage=artifacts/change-package/change-package-v2.json`,
+      `Change Package v2: claims=${changePackageV2Claims.length}, proofObligations=${changePackageV2ProofObligations.length}, waivers=${changePackageV2Waivers.length}, assurance=${changePackageV2Assurance?.targetLevel ?? 'n/a'}/${changePackageV2Assurance?.achievedLevel ?? 'n/a'}/${changePackageV2Assurance?.status ?? 'n/a'}, claimStates=${changePackageV2StateLine}, evidencePackage=artifacts/change-package/change-package-v2.json`,
     )
   : '';
 const changePackageV2DetailBlock = changePackageV2Line
-  ? `- ${changePackageV2Line}\n`
+  ? `- ${changePackageV2Line}\n- Change Package v2 claim states: ${changePackageV2StateLine}\n${changePackageV2PolicyDecision ? `- Change Package v2 policy decision: ${changePackageV2PolicyDecision.result ?? 'n/a'} (${changePackageV2PolicyDecision.mode ?? 'n/a'}, enforced=${changePackageV2PolicyDecision.enforced ?? 'n/a'})\n` : ''}${changePackageV2ReleaseControls ? `- Change Package v2 release controls: pre=${Array.isArray(changePackageV2ReleaseControls.preDeployChecks) ? changePackageV2ReleaseControls.preDeployChecks.length : 'n/a'}, post=${Array.isArray(changePackageV2ReleaseControls.postDeployChecks) ? changePackageV2ReleaseControls.postDeployChecks.length : 'n/a'}, rollback=${Array.isArray(changePackageV2ReleaseControls.rollbackSignals) ? changePackageV2ReleaseControls.rollbackSignals.length : 'n/a'}\n` : ''}`
   : '';
 const qualityScorecardSummary = qualityScorecard?.summary && typeof qualityScorecard.summary === 'object'
   ? qualityScorecard.summary

--- a/scripts/summary/render-pr-summary.mjs
+++ b/scripts/summary/render-pr-summary.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 /* global process, console */
-/* eslint-disable no-empty */
 import fs from 'node:fs';
 function r(p){ try { return JSON.parse(fs.readFileSync(p,'utf-8')); } catch { return undefined; } }
 const lang = (process.env.SUMMARY_LANG||'en').toLowerCase();
@@ -43,18 +42,6 @@ for (const p of props) if (p?.traceId) traceIds.add(p.traceId);
 const replayLine = replay.totalEvents!==undefined 
   ? t(`Replay ev/viol=${replay.totalEvents}/${(replay.violatedInvariants||[]).length}`, `リプレイ ev/viol=${replay.totalEvents}/${(replay.violatedInvariants||[]).length}`)
   : t('Replay: n/a','リプレイ: なし');
-// Properties (PBT) quick count: prefer aggregate 'count' or fallback to array length
-let propsCount = 0;
-if (Array.isArray(props) && props.length) {
-  for (const p of props) {
-    if (p && typeof p.count === 'number') {
-      propsCount += p.count;
-    } else {
-      propsCount += 1;
-    }
-  }
-}
-void propsCount;
 const ltlLine = ltlSug && typeof ltlSug.count === 'number'
   ? t(`LTL sugg: ${ltlSug.count}`, `LTL候補: ${ltlSug.count}`)
   : t('LTL sugg: n/a', 'LTL候補: なし');
@@ -176,7 +163,7 @@ const changePackageV2Line = changePackageV2?.schemaVersion === 'change-package/v
     )
   : '';
 const changePackageV2DetailBlock = changePackageV2Line
-  ? `- ${changePackageV2Line}\n- Change Package v2 claim states: ${changePackageV2StateLine}\n${changePackageV2PolicyDecision ? `- Change Package v2 policy decision: ${changePackageV2PolicyDecision.result ?? 'n/a'} (${changePackageV2PolicyDecision.mode ?? 'n/a'}, enforced=${changePackageV2PolicyDecision.enforced ?? 'n/a'})\n` : ''}${changePackageV2ReleaseControls ? `- Change Package v2 release controls: pre=${Array.isArray(changePackageV2ReleaseControls.preDeployChecks) ? changePackageV2ReleaseControls.preDeployChecks.length : 'n/a'}, post=${Array.isArray(changePackageV2ReleaseControls.postDeployChecks) ? changePackageV2ReleaseControls.postDeployChecks.length : 'n/a'}, rollback=${Array.isArray(changePackageV2ReleaseControls.rollbackSignals) ? changePackageV2ReleaseControls.rollbackSignals.length : 'n/a'}\n` : ''}`
+  ? `- ${changePackageV2Line}\n${changePackageV2PolicyDecision ? `- Change Package v2 policy decision: ${changePackageV2PolicyDecision.result ?? 'n/a'} (${changePackageV2PolicyDecision.mode ?? 'n/a'}, enforced=${changePackageV2PolicyDecision.enforced ?? 'n/a'})\n` : ''}${changePackageV2ReleaseControls ? `- Change Package v2 release controls: pre=${Array.isArray(changePackageV2ReleaseControls.preDeployChecks) ? changePackageV2ReleaseControls.preDeployChecks.length : 'n/a'}, post=${Array.isArray(changePackageV2ReleaseControls.postDeployChecks) ? changePackageV2ReleaseControls.postDeployChecks.length : 'n/a'}, rollback=${Array.isArray(changePackageV2ReleaseControls.rollbackSignals) ? changePackageV2ReleaseControls.rollbackSignals.length : 'n/a'}\n` : ''}`
   : '';
 const qualityScorecardSummary = qualityScorecard?.summary && typeof qualityScorecard.summary === 'object'
   ? qualityScorecard.summary
@@ -218,7 +205,9 @@ try {
       `時相: present=${!!temp.present}${ops? ` ops=[${ops}]`:''}${pops? ` past=[${pops}]`:''}`
     );
   }
-} catch {}
+} catch {
+  /* Optional formal aggregate temporal metadata may be absent or malformed. */
+}
 const alerts=[];
 if ((statusCounts.error||0) > errorMax) alerts.push(t(`adapter errors>${errorMax}`, `アダプタ失敗>${errorMax}`));
 if ((statusCounts.warn||0) > warnMax) alerts.push(t(`adapter warnings>${warnMax}`, `アダプタ注意>${warnMax}`));
@@ -242,7 +231,9 @@ try {
     const ja = `適合: 率=${vr ?? 'n/a'}${mr!==null? ` 一致率=${mr}`:''}${delta}${evs}`;
     conformanceLine = t(en, ja);
   }
-} catch {}
+} catch {
+  /* Optional conformance metadata may be absent or malformed. */
+}
 
 let md;
 if (mode === 'digest') {
@@ -261,7 +252,9 @@ try {
     const line = t(`Formal: present ${pc}/${total}${pc? ` (${presentKeys})`:''}`, `フォーマル: present ${pc}/${total}${pc? `（${presentKeys}）`:''}`);
     if (mode === 'digest') md += ` | ${line}`; else md += `\n- ${line}`;
   }
-} catch {}
+} catch {
+  /* Optional formal aggregate fallback may be absent or malformed. */
+}
 
 // (Removed duplicate conformance fallback line; unified above using aggregate JSON)
 fs.mkdirSync('artifacts/summary',{recursive:true});
@@ -290,7 +283,9 @@ try {
           const sum = String(j.summary).replace(/\s+/g,' ').slice(0, 100);
           samples.push(`${id}: ${sum}`);
         }
-      } catch {}
+      } catch {
+        /* Optional adapter sample artifacts may be absent or malformed. */
+      }
     }
     if (samples.length) extra += `\n- ${t('Adapter samples','アダプタ例')}: ${samples.join('; ')}`;
   }
@@ -299,4 +294,6 @@ try {
     fs.appendFileSync(p, `\n${extra}\n`);
     console.log(extra);
   }
-} catch {}
+} catch {
+  /* Optional summary detection metadata may be absent or malformed. */
+}

--- a/tests/contracts/change-package-v2-contract.test.ts
+++ b/tests/contracts/change-package-v2-contract.test.ts
@@ -40,4 +40,45 @@ describe('change-package v2 contract', () => {
     expect(validate(invalidFixture)).toBe(false);
     expect(validate.errors?.some((entry) => entry.instancePath === '/waivers/0/relatedClaimIds')).toBe(true);
   });
+
+  it('preserves failed and not-applicable as first-class claim states', () => {
+    const claims = (fixture as { claims: Array<{ id: string; status: string }> }).claims;
+
+    expect(claims).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'strict-proof-failure', status: 'failed' }),
+      expect.objectContaining({ id: 'ui-out-of-scope', status: 'not-applicable' }),
+    ]));
+  });
+
+  it('requires waiver evidence refs in the stabilized v2 contract', () => {
+    const ajv = new Ajv2020({ allErrors: true, strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(schema);
+    const invalidFixture = structuredClone(fixture) as {
+      claims: Array<Record<string, unknown>>;
+      waivers: Array<Record<string, unknown>>;
+    };
+
+    invalidFixture.claims.push({
+      id: 'waived-without-evidence',
+      statement: 'Waiver evidence must remain linked.',
+      status: 'waived',
+      criticality: 'medium',
+      targetLevel: 'A2',
+      achievedLevel: 'A1',
+      requirementRefs: [],
+      artifactRefs: ['docs/ci/change-package.md'],
+    });
+    invalidFixture.waivers = [
+      {
+        owner: '@team-platform',
+        expires: '2026-12-31',
+        reason: 'temporary rollout exception',
+        relatedClaimIds: ['waived-without-evidence'],
+      },
+    ];
+
+    expect(validate(invalidFixture)).toBe(false);
+    expect(validate.errors?.some((entry) => entry.instancePath === '/waivers/0')).toBe(true);
+  });
 });

--- a/tests/scripts/claim-evidence-manifest.test.ts
+++ b/tests/scripts/claim-evidence-manifest.test.ts
@@ -78,9 +78,9 @@ describe.sequential('claim evidence manifest generator', () => {
         schemaVersion: 'claim-evidence-manifest/v1',
         generatedAt: '2026-04-28T18:20:00.000Z',
         summary: {
-          totalClaims: 2,
+          totalClaims: 4,
           fullySupported: 1,
-          partiallySupported: 1,
+          partiallySupported: 3,
           waived: 0,
           unresolved: 0,
         },
@@ -120,7 +120,47 @@ describe.sequential('claim evidence manifest generator', () => {
       const markdown = readFileSync(outputMd, 'utf8');
       expect(markdown).toContain('# Claim Evidence Manifest');
       expect(markdown).toContain('| no-negative-balance | n/a | high | A3 | A2 | partial |');
+      expect(markdown).toContain('| strict-proof-failure | n/a | high | A3 | A2 | partial |');
+      expect(markdown).toContain('| ui-out-of-scope | n/a | low | A3 | A2 | partial |');
       expect(markdown).toContain('## Missing evidence');
+
+      const strictProofClaim = manifest.claims.find((claim: { id: string }) => claim.id === 'strict-proof-failure');
+      expect(strictProofClaim).toMatchObject({
+        targetLevel: 'A3',
+        achievedLevel: 'A2',
+        status: 'partial',
+      });
+      expect(strictProofClaim.evidenceRefs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            description: expect.stringContaining('status=failed'),
+            sourceArtifactId: 'change-package-v2',
+          }),
+        ]),
+      );
+      expect(strictProofClaim.missingEvidenceRefs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'change-package-v2:strict-proof-failure:proof-obligation:obl-strict-proof-failure',
+            expectedKind: 'proof',
+          }),
+        ]),
+      );
+
+      const outOfScopeClaim = manifest.claims.find((claim: { id: string }) => claim.id === 'ui-out-of-scope');
+      expect(outOfScopeClaim).toMatchObject({
+        targetLevel: 'A3',
+        achievedLevel: 'A2',
+        status: 'partial',
+      });
+      expect(outOfScopeClaim.evidenceRefs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            description: expect.stringContaining('status=not-applicable'),
+            sourceArtifactId: 'change-package-v2',
+          }),
+        ]),
+      );
     } finally {
       rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/scripts/render-pr-summary.test.ts
+++ b/tests/scripts/render-pr-summary.test.ts
@@ -224,8 +224,10 @@ describe.sequential('render-pr-summary', () => {
               status: 'partial',
             },
             claims: [
-              { id: 'no-negative-stock' },
-              { id: 'manual-review' },
+              { id: 'no-negative-stock', status: 'tested' },
+              { id: 'manual-review', status: 'waived' },
+              { id: 'strict-proof', status: 'failed' },
+              { id: 'ui-out-of-scope', status: 'not-applicable' },
             ],
             proofObligations: [
               { id: 'obl-no-negative-stock' },
@@ -233,6 +235,16 @@ describe.sequential('render-pr-summary', () => {
             waivers: [
               { owner: '@team-risk', relatedClaimIds: ['manual-review'] },
             ],
+            policyDecision: {
+              result: 'report-only',
+              mode: 'report-only',
+              enforced: false,
+            },
+            releaseControls: {
+              preDeployChecks: ['pnpm run verify:lite'],
+              postDeployChecks: ['post-deploy-verify'],
+              rollbackSignals: ['post-deploy-verify.status=fail'],
+            },
           },
           null,
           2,
@@ -243,7 +255,9 @@ describe.sequential('render-pr-summary', () => {
       expect(result.status, result.stderr || result.stdout).toBe(0);
 
       const output = readFileSync(join(sandbox, 'artifacts', 'summary', 'PR_SUMMARY.md'), 'utf8');
-      expect(output).toContain('Change Package v2: claims=2, proofObligations=1, waivers=1, assurance=A3/A2/partial');
+      expect(output).toContain('Change Package v2: claims=4, proofObligations=1, waivers=1, assurance=A3/A2/partial');
+      expect(output).toContain('evidencePackage=artifacts/change-package/change-package-v2.json');
+      expect(output).toContain('claimStates=satisfied=0, tested=1, model-checked=0, proved=0, runtime-mitigated=0, waived=1, unresolved=0, failed=1, not-applicable=1');
     } finally {
       rmSync(sandbox, { recursive: true, force: true });
     }

--- a/tests/unit/ci/change-package-generate.test.ts
+++ b/tests/unit/ci/change-package-generate.test.ts
@@ -165,6 +165,168 @@ async function writeV2InputArtifacts(workdir: string): Promise<{
   return { manifestPath, policyDecisionPath, assuranceSummaryPath };
 }
 
+async function writeClaimLevelSummaryArtifact(workdir: string): Promise<string> {
+  const claimLevelSummaryPath = join(workdir, 'artifacts', 'assurance', 'claim-level-summary.json');
+  await writeJson(claimLevelSummaryPath, {
+    schemaVersion: 'claim-level-summary/v1',
+    generatedAt: '2026-05-08T00:00:00.000Z',
+    source: {
+      repository: 'itdojp/ae-framework',
+      prNumber: 3309,
+      baseRef: 'main',
+      headRef: 'feat/3309-change-package-proof',
+    },
+    inputs: {
+      claimEvidenceManifest: {
+        id: 'claim-evidence-manifest',
+        path: 'artifacts/assurance/claim-evidence-manifest.json',
+        present: true,
+        required: true,
+      },
+      policyGateSummary: {
+        id: 'policy-gate-summary',
+        path: 'artifacts/ci/policy-gate-summary.json',
+        present: true,
+        required: false,
+      },
+      temporaryOverrides: [],
+      changePackageV2: null,
+    },
+    summary: {
+      totalClaims: 3,
+      satisfied: 0,
+      tested: 1,
+      modelChecked: 0,
+      proved: 0,
+      runtimeMitigated: 1,
+      waived: 0,
+      unresolved: 0,
+      failed: 1,
+      notApplicable: 0,
+      enforcedDecisions: 1,
+      reportOnlyDecisions: 2,
+    },
+    claims: [
+      {
+        claimId: 'reservation-tested',
+        statement: 'Reservation behavior is covered by tests.',
+        criticality: 'medium',
+        targetLevel: 'A2',
+        achievedLevel: 'A2',
+        state: 'tested',
+        stateRationale: 'Behavior evidence is observed.',
+        decision: {
+          mode: 'report-only',
+          result: 'pass',
+          enforced: false,
+          reason: 'Test evidence is present.',
+          sourceArtifactId: 'policy-gate-summary',
+          evidenceRefs: ['ev-reservation-test'],
+          missingEvidenceRefs: [],
+          waiverRefs: [],
+        },
+        evidenceRefs: [
+          {
+            id: 'ev-reservation-test',
+            kind: 'behavior',
+            status: 'observed',
+            artifactPath: 'artifacts/testing/property-summary.json',
+            sourceArtifactId: 'verify-lite',
+            description: 'Behavior test evidence.',
+          },
+        ],
+        missingEvidenceRefs: [],
+        waiverRefs: [],
+        assumptions: [],
+        runtimeControls: [],
+        notes: ['requirement:docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md'],
+      },
+      {
+        claimId: 'rollout-runtime',
+        statement: 'Rollout risk is mitigated by runtime controls.',
+        criticality: 'high',
+        targetLevel: 'A3',
+        achievedLevel: 'A2',
+        state: 'runtime-mitigated',
+        stateRationale: 'Runtime control is linked.',
+        decision: {
+          mode: 'report-only',
+          result: 'report-only',
+          enforced: false,
+          reason: 'Runtime mitigation remains distinct from proof.',
+          sourceArtifactId: 'policy-gate-summary',
+          evidenceRefs: ['ev-runtime-control'],
+          missingEvidenceRefs: [],
+          waiverRefs: [],
+        },
+        evidenceRefs: [
+          {
+            id: 'ev-runtime-control',
+            kind: 'runtime',
+            status: 'observed',
+            artifactPath: 'artifacts/runtime/manual-review.json',
+            sourceArtifactId: 'change-package-v2',
+            description: 'Runtime rollout guard.',
+          },
+        ],
+        missingEvidenceRefs: [],
+        waiverRefs: [],
+        assumptions: [
+          {
+            id: 'assumption-rollout-window',
+            statement: 'Rollback window remains staffed.',
+            status: 'residual-risk',
+            artifactPath: 'docs/ci/change-package.md',
+          },
+        ],
+        runtimeControls: [
+          {
+            id: 'rollout_guard_violation',
+            kind: 'alert',
+            description: 'Rollback if rollout guard emits an alert.',
+          },
+        ],
+        notes: [],
+      },
+      {
+        claimId: 'strict-proof-failure',
+        statement: 'Strict proof still has an open counterexample.',
+        criticality: 'critical',
+        targetLevel: 'A4',
+        achievedLevel: 'A1',
+        state: 'failed',
+        stateRationale: 'Proof evidence failed.',
+        decision: {
+          mode: 'strict',
+          result: 'block',
+          enforced: true,
+          reason: 'Failed proof blocks strict enforcement.',
+          sourceArtifactId: 'policy-gate-summary',
+          evidenceRefs: ['ev-proof-failed'],
+          missingEvidenceRefs: [],
+          waiverRefs: [],
+        },
+        evidenceRefs: [
+          {
+            id: 'ev-proof-failed',
+            kind: 'proof',
+            status: 'failed',
+            artifactPath: 'artifacts/formal/no-negative-summary.json',
+            sourceArtifactId: 'formal-summary',
+            description: 'Failed proof evidence.',
+          },
+        ],
+        missingEvidenceRefs: [],
+        waiverRefs: [],
+        assumptions: [],
+        runtimeControls: [],
+        notes: [],
+      },
+    ],
+  });
+  return claimLevelSummaryPath;
+}
+
 describe('change-package generate', () => {
   it('generates change-package json/md from changed files and event payload', async () => {
     const workdir = await createWorkdir('change-package-generate-');
@@ -402,6 +564,82 @@ describe('change-package generate', () => {
     expect(markdown).toContain('### Claims');
     expect(markdown).toContain('### Proof Obligations');
     expect(markdown).toContain('### Waivers');
+  });
+
+  it('projects claim-level-summary states, release controls, policy decision, and residual risks into v2', async () => {
+    const workdir = await createWorkdir('change-package-generate-claim-level-v2-');
+    const changedFilesPath = join(workdir, 'changed-files.txt');
+    const outputJsonPath = join(workdir, 'artifacts', 'change-package', 'change-package-v2.json');
+    const outputMarkdownPath = join(workdir, 'artifacts', 'change-package', 'change-package-v2.md');
+    const { manifestPath, policyDecisionPath, assuranceSummaryPath } = await writeV2InputArtifacts(workdir);
+    const claimLevelSummaryPath = await writeClaimLevelSummaryArtifact(workdir);
+
+    await writeFile(
+      changedFilesPath,
+      [
+        'docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md',
+        'scripts/change-package/generate.mjs',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = spawnSync(process.execPath, [
+      generateScript,
+      '--policy', policyPath,
+      '--schema-version', 'v2',
+      '--changed-files-file', changedFilesPath,
+      '--artifact-root', workdir,
+      '--claim-evidence-manifest', manifestPath,
+      '--policy-decision', policyDecisionPath,
+      '--assurance-summary', assuranceSummaryPath,
+      '--claim-level-summary', claimLevelSummaryPath,
+      '--output-json', outputJsonPath,
+      '--output-md', outputMarkdownPath,
+      '--mode', 'detailed',
+    ], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: isolatedGenerateEnv,
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+
+    const generated = JSON.parse(await readFile(outputJsonPath, 'utf8')) as {
+      assurance: { status: string };
+      requirements: { changedRefs: string[] };
+      validationLanes: Array<{ id: string; status: string }>;
+      policyDecision: { result: string; mode: string; enforced: boolean };
+      releaseControls: { preDeployChecks: string[]; postDeployChecks: string[]; rollbackSignals: string[] };
+      residualRisks: Array<{ id: string; claimIds: string[] }>;
+      claims: Array<{ id: string; status: string; targetLevel: string; achievedLevel: string }>;
+      evidence: { items: Array<{ id: string; present: boolean }> };
+    };
+
+    expect(generated.assurance.status).toBe('failed');
+    expect(generated.requirements.changedRefs).toContain('docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md');
+    expect(generated.claims).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'rollout-runtime', status: 'runtime-mitigated', targetLevel: 'A3', achievedLevel: 'A2' }),
+      expect.objectContaining({ id: 'strict-proof-failure', status: 'failed', targetLevel: 'A4', achievedLevel: 'A1' }),
+    ]));
+    expect(generated.validationLanes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'proof', status: 'fail' }),
+      expect.objectContaining({ id: 'runtime', status: 'pass' }),
+    ]));
+    expect(generated.policyDecision).toMatchObject({ result: 'waived', mode: 'unknown', enforced: false });
+    expect(generated.releaseControls.preDeployChecks).toContain('pnpm run verify:lite');
+    expect(generated.releaseControls.postDeployChecks).toContain('post-deploy-verify workflow or release verification artifact required before production rollout');
+    expect(generated.releaseControls.rollbackSignals).toContain('post-deploy-verify.status=fail');
+    expect(generated.residualRisks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'claim:strict-proof-failure:failed', claimIds: ['strict-proof-failure'] }),
+      expect.objectContaining({ id: 'assumption:assumption-rollout-window', claimIds: ['rollout-runtime'] }),
+    ]));
+    expect(generated.evidence.items).toContainEqual(expect.objectContaining({ id: 'claimLevelSummary', present: true }));
+
+    const markdown = await readFile(outputMarkdownPath, 'utf8');
+    expect(markdown).toContain('evidence package:');
+    expect(markdown).toContain('claim states: satisfied=');
+    expect(markdown).toContain('### Release / Post-deploy Controls');
+    expect(markdown).toContain('### Residual Risks');
   });
 
   it('derives v2 assurance status from unresolved and partial assurance-summary claims', async () => {

--- a/tests/unit/ci/change-package-validate.test.ts
+++ b/tests/unit/ci/change-package-validate.test.ts
@@ -76,6 +76,34 @@ async function writeV2Fixture(workdir: string): Promise<{ inputPath: string; pol
       presentCount: 1,
       missingCount: 0,
     },
+    requirements: {
+      changedRefs: [],
+      claimRefs: [
+        { claimId: 'manual-review', refs: ['docs/ci/change-package.md'] },
+      ],
+    },
+    validationLanes: [
+      {
+        id: 'behavior',
+        status: 'pass',
+        evidenceRefs: ['artifacts/testing/property-summary.json'],
+      },
+      {
+        id: 'runtime',
+        status: 'pass',
+        evidenceRefs: ['artifacts/runtime/manual-review.json'],
+      },
+    ],
+    policyDecision: {
+      present: true,
+      sourceArtifactPath: 'policy-decision-js-v1.json',
+      result: 'waived',
+      mode: 'report-only',
+      enforced: false,
+      reason: 'Policy decision accepted a waiver for manual review.',
+      warnings: [],
+      errors: [],
+    },
     reproducibility: { commands: ['pnpm run verify:lite'] },
     rolloutPlan: {
       strategy: 'manual-approval-and-gate-green',
@@ -98,6 +126,9 @@ async function writeV2Fixture(workdir: string): Promise<{ inputPath: string; pol
         statement: 'Manual review is active.',
         status: 'waived',
         criticality: 'medium',
+        targetLevel: 'A3',
+        achievedLevel: 'A2',
+        requirementRefs: ['docs/ci/change-package.md'],
         artifactRefs: ['artifacts/runtime/manual-review.json'],
       },
       {
@@ -105,6 +136,9 @@ async function writeV2Fixture(workdir: string): Promise<{ inputPath: string; pol
         statement: 'Inventory stock never becomes negative.',
         status: 'tested',
         criticality: 'high',
+        targetLevel: 'A3',
+        achievedLevel: 'A3',
+        requirementRefs: [],
         artifactRefs: ['artifacts/testing/property-summary.json'],
       },
     ],
@@ -126,12 +160,27 @@ async function writeV2Fixture(workdir: string): Promise<{ inputPath: string; pol
       alerts: [],
       featureFlags: [],
     },
+    releaseControls: {
+      preDeployChecks: ['pnpm run verify:lite'],
+      postDeployChecks: ['post-deploy-verify workflow or release verification artifact required before production rollout'],
+      rollbackSignals: ['post-deploy-verify.status=fail'],
+    },
+    residualRisks: [
+      {
+        id: 'claim:manual-review:waived',
+        statement: 'waived claim requires human review: Manual review is active.',
+        severity: 'medium',
+        source: 'change-package/v2 test fixture',
+        claimIds: ['manual-review'],
+      },
+    ],
     waivers: [
       {
         owner: '@team-risk',
         expires: '2099-12-31',
         reason: 'Manual review control is active.',
         relatedClaimIds: ['manual-review'],
+        evidenceRefs: ['artifacts/runtime/manual-review.json'],
       },
     ],
   });


### PR DESCRIPTION
## Summary

Closes #3309.

This PR stabilizes `change-package/v2` as a proof-carrying PR/release assurance package by wiring schema, generation, validation, PR-summary rendering, fixtures, and documentation.

Key changes:

- Adds first-class v2 sections for `requirements`, `validationLanes`, `policyDecision`, `releaseControls`, and `residualRisks`.
- Adds per-claim `targetLevel`, `achievedLevel`, `requirementRefs`, and optional decision metadata.
- Preserves and surfaces distinct claim states, including `satisfied`, `failed`, and `not-applicable`.
- Requires waiver evidence refs in the stabilized v2 contract.
- Projects `claim-level-summary/v1` and optional post-deploy verification into v2 packages.
- Updates v2 Markdown and PR summaries to include the evidence package path, claim-state counts, policy decision, release controls, and residual risks.
- Keeps `change-package/v1` as the default compatibility contract and documents v2 migration via opt-in / dual-write / dual-validate.

## Verification

Local checks passed:

- `pnpm -s exec vitest run tests/scripts/claim-evidence-manifest.test.ts --reporter dot` — 7 tests passed.
- `pnpm -s exec vitest run tests/scripts/claim-evidence-manifest.test.ts tests/unit/ci/change-package-generate.test.ts tests/unit/ci/change-package-validate.test.ts tests/scripts/render-pr-summary.test.ts tests/contracts/change-package-v2-contract.test.ts tests/scripts/claim-level-summary.test.ts tests/unit/ci/workflow-permission-boundary.test.ts tests/unit/ci/automation-config.test.ts --reporter dot` — 8 files / 57 tests passed.
- `node --check scripts/change-package/generate.mjs`
- `node --check scripts/change-package/validate.mjs`
- `node --check scripts/assurance/aggregate-claim-levels.mjs`
- `node --check scripts/summary/render-pr-summary.mjs`
- `pnpm -s exec eslint --no-ignore scripts/change-package/generate.mjs scripts/change-package/validate.mjs scripts/summary/render-pr-summary.mjs scripts/assurance/aggregate-claim-levels.mjs tests/unit/ci/change-package-generate.test.ts tests/unit/ci/change-package-validate.test.ts tests/scripts/render-pr-summary.test.ts tests/contracts/change-package-v2-contract.test.ts tests/scripts/claim-evidence-manifest.test.ts`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency` — docs scanned: 402, warnings: 0.
- `pnpm -s run verify:lite` — passed; existing lint baseline warnings remain warn-only.
- `pnpm -s run assurance:e2e -- --scenario inventory-waiver --output-dir artifacts/assurance-e2e/inventory-waiver/latest` — comparison: ok.
- v2 smoke: generated a proof-carrying package from `fixtures/assurance/claim-level-summary/expected/claim-level-summary.json`, validated against `schema/change-package-v2.schema.json`, and confirmed claim-state counts, validation lanes, release controls, and residual risks.
- `git diff --check`

Broad local `pnpm -s run test:fast` was attempted. It now has no change-package / claim-manifest failures; the only remaining local failures are the pre-existing environment limitation in `tests/container/container-agent.test.ts` because this environment has no Docker/Podman container engine:

```text
No container engines available. Please install Docker or Podman.
```

Result observed: 605 test files passed, 1 skipped, 1 failed file (`tests/container/container-agent.test.ts`); 2595 tests passed, 1 skipped, 7 failed container-engine-dependent tests.
