### PR TITLE
fix(ci): require trusted PR command mutations

### DIFF
--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -26,15 +26,31 @@ jobs:
             const body = (context.payload.comment.body || '').trim();
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
+            const cmd = body.split(/\s+/)[0];
+            const arg = body.split(/\s+/)[1] || '';
+            const association = context.payload.comment.author_association || '';
+            const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            const isTrusted = trustedAssociations.includes(association);
+            const trustedAssociationText = trustedAssociations.join(' / ');
 
+            const reply = async (msg) => {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body: `<!-- AE-AGENTS-REPLY -->\n${msg}` });
+            };
+            const assertTrustedForMutation = (operation) => {
+              if (isTrusted) return;
+              throw new Error(`Refusing ${operation} for untrusted PR commenter (association: ${association || 'NONE'}, command: ${cmd || '(none)'})`);
+            };
             const addLabels = async (labels) => {
               if (!labels || labels.length === 0) return;
+              assertTrustedForMutation('addLabels');
               await github.rest.issues.addLabels({ owner, repo, issue_number, labels });
             };
             const removeLabel = async (label) => {
+              assertTrustedForMutation('removeLabel');
               try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label }); } catch {}
             };
             const removeLabelsByPrefix = async (prefix) => {
+              assertTrustedForMutation('removeLabelsByPrefix');
               const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number, per_page: 100 });
               const targets = labels.map(l=>l.name).filter(n => n.startsWith(prefix));
               for (const name of targets) {
@@ -42,13 +58,9 @@ jobs:
               }
             };
 
-            const reply = async (msg) => {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body: `<!-- AE-AGENTS-REPLY -->\n${msg}` });
-            };
-            const association = context.payload.comment.author_association || '';
-            const isTrusted = ['MEMBER', 'OWNER', 'COLLABORATOR'].includes(association);
             const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
             const dispatchWorkflow = async (workflow_id, ref, inputs = undefined) => {
+              assertTrustedForMutation('createWorkflowDispatch');
               await github.rest.actions.createWorkflowDispatch({
                 owner,
                 repo,
@@ -107,8 +119,6 @@ jobs:
             // /formal-aggregate-dispatch (aggregate workflow_dispatch)
             // /formal-help (prints quick tips and docs links)
             // /formal-quickstart (alias of /formal-help)
-            const cmd = body.split(/\s+/)[0];
-            const arg = body.split(/\s+/)[1] || '';
             const autoFixMarker = '<!-- AE-COPILOT-AUTO-FIX v1 -->';
             const isAutoFixComment =
               context.payload.comment?.user?.type === 'Bot'
@@ -136,6 +146,64 @@ jobs:
                 inputs: { pr_number: String(issue_number) }
               });
               core.notice(`Dispatched copilot-review-gate for PR #${issue_number} on ${ref}`);
+              return;
+            }
+
+            const mutatingCommands = new Set([
+              '/enforce-bdd-lint',
+              '/run-qa',
+              '/run-security',
+              '/run-cedar',
+              '/non-blocking',
+              '/blocking',
+              '/ready',
+              '/run-hermetic',
+              '/run-spec',
+              '/run-drift',
+              '/enforce-typecov',
+              '/coverage',
+              '/enforce-coverage',
+              '/enforce-context-pack',
+              '/pr-digest',
+              '/pr-detailed',
+              '/handoff',
+              '/verify-lite',
+              '/review',
+              '/run-qa-dispatch',
+              '/run-security-dispatch',
+              '/ci-fast-dispatch',
+              '/formal-verify-dispatch',
+              '/formal-apalache-dispatch',
+              '/run-flake-dispatch',
+              '/spec-validation-dispatch',
+              '/run-cedar-dispatch',
+              '/formal-aggregate-dispatch',
+              '/qa-batch-commands',
+              '/run-qa:commands',
+              '/qa-batch-cli',
+              '/run-qa:cli',
+              '/qa-batch-property',
+              '/run-qa:property',
+              '/qa-batch-agents',
+              '/run-qa:agents',
+              '/run-adapters',
+              '/run-resilience',
+              '/enforce-perf',
+              '/enforce-lh',
+              '/perf',
+              '/lh',
+              '/enforce-a11y',
+              '/run-formal',
+              '/enforce-formal',
+              '/enforce-contracts'
+            ]);
+            const requireTrustedCommand = async () => {
+              if (isTrusted) return true;
+              await reply(`Permission denied for ${cmd || 'command'} (association: ${association || 'NONE'}). Mutating PR commands require ${trustedAssociationText}.`);
+              return false;
+            };
+            if (mutatingCommands.has(cmd) && !(await requireTrustedCommand())) {
+              core.notice(`Denied mutating PR command ${cmd} for association ${association || 'NONE'}.`);
               return;
             }
 
@@ -226,7 +294,7 @@ jobs:
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'verify-lite.yml', ref });
+                await dispatchWorkflow('verify-lite.yml', ref);
                 return reply(`Dispatched verify-lite on ${ref}`);
               }
               case '/review': {
@@ -268,56 +336,56 @@ jobs:
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'ae-ci.yml', ref });
+                await dispatchWorkflow('ae-ci.yml', ref);
                 return reply(`Dispatched ae-ci (QA) on ${ref}`);
               }
               case '/run-security-dispatch': {
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'sbom-generation.yml', ref, inputs: { include_vulnerabilities: 'true' } });
+                await dispatchWorkflow('sbom-generation.yml', ref, { include_vulnerabilities: 'true' });
                 return reply(`Dispatched sbom-generation (security) on ${ref}`);
               }
               case '/ci-fast-dispatch': {
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'ci-fast.yml', ref });
+                await dispatchWorkflow('ci-fast.yml', ref);
                 return reply(`Dispatched CI Fast on ${ref}`);
               }
               case '/formal-verify-dispatch': {
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'formal-verify.yml', ref });
+                await dispatchWorkflow('formal-verify.yml', ref);
                 return reply(`Dispatched Formal Verify on ${ref}`);
               }
               case '/formal-apalache-dispatch': {
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'formal-verify.yml', ref, inputs: { target: 'apalache' } });
+                await dispatchWorkflow('formal-verify.yml', ref, { target: 'apalache' });
                 return reply(`Dispatched Formal Verify (Apalache) on ${ref}`);
               }
               case '/run-flake-dispatch': {
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'flake-detect.yml', ref });
+                await dispatchWorkflow('flake-detect.yml', ref);
                 return reply(`Dispatched flake-detect on ${ref}`);
               }
               case '/spec-validation-dispatch': {
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'spec-validation.yml', ref });
+                await dispatchWorkflow('spec-validation.yml', ref);
                 return reply(`Dispatched spec-validation on ${ref}`);
               }
               case '/run-cedar-dispatch': {
                 if (!context.payload.issue.pull_request) return reply('Not a PR');
                 const pr = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
                 const ref = pr.data.head.ref;
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'cedar-quality-gates.yml', ref });
+                await dispatchWorkflow('cedar-quality-gates.yml', ref);
                 return reply(`Dispatched cedar-quality-gates on ${ref}`);
               }
               case '/formal-aggregate-dispatch': {
@@ -333,7 +401,7 @@ jobs:
                   const arts = await github.rest.actions.listArtifactsForRepo({ owner, repo, per_page: 100 });
                   hasAggArtifacts = arts.data.artifacts?.some(a => a?.name === 'formal-reports-aggregate-json' || a?.name === 'formal-reports-aggregate') || false;
                 } catch {}
-                await github.rest.actions.createWorkflowDispatch({ owner, repo, workflow_id: 'formal-aggregate.yml', ref });
+                await dispatchWorkflow('formal-aggregate.yml', ref);
                 const lines = [];
                 lines.push(`Dispatched formal-aggregate on ${ref}`);
                 if (last) lines.push(`- last post: ${new Date(last).toISOString()}`); else lines.push('- last post: n/a');

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -2,7 +2,7 @@
 docRole: derived
 canonicalSource:
   - .github/workflows/agent-commands.yml
-lastVerified: '2026-05-10'
+lastVerified: '2026-06-01'
 ---
 
 # Agent Commands Catalog

--- a/docs/ci/OPT-IN-CONTROLS.md
+++ b/docs/ci/OPT-IN-CONTROLS.md
@@ -112,9 +112,9 @@ Representative variables for follow-on automation:
 Entry point: `.github/workflows/agent-commands.yml`
 
 Operational note:
-- Most PR commands are label-attachment commands and do not require trusted association.
-- `/review` is the main exception and is restricted to trusted actors (`MEMBER` / `OWNER` / `COLLABORATOR`).
-- Trace revalidation remains label-only through `run-trace` in the current repository.
+- PR commands that mutate labels or dispatch workflows require trusted actors (`MEMBER` / `OWNER` / `COLLABORATOR`).
+- Untrusted PR commenters can still receive read-only help output, such as `/formal-help` and `/formal-quickstart`, but cannot change labels or dispatch workflows.
+- Trace revalidation remains label-driven through `run-trace` in the current repository; changing control labels through PR comments is restricted to trusted actors.
 
 #### 5.1 Main commands
 - `/verify-lite`
@@ -279,7 +279,7 @@ Codex Autopilot Lane を使う場合:
 ## 4. PR向け Slash コマンド（PRコメント）
 
 > 入口: `.github/workflows/agent-commands.yml`  
-> 権限: 多くのコマンドは `author_association` 制限なし（ラベル付与型）。`/review` のみ trusted 必須（`MEMBER/OWNER/COLLABORATOR`）。
+> 権限: ラベル変更または `workflow_dispatch` を行う PR コマンドは trusted 必須（`MEMBER/OWNER/COLLABORATOR`）。untrusted PR commenter は `/formal-help` / `/formal-quickstart` のような read-only help のみ利用できます。
 
 ### 4.1 主要コマンド
 - `/verify-lite`  

--- a/docs/ci/automation-permission-boundaries.md
+++ b/docs/ci/automation-permission-boundaries.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-03-24'
+lastVerified: '2026-06-01'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -25,6 +25,7 @@ Primary sources:
 
 | Workflow | Trigger | Boundary condition | Intent |
 | --- | --- | --- | --- |
+| agent-commands (`PR slash command mutations`) | `issue_comment` | requires a comment attached to a PR plus trusted `author_association` (`MEMBER` / `OWNER` / `COLLABORATOR`) before label mutation or workflow dispatch commands execute | prevent arbitrary PR commenters from changing control labels or starting privileged workflows |
 | agent-commands (`copilot-review-gate dispatch`) | `issue_comment` | requires a comment attached to a PR plus `github-actions[bot]` and `<!-- AE-COPILOT-AUTO-FIX v1 -->` marker | prevent arbitrary comment-driven dispatch |
 | Copilot Review Gate (`gate`) | `workflow_dispatch` | on the default branch, manual runs must provide `pr_number`; otherwise the gate skips or errors | prevent accidental execution against unrelated branches |
 | Copilot Auto Fix | `pull_request_review` | excludes fork PRs, limits actors to Copilot identities, and respects the global kill switch | constrain write permission and apply authority |
@@ -36,7 +37,7 @@ Primary sources:
 ### 2. Implementation notes
 
 - the global kill switch (`AE_AUTOMATION_GLOBAL_DISABLE`) is enforced in automation lanes that mutate or dispatch follow-up work (`Codex Autopilot Lane`, `PR Maintenance`, `Copilot Auto Fix`); `Copilot Review Gate` does not currently use that kill switch
-- `issue_comment` entrypoints must first prove that the comment is attached to a PR, then add actor or marker validation where required
+- `issue_comment` entrypoints must first prove that the comment is attached to a PR, then add actor or marker validation before repository mutations such as label changes or workflow dispatches
 - `workflow_dispatch` entrypoints must require or default critical inputs such as `pr_number` or `mode` so operators do not accidentally target the wrong PR or lane
 
 ### 3. Test policy
@@ -61,6 +62,7 @@ The purpose of this test is to guarantee the presence of the boundary policy. It
 
 | Workflow | Trigger | 境界条件 | 意図 |
 | --- | --- | --- | --- |
+| agent-commands（`PR slash command mutations`） | `issue_comment` | PRに紐づくコメントのみ、ラベル変更または workflow dispatch の前に trusted `author_association`（`MEMBER` / `OWNER` / `COLLABORATOR`）を要求 | 任意のPRコメント投稿者による制御ラベル変更や特権workflow起動を防止 |
 | agent-commands (`copilot-review-gate dispatch`) | `issue_comment` | PRに紐づくコメントのみ、`github-actions[bot]` + `<!-- AE-COPILOT-AUTO-FIX v1 -->` を要求 | 任意コメントからのdispatch起動を防止 |
 | Copilot Review Gate (`gate`) | `workflow_dispatch` | default branch 上の手動実行では `pr_number` が必要。未指定なら gate は skip または error になる | 無関係ブランチでの誤起動を防止 |
 | Copilot Auto Fix | `pull_request_review` | fork PR除外、Copilot actor限定、global kill-switch考慮 | 書き込み権限と適用主体を制限 |
@@ -72,7 +74,7 @@ The purpose of this test is to guarantee the presence of the boundary policy. It
 ## 2. 実装上の補足
 
 - global kill-switch (`AE_AUTOMATION_GLOBAL_DISABLE`) は、更新系 / follow-up dispatch 系の lane（`Codex Autopilot Lane`, `PR Maintenance`, `Copilot Auto Fix`）で workflow 条件とスクリプト内部の両方からガードします。`Copilot Review Gate` 自体は現時点ではこの kill-switch の対象外です。
-- `issue_comment` 起点は「PRに紐づいているか」を必須条件とし、必要な場合のみ actor/marker を追加検証します。
+- `issue_comment` 起点は「PRに紐づいているか」を必須条件とし、ラベル変更や workflow dispatch などの repository mutation の前に actor または marker を検証します。
 - `workflow_dispatch` 起点は `pr_number` や `mode` のような重要入力を必須化または既定化し、誤対象への実行を避けます。
 
 ## 3. テスト方針

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -14,11 +14,63 @@ type WorkflowDocument = {
       workflows?: string[];
     };
   };
+  jobs?: Record<string, any>;
 };
 
 const parseWorkflow = (name: string) => yaml.load(readWorkflow(name)) as WorkflowDocument;
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const extractAgentCommandsPrScript = () => {
+  const workflow = parseWorkflow('agent-commands.yml');
+  const steps = workflow.jobs?.handle_pr?.steps;
+  if (!Array.isArray(steps)) {
+    throw new Error('agent-commands handle_pr steps not found');
+  }
+  const scriptStep = steps.find((step) => step?.uses === 'actions/github-script@v7');
+  const script = scriptStep?.with?.script;
+  if (typeof script !== 'string' || script.length === 0) {
+    throw new Error('agent-commands handle_pr github-script body not found');
+  }
+  return script;
+};
+
+const extractMutatingCommandSet = (prSection: string) => {
+  const match = prSection.match(/const mutatingCommands = new Set\(\[([\s\S]*?)\]\);/);
+  if (!match) {
+    throw new Error('mutatingCommands set not found');
+  }
+  return new Set([...match[1].matchAll(/'([^']+)'/g)].map((item) => item[1]));
+};
+
+const detectPrCommandsThatReachMutationSinks = (script: string) => {
+  const switchStart = script.indexOf('switch (cmd) {');
+  const switchEnd = script.indexOf('default:', switchStart);
+  if (switchStart < 0 || switchEnd < 0 || switchEnd <= switchStart) {
+    throw new Error('agent-commands PR switch not found');
+  }
+  const switchBody = script.slice(switchStart, switchEnd);
+  const mutating = new Set<string>();
+  let activeCases: string[] = [];
+
+  for (const line of switchBody.split('\n')) {
+    const caseMatch = line.match(/case '([^']+)':/);
+    if (caseMatch) {
+      activeCases.push(caseMatch[1]);
+      continue;
+    }
+    if (/(await\s+addLabels|await\s+removeLabel|await\s+removeLabelsByPrefix|await\s+dispatchWorkflow|dispatchWithResult\(|github\.rest\.issues\.addLabels|github\.rest\.issues\.removeLabel|github\.rest\.actions\.createWorkflowDispatch)/.test(line)) {
+      for (const command of activeCases) {
+        mutating.add(command);
+      }
+    }
+    if (/^\s*return\b/.test(line)) {
+      activeCases = [];
+    }
+  }
+
+  return mutating;
+};
 
 const extractJobBlock = (workflow: string, jobName: string) => {
   const pattern = new RegExp(
@@ -55,6 +107,30 @@ describe('workflow permission boundaries', () => {
     expect(workflow).toContain("context.payload.comment?.user?.login === 'github-actions[bot]'");
     expect(workflow).toContain('body.includes(autoFixMarker)');
     expect(workflow).toContain("workflow_id: 'copilot-review-gate.yml'");
+  });
+
+  it('agent-commands requires trusted PR commenters before label mutations or workflow dispatches', () => {
+    const prScript = extractAgentCommandsPrScript();
+    const mutatingCommands = extractMutatingCommandSet(prScript);
+    const commandsThatReachMutationSinks = detectPrCommandsThatReachMutationSinks(prScript);
+
+    expect(prScript).toContain("const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR']");
+    expect(prScript).toContain('const isTrusted = trustedAssociations.includes(association)');
+    expect(prScript).toContain('assertTrustedForMutation');
+    expect(prScript).toContain("assertTrustedForMutation('addLabels')");
+    expect(prScript).toContain("assertTrustedForMutation('removeLabel')");
+    expect(prScript).toContain("assertTrustedForMutation('removeLabelsByPrefix')");
+    expect(prScript).toContain("assertTrustedForMutation('createWorkflowDispatch')");
+    expect(prScript.indexOf('if (mutatingCommands.has(cmd)')).toBeGreaterThanOrEqual(0);
+    expect(prScript.indexOf('if (mutatingCommands.has(cmd)')).toBeLessThan(prScript.indexOf('switch (cmd)'));
+    expect(prScript).toContain('Permission denied for ${cmd');
+
+    for (const command of commandsThatReachMutationSinks) {
+      expect(mutatingCommands.has(command), `${command} must require trusted association`).toBe(true);
+    }
+    expect([...mutatingCommands].sort()).toEqual([...commandsThatReachMutationSinks].sort());
+    expect(mutatingCommands.has('/formal-help')).toBe(false);
+    expect(mutatingCommands.has('/formal-quickstart')).toBe(false);
   });
 
   it('pr-maintenance update-branch enforces fork guard, explicit mode, and global kill-switch', () => {


### PR DESCRIPTION
## Summary
- require trusted PR commenters (`MEMBER` / `OWNER` / `COLLABORATOR`) before agent-command PR slash commands can mutate labels or dispatch workflows
- keep read-only help commands available to untrusted commenters and preserve the existing GitHub Actions bot marker path for Copilot Auto Fix gate refreshes
- add a workflow-permission regression test that maps PR command mutation sinks to the trusted-command guard
- update automation permission docs and regenerate the agent commands catalog timestamp

## Security / Acceptance
- Closes #3340
- Label mutation helpers (`addLabels`, `removeLabel`, `removeLabelsByPrefix`) fail closed without trusted association
- Workflow dispatch helper (`dispatchWorkflow`) fails closed without trusted association
- Every PR command path reaching label mutation or workflow dispatch is included in the trusted-command guard set
- Untrusted PR commenters receive a permission-denied reply instead of label/dispatch side effects

## Validation
- `pnpm install --frozen-lockfile` (new worktree dependency setup)
- `pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts tests/unit/docs/check-agent-commands-doc-sync.test.ts --reporter dot`
- `node scripts/docs/check-agent-commands-doc-sync.mjs --check`
- `node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.github/workflows/agent-commands.yml','utf8')); console.log('agent-commands.yml YAML parse: OK');"`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:schemas`
- `pnpm -s run types:check`
- `git diff --check`

## Rollback
- Revert this PR to restore the previous PR comment command behavior. If rollback is required, also reassess #3340 because untrusted PR commenters would again be able to change control labels or dispatch workflows.