### PR TITLE
feat(assurance): add contract governance check

### DIFF
--- a/docs/reference/SCHEMA-GOVERNANCE.md
+++ b/docs/reference/SCHEMA-GOVERNANCE.md
@@ -63,6 +63,7 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
 ### 7. CI checkpoints
 
 - `schema/**` changes trigger `.github/workflows/spec-validation.yml`.
+- Assurance contract governance markers can be checked locally with `pnpm -s run check:assurance-contract-governance`; this check is deterministic documentation/schema consistency support and does not prove code correctness.
 - Schema/artifact validation is executed in:
   - `.github/workflows/validate-artifacts-ajv.yml`
   - `.github/workflows/verify-lite.yml`
@@ -163,6 +164,7 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
 ### 7. CI観点
 
 - `schema/**` の変更は `.github/workflows/spec-validation.yml` のトリガー対象。
+- Assurance contract governance marker は `pnpm -s run check:assurance-contract-governance` でローカル確認できます。この check は決定的な documentation / schema consistency support であり、コード正しさの証明ではありません。
 - スキーマ/成果物検証は次で実行される。
   - `.github/workflows/validate-artifacts-ajv.yml`
   - `.github/workflows/verify-lite.yml`

--- a/package.json
+++ b/package.json
@@ -434,7 +434,8 @@
     "pipelines:e2e-demo": "node scripts/pipelines/run-e2e-demo.mjs",
     "pipelines:trace": "node scripts/pipelines/run-trace-conformance.mjs",
     "podman:smoke": "bash scripts/podman/smoke-test.sh",
-    "mutation:report": "node scripts/mutation/mutation-report.mjs"
+    "mutation:report": "node scripts/mutation/mutation-report.mjs",
+    "check:assurance-contract-governance": "node scripts/assurance/check-contract-governance.mjs"
   },
   "dependencies": {
     "@ae-framework/agent-builder-adapter": "file:./packages/agent-builder-adapter",

--- a/scripts/assurance/check-contract-governance.mjs
+++ b/scripts/assurance/check-contract-governance.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_ROOT = process.cwd();
+
+const CHECKS = [
+  {
+    id: 'schema-governance-migration-rules',
+    file: 'docs/reference/SCHEMA-GOVERNANCE.md',
+    description: 'Schema governance must document dual-write / dual-validate migration and breaking-change requirements.',
+    markers: [
+      'Dual-write / dual-validate migration rules',
+      'Breaking-change checklist',
+      'migration note',
+      'contract catalog update'
+    ]
+  },
+  {
+    id: 'contract-catalog-route-linkage',
+    file: 'docs/reference/CONTRACT-CATALOG.md',
+    description: 'Contract catalog must link contract inventory to canonical route states and cleanup markers.',
+    markers: [
+      'docs/reference/ASSURANCE-CANONICAL-ROUTES.md',
+      'Current cleanup markers',
+      'preview',
+      'legacy',
+      'compatibility'
+    ]
+  },
+  {
+    id: 'canonical-routes-compatibility-rules',
+    file: 'docs/reference/ASSURANCE-CANONICAL-ROUTES.md',
+    description: 'Canonical routes must keep compatibility rules and tested cleanup backlog visible.',
+    markers: [
+      'Compatibility rules',
+      'Cleanup backlog',
+      'Quality scorecard',
+      'Formal evidence status',
+      'Counterexample GWT summary',
+      'Change package'
+    ]
+  },
+  {
+    id: 'current-state-state-legend',
+    file: 'docs/reports/ASSURANCE-CONTROL-PLANE-CURRENT-STATE.md',
+    description: 'Current-state report must keep the assurance maturity state legend discoverable.',
+    markers: [
+      '`ready`',
+      '`partial`',
+      '`preview`',
+      '`missing`',
+      '`duplicate`',
+      '`obsolete`'
+    ]
+  }
+];
+
+function parseArgs(argv) {
+  const args = {
+    root: DEFAULT_ROOT,
+    json: false,
+    help: false
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--root' && next) {
+      args.root = next;
+      i += 1;
+    } else if (arg.startsWith('--root=')) {
+      args.root = arg.slice('--root='.length);
+    } else if (arg === '--json') {
+      args.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/assurance/check-contract-governance.mjs [--root <repo>] [--json]
+
+Checks that assurance contract governance docs keep deterministic migration,
+compatibility, canonical-route, and current-state markers discoverable.
+`);
+}
+
+function readText(root, relativePath) {
+  const absolutePath = path.resolve(root, relativePath);
+  return fs.readFileSync(absolutePath, 'utf8');
+}
+
+function evaluateCheck(root, check) {
+  let text = '';
+  try {
+    text = readText(root, check.file);
+  } catch (error) {
+    return {
+      id: check.id,
+      file: check.file,
+      ok: false,
+      missing: check.markers,
+      error: `failed to read ${check.file}: ${error instanceof Error ? error.message : String(error)}`
+    };
+  }
+
+  const missing = check.markers.filter((marker) => !text.includes(marker));
+  return {
+    id: check.id,
+    file: check.file,
+    ok: missing.length === 0,
+    missing
+  };
+}
+
+function run(root) {
+  const resolvedRoot = path.resolve(root);
+  const checks = CHECKS.map((check) => evaluateCheck(resolvedRoot, check));
+  const failures = checks.filter((check) => !check.ok);
+  return {
+    root: resolvedRoot,
+    ok: failures.length === 0,
+    checks,
+    failures
+  };
+}
+
+function printTextReport(result) {
+  console.log('Assurance contract governance check');
+  console.log(`- root: ${result.root}`);
+  console.log(`- checks: ${result.checks.length}`);
+  console.log(`- failures: ${result.failures.length}`);
+  for (const check of result.checks) {
+    if (check.ok) {
+      console.log(`✓ ${check.id}: ${check.file}`);
+      continue;
+    }
+    console.log(`✗ ${check.id}: ${check.file}`);
+    if (check.error) console.log(`  - ${check.error}`);
+    for (const marker of check.missing) {
+      console.log(`  - missing marker: ${marker}`);
+    }
+  }
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+  const result = run(args.root);
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printTextReport(result);
+  }
+  return result.ok ? 0 : 1;
+}
+
+process.exitCode = main();

--- a/tests/unit/assurance/check-contract-governance.test.ts
+++ b/tests/unit/assurance/check-contract-governance.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = process.cwd();
+const scriptPath = join(repoRoot, 'scripts', 'assurance', 'check-contract-governance.mjs');
+
+function writeText(root: string, relativePath: string, text: string): void {
+  const absolutePath = join(root, relativePath);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, text);
+}
+
+function writeValidGovernanceDocs(root: string): void {
+  writeText(
+    root,
+    'docs/reference/SCHEMA-GOVERNANCE.md',
+    [
+      '# Schema Governance',
+      '## Dual-write / dual-validate migration rules',
+      '## Breaking-change checklist',
+      '- migration note',
+      '- contract catalog update'
+    ].join('\n'),
+  );
+  writeText(
+    root,
+    'docs/reference/CONTRACT-CATALOG.md',
+    [
+      '# Contract Catalog',
+      'Link: docs/reference/ASSURANCE-CANONICAL-ROUTES.md',
+      '## Current cleanup markers',
+      'preview legacy compatibility'
+    ].join('\n'),
+  );
+  writeText(
+    root,
+    'docs/reference/ASSURANCE-CANONICAL-ROUTES.md',
+    [
+      '# Assurance Canonical Routes',
+      '## Compatibility rules',
+      '## Cleanup backlog',
+      'Quality scorecard',
+      'Formal evidence status',
+      'Counterexample GWT summary',
+      'Change package'
+    ].join('\n'),
+  );
+  writeText(
+    root,
+    'docs/reports/ASSURANCE-CONTROL-PLANE-CURRENT-STATE.md',
+    [
+      '# Current State',
+      '`ready`',
+      '`partial`',
+      '`preview`',
+      '`missing`',
+      '`duplicate`',
+      '`obsolete`'
+    ].join('\n'),
+  );
+}
+
+function runCheck(root: string, ...extraArgs: string[]) {
+  return spawnSync(process.execPath, [scriptPath, '--root', root, ...extraArgs], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+describe('check-contract-governance', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(join(tmpdir(), 'ae-contract-governance-'));
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it('passes when required governance markers are present', () => {
+    writeValidGovernanceDocs(workdir);
+
+    const result = runCheck(workdir);
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    expect(result.stdout).toContain('Assurance contract governance check');
+    expect(result.stdout).toContain('- failures: 0');
+  });
+
+  it('fails with clear missing marker output', () => {
+    writeValidGovernanceDocs(workdir);
+    writeText(
+      workdir,
+      'docs/reference/ASSURANCE-CANONICAL-ROUTES.md',
+      [
+        '# Assurance Canonical Routes',
+        '## Compatibility rules',
+        'Quality scorecard'
+      ].join('\n'),
+    );
+
+    const result = runCheck(workdir);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('canonical-routes-compatibility-rules');
+    expect(result.stdout).toContain('missing marker: Cleanup backlog');
+    expect(result.stdout).toContain('missing marker: Formal evidence status');
+  });
+
+  it('emits machine-readable JSON for CI consumers', () => {
+    writeValidGovernanceDocs(workdir);
+
+    const result = runCheck(workdir, '--json');
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+    const payload = JSON.parse(result.stdout) as { ok: boolean; checks: unknown[]; failures: unknown[] };
+    expect(payload.ok).toBe(true);
+    expect(payload.checks).toHaveLength(4);
+    expect(payload.failures).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `scripts/assurance/check-contract-governance.mjs`, a deterministic no-network checker for assurance contract governance documentation markers.
- Wire `pnpm -s run check:assurance-contract-governance` into `package.json`.
- Add focused tests covering pass, missing-marker failure output, and JSON output.
- Link the checker from `docs/reference/SCHEMA-GOVERNANCE.md` as documentation/schema consistency support, not a code-correctness proof.

Closes #3330.

## Notes

Issue #3324 is still open, so this PR avoids inventing a competing governance model. The checker is intentionally marker-based and report-only: it anchors to concrete current docs (`SCHEMA-GOVERNANCE`, `CONTRACT-CATALOG`, `ASSURANCE-CANONICAL-ROUTES`, and the current-state report) and can be expanded after #3324 finalizes additional policy states.

## Validation

- `node --check scripts/assurance/check-contract-governance.mjs`
- `pnpm -s run check:assurance-contract-governance`
- `pnpm -s exec vitest run tests/unit/assurance/check-contract-governance.test.ts --reporter dot`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:schemas`
- `pnpm -s run types:check`
- `git diff --check`

## Acceptance

- The checker validates concrete governance markers that are easy to regress.
- The checker is deterministic and has clear failure output.
- The command is available as a package script and documented as consistency support.

## Rollback

Revert this PR to remove the checker, package script, tests, and governance-doc command reference.