### PR TITLE
docs(assurance): refresh post-roadmap governance reports

### DIFF
--- a/docs/reference/ASSURANCE-CANONICAL-ROUTES.md
+++ b/docs/reference/ASSURANCE-CANONICAL-ROUTES.md
@@ -6,7 +6,7 @@ canonicalSource:
 - docs/architecture/ASSURANCE-CONTROL-PLANE-DETAILED-DESIGN.md
 - docs/reference/CONTRACT-CATALOG.md
 - docs/quality/ARTIFACTS-CONTRACT.md
-lastVerified: '2026-05-09'
+lastVerified: '2026-05-10'
 ---
 # Assurance Canonical Routes and Legacy Compatibility
 
@@ -46,14 +46,16 @@ This reference document resolves the duplicate route findings from the assurance
 - Prefer report-only documentation when the replacement is not yet enforced by CI.
 - Keep README and index pages pointed at the canonical route first, with compatibility notes secondary.
 
-### 4. Cleanup backlog that still needs tests
+### 4. Cleanup backlog and disposition
 
-| Candidate cleanup | Current blocker | Minimum evidence before changing behavior |
-| --- | --- | --- |
-| Repoint `quality:scorecard` to v1 | The compatibility script now delegates to v1 when required inputs are supplied, but no-input legacy diagnostic callers can still exist. | Keep the wrapper test and migrate workflow/operator callers to supply `verify-lite-run-summary` and `report-envelope` before removing no-input legacy behavior. |
-| Keep `formal/summary.json` as final PR summary compatibility fallback | `render-pr-summary.mjs` and the workflow inline fallback now read formal-summary v2/v1 and the hermetic aggregate before `formal/summary.json`. Full removal still needs consumer migration evidence. | Maintain renderer/workflow tests that prove canonical artifacts populate the formal line and legacy fallback still works until all consumers are migrated. |
-| Keep `format-counterexamples.mjs` independent of legacy `formal/summary.json` | The script now reads the hermetic aggregate and `artifacts/formal/formal-aggregate.json` before the legacy compatibility fallback. Full removal of the fallback still needs consumer migration evidence. | Maintain formatter tests that derive `artifacts/formal/gwt.summary.json` from a current formal aggregate source and verify legacy fallback remains available. |
-| Remove duplicate judgment explanations from older docs | Older docs still carry useful operator context. | Index updates and redirects/replacement links that preserve discoverability. |
+Every legacy or compatibility route listed in this document currently has an explicit disposition. These dispositions are intentionally conservative: compatibility behavior stays available until consumer-path tests and rollback notes prove that a behavior change is safe.
+
+| Candidate cleanup | Disposition | Current blocker | Minimum evidence before changing behavior | Rollback guidance |
+| --- | --- | --- | --- | --- |
+| Repoint `quality:scorecard` to v1 | `legacy-compatible` / keep wrapper | The compatibility script now delegates to v1 when required inputs are supplied, but no-input legacy diagnostic callers can still exist. | Keep the wrapper test and migrate workflow/operator callers to supply `verify-lite-run-summary` and `report-envelope` before removing no-input legacy behavior. | Restore the wrapper branch to call `scripts/quality-scorecard-generator.js` for affected callers and keep `quality:scorecard:v1` available as the canonical route. |
+| Keep `formal/summary.json` as final PR summary compatibility fallback | `legacy-compatible` / canonical aggregate preferred | `render-pr-summary.mjs` and the workflow inline fallback now read formal-summary v2/v1 and the hermetic aggregate before `formal/summary.json`. Full removal still needs consumer migration evidence. | Maintain renderer/workflow tests that prove canonical artifacts populate the formal line and legacy fallback still works until all consumers are migrated. | Re-enable the legacy fallback read path and document the consumer that still requires it. |
+| Keep `format-counterexamples.mjs` independent of legacy `formal/summary.json` | `legacy-compatible` / canonical aggregate preferred | The script now reads the hermetic aggregate and `artifacts/formal/formal-aggregate.json` before the legacy compatibility fallback. Full removal of the fallback still needs consumer migration evidence. | Maintain formatter tests that derive `artifacts/formal/gwt.summary.json` from a current formal aggregate source and verify legacy fallback remains available. | Restore the legacy fallback parser while keeping canonical aggregate parsing first. |
+| Remove duplicate judgment explanations from older docs | `legacy-compatible` / docs-only cleanup | Older docs still carry useful operator context. | Index updates and redirects/replacement links that preserve discoverability. | Revert the docs-only consolidation and keep replacement links in the canonical route map. |
 
 ---
 
@@ -89,11 +91,13 @@ This reference document resolves the duplicate route findings from the assurance
 - replacement が CI enforcement されていない場合は、report-only として文書化する。
 - README と index は、正準導線を先に示し、互換注記は secondary として扱う。
 
-### 4. test が必要な残 cleanup
+### 4. cleanup backlog と disposition
 
-| cleanup 候補 | 現在の blocker | 挙動変更前に必要な最低証跡 |
-| --- | --- | --- |
-| `quality:scorecard` を v1 に向ける | 互換 script は必須入力が渡された場合に v1 へ委譲するが、入力なし legacy diagnostic caller は残り得る。 | wrapper test を維持し、入力なし legacy 挙動を削除する前に workflow / operator caller が `verify-lite-run-summary` と `report-envelope` を渡すよう移行する。 |
-| `formal/summary.json` を PR summary の final compatibility fallback として維持する | `render-pr-summary.mjs` と workflow inline fallback は formal-summary v2/v1 と hermetic aggregate を `formal/summary.json` より先に読む。完全削除には consumer migration evidence がまだ必要。 | current canonical artifact から formal line が埋まり、legacy fallback も残ることを示す renderer / workflow tests を維持する。 |
-| `format-counterexamples.mjs` を legacy `formal/summary.json` から独立した状態で維持する | script は hermetic aggregate と `artifacts/formal/formal-aggregate.json` を legacy compatibility fallback より先に読む。fallback の完全削除には consumer migration evidence がまだ必要。 | current formal aggregate source から `artifacts/formal/gwt.summary.json` を生成し、legacy fallback も残ることを示す formatter test を維持する。 |
-| 古い docs の重複 judgment 説明を削減する | 古い docs にも有用な operator context が残っている。 | discoverability を維持する index 更新と replacement link。 |
+本ドキュメントに列挙した legacy / compatibility route は、現時点で明示的な disposition を持ちます。挙動変更は保守的に扱い、consumer-path test と rollback note が揃うまで互換挙動を維持します。
+
+| cleanup 候補 | disposition | 現在の blocker | 挙動変更前に必要な最低証跡 | rollback guidance |
+| --- | --- | --- | --- | --- |
+| `quality:scorecard` を v1 に向ける | `legacy-compatible` / wrapper 維持 | 互換 script は必須入力が渡された場合に v1 へ委譲するが、入力なし legacy diagnostic caller は残り得る。 | wrapper test を維持し、入力なし legacy 挙動を削除する前に workflow / operator caller が `verify-lite-run-summary` と `report-envelope` を渡すよう移行する。 | 影響 caller 向けに wrapper branch を `scripts/quality-scorecard-generator.js` 呼び出しへ戻し、canonical route として `quality:scorecard:v1` は維持する。 |
+| `formal/summary.json` を PR summary の final compatibility fallback として維持する | `legacy-compatible` / canonical aggregate 優先 | `render-pr-summary.mjs` と workflow inline fallback は formal-summary v2/v1 と hermetic aggregate を `formal/summary.json` より先に読む。完全削除には consumer migration evidence がまだ必要。 | current canonical artifact から formal line が埋まり、legacy fallback も残ることを示す renderer / workflow tests を維持する。 | legacy fallback read path を戻し、まだ必要としている consumer を文書化する。 |
+| `format-counterexamples.mjs` を legacy `formal/summary.json` から独立した状態で維持する | `legacy-compatible` / canonical aggregate 優先 | script は hermetic aggregate と `artifacts/formal/formal-aggregate.json` を legacy compatibility fallback より先に読む。fallback の完全削除には consumer migration evidence がまだ必要。 | current formal aggregate source から `artifacts/formal/gwt.summary.json` を生成し、legacy fallback も残ることを示す formatter test を維持する。 | canonical aggregate parsing を優先したまま、legacy fallback parser を戻す。 |
+| 古い docs の重複 judgment 説明を削減する | `legacy-compatible` / docs-only cleanup | 古い docs にも有用な operator context が残っている。 | discoverability を維持する index 更新と replacement link。 | docs-only consolidation を revert し、canonical route map には replacement link を残す。 |

--- a/docs/reference/SCHEMA-GOVERNANCE.md
+++ b/docs/reference/SCHEMA-GOVERNANCE.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-03-14'
+lastVerified: '2026-05-10'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -32,7 +32,27 @@ The following schemas currently keep GitHub Pages-based `$id` for compatibility:
 - `schema/quality-report.schema.json`
 - `schema/verify-profile-summary.schema.json`
 
-### 3. Anti-pattern (forbidden)
+### 3. Contract lifecycle states
+
+Use the following lifecycle states for assurance-related schema and artifact contracts. These states are documentation and release-governance labels; they do not by themselves change CI enforcement.
+
+| State | Meaning | Producer / consumer rule | Promotion or removal condition |
+| --- | --- | --- | --- |
+| `stable` | Default contract for production or release evidence in its scope. | Producers may emit it by default; consumers may rely on it without opt-in flags. | Breaking changes require a new versioned contract, migration note, consumer-impact assessment, and compatibility window. |
+| `preview` | Implemented for early adoption, report-only use, or dual-write validation. | Producers may emit it behind opt-in, dual-write, or documented preview commands; consumers must tolerate absence. | Promote only after fixture coverage, contract validation, summary rendering, and consumer-path tests are present. |
+| `deprecated` | Supported but scheduled for replacement. | Producers and consumers may still read/write it during the deprecation window. New work should link to the replacement. | Remove only after replacement adoption evidence, rollback guidance, and a retirement issue are recorded. |
+| `legacy-compatible` | Compatibility route retained because at least one workflow, script, document, or operator path can still consume it. | Keep validation or adapter behavior stable; clearly mark the canonical replacement. | Reclassify to `deprecated` or `removed` only after consumer-path tests prove the canonical route covers the behavior. |
+| `removed` | Contract or route is no longer supported by current producers/consumers. | Do not emit new artifacts in this shape. Consumers should fail with explicit migration guidance when feasible. | Requires prior deprecation evidence or a documented security/correctness exception. |
+
+Preview-to-stable promotion requires all of the following evidence in the same PR or linked issue:
+
+- schema and fixture validation for the promoted contract;
+- contract catalog and canonical-route updates;
+- producer and consumer tests for the promoted route;
+- PR/release summary behavior for non-green, waived, partial, or migration-relevant states when applicable;
+- migration note and rollback guidance when replacing an existing route.
+
+### 4. Anti-pattern (forbidden)
 
 Do not use repository URLs directly in `$id` or `$ref`:
 
@@ -41,26 +61,26 @@ Do not use repository URLs directly in `$id` or `$ref`:
 
 These URLs are branch/path-coupled and are not stable schema identifiers.
 
-### 4. Why this policy
+### 5. Why this policy
 
 - Keep schema identity independent from hosting location.
 - Preserve backward compatibility for already consumed legacy schema IDs.
 - Prevent accidental dependence on mutable GitHub repository paths.
 
-### 5. Operational rules
+### 6. Operational rules
 
 - Keep `<file>` in URI exactly equal to the schema filename under `schema/`.
 - If changing `$id` of an already published schema, treat it as compatibility-impacting and follow `docs/project/RELEASE.md`.
 - Every `schema/*.schema.json` file must define `$id`.
 
-### 6. Review checklist
+### 7. Review checklist
 
 - `$id` follows canonical/legacy exception rules above.
 - No `github.com` or `raw.githubusercontent.com` URL appears in `$id`/`$ref`.
 - Compatibility impact is assessed when `$id` changes.
 - Related docs and fixtures are updated.
 
-### 7. CI checkpoints
+### 8. CI checkpoints
 
 - `schema/**` changes trigger `.github/workflows/spec-validation.yml`.
 - Assurance contract governance markers can be checked locally with `pnpm -s run check:assurance-contract-governance`; this check is deterministic documentation/schema consistency support and does not prove code correctness.
@@ -70,7 +90,7 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
   - `.github/workflows/minimal-pipeline.yml`
 - Documentation consistency is checked by `pnpm docs:lint`.
 
-### 8. Payload versioning (`schemaVersion` / `contractId`)
+### 9. Payload versioning (`schemaVersion` / `contractId`)
 
 - `schemaVersion` is a payload compatibility marker; `$id` and `$schema` are schema-identifier metadata. Treat them separately.
 - Allowed forms in current implementation:
@@ -81,7 +101,7 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
 - Mixed version expression inside one contract family is forbidden. Choose one migration target and keep dual-read compatibility during transition.
 - Release / migration notes must describe the boundary change in the contract family's own style. Do not force a contract-style family into semver just to satisfy release bookkeeping.
 
-### 9. Dual-write / dual-validate migration rules
+### 10. Dual-write / dual-validate migration rules
 
 - When introducing breaking changes, do not overwrite the existing schema/artifact contract in place.
 - Use migration phases:
@@ -95,7 +115,7 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
   - rollback rule and flag strategy
   - required fixture/test updates
 
-### 10. Breaking-change checklist (schema contracts)
+### 11. Breaking-change checklist (schema contracts)
 
 - Breaking examples:
   - removing/renaming required fields
@@ -108,6 +128,18 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
   - CI validation update (`scripts/ci/validate-json.mjs`, `scripts/ci/validate-artifacts-ajv.mjs` as needed)
   - release note entry and migration note (`docs/project/RELEASE.md`)
   - contract catalog update (`docs/reference/CONTRACT-CATALOG.md`)
+
+### 12. Migration note examples
+
+Acceptable migration note:
+
+> `claim-level-summary/v1` remains preview. This PR adds `contractMigrationNotes[]` to `change-package/v2` as an optional field. Existing v2 consumers continue to validate because the field is additive. Producers that include the field must also update PR summary rendering tests. Rollback: omit `contractMigrationNotes[]` and keep the previous v2 payload shape.
+
+Unacceptable migration note:
+
+> Updated the schema.
+
+The unacceptable note does not identify the contract family, compatibility impact, consumer action, validation evidence, or rollback path.
 
 ---
 
@@ -133,7 +165,27 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
 - `schema/quality-report.schema.json`
 - `schema/verify-profile-summary.schema.json`
 
-### 3. Anti-pattern（禁止）
+### 3. 契約ライフサイクル状態
+
+Assurance 関連の schema / artifact 契約は、次の lifecycle state で管理します。これらは documentation / release governance 上のラベルであり、それ自体は CI enforcement を変更しません。
+
+| 状態 | 意味 | Producer / consumer ルール | 昇格または削除条件 |
+| --- | --- | --- | --- |
+| `stable` | 対象スコープで production / release evidence の既定契約。 | producer は既定で出力可能。consumer は opt-in flag なしで依存可能。 | 破壊的変更には、新しい versioned contract、migration note、consumer-impact assessment、互換期間が必要。 |
+| `preview` | early adoption、report-only、dual-write validation 向けに実装済み。 | producer は opt-in、dual-write、または明示された preview command で出力可能。consumer は欠落を許容する。 | fixture coverage、contract validation、summary rendering、consumer-path test が揃った後にのみ stable 昇格可能。 |
+| `deprecated` | replacement があり、互換期間中のみサポートする契約。 | producer / consumer は deprecation window 中は読み書き可能。新規作業は replacement へリンクする。 | replacement adoption evidence、rollback guidance、retirement issue が揃った後に削除可能。 |
+| `legacy-compatible` | workflow、script、document、operator path のいずれかがまだ消費するため保持する互換導線。 | validation または adapter behavior を安定させ、canonical replacement を明記する。 | consumer-path test が canonical route で挙動を覆うことを証明した後にのみ `deprecated` / `removed` へ再分類可能。 |
+| `removed` | 現行 producer / consumer でサポートしない契約または導線。 | 新規 artifact をこの形で出力しない。可能な場合、consumer は明示的な migration guidance とともに失敗する。 | 事前 deprecation evidence、または security / correctness 例外の文書化が必要。 |
+
+Preview から stable への昇格には、同一 PR または linked issue で次の証跡が必要です。
+
+- 昇格対象 contract の schema / fixture validation;
+- contract catalog と canonical route の更新;
+- 昇格 route の producer / consumer tests;
+- non-green、waived、partial、migration 関連 state を持つ場合の PR/release summary behavior;
+- 既存 route を置き換える場合の migration note と rollback guidance。
+
+### 4. Anti-pattern（禁止）
 
 `$id` / `$ref` に GitHub リポジトリ URL を直接使わないこと。
 
@@ -142,26 +194,26 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
 
 これらはブランチやパスに依存し、安定識別子として不適切です。
 
-### 4. この方針の変更理由
+### 5. この方針の変更理由
 
 - スキーマ識別子と配布基盤を分離し、運用変更に強くするため。
 - 既存利用者が参照する legacy `$id` 互換性を維持するため。
 - GitHub URL への暗黙依存を排除し、識別子の安定性を担保するため。
 
-### 5. 運用ルール
+### 6. 運用ルール
 
 - URI の `<file>` は `schema/` 配下の実ファイル名と一致させる。
 - 公開済みスキーマの `$id` 変更は互換性影響ありとして扱い、`docs/project/RELEASE.md` の手順に従う。
 - `schema/*.schema.json` は `$id` 定義を必須とする。
 
-### 6. レビュー観点
+### 7. レビュー観点
 
 - `$id` が canonical/例外ルールに準拠しているか。
 - `$id` / `$ref` に `github.com` / `raw.githubusercontent.com` が混入していないか。
 - `$id` 変更時に互換性評価が実施されているか。
 - 関連ドキュメント・fixtures の更新が揃っているか。
 
-### 7. CI観点
+### 8. CI観点
 
 - `schema/**` の変更は `.github/workflows/spec-validation.yml` のトリガー対象。
 - Assurance contract governance marker は `pnpm -s run check:assurance-contract-governance` でローカル確認できます。この check は決定的な documentation / schema consistency support であり、コード正しさの証明ではありません。
@@ -171,7 +223,7 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
   - `.github/workflows/minimal-pipeline.yml`
 - ドキュメント整合は `pnpm docs:lint` で確認する。
 
-### 8. ペイロード版管理（`schemaVersion` / `contractId`）
+### 9. ペイロード版管理（`schemaVersion` / `contractId`）
 
 - `schemaVersion` はペイロード互換性の識別子、`$id` / `$schema` はスキーマ識別子です。役割を分離して扱います。
 - 現行実装で許容される形式:
@@ -182,7 +234,7 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
 - 同一契約系列内で版表現を混在させないこと。移行時は dual-read 互換期間を明示します。
 - リリースノートや移行注記では、契約系列が採用している版表現で互換境界を説明します。release 手順のためだけに contract-style 系列を semver へ変換しないでください。
 
-### 9. dual-write / dual-validate 運用ルール
+### 10. dual-write / dual-validate 運用ルール
 
 - 互換性破壊を伴う変更では、既存契約を上書き変更しません。
 - 移行は次の段階で実施します。
@@ -196,7 +248,7 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
   - ロールバック手順と feature flag 戦略
   - 必須 fixture / test 更新
 
-### 10. 互換性破壊チェックリスト（schema契約）
+### 11. 互換性破壊チェックリスト（schema契約）
 
 - 破壊的変更の例:
   - required フィールドの削除/改名
@@ -209,3 +261,15 @@ These URLs are branch/path-coupled and are not stable schema identifiers.
   - CI検証更新（必要に応じて `scripts/ci/validate-json.mjs`, `scripts/ci/validate-artifacts-ajv.mjs`）
   - リリースノートと移行注記（`docs/project/RELEASE.md`）
   - 契約カタログ更新（`docs/reference/CONTRACT-CATALOG.md`）
+
+### 12. 移行注記例
+
+適切な migration note:
+
+> `claim-level-summary/v1` は preview のまま維持します。この PR は `change-package/v2` に optional な `contractMigrationNotes[]` を追加します。追加フィールドなので既存 v2 consumer は引き続き validation 可能です。このフィールドを出力する producer は、PR summary rendering tests も更新する必要があります。Rollback: `contractMigrationNotes[]` を省略し、従来の v2 payload shape を維持します。
+
+不適切な migration note:
+
+> schema を更新しました。
+
+不適切な例は、contract family、互換性影響、consumer action、validation evidence、rollback path を示していません。

--- a/docs/reports/ASSURANCE-CONTROL-PLANE-CURRENT-STATE.md
+++ b/docs/reports/ASSURANCE-CONTROL-PLANE-CURRENT-STATE.md
@@ -2,11 +2,14 @@
 docRole: derived
 canonicalSource:
   - docs/product/ASSURANCE-CONTROL-PLANE.md
+  - docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
+  - docs/architecture/ASSURANCE-CONTROL-PLANE-DETAILED-DESIGN.md
   - docs/quality/ASSURANCE-MODEL.md
   - docs/quality/ARTIFACTS-CONTRACT.md
   - docs/reference/CONTRACT-CATALOG.md
+  - docs/reference/SCHEMA-GOVERNANCE.md
   - docs/reference/change-package-v2.md
-lastVerified: '2026-05-08'
+lastVerified: '2026-05-10'
 ---
 
 # Assurance Control Plane Current-State Report
@@ -19,166 +22,158 @@ lastVerified: '2026-05-08'
 
 ### 1. Executive summary
 
-This report records the current `main` state at commit `cb307e05` (`feat(security): generate audit prompt packs (#3301)`). The repository already contains a substantial assurance-control-plane implementation: product positioning, assurance terminology, Context Pack checks, Verify Lite summaries, formal and conformance producers, quality scorecards, policy-gate outputs, claim-evidence manifests, change-package v2, PR-summary inputs, and Security Assurance Lane producers.
+This report records the post-roadmap `main` state at full commit `a4245f693bff38229bf6431f27fbf3d20266d259` (`test(assurance): assert canonical route scenario (#3338)`). It replaces the older inspection baseline `cb307e05` from the pre-roadmap audit and treats Issues #3302-#3312 / PRs #3313-#3322 as completed historical work.
 
-The current gap is not a lack of individual producers. The main gap is convergence: several contracts and docs exist, but the next work should make the canonical policy, detailed design, schema boundaries, report-only versus enforcement semantics, and PR/release package flow easier to follow from one route.
+The repository now contains an assurance control plane for agent-driven SDLC rather than a coding-agent runtime: policy and detailed-design docs, contract catalog, canonical-route guidance, schema governance, claim and evidence producers, policy-gate summaries, change-package v1/v2 flows, PR summary rendering, E2E fixtures, and Security Assurance Lane producers.
 
-Recommended next slice: start with Issue #3304 and converge policy/terminology around the existing `docs/product/ASSURANCE-CONTROL-PLANE.md` and `docs/quality/ASSURANCE-MODEL.md` before creating new schema or enforcement behavior. This is the smallest low-risk step because it reduces duplication and over-claiming without changing CI behavior.
+The current work is no longer to invent the roadmap. The current work is governance and maintenance: keep canonical routes discoverable, preserve compatibility until consumer tests prove migration safety, surface migration notes for contract changes, and keep current-state reporting anchored to the inspected HEAD.
+
+No separate `docs/reports/ASSURANCE-CONTROL-PLANE-REPO-SNAPSHOT.md` is introduced in this refresh. This report is the canonical repository snapshot for the assurance control plane because it already records the HEAD, command inventory, contract inventory, route state, and residual follow-up guidance in one derived document.
 
 ### 2. Inspection baseline
 
-Inspection was performed before editing this report.
+Inspection was performed before editing this report in worktree `ae-framework-3323-current-state-refresh`.
 
 | Check | Evidence |
 | --- | --- |
-| Working tree | `git status --short` was empty in worktree `ae-framework-3303-current-state` before editing. |
-| Current commit | `git rev-parse --short HEAD` = `cb307e05`. |
-| Recent history | `git log --oneline -n 20` shows recent security-assurance and testing work from #3274 through #3301. |
-| Package scripts | `cat package.json` confirmed assurance, claim-evidence, policy-gate, change-package, Context Pack, conformance, formal, Codex/MCP, schema, and doc-consistency scripts. |
-| Docs inspected | `docs/product/`, `docs/quality/`, `docs/architecture/`, `docs/integrations/`, `docs/reference/`, `docs/agents/`, `docs/ci/`, `docs/verify/`, and `docs/security/`. |
-| Contracts inspected | `schema/` contains assurance, claim-evidence, policy, policy-gate, change-package, quality-scorecard, verify-lite, formal, conformance, and security-assurance schemas. |
-| Scripts and tests inspected | `scripts/`, `src/`, `tests/`, `.github/workflows/`, `fixtures/`, `samples/`, and `artifacts/` were searched for assurance-control-plane terms and files. |
+| Working tree | `git status --short --branch` showed branch `docs/3323-current-state-refresh` based on `origin/main` before content changes. |
+| Current commit | `git rev-parse HEAD` = `a4245f693bff38229bf6431f27fbf3d20266d259`. |
+| Recent history | `git log --oneline -n 25` shows the completed roadmap sequence #3313-#3322 followed by post-roadmap hardening #3333-#3338. |
+| Package scripts | `cat package.json` / script inventory confirmed assurance, claim-evidence, claim-level-summary, policy-gate, change-package, quality scorecard, Security Assurance Lane, schema, and doc-consistency commands. |
+| Docs inspected | `docs/product/`, `docs/architecture/`, `docs/quality/`, `docs/reference/`, `docs/reports/`, `docs/integrations/`, `docs/agents/`, `docs/ci/`, `docs/verify/`, and `docs/security/`. |
+| Contracts inspected | `schema/` contains assurance, claim, policy, policy-gate, change-package, quality-scorecard, verify-lite, formal, conformance, temporary-override, and security-assurance schemas. |
+| Scripts and tests inspected | `scripts/`, `src/`, `tests/`, `.github/workflows/`, `fixtures/`, and `samples/` were searched for assurance-control-plane entry points and evidence routes. |
 
-### 3. Recent repository changes relevant to assurance
+### 3. Completed assurance-control-plane roadmap evidence
 
-The last 20 commits on `main` show the repo is actively extending assurance evidence and test coverage:
+The completed roadmap is now historical baseline evidence, not planned work:
 
-| Commit | Relevance |
+| Merge | Relevance |
 | --- | --- |
-| `cb307e05` | Adds Security Assurance Lane audit prompt packs (#3301). |
-| `2c396e89` | Adds assumption-aware security claim review handling (#3300). |
-| `7265908a` | Adds entrypoint-map evidence for trust-boundary review (#3299). |
-| `45405340` | Adds symbol-index input for code map (#3298). |
-| `96b55041` | Preserves original security IDs in claim-evidence manifests (#3297). |
-| `fb2fbc3a` | Adds testing inventory freshness reporting (#3291). |
-| `1835daf0` | Adds agent MCP smoke lane (#3290). |
-| `937c23fa` | Adds package app smoke lane (#3289). |
-| `e9c4d088` | Covers CLI command boundary regressions (#3288). |
-| `a866564d` | Covers security assurance CLI boundaries (#3287). |
-| `6d8330fd` | Documents test portfolio baseline (#3286). |
-| `944fc818` | Adds Security Assurance Lane overview (#3278). |
-| `06f5af56` | Adds Codex Security Assurance Lane runbook (#3277). |
-| `0da06ed9` | Adds security assurance fixture golden scenario (#3276). |
-| `936228f7` and related commits | Integrate security findings into assurance artifacts (#3275). |
-| `438c3345` | Adds rule-based security review producer (#3274). |
+| #3313 / `58d5b9c8` | Added the first assurance-control-plane current-state audit. |
+| #3314 / `188bbc82` | Defined the assurance-control-plane policy. |
+| #3315 / `3cadc892` | Added detailed design for claim, evidence, achieved-level, policy, waiver, and package semantics. |
+| #3316 / `2427eb9c` | Stabilized preview claim-summary schemas. |
+| #3317 / `6bbe479c` | Added deterministic claim-level summary generation. |
+| #3318 / `c80fdd24` | Added assurance-aware policy-gate modes while preserving report-only defaults. |
+| #3319 / `9c3c6ecf` | Stabilized proof-carrying change-package v2 behavior. |
+| #3320 / `737e50c6` | Added the assurance agent runbook. |
+| #3321 / `5d3e9dd1` | Extended the E2E assurance validation fixture. |
+| #3322 / `dc518ddb` | Marked canonical and legacy assurance routes. |
 
-### 4. Current positioning and architecture
+### 4. Post-roadmap hardening evidence
 
-Current positioning is already documented as BYO-agent plus assurance control plane:
+Post-roadmap hardening has also landed on `main`:
 
-- `docs/product/ASSURANCE-CONTROL-PLANE.md` defines ae-framework as the layer above producer agents and verification tools that keeps specification, verification, evidence, policy/PR gates, and release judgment under consistent contracts.
-- `docs/quality/ASSURANCE-MODEL.md` defines claim, assurance level, validation lane, evidence kind, assumption, waiver, and runtime control.
-- `docs/architecture/CURRENT-SYSTEM-OVERVIEW.md` is cited as an implementation-aligned system overview by `docs/README.md`.
-- `docs/reference/CONTRACT-CATALOG.md` maps current contracts to schemas, producers, and consumers.
-- `docs/security/security-assurance-lane.md` extends the model with security-specific claims, findings, code maps, reviews, assumption handling, and prompt packs.
+| Merge | Relevance |
+| --- | --- |
+| #3333 / `a0308acc` | Wrapped the legacy quality-scorecard route and added compatibility coverage. |
+| #3334 / `74ccadaf` | Made PR summary formal evidence prefer canonical aggregate artifacts over legacy fallback paths. |
+| #3335 / `a3d4e968` | Derived counterexample GWT output from canonical formal evidence. |
+| #3336 / `95e98b00` | Added a schema-governance consistency check and governance documentation. |
+| #3337 / `c725be7a` | Added `contractMigrationNotes` support in change-package v2 generation and PR summary rendering. |
+| #3338 / `a4245f69` | Added a canonical-route regression over the assurance E2E fixture. |
 
-The architecture is therefore better described as a federated set of evidence producers and judgment-side contracts than as a single monolithic runner.
+### 5. Current positioning and architecture
 
-### 5. Capability inventory
+Current positioning is documented as a BYO-agent assurance control plane:
+
+- `docs/product/ASSURANCE-CONTROL-PLANE.md` positions ae-framework as a control plane above producer agents and verification tools.
+- `docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md` is the SSOT policy for BYO-agent boundaries, claim-based assurance, evidence-state wording, report-only defaults, and contract evolution.
+- `docs/architecture/ASSURANCE-CONTROL-PLANE-DETAILED-DESIGN.md` defines claim/evidence/achieved-level/waiver/policy/change-package semantics.
+- `docs/reference/CONTRACT-CATALOG.md` maps contracts to schemas, producers, consumers, and validation evidence.
+- `docs/reference/ASSURANCE-CANONICAL-ROUTES.md` distinguishes canonical routes from compatibility or preview routes.
+- `docs/reference/SCHEMA-GOVERNANCE.md` defines schema-governance requirements and is checked by `pnpm run check:assurance-contract-governance`.
+- `docs/security/security-assurance-lane.md` extends the model for security claims, findings, code maps, reviews, and audit prompt packs.
+
+The architecture is best described as federated evidence producers plus contract-governed judgment and release artifacts. Producer agents remain replaceable inputs; the control-plane contracts are the durable boundary.
+
+### 6. Capability inventory
 
 Status meanings used below:
 
 - `ready`: executable contract, producer, consumer, fixture, and test or workflow evidence are present for the stated scope.
 - `partial`: useful implementation exists, but coverage or integration is not complete enough to call the whole capability ready.
 - `preview`: implemented behind opt-in, dual-write, report-only, or compatibility behavior.
+- `compatibility`: intentionally retained legacy behavior with a canonical replacement or preferred route.
 - `missing`: no direct implementation was found for the stated capability.
-- `obsolete`: superseded or legacy behavior remains and should be marked rather than deleted immediately.
-- `duplicate`: multiple routes or names exist and need canonicalization.
 
-| Capability | Status | Evidence from current HEAD | Gap / next action |
+| Capability | Status | Evidence from current HEAD | Residual guidance |
 | --- | --- | --- | --- |
-| Assurance-control-plane product positioning | ready | `docs/product/ASSURANCE-CONTROL-PLANE.md`; `docs/quality/ASSURANCE-MODEL.md`; the root `../../README.md` links to the product doc. | #3304 should converge policy wording and avoid creating a competing policy doc unless it explicitly supersedes the current product doc. |
-| Context Pack structural validation | ready | Package scripts `context-pack:validate`, `context-pack:verify-functor`, `context-pack:verify-natural-transformation`, `context-pack:verify-product-coproduct`, `context-pack:e2e-fixture`; `fixtures/context-pack/e2e/evidence/*`; docs under `docs/agents/context-pack.md` and `docs/guides/context-pack-*`. | Link Context Pack evidence more directly into claim-level aggregation in #3307 if current artifact routing is insufficient. |
-| Verify Lite summaries and workflow | ready | `.github/workflows/verify-lite.yml`; `scripts/ci/verify-lite.sh`; `scripts/ci/write-verify-lite-summary.mjs`; `scripts/ci/render-verify-lite-summary.mjs`; `schema/verify-lite-run-summary.schema.json`; `tests/scripts/run-verify-lite-local.test.ts`; `tests/unit/ci/write-verify-lite-summary.test.ts`. | Keep as a core input; do not rewrite for #3303. |
-| Formal summaries | ready | `schema/formal-summary-v1.schema.json`; `schema/formal-summary-v2.schema.json`; `scripts/formal/aggregate-formal.mjs`; `scripts/formal/print-summary.mjs`; `.github/workflows/formal-aggregate.yml`; `fixtures/formal/sample.formal-summary-v2.json`; `tests/unit/ci/validate-formal-summary-v2.test.ts`. | Formal evidence should state model scope and assumptions in #3305/#3307. |
-| Conformance summaries | partial | `schema/conformance-verify-result.schema.json`; scripts `conformance:verify:sample`, `conformance:report`, `verify:conformance`; `src/conformance/*`; `tests/conformance/*`; `fixtures/conformance/*`; `samples/conformance/*`. | Conformance exists as producer evidence, but its canonical claim-level mapping should be clarified in #3305/#3307. |
-| Quality scorecard | ready | `schema/quality-scorecard.schema.json`; package scripts `quality:scorecard:v1` and `quality:scorecard:validate`; `scripts/quality/build-quality-scorecard.mjs`; `scripts/ci/validate-quality-scorecard.mjs`; `fixtures/quality/sample.quality-scorecard.json`; `tests/scripts/build-quality-scorecard.test.ts`; `tests/contracts/quality-scorecard-contract.test.ts`. | Legacy `quality:scorecard` still points to `scripts/quality-scorecard-generator.js`; canonical route should be made explicit in #3312. |
-| Policy gate baseline | ready | `.github/workflows/policy-gate.yml`; `scripts/ci/policy-gate.mjs`; `scripts/ci/policy-shadow-compare.mjs`; `schema/policy-input-v1.schema.json`; `schema/policy-decision-v1.schema.json`; `schema/policy-gate-summary-v1.schema.json`; `fixtures/policy-gate/sample.policy-gate-summary-v1.json`; `tests/unit/ci/policy-gate.test.ts`. | Assurance-aware enforcement is not fully converged; #3308 should preserve report-only behavior unless explicit enforcement is selected. |
-| Assurance summary v1 | ready | `schema/assurance-summary.schema.json`; `fixtures/assurance/sample.assurance-summary.json`; `scripts/assurance/aggregate-lanes.mjs`; `scripts/ci/validate-assurance-summary.mjs`; `tests/contracts/assurance-summary-contract.test.ts`; `tests/unit/ci/validate-assurance-summary.test.ts`. | Document exact producer inputs and confidence boundaries in #3305. |
-| Claim-evidence manifest and achieved-level sidecar | partial | `schema/claim-evidence-manifest.schema.json`; package script `claim-evidence:generate`; `scripts/assurance/build-claim-evidence-manifest.mjs`; `fixtures/assurance/sample.claim-evidence-manifest.json`; `tests/scripts/claim-evidence-manifest.test.ts`; `tests/contracts/claim-evidence-manifest-contract.test.ts`; `docs/quality/assurance-profile.md` describes report-only achieved-level summary behavior. | #3307 should close the gap between sidecar generation and a stable per-claim summary artifact/Markdown output for PR judgment. |
-| Waiver handling | partial | `docs/quality/ASSURANCE-MODEL.md`; `schema/claim-evidence-manifest.schema.json`; `schema/change-package-v2.schema.json`; `schema/policy-decision-v1.schema.json`; `schema/policy-gate-summary-v1.schema.json`; `fixtures/assurance-e2e/inventory-waiver/*`; `scripts/change-package/validate.mjs`; `scripts/assurance/build-claim-evidence-manifest.mjs`. | Waivers exist in multiple contracts, but a canonical temporary-override contract and enforcement semantics remain to be specified in #3305/#3306/#3308. |
-| Change package v1/v2 | preview | `schema/change-package.schema.json`; `schema/change-package-v2.schema.json`; `docs/reference/change-package-v2.md`; package scripts `change-package:generate`, `change-package:generate:v2`, `change-package:generate:dual`, `change-package:validate:v2`; `fixtures/change-package/*`; `tests/contracts/change-package-v2-contract.test.ts`; `tests/unit/ci/change-package-generate.test.ts`. | v2 is opt-in/dual-write. #3309 should stabilize the proof-carrying package path without breaking v1. |
-| PR summary consumption | partial | `scripts/summary/render-pr-summary.mjs`; `docs/quality/pr-summary.md`; `docs/quality/pr-summary-tool.md`; PR summary docs mention assurance summary, claim-evidence manifest, quality scorecard, formal aggregate, and change-package v2 inputs. | UX should clearly surface evidence-backed, waived, runtime-mitigated, unresolved, failed, and not-applicable states in #3309. |
-| Codex integration | partial | `docs/integrations/CODEX-INTEGRATION.md`; `docs/integrations/CODEX-CONTINUATION-CONTRACT.md`; `docs/integrations/CODEX-SECURITY-AUDIT.md`; `docs/integrations/QUICK-START-CODEX.md`; scripts under `scripts/codex/`; package scripts `codex:*`; `fixtures/codex/*`; `tests/codex/*`. | #3310 should provide one assurance-control-plane runbook that treats Codex as a producer and lists expected evidence artifacts. |
-| Claude / agent integration docs | partial | `docs/integrations/CLAUDE-CODE-INTEGRATION-GUIDE.md`; `docs/integrations/CLAUDE-CODE-TASK-TOOL-INTEGRATION.md`; `docs/agents/*`; `docs/agents/recipes/*`; `tests/agents/agent-mcp-boundary-smoke.test.ts`; recent commit `1835daf0`. | #3310 should separate optional harness guidance from required assurance-control-plane contracts. |
-| MCP servers | partial | Package scripts `codex:mcp:*`, `mcp:*`, `formal-agent`; `src/mcp-server/*`; `samples/codex-mcp-config.json`; `samples/codex-mcp-config.yaml`; `tests/services/mcp-server.test.ts`; `tests/agents/agent-mcp-boundary-smoke.test.ts`. | MCP is an integration surface; it is not yet the canonical assurance evidence flow. Cover in #3310. |
-| Spec & Verification Kit | partial | `docs/reference/SPEC-VERIFICATION-KIT-MIN.md`; `docs/reference/SPEC-VERIFICATION-KIT-EXTENSIONS.md`; `docs/verify/FORMAL-CHECKS.md`; Context Pack and formal scripts. | Tie kit outputs to claim/evidence contracts in #3305/#3307. |
-| Security Assurance Lane | ready | `docs/security/security-assurance-lane.md`; `docs/integrations/CODEX-SECURITY-AUDIT.md`; schemas `security-*-v1`; CLI scripts `security:import-speca`, `security:extract-claims`, `security:map-code`, `security:proof-audit`, `security:review`, `security:audit-prompt`; `fixtures/security-assurance/*`; `scripts/security/run-security-assurance-fixture.mjs`; `tests/contracts/security-assurance-contract.test.ts`; `tests/unit/security-assurance/*`. | Good exemplar for #3311 end-to-end fixture design. |
-| End-to-end assurance fixture | ready | `fixtures/assurance-e2e/inventory-waiver/*`; package script `assurance:e2e`; `scripts/assurance/run-e2e-scenario.mjs`; `tests/scripts/assurance-e2e-scenario.test.ts`. | #3311 can extend this fixture rather than starting from scratch. |
-| Current-state reporting | partial | This report adds `docs/reports/ASSURANCE-CONTROL-PLANE-CURRENT-STATE.md`. | Optional machine-readable `artifacts/assurance-control-plane/current-state.json` was not created in this slice. |
-| Legacy or competing quality scorecard route | duplicate | `docs/quality/quality-scorecard.md` states legacy `quality:scorecard` still points to `scripts/quality-scorecard-generator.js`, while `quality:scorecard:v1` points to `scripts/quality/build-quality-scorecard.mjs`. | #3312 should mark the canonical route and preserve compatibility. |
-| Legacy formal summary path | obsolete | `docs/quality/pr-summary.md`, `docs/quality/pr-summary-tool.md`, and `docs/quality/counterexample-gwt.md` retain legacy `formal/summary.json` compatibility references. | #3312 should mark the replacement path rather than deleting compatibility without migration. |
+| Product and policy positioning | ready | `docs/product/ASSURANCE-CONTROL-PLANE.md`; `docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md`; `docs/architecture/ASSURANCE-CONTROL-PLANE-DETAILED-DESIGN.md`; `docs/quality/ASSURANCE-MODEL.md`. | Keep new docs linked to these SSOT files rather than creating a competing policy route. |
+| Contract catalog and governance | ready | `docs/reference/CONTRACT-CATALOG.md`; `docs/reference/SCHEMA-GOVERNANCE.md`; package script `check:assurance-contract-governance`; `scripts/assurance/check-contract-governance.mjs`; `tests/unit/assurance/check-contract-governance.test.ts`. | Keep governance checks docs/check-only unless a separate enforcement issue changes policy. |
+| Canonical route map | ready | `docs/reference/ASSURANCE-CANONICAL-ROUTES.md`; `fixtures/assurance-e2e/inventory-waiver/README.md`; `tests/scripts/assurance-e2e-scenario.test.ts`. | Treat compatibility language as migration support, not as canonical-route preference. |
+| Context Pack structural validation | ready | Package scripts `context-pack:validate`, `context-pack:verify-functor`, `context-pack:verify-natural-transformation`, `context-pack:verify-product-coproduct`, `context-pack:verify-boundary-map`; fixture evidence under `fixtures/context-pack/`. | Keep Context Pack as producer evidence; route judgment through claim/evidence artifacts. |
+| Verify Lite summaries and workflow | ready | `.github/workflows/verify-lite.yml`; `scripts/ci/verify-lite.sh`; `scripts/ci/write-verify-lite-summary.mjs`; `schema/verify-lite-run-summary.schema.json`; related tests under `tests/scripts/` and `tests/unit/ci/`. | Continue using Verify Lite as one evidence producer, not as a complete assurance claim by itself. |
+| Formal summaries | ready | `schema/formal-summary-v1.schema.json`; `schema/formal-summary-v2.schema.json`; `scripts/formal/aggregate-formal.mjs`; `scripts/formal/print-summary.mjs`; `.github/workflows/formal-aggregate.yml`; formal fixtures and validation tests. | Canonical summary consumption should prefer aggregate formal artifacts; legacy `formal/summary.json` remains compatibility-only. |
+| Conformance summaries | partial | `schema/conformance-verify-result.schema.json`; `src/conformance/*`; `tests/conformance/*`; `fixtures/conformance/*`; package scripts `conformance:verify:sample`, `conformance:report`, and `verify:conformance`. | Keep mapping into claim-level summaries explicit when conformance evidence is used for release judgment. |
+| Quality scorecard | ready | Canonical v1 route: `quality:scorecard:v1`, `scripts/quality/build-quality-scorecard.mjs`, `schema/quality-scorecard.schema.json`, `tests/scripts/build-quality-scorecard.test.ts`, and `tests/contracts/quality-scorecard-contract.test.ts`; compatibility wrapper: `quality:scorecard`. | Prefer v1 route in new docs and tooling; keep legacy wrapper until downstream consumer coverage permits removal. |
+| Policy gate baseline | ready | `.github/workflows/policy-gate.yml`; `scripts/ci/policy-gate.mjs`; `schema/policy-input-v1.schema.json`; `schema/policy-decision-v1.schema.json`; `schema/policy-gate-summary-v1.schema.json`; policy-gate tests. | Default assurance behavior remains report-only unless explicit enforcement mode is selected. |
+| Assurance summary | ready | `schema/assurance-summary.schema.json`; `fixtures/assurance/sample.assurance-summary.json`; `scripts/assurance/aggregate-lanes.mjs`; package script `verify:assurance`; contract/unit tests. | Keep evidence scope and confidence boundaries visible in rendered summaries. |
+| Claim evidence and claim-level summary | ready | `schema/claim-evidence-manifest.schema.json`; `schema/claim-level-summary-v1.schema.json`; package scripts `claim-evidence:generate` and `claim-level-summary:generate`; `scripts/assurance/build-claim-evidence-manifest.mjs`; `scripts/assurance/aggregate-claim-levels.mjs`; fixtures and tests. | `claim-level-summary/v1` remains the review projection for richer state rendering; do not silently change primary emitted state sets. |
+| Waiver and temporary override handling | preview | `schema/temporary-override-v1.schema.json`; waiver fields in claim-evidence, policy, and change-package schemas; `fixtures/assurance-e2e/inventory-waiver/*`; E2E tests. | Waived claims are not satisfied claims; render owner/reason/expiry and preserve report-only boundaries. |
+| Change package v1/v2 | preview | `schema/change-package.schema.json`; `schema/change-package-v2.schema.json`; `docs/reference/change-package-v2.md`; package scripts `change-package:generate`, `change-package:generate:v2`, `change-package:generate:dual`, `change-package:validate:v2`; fixtures and contract/unit tests. | v2 is proof-carrying and dual-write capable; do not make it mandatory for all PRs without a separate policy change. |
+| Contract migration notes | ready | `schema/change-package-v2.schema.json` optional `contractMigrationNotes`; `scripts/change-package/generate.mjs`; `scripts/summary/render-pr-summary.mjs`; `docs/reference/change-package-v2.md`; `docs/quality/pr-summary.md`; related tests. | Contract-impacting PRs should include explicit migration notes and consumer-impact information. |
+| PR summary consumption | partial | `scripts/summary/render-pr-summary.mjs`; `docs/quality/pr-summary.md`; `docs/quality/pr-summary-tool.md`; change-package v2, formal aggregate, claim-level summary, and quality scorecard inputs. | Keep rendering conservative: show non-green states, waivers, residual risks, and migration notes separately from satisfied evidence. |
+| Codex / agent integration | partial | `docs/integrations/CODEX-INTEGRATION.md`; `docs/integrations/CODEX-CONTINUATION-CONTRACT.md`; `docs/integrations/CODEX-SECURITY-AUDIT.md`; `docs/integrations/QUICK-START-CODEX.md`; `docs/agents/*`; `tests/agents/agent-mcp-boundary-smoke.test.ts`; package scripts with `codex:` and `mcp:` prefixes. | Treat agents as producer surfaces, not as the product boundary. |
+| Security Assurance Lane | ready | `docs/security/security-assurance-lane.md`; schemas `security-*-v1`; package scripts `security:import-speca`, `security:extract-claims`, `security:map-code`, `security:proof-audit`, `security:review`, and `security:audit-prompt`; fixtures and tests. | Security assumptions, candidate findings, and confirmed vulnerabilities must remain distinct. |
+| End-to-end assurance fixture | ready | `fixtures/assurance-e2e/inventory-waiver/*`; package script `assurance:e2e`; `scripts/assurance/run-e2e-scenario.mjs`; `tests/scripts/assurance-e2e-scenario.test.ts`. | Use this fixture for smoke-level canonical-route regression; do not make heavy formal verification part of the smoke scenario. |
+| Current-state reporting | ready | This file records branch/HEAD evidence and supersedes the older `cb307e05` baseline. | Refresh when control-plane route semantics or contract states materially change. |
 
-### 6. Command / artifact / schema / workflow map
+### 7. Command / artifact / schema / workflow map
 
 | Area | Command or workflow | Primary artifacts | Schema / contract | Tests or validation evidence |
 | --- | --- | --- | --- | --- |
-| Context Pack | `pnpm run context-pack:validate`, `pnpm run context-pack:verify-functor`, `pnpm run context-pack:verify-natural-transformation`, `pnpm run context-pack:verify-product-coproduct` | Context Pack reports and fixture evidence | Context Pack docs and fixture conventions | Context Pack fixture scripts and docs under `docs/agents/` / `docs/guides/` |
-| Verify Lite | `pnpm run verify:lite`, `.github/workflows/verify-lite.yml` | `artifacts/verify-lite/verify-lite-run-summary.json` | `schema/verify-lite-run-summary.schema.json` | `tests/scripts/run-verify-lite-local.test.ts`, `tests/unit/ci/write-verify-lite-summary.test.ts` |
-| Assurance summary | `pnpm run verify:assurance` | `artifacts/assurance/assurance-summary.json` | `schema/assurance-summary.schema.json` | `tests/contracts/assurance-summary-contract.test.ts`, `tests/unit/ci/validate-assurance-summary.test.ts` |
-| Claim evidence | `pnpm run claim-evidence:generate` | `artifacts/assurance/claim-evidence-manifest.json`, Markdown sidecar | `schema/claim-evidence-manifest.schema.json` | `tests/contracts/claim-evidence-manifest-contract.test.ts`, `tests/scripts/claim-evidence-manifest.test.ts` |
-| Formal aggregate | `pnpm run formal:summary`, `.github/workflows/formal-aggregate.yml` | Formal aggregate / summary JSON | `schema/formal-summary-v1.schema.json`, `schema/formal-summary-v2.schema.json` | `tests/unit/ci/validate-formal-summary-v2.test.ts`, `tests/formal/*` |
-| Conformance | `pnpm run conformance:verify:sample`, `pnpm run conformance:report` | Conformance verify result and reports | `schema/conformance-verify-result.schema.json` | `tests/conformance/*`, `tests/unit/cli/conformance-ingest.test.ts` |
-| Quality scorecard | `pnpm run quality:scorecard:v1`, `pnpm run quality:scorecard:validate` | `artifacts/quality/quality-scorecard.json` | `schema/quality-scorecard.schema.json` | `tests/contracts/quality-scorecard-contract.test.ts`, `tests/scripts/build-quality-scorecard.test.ts` |
-| Policy gate | `.github/workflows/policy-gate.yml`, `scripts/ci/policy-gate.mjs` | `artifacts/ci/policy-input-v1.json`, `policy-decision-js-v1.json`, `policy-gate-summary.json` | `schema/policy-input-v1.schema.json`, `schema/policy-decision-v1.schema.json`, `schema/policy-gate-summary-v1.schema.json` | `tests/unit/ci/policy-gate.test.ts`, `tests/unit/ci/policy-shadow-compare.test.ts` |
-| Change package | `pnpm run change-package:generate`, `pnpm run change-package:generate:v2`, `pnpm run change-package:validate:v2` | `artifacts/change-package/change-package.json`, `change-package-v2.json`, Markdown summary | `schema/change-package.schema.json`, `schema/change-package-v2.schema.json` | `tests/contracts/change-package-v2-contract.test.ts`, `tests/unit/ci/change-package-*.test.ts` |
-| Security assurance | `pnpm run test:security-assurance`, package scripts with the `security:` prefix | Security claims, threat model, audit scope, findings, review, prompt pack, summaries | `schema/security-*-v1.schema.json` | `tests/contracts/security-assurance-contract.test.ts`, `tests/unit/security-assurance/*` |
-| Agent / Codex / MCP | package scripts with the `codex:` and `mcp:` prefixes | Codex responses, MCP interactions, prompt packs | `fixtures/codex/*`, `docs/integrations/schemas/*` | `tests/codex/*`, `tests/agents/agent-mcp-boundary-smoke.test.ts`, `tests/services/mcp-server.test.ts` |
+| Context Pack | `pnpm run context-pack:validate`; `pnpm run context-pack:verify-*` | Context Pack reports and fixture evidence | Context Pack docs and fixture conventions | Context Pack fixture scripts and docs under `docs/agents/` / `docs/guides/` |
+| Verify Lite | `pnpm run verify:lite`; `.github/workflows/verify-lite.yml` | `artifacts/verify-lite/verify-lite-run-summary.json` | `schema/verify-lite-run-summary.schema.json` | `tests/scripts/run-verify-lite-local.test.ts`; `tests/unit/ci/write-verify-lite-summary.test.ts` |
+| Assurance summary | `pnpm run verify:assurance` | `artifacts/assurance/assurance-summary.json` | `schema/assurance-summary.schema.json` | `tests/contracts/assurance-summary-contract.test.ts`; `tests/unit/ci/validate-assurance-summary.test.ts` |
+| Claim evidence | `pnpm run claim-evidence:generate` | `artifacts/assurance/claim-evidence-manifest.json`; Markdown sidecar | `schema/claim-evidence-manifest.schema.json` | `tests/contracts/claim-evidence-manifest-contract.test.ts`; `tests/scripts/claim-evidence-manifest.test.ts` |
+| Claim-level summary | `pnpm run claim-level-summary:generate` | `artifacts/assurance/claim-level-summary.json`; review Markdown | `schema/claim-level-summary-v1.schema.json` | `tests/scripts/claim-level-summary.test.ts`; assurance-control-plane contract tests |
+| Formal aggregate | `pnpm run formal:summary`; `.github/workflows/formal-aggregate.yml` | Formal aggregate / summary JSON | `schema/formal-summary-v1.schema.json`; `schema/formal-summary-v2.schema.json` | `tests/unit/ci/validate-formal-summary-v2.test.ts`; formal tests |
+| Conformance | `pnpm run conformance:verify:sample`; `pnpm run conformance:report` | Conformance verify result and reports | `schema/conformance-verify-result.schema.json` | `tests/conformance/*`; `tests/unit/cli/conformance-ingest.test.ts` |
+| Quality scorecard | `pnpm run quality:scorecard:v1`; `pnpm run quality:scorecard:validate` | `artifacts/quality/quality-scorecard.json` | `schema/quality-scorecard.schema.json` | `tests/contracts/quality-scorecard-contract.test.ts`; `tests/scripts/build-quality-scorecard.test.ts` |
+| Policy gate | `.github/workflows/policy-gate.yml`; `scripts/ci/policy-gate.mjs` | `artifacts/ci/policy-input-v1.json`; `artifacts/ci/policy-decision-js-v1.json`; `artifacts/ci/policy-gate-summary.json` | `schema/policy-input-v1.schema.json`; `schema/policy-decision-v1.schema.json`; `schema/policy-gate-summary-v1.schema.json` | `tests/unit/ci/policy-gate.test.ts`; `tests/unit/ci/policy-shadow-compare.test.ts` |
+| Change package | `pnpm run change-package:generate`; `pnpm run change-package:generate:v2`; `pnpm run change-package:validate:v2` | `artifacts/change-package/change-package.json`; `artifacts/change-package/change-package-v2.json`; `artifacts/change-package/change-package-v2.md` | `schema/change-package.schema.json`; `schema/change-package-v2.schema.json` | `tests/contracts/change-package-v2-contract.test.ts`; `tests/unit/ci/change-package-*.test.ts` |
+| Contract governance | `pnpm run check:assurance-contract-governance` | Governance check output | `docs/reference/SCHEMA-GOVERNANCE.md`; contract catalog conventions | `tests/unit/assurance/check-contract-governance.test.ts` |
+| Security assurance | `pnpm run test:security-assurance`; package scripts with `security:` prefix | Security claims, findings, code map, review, prompt pack, summaries | `schema/security-*-v1.schema.json` | `tests/contracts/security-assurance-contract.test.ts`; `tests/unit/security-assurance/*` |
+| Agent / Codex / MCP | package scripts with `codex:` and `mcp:` prefixes | Codex responses, MCP interactions, prompt packs | `fixtures/codex/*`; integration schemas | `tests/codex/*`; `tests/agents/agent-mcp-boundary-smoke.test.ts`; `tests/services/mcp-server.test.ts` |
 
-### 7. Gap and duplication table
+### 8. Canonical-route and compatibility table
 
-| Topic | Classification | Current evidence | Risk if left unresolved | Suggested owner issue |
-| --- | --- | --- | --- | --- |
-| Canonical assurance-control-plane policy route | partial | `docs/product/ASSURANCE-CONTROL-PLANE.md` and `docs/quality/ASSURANCE-MODEL.md` both define core concepts. | Future issues may create another policy doc and fragment terminology. | #3304 |
-| Detailed design for claim/evidence/achieved-level/policy package | missing | Pieces exist in product, quality, schemas, scripts, and reference docs, but no single detailed architecture doc was found. | Implementations may infer different semantics for missing, stale, waived, runtime-mitigated, or not-applicable evidence. | #3305 |
-| Temporary override / waiver contract | partial | Waiver fields exist in claim-evidence, change-package v2, policy input/decision/summary, and assurance model docs. | Enforcement may treat waived as satisfied or omit required owner/reason/expiry links. | #3305, #3306, #3308 |
-| Per-claim achieved-level artifact and PR Markdown | partial | Claim-evidence manifest includes `achievedLevel` and Markdown rendering; a separate stable summary artifact is not yet canonical. | PR reviewers may need to inspect multiple artifacts instead of a compact claim-level judgment summary. | #3307 |
-| Assurance-aware policy-gate enforcement | partial | Policy gate carries report-only assurance sections and waiver-aware decisions. | Enabling enforcement without clear mode boundaries could break normal PR flow. | #3308 |
-| Change-package v2 production path | preview | v2 schema, docs, generator, dual-write, strict validation, and fixtures exist. | Reviewers may confuse preview v2 with default production v1. | #3309 |
-| Agent integration runbook | partial | Codex, Claude, MCP, and agent docs exist across several directories. | Producer agents may be treated as the product boundary instead of evidence producers. | #3310 |
-| E2E assurance fixture | ready but extendable | `fixtures/assurance-e2e/inventory-waiver` exists and includes non-green waiver-aware cases. | New schema/policy work may not be validated end-to-end if this fixture is not extended. | #3311 |
-| Legacy scorecard route | duplicate | `quality:scorecard` and `quality:scorecard:v1` coexist. | Operators may invoke the legacy route by accident. | #3312 |
-| Legacy formal summary path | obsolete compatibility | Legacy `formal/summary.json` is retained in PR summary docs as a fallback. | Compatibility language may be mistaken for the preferred contract. | #3312 |
+| Topic | Current route state | Evidence | Residual risk / control |
+| --- | --- | --- | --- |
+| Quality scorecard | Canonical v1 route with legacy wrapper retained. | `docs/reference/ASSURANCE-CANONICAL-ROUTES.md`; `quality:scorecard:v1`; `quality:scorecard`; #3333. | Do not remove the wrapper until consumer-path tests and migration guidance are explicit. |
+| Formal summary consumption | Canonical aggregate formal evidence preferred; legacy fallback retained. | `scripts/summary/render-pr-summary.mjs`; `docs/quality/pr-summary.md`; #3334. | Render compatibility as fallback, not as preferred proof route. |
+| Counterexample GWT | Derived from canonical formal counterexample evidence. | `docs/quality/counterexample-gwt.md`; #3335. | Keep model scope and source artifact references visible. |
+| Change package | v1 production route plus proof-carrying v2 preview / dual-write route. | `docs/reference/change-package-v2.md`; `schema/change-package-v2.schema.json`; #3337. | Explicit migration notes are required for contract-impacting changes. |
+| Assurance E2E smoke route | `claim-level-summary/v1 -> policy-decision/v1 -> change-package/v2` for the inventory-waiver scenario. | `fixtures/assurance-e2e/inventory-waiver/README.md`; `tests/scripts/assurance-e2e-scenario.test.ts`; #3338. | Keep the smoke deterministic and non-heavy; it is not a full formal verification run. |
 
-### 8. Over-claiming risk table
+### 9. Over-claiming risk table
 
-| Risk | Current state | Control to apply in follow-up issues |
+| Risk | Current state | Control to preserve |
 | --- | --- | --- |
-| Treating green CI as high assurance | Docs already distinguish assurance levels and verification lanes. | Keep the distinction explicit in #3304 and #3305. |
-| Treating runtime mitigation as proof | `docs/quality/ASSURANCE-MODEL.md` separates runtime controls from proof/model-check evidence. | Ensure #3305 and #3309 preserve separate rendered states. |
-| Treating waived claims as satisfied claims | Schemas and generators carry `waived` states and waiver refs. | #3308 should fail closed only in explicit enforcement mode and should render waivers separately. |
-| Treating change-package v2 as default production contract | `docs/reference/change-package-v2.md` says v1 remains default and v2 is opt-in/dual-write. | #3309 should retain compatibility or document migration windows. |
-| Treating producer agents as ae-framework runtime | Integration docs exist, but routes are distributed. | #3310 should state producer/control-plane boundaries in a single runbook. |
-| Treating formal summary as full proof | Formal summary schemas and docs exist, but model scope assumptions must be explicit. | #3305/#3307 should require scope/assumption links for model/proof evidence. |
-| Treating security assumption findings as confirmed vulnerabilities | Security Assurance Lane docs and prompt pack work separate candidate findings and assumption handling. | Reuse that pattern for general claim evidence in #3307/#3309. |
+| Treating green CI as high assurance | Docs and summaries distinguish verification lanes, assurance levels, and evidence states. | Keep PR/release summaries from equating pass/fail CI with achieved assurance level. |
+| Treating runtime mitigation as proof | The assurance model and change-package v2 distinguish runtime controls from proof/model-check evidence. | Render runtime controls and residual risks separately. |
+| Treating waived claims as satisfied claims | E2E fixtures include waived and report-only states; generated change-package v2 now includes policy decision context. | Surface waiver owner/reason/expiry and avoid counting waived as satisfied. |
+| Treating preview contracts as mandatory production contracts | `change-package/v2`, `claim-level-summary/v1`, and `temporary-override/v1` are preview or dual-write where documented. | Require separate policy issues for enforcement or default-production promotion. |
+| Treating compatibility routes as canonical | Canonical route docs and regression tests distinguish preferred routes from legacy fallbacks. | Keep compatibility text until consumer-path tests justify removal. |
+| Treating producer agents as the product boundary | Integration docs and policy frame agents as producers. | Keep durable contracts at the control-plane boundary. |
+| Treating security assumption findings as confirmed vulnerabilities | Security Assurance Lane keeps assumptions, candidate findings, and reviews distinct. | Preserve those distinctions when mapping security artifacts into claim evidence. |
 
-### 9. Recommended smallest next implementation slice
+### 10. Current follow-up guidance
 
-Proceed with #3304 as a docs-only convergence PR:
+The next work should be narrowly scoped maintenance rather than another broad roadmap:
 
-1. Update or extend `docs/product/ASSURANCE-CONTROL-PLANE.md` rather than creating a competing product policy unless a new file is clearly marked as canonical.
-2. Cross-link `docs/quality/ASSURANCE-MODEL.md`, `docs/quality/ARTIFACTS-CONTRACT.md`, `docs/reference/CONTRACT-CATALOG.md`, and this report.
-3. Add explicit valid/invalid wording examples to avoid over-claiming.
-4. Keep validation to `pnpm -s run check:doc-consistency` unless broader changes are made.
-
-Rationale: the current repo already has executable contracts. Clarifying policy and terminology first reduces duplication risk for schema, policy-gate, and change-package work.
-
-### 10. Suggested child issue updates based on current state
-
-| Issue | Suggested adjustment |
-| --- | --- |
-| #3304 | Treat `docs/product/ASSURANCE-CONTROL-PLANE.md` and `docs/quality/ASSURANCE-MODEL.md` as the current canonical starting point. Add policy examples and cross-links rather than duplicating content. |
-| #3305 | Create a detailed design that references existing schemas and scripts. Focus on semantics that are currently spread across docs and code. |
-| #3306 | Reuse `schema/assurance-summary.schema.json`, `schema/claim-evidence-manifest.schema.json`, `schema/policy-*.schema.json`, and `schema/change-package-v2.schema.json`. Add new schema only where a real gap remains. |
-| #3307 | Extend the existing claim-evidence generation path before adding a separate aggregator. Keep output deterministic and PR-reviewable. |
-| #3308 | Preserve current policy-gate behavior as compatible report-only by default; make fail-closed behavior explicit and opt-in. |
-| #3309 | Stabilize v2 as proof-carrying package while preserving v1 compatibility or dual validation. |
-| #3310 | Build one runbook from existing Codex, Claude, MCP, and Security Assurance Lane docs. Make agents producers, not required runtime dependencies. |
-| #3311 | Reuse `fixtures/assurance-e2e/inventory-waiver` and security-assurance fixtures as proven examples. |
-| #3312 | Mark canonical versus legacy routes for scorecard, formal summary fallback, and duplicated judgment docs before deleting anything. |
+1. Keep `docs/reports/ASSURANCE-CONTROL-PLANE-CURRENT-STATE.md` as the canonical snapshot and refresh it when HEAD evidence materially changes.
+2. Keep `docs/reference/SCHEMA-GOVERNANCE.md` and `pnpm run check:assurance-contract-governance` aligned with new assurance schemas.
+3. Continue preferring canonical route tests before changing compatibility behavior.
+4. Require explicit `contractMigrationNotes` and consumer-impact text for assurance contract changes.
+5. Avoid treating report-only policy-gate output as enforcement unless a dedicated policy issue changes the mode.
 
 ### 11. 日本語要約
 
-現行 `main` には、assurance control plane の主要部品が既に多数存在します。特に、Verify Lite、assurance summary、claim-evidence manifest、policy gate、quality scorecard、change-package v2、Security Assurance Lane は、schema・fixture・script・test の形で確認できます。
+このレポートは、`main` の `a4245f693bff38229bf6431f27fbf3d20266d259` を対象に、assurance control plane の現状を再記録します。以前の `cb307e05` ベースラインは現行状態ではなく、#3302〜#3312 / PR #3313〜#3322 は完了済みの履歴として扱います。
 
-ただし、設計と運用導線は複数文書に分散しています。次に実装を増やす前に、#3304 で policy / terminology を収束させ、#3305 で詳細設計を固定するのが最小リスクです。
+現在のリポジトリには、policy、detailed design、contract catalog、canonical route、schema governance、claim/evidence producer、policy-gate summary、change-package v1/v2、PR summary、E2E fixture、Security Assurance Lane が存在します。今後の主眼は、新しい大規模ロードマップの作成ではなく、正準導線の維持、互換導線の安全な移行、契約変更時の migration note、current-state report の鮮度維持です。
+
+別ファイルの repository snapshot は追加していません。本レポートが、HEAD、command inventory、contract inventory、route state、残余フォローアップをまとめて記録する canonical snapshot として機能します。


### PR DESCRIPTION
## Summary
- refresh the assurance control plane current-state report from the old `cb307e05` baseline to current post-roadmap `main` (`a4245f693bff38229bf6431f27fbf3d20266d259`)
- record completed roadmap PRs #3313-#3322 and post-roadmap hardening PRs #3333-#3338 as historical/current evidence
- define assurance contract lifecycle states and migration-note examples in schema governance
- add explicit legacy-route cleanup dispositions and rollback guidance to the canonical route map

## Acceptance
- Closes #3323
- Closes #3324
- Closes #3325
- The report records the branch/HEAD used for the refresh
- The older `cb307e05` baseline is no longer presented as current
- Capability and route claims cite current docs, scripts, schemas, fixtures, or tests
- Completed roadmap issues are treated as historical completion evidence, not planned work
- Governance rules define stable/preview/deprecated/legacy-compatible/removed states and migration-note expectations
- Legacy cleanup planning has explicit dispositions, consumer-test requirements, and rollback guidance

## Validation
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:schemas`
- `git diff --check`

## Rollback
- Revert this docs-only commit if the current-state report, governance taxonomy, or cleanup dispositions need to return to the prior wording.