### PR TITLE
fix(container): harden MCP container boundaries

### DIFF
--- a/src/agents/container-agent.ts
+++ b/src/agents/container-agent.ts
@@ -4,6 +4,7 @@
  */
 
 import { ContainerManager } from '../services/container/container-manager.js';
+import { resolveApprovedWorkspacePath } from '../services/container/container-security-policy.js';
 import type { ContainerManagerConfig, VerificationJob, VerificationEnvironment } from '../services/container/container-manager.js';
 import { ContainerEngineFactory, type ContainerEngineName } from '../services/container/container-engine.js';
 import * as path from 'path';
@@ -47,6 +48,7 @@ export interface ContainerBuildRequest {
   baseImage?: string;
   tag?: string;
   push?: boolean;
+  pushApproval?: 'none' | 'approved-container-image-push';
   buildArgs?: Record<string, string>;
 }
 
@@ -185,13 +187,19 @@ export class ContainerAgent {
     try {
       await this.ensureInitialized();
 
-      // Validate project path exists
+      let approvedProjectPath: string;
       try {
-        await fs.access(request.projectPath);
-      } catch {
+        const approved = await resolveApprovedWorkspacePath({
+          projectPath: request.projectPath,
+          ...(this.config.workspaceRoot !== undefined ? { workspaceRoot: this.config.workspaceRoot } : {}),
+        });
+        approvedProjectPath = approved.projectPath;
+        await fs.access(approvedProjectPath);
+      } catch (error: unknown) {
+        const message = toMessage(error);
         return {
           success: false,
-          message: `Project path does not exist: ${request.projectPath}`,
+          message,
           error: 'INVALID_PROJECT_PATH'
         };
       }
@@ -215,7 +223,7 @@ export class ContainerAgent {
       // Create and run verification job
       const job = await this.containerManager.runVerificationJob({
         name: request.jobName || `${request.language}-verification-${Date.now()}`,
-        projectPath: request.projectPath,
+        projectPath: approvedProjectPath,
         language: request.language,
         tools: request.tools
       });
@@ -260,7 +268,8 @@ export class ContainerAgent {
         {
           tag,
           ...(request.buildArgs ? { buildArgs: request.buildArgs } : {}),
-          ...(request.push !== undefined ? { push: request.push } : {})
+          ...(request.push !== undefined ? { push: request.push } : {}),
+          ...(request.pushApproval !== undefined ? { pushApproval: request.pushApproval } : {})
         }
       );
 
@@ -435,7 +444,7 @@ export class ContainerAgent {
   /**
    * Cleanup old containers and resources
    */
-  async cleanup(options?: { maxAge?: number; keepCompleted?: number; force?: boolean }): Promise<AgentResult> {
+  async cleanup(options?: { maxAge?: number; keepCompleted?: number; force?: boolean; dryRun?: boolean; confirm?: 'delete-ae-framework-resources' | 'force-delete-ae-framework-resources' }): Promise<AgentResult> {
     try {
       await this.ensureInitialized();
 
@@ -443,12 +452,15 @@ export class ContainerAgent {
 
       return {
         success: true,
-        message: `Cleanup completed: removed ${result.jobsRemoved} jobs, ${result.containersRemoved} containers`,
+        message: result.dryRun
+          ? `Cleanup dry-run completed: would remove ${result.jobsRemoved} jobs and ${result.containersRemoved} ae-framework containers`
+          : `Cleanup completed: removed ${result.jobsRemoved} jobs, ${result.containersRemoved} containers`,
         data: {
           jobsRemoved: result.jobsRemoved,
           containersRemoved: result.containersRemoved,
           spaceSaved: result.spaceSaved,
-          options
+          dryRun: result.dryRun,
+          labelFilter: result.labelFilter,
         }
       };
     } catch (error: unknown) {

--- a/src/mcp-server/container-server.ts
+++ b/src/mcp-server/container-server.ts
@@ -131,6 +131,12 @@ export class ContainerServer {
               description: 'Whether to push the image to a registry',
               default: false,
             },
+            pushApproval: {
+              type: 'string',
+              enum: ['none', 'approved-container-image-push'],
+              description: 'Required explicit approval token when push is true',
+              default: 'none',
+            },
             buildArgs: {
               type: 'object',
               additionalProperties: { type: 'string' },
@@ -221,6 +227,16 @@ export class ContainerServer {
               description: 'Force cleanup even if resources are in use',
               default: false,
             },
+            dryRun: {
+              type: 'boolean',
+              description: 'Preview ae-framework-scoped cleanup without deleting container resources',
+              default: true,
+            },
+            confirm: {
+              type: 'string',
+              enum: ['delete-ae-framework-resources', 'force-delete-ae-framework-resources'],
+              description: 'Required confirmation token when dryRun is false',
+            },
           },
           additionalProperties: false,
         },
@@ -296,6 +312,7 @@ export class ContainerServer {
               language: parsed.language,
               tools: parsed.tools,
               push: parsed.push,
+              pushApproval: parsed.pushApproval,
               buildArgs: parsed.buildArgs,
               ...(parsed.baseImage !== undefined ? { baseImage: parsed.baseImage } : {}),
               ...(parsed.tag !== undefined ? { tag: parsed.tag } : {}),
@@ -372,6 +389,8 @@ export class ContainerServer {
               maxAge: parsed.maxAge,
               keepCompleted: parsed.keepCompleted,
               force: parsed.force,
+              dryRun: parsed.dryRun,
+              ...(parsed.confirm !== undefined ? { confirm: parsed.confirm } : {}),
             };
             const result = await this.agent.cleanup(options);
             return {

--- a/src/mcp-server/schemas.ts
+++ b/src/mcp-server/schemas.ts
@@ -182,10 +182,16 @@ export type AnalyzeCoverageArgs = z.infer<typeof AnalyzeCoverageArgsSchema>;
 // ---------- Container MCP Schemas ----------
 export const LanguageEnum = z.enum(['rust', 'elixir', 'multi']);
 
+const ContainerToolNameSchema = z.string().min(1).max(64).regex(/^[A-Za-z0-9][A-Za-z0-9._+@-]*$/, 'tool names may only contain letters, numbers, dot, underscore, plus, at, and dash');
+const BuildArgKeySchema = z.string().min(1).max(64).regex(/^[A-Za-z_][A-Za-z0-9_]*$/, 'build argument keys must be shell-safe identifiers');
+const BuildArgValueSchema = z.string()
+  .max(2048)
+  .regex(/^[A-Za-z0-9._+@:/,=-]*$/, 'build argument values may only contain URL/version-safe characters');
+
 export const RunContainerVerificationArgsSchema = z.object({
   projectPath: z.string().min(1),
   language: LanguageEnum,
-  tools: z.array(z.string()).min(1),
+  tools: z.array(ContainerToolNameSchema).min(1),
   jobName: z.string().optional(),
   timeout: z.number().optional(),
   buildImages: z.boolean().optional().default(false),
@@ -195,11 +201,12 @@ export type RunContainerVerificationArgs = z.infer<typeof RunContainerVerificati
 
 export const BuildVerificationImageArgsSchema = z.object({
   language: LanguageEnum,
-  tools: z.array(z.string()).min(1),
+  tools: z.array(ContainerToolNameSchema).min(1),
   baseImage: z.string().optional(),
   tag: z.string().optional(),
   push: z.boolean().optional().default(false),
-  buildArgs: z.record(z.string()).optional().default({}),
+  pushApproval: z.enum(['none', 'approved-container-image-push']).optional().default('none'),
+  buildArgs: z.record(BuildArgKeySchema, BuildArgValueSchema).optional().default({}),
 });
 export type BuildVerificationImageArgs = z.infer<typeof BuildVerificationImageArgsSchema>;
 
@@ -219,6 +226,8 @@ export const CleanupArgsSchema = z.object({
   maxAge: z.number().optional().default(3600),
   keepCompleted: z.number().optional().default(10),
   force: z.boolean().optional().default(false),
+  dryRun: z.boolean().optional().default(true),
+  confirm: z.enum(['delete-ae-framework-resources', 'force-delete-ae-framework-resources']).optional(),
 });
 export type CleanupArgs = z.infer<typeof CleanupArgsSchema>;
 

--- a/src/services/container/container-engine.ts
+++ b/src/services/container/container-engine.ts
@@ -288,6 +288,7 @@ export abstract class ContainerEngine extends EventEmitter {
     volumes?: boolean; 
     networks?: boolean; 
     force?: boolean;
+    labelFilters?: string[];
   }): Promise<{
     containers: number;
     images: number; 

--- a/src/services/container/container-manager.ts
+++ b/src/services/container/container-manager.ts
@@ -9,6 +9,17 @@ import {
   ContainerEngine, 
   ContainerEngineFactory
 } from './container-engine.js';
+import {
+  AE_CONTAINER_LABEL_FILTER,
+  AE_CONTAINER_MANAGED_LABEL,
+  AE_CONTAINER_MANAGED_LABEL_VALUE,
+  assertCleanupConfirmation,
+  assertPushPolicy,
+  validateBuildArgs,
+  validateContainerToolsForLanguage,
+  validateImageReference,
+  type ContainerImagePolicy,
+} from './container-security-policy.js';
 import type {
   ContainerConfig, 
   ContainerRunOptions, 
@@ -32,6 +43,9 @@ export interface ContainerManagerConfig {
     readOnlyRootFilesystem?: boolean;
     noNewPrivileges?: boolean;
   };
+  workspaceRoot?: string;
+  imagePolicy?: ContainerImagePolicy;
+  allowShutdownCleanup?: boolean;
 }
 
 export interface VerificationEnvironment {
@@ -185,6 +199,7 @@ export class ContainerManager extends EventEmitter {
         resources: env.resources,
         security: this.config.securityDefaults ? { ...this.config.securityDefaults, readOnlyRootFilesystem: false } : { readOnlyRootFilesystem: false },
         labels: {
+          [AE_CONTAINER_MANAGED_LABEL]: AE_CONTAINER_MANAGED_LABEL_VALUE,
           'ae-framework.type': 'verification',
           'ae-framework.language': env.language,
           'ae-framework.tools': env.tools.join(','),
@@ -217,13 +232,15 @@ export class ContainerManager extends EventEmitter {
    * Run verification job in container
    */
   async runVerificationJob(job: Omit<VerificationJob, 'id' | 'status' | 'startTime'>): Promise<VerificationJob> {
+    const validatedTools = validateContainerToolsForLanguage(job.language, job.tools);
     const jobId = `verify-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     
     const verificationJob: VerificationJob = {
       id: jobId,
       status: 'pending',
       startTime: new Date(),
-      ...job
+      ...job,
+      tools: validatedTools
     };
 
     this.activeJobs.set(jobId, verificationJob);
@@ -267,6 +284,7 @@ export class ContainerManager extends EventEmitter {
         },
         security: this.config.securityDefaults ? { ...this.config.securityDefaults } : {},
         labels: {
+          [AE_CONTAINER_MANAGED_LABEL]: AE_CONTAINER_MANAGED_LABEL_VALUE,
           'ae-framework.job-id': jobId,
           'ae-framework.type': 'verification-job',
           'ae-framework.language': job.language,
@@ -402,48 +420,50 @@ export class ContainerManager extends EventEmitter {
       tag?: string;
       buildArgs?: Record<string, string>;
       push?: boolean;
+      pushApproval?: 'none' | 'approved-container-image-push';
     }
   ): Promise<string> {
+    const sanitizedTools = validateContainerToolsForLanguage(language, tools);
     const tag = options?.tag || `ae-framework/verify-${language}:latest`;
-    
+    const imageRef = validateImageReference(tag);
+    assertPushPolicy({
+      imageRef,
+      ...(options?.push !== undefined ? { push: options.push } : {}),
+      ...(options?.pushApproval !== undefined ? { pushApproval: options.pushApproval } : {}),
+      ...(this.config.imagePolicy !== undefined ? { policy: this.config.imagePolicy } : {}),
+    });
+
     try {
       const buildContext: ImageBuildContext = {
         contextPath: path.join(process.cwd(), 'containers'),
         dockerfilePath: `Containerfile.${language}`,
         target: 'verification',
         buildArgs: {
-          VERIFICATION_TOOLS: tools.join(','),
-          ...options?.buildArgs
+          VERIFICATION_TOOLS: sanitizedTools.join(','),
+          ...validateBuildArgs(options?.buildArgs ?? {})
         },
         labels: {
+          [AE_CONTAINER_MANAGED_LABEL]: AE_CONTAINER_MANAGED_LABEL_VALUE,
           'ae-framework.type': 'verification-image',
           'ae-framework.language': language,
-          'ae-framework.tools': tools.join(','),
+          'ae-framework.tools': sanitizedTools.join(','),
           'ae-framework.version': '1.0.0'
         },
         cache: true,
         pullBaseImage: true
       };
 
-      const imageId = await this.engine.buildImage(buildContext, tag);
+      const imageId = await this.engine.buildImage(buildContext, imageRef.reference);
 
       if (options?.push) {
-        // Validate tag format before splitting
-        if (typeof tag !== 'string' || !tag.includes(':')) {
-          throw new Error(`Invalid image tag format: "${tag}". Expected format "name:tag".`);
-        }
-        const [imageName, imageTag] = tag.split(':');
-        if (!imageName) {
-          throw new Error(`Image name is empty in tag: "${tag}".`);
-        }
-        await this.engine.pushImage(imageName, imageTag || 'latest');
+        await this.engine.pushImage(imageRef.name, imageRef.tag);
       }
 
       this.emit('imageBuilt', {
-        tag,
+        tag: imageRef.reference,
         imageId,
         language,
-        tools
+        tools: sanitizedTools
       });
 
       return imageId;
@@ -542,10 +562,14 @@ export class ContainerManager extends EventEmitter {
     maxAge?: number; // seconds
     keepCompleted?: number;
     force?: boolean;
+    dryRun?: boolean;
+    confirm?: 'delete-ae-framework-resources' | 'force-delete-ae-framework-resources';
   }): Promise<{
     jobsRemoved: number;
     containersRemoved: number;
     spaceSaved: number;
+    dryRun: boolean;
+    labelFilter: string;
   }> {
     const maxAge = options?.maxAge || 3600; // 1 hour default
     const keepCompleted = options?.keepCompleted || 10;
@@ -556,46 +580,48 @@ export class ContainerManager extends EventEmitter {
     let spaceSaved = 0;
 
     try {
+      const confirmation = assertCleanupConfirmation(options);
       // Cleanup old jobs
       const completedJobs = Array.from(this.activeJobs.values())
         .filter(job => job.status === 'completed' && job.endTime && job.endTime.getTime() < cutoffTime)
         .sort((a, b) => (b.endTime?.getTime() || 0) - (a.endTime?.getTime() || 0))
         .slice(keepCompleted); // Keep most recent
 
-      for (const job of completedJobs) {
-        this.activeJobs.delete(job.id);
-        jobsRemoved++;
-      }
-
       // Cleanup failed jobs older than cutoff
       const failedJobs = Array.from(this.activeJobs.values())
         .filter(job => job.status === 'failed' && job.endTime && job.endTime.getTime() < cutoffTime);
 
-      for (const job of failedJobs) {
-        this.activeJobs.delete(job.id);
-        jobsRemoved++;
+      jobsRemoved = completedJobs.length + failedJobs.length;
+
+      if (!confirmation.dryRun) {
+        for (const job of [...completedJobs, ...failedJobs]) {
+          this.activeJobs.delete(job.id);
+        }
+
+        // Cleanup only ae-framework-managed containers and images. Volumes and networks stay disabled by default.
+        const cleanupOpts: Parameters<typeof this.engine.cleanup>[0] = {
+          containers: true,
+          images: true,
+          volumes: false, // Keep volumes for now
+          networks: false,
+          labelFilters: [AE_CONTAINER_LABEL_FILTER],
+          ...(options?.force !== undefined ? { force: options.force } : {})
+        };
+        const engineCleanup = await this.engine.cleanup(cleanupOpts);
+
+        containersRemoved = engineCleanup.containers;
+        spaceSaved = engineCleanup.spaceSaved;
       }
-
-      // Cleanup containers and images
-      const cleanupOpts: Parameters<typeof this.engine.cleanup>[0] = {
-        containers: true,
-        images: true,
-        volumes: false, // Keep volumes for now
-        networks: false,
-        ...(options?.force !== undefined ? { force: options.force } : {})
-      };
-      const engineCleanup = await this.engine.cleanup(cleanupOpts);
-
-      containersRemoved = engineCleanup.containers;
-      spaceSaved = engineCleanup.spaceSaved;
 
       this.emit('cleanupCompleted', {
         jobsRemoved,
         containersRemoved,
-        spaceSaved
+        spaceSaved,
+        dryRun: confirmation.dryRun,
+        labelFilter: AE_CONTAINER_LABEL_FILTER,
       });
 
-      return { jobsRemoved, containersRemoved, spaceSaved };
+      return { jobsRemoved, containersRemoved, spaceSaved, dryRun: confirmation.dryRun, labelFilter: AE_CONTAINER_LABEL_FILTER };
 
     } catch (error: any) {
       this.emit('error', {
@@ -626,9 +652,9 @@ export class ContainerManager extends EventEmitter {
         }
       }
 
-      // Cleanup if enabled
-      if (this.config.autoCleanup) {
-        await this.cleanup({ force: true });
+      // Cleanup on shutdown is intentionally disabled unless trusted policy opts in.
+      if (this.config.autoCleanup && this.config.allowShutdownCleanup) {
+        await this.cleanup({ force: true, dryRun: false, confirm: 'force-delete-ae-framework-resources' });
       }
 
       this.emit('shutdown');
@@ -667,7 +693,7 @@ export class ContainerManager extends EventEmitter {
     if (this.config.autoCleanup) {
       this.cleanupTimer = setInterval(async () => {
         try {
-          await this.cleanup();
+          await this.cleanup({ dryRun: false, confirm: 'delete-ae-framework-resources' });
         } catch (error) {
           console.warn('Cleanup failed:', error);
         }

--- a/src/services/container/container-security-policy.ts
+++ b/src/services/container/container-security-policy.ts
@@ -1,0 +1,264 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { ImageBuildContext } from './container-engine.js';
+
+export const AE_CONTAINER_MANAGED_LABEL = 'ae-framework.managed';
+export const AE_CONTAINER_MANAGED_LABEL_VALUE = 'true';
+export const AE_CONTAINER_LABEL_FILTER = `label=${AE_CONTAINER_MANAGED_LABEL}=${AE_CONTAINER_MANAGED_LABEL_VALUE}`;
+
+export const CONTAINER_PUSH_APPROVAL = 'approved-container-image-push' as const;
+export const CONTAINER_CLEANUP_CONFIRM = 'delete-ae-framework-resources' as const;
+export const CONTAINER_FORCE_CLEANUP_CONFIRM = 'force-delete-ae-framework-resources' as const;
+
+const MAX_BUILD_ARG_VALUE_LENGTH = 2048;
+const MAX_TOOL_NAME_LENGTH = 64;
+const MAX_IMAGE_REFERENCE_LENGTH = 255;
+
+const toolNamePattern = /^[A-Za-z0-9][A-Za-z0-9._+@-]{0,63}$/;
+const buildArgKeyPattern = /^[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+const buildArgValuePattern = /^[A-Za-z0-9._+@:/,=-]*$/;
+const registryComponentPattern = /^(?:localhost|[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*)(?::[0-9]{1,5})?$/;
+const repositoryComponentPattern = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
+const tagPattern = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$/;
+
+export interface ContainerImagePolicy {
+  /** Prefixes of fully-qualified image references that may be pushed after request approval. */
+  allowedPushPrefixes?: string[];
+}
+
+export interface ValidatedImageReference {
+  reference: string;
+  name: string;
+  tag: string;
+  registry?: string;
+}
+
+export interface PushPolicyRequest {
+  imageRef: ValidatedImageReference;
+  push?: boolean;
+  pushApproval?: string;
+  policy?: ContainerImagePolicy;
+}
+
+export interface CleanupConfirmationOptions {
+  dryRun?: boolean;
+  force?: boolean;
+  confirm?: string;
+}
+
+export interface WorkspaceResolutionOptions {
+  projectPath: string;
+  workspaceRoot?: string;
+}
+
+export interface WorkspaceResolutionResult {
+  workspaceRoot: string;
+  projectPath: string;
+}
+
+const allowedToolsByLanguage: Record<'rust' | 'elixir' | 'multi', Set<string>> = {
+  rust: new Set(['cargo', 'rustc', 'prusti', 'kani', 'miri']),
+  elixir: new Set(['elixir', 'mix', 'exunit']),
+  multi: new Set(['cargo', 'rustc', 'prusti', 'kani', 'miri', 'elixir', 'mix', 'exunit']),
+};
+
+export const validateContainerTools = (tools: string[]): string[] => {
+  if (!Array.isArray(tools) || tools.length === 0) {
+    throw new Error('At least one verification tool is required');
+  }
+
+  return tools.map((tool) => {
+    if (typeof tool !== 'string' || tool.length === 0 || tool.length > MAX_TOOL_NAME_LENGTH || !toolNamePattern.test(tool)) {
+      throw new Error(`Invalid verification tool name: ${JSON.stringify(tool)}`);
+    }
+    return tool;
+  });
+};
+
+export const validateContainerToolsForLanguage = (language: 'rust' | 'elixir' | 'multi', tools: string[]): string[] => {
+  const sanitized = validateContainerTools(tools);
+  const allowedTools = allowedToolsByLanguage[language];
+  const unsupported = sanitized.filter((tool) => !allowedTools.has(tool));
+  if (unsupported.length > 0) {
+    throw new Error(`Unsupported verification tools for ${language}: ${unsupported.join(', ')}`);
+  }
+  return sanitized;
+};
+
+export const validateBuildArgs = (buildArgs: Record<string, string> = {}): Record<string, string> => {
+  const sanitized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(buildArgs)) {
+    if (!buildArgKeyPattern.test(key)) {
+      throw new Error(`Invalid build argument key: ${JSON.stringify(key)}`);
+    }
+    if (typeof value !== 'string') {
+      throw new Error(`Build argument ${key} must be a string`);
+    }
+    if (value.length > MAX_BUILD_ARG_VALUE_LENGTH || !buildArgValuePattern.test(value)) {
+      throw new Error(`Invalid build argument value for ${key}`);
+    }
+    sanitized[key] = value;
+  }
+  return sanitized;
+};
+
+export const validateImageReference = (reference: string): ValidatedImageReference => {
+  if (typeof reference !== 'string' || reference.length === 0 || reference.length > MAX_IMAGE_REFERENCE_LENGTH) {
+    throw new Error('Image reference must be a non-empty string within length limits');
+  }
+  if ([...reference].some((char) => {
+    const code = char.charCodeAt(0);
+    return code <= 32 || code === 127 || ';$`|&<>\\'.includes(char);
+  })) {
+    throw new Error(`Image reference contains unsupported characters: ${JSON.stringify(reference)}`);
+  }
+  if (reference.includes('@')) {
+    throw new Error('Build image reference must use a tag, not a digest');
+  }
+
+  const lastSlash = reference.lastIndexOf('/');
+  const lastColon = reference.lastIndexOf(':');
+  if (lastColon <= lastSlash) {
+    throw new Error(`Image reference must include an explicit tag: ${reference}`);
+  }
+
+  const name = reference.slice(0, lastColon);
+  const tag = reference.slice(lastColon + 1);
+  if (!name || !tagPattern.test(tag)) {
+    throw new Error(`Invalid image tag in reference: ${reference}`);
+  }
+
+  const components = name.split('/');
+  let registry: string | undefined;
+  const first = components[0];
+  const hasRegistry = components.length > 1 && first !== undefined && (
+    first.includes('.') || first.includes(':') || first === 'localhost'
+  );
+  const repositoryComponents = hasRegistry ? components.slice(1) : components;
+  if (hasRegistry) {
+    if (!first || !registryComponentPattern.test(first)) {
+      throw new Error(`Invalid image registry in reference: ${reference}`);
+    }
+    registry = first;
+  }
+
+  if (repositoryComponents.length === 0 || repositoryComponents.some((component) => !repositoryComponentPattern.test(component))) {
+    throw new Error(`Invalid image repository in reference: ${reference}`);
+  }
+
+  return {
+    reference,
+    name,
+    tag,
+    ...(registry !== undefined ? { registry } : {}),
+  };
+};
+
+export const assertPushPolicy = ({ imageRef, push, pushApproval, policy }: PushPolicyRequest): void => {
+  if (!push) return;
+  if (pushApproval !== CONTAINER_PUSH_APPROVAL) {
+    throw new Error(`Pushing verification images requires pushApproval=${CONTAINER_PUSH_APPROVAL}`);
+  }
+
+  const allowedPrefixes = policy?.allowedPushPrefixes ?? [];
+  if (allowedPrefixes.length === 0) {
+    throw new Error('Pushing verification images is disabled until allowedPushPrefixes is configured');
+  }
+  if (!allowedPrefixes.some((prefix) => imageRef.reference.startsWith(prefix))) {
+    throw new Error(`Image reference is not allowed by container image push policy: ${imageRef.reference}`);
+  }
+};
+
+export const assertCleanupConfirmation = (options: CleanupConfirmationOptions = {}): { dryRun: boolean } => {
+  const dryRun = options.dryRun !== false;
+  if (dryRun) {
+    return { dryRun: true };
+  }
+
+  const expected = options.force ? CONTAINER_FORCE_CLEANUP_CONFIRM : CONTAINER_CLEANUP_CONFIRM;
+  if (options.confirm !== expected) {
+    throw new Error(`Container cleanup requires confirm=${expected}`);
+  }
+  return { dryRun: false };
+};
+
+export const redactBuildArgsInMessage = (message: string): string => message
+  .replace(/(--build-arg(?:=|\s+))([^\s]+=[^\s]+)/g, '$1<redacted>')
+  .replace(/(VERIFICATION_TOOLS=)[^\s]+/g, '$1<redacted>');
+
+export const redactImageBuildContext = (buildContext: ImageBuildContext): ImageBuildContext => {
+  const redacted: ImageBuildContext = { ...buildContext };
+  if (redacted.buildArgs) {
+    redacted.buildArgs = Object.fromEntries(
+      Object.keys(redacted.buildArgs).map((key) => [key, '<redacted>']),
+    );
+  }
+  return redacted;
+};
+
+const isPathInside = (candidate: string, root: string): boolean => {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
+const isSensitiveHostPath = (candidate: string): boolean => {
+  const normalized = path.resolve(candidate);
+  if (normalized === path.parse(normalized).root) return true;
+  const sensitiveRoots = [
+    '/bin',
+    '/boot',
+    '/dev',
+    '/etc',
+    '/proc',
+    '/root',
+    '/run',
+    '/sys',
+    '/var/lib/containers',
+    '/var/lib/docker',
+    '/var/run',
+  ];
+  return sensitiveRoots.some((sensitive) => normalized === sensitive || normalized.startsWith(`${sensitive}${path.sep}`));
+};
+
+export const resolveApprovedWorkspacePath = async ({
+  projectPath,
+  workspaceRoot = process.env['AE_CONTAINER_WORKSPACE_ROOT'] || process.cwd(),
+}: WorkspaceResolutionOptions): Promise<WorkspaceResolutionResult> => {
+  if (typeof projectPath !== 'string' || projectPath.length === 0) {
+    throw new Error('projectPath is required');
+  }
+
+  let resolvedRoot: string;
+  try {
+    resolvedRoot = await fs.realpath(path.resolve(workspaceRoot));
+  } catch (error) {
+    throw new Error(`Approved workspace root does not exist: ${workspaceRoot}`);
+  }
+
+  if (isSensitiveHostPath(resolvedRoot)) {
+    throw new Error(`Approved workspace root is too broad or sensitive: ${resolvedRoot}`);
+  }
+
+  const candidate = path.isAbsolute(projectPath)
+    ? path.resolve(projectPath)
+    : path.resolve(resolvedRoot, projectPath);
+
+  let resolvedProject: string;
+  try {
+    resolvedProject = await fs.realpath(candidate);
+  } catch (error) {
+    throw new Error(`Project path does not exist: ${projectPath}`);
+  }
+
+  if (!isPathInside(resolvedProject, resolvedRoot)) {
+    throw new Error(`Project path is outside approved workspace root: ${projectPath}`);
+  }
+  if (isSensitiveHostPath(resolvedProject)) {
+    throw new Error(`Project path points to a sensitive host directory: ${projectPath}`);
+  }
+
+  return {
+    workspaceRoot: resolvedRoot,
+    projectPath: resolvedProject,
+  };
+};

--- a/src/services/container/container-security-policy.ts
+++ b/src/services/container/container-security-policy.ts
@@ -20,6 +20,7 @@ const buildArgValuePattern = /^[A-Za-z0-9._+@:/,=-]*$/;
 const registryComponentPattern = /^(?:localhost|[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*)(?::[0-9]{1,5})?$/;
 const repositoryComponentPattern = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
 const tagPattern = /^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$/;
+const tagPrefixBoundaryPattern = /[._-]/;
 
 export interface ContainerImagePolicy {
   /** Prefixes of fully-qualified image references that may be pushed after request approval. */
@@ -102,32 +103,18 @@ export const validateBuildArgs = (buildArgs: Record<string, string> = {}): Recor
   return sanitized;
 };
 
-export const validateImageReference = (reference: string): ValidatedImageReference => {
-  if (typeof reference !== 'string' || reference.length === 0 || reference.length > MAX_IMAGE_REFERENCE_LENGTH) {
-    throw new Error('Image reference must be a non-empty string within length limits');
-  }
-  if ([...reference].some((char) => {
-    const code = char.charCodeAt(0);
-    return code <= 32 || code === 127 || ';$`|&<>\\'.includes(char);
-  })) {
-    throw new Error(`Image reference contains unsupported characters: ${JSON.stringify(reference)}`);
-  }
-  if (reference.includes('@')) {
-    throw new Error('Build image reference must use a tag, not a digest');
-  }
+const imageReferenceHasUnsupportedCharacters = (reference: string): boolean => [...reference].some((char) => {
+  const code = char.charCodeAt(0);
+  return code <= 32 || code === 127 || ';$`|&<>\\'.includes(char);
+});
 
+const getImageTagSeparatorIndex = (reference: string): number => {
   const lastSlash = reference.lastIndexOf('/');
   const lastColon = reference.lastIndexOf(':');
-  if (lastColon <= lastSlash) {
-    throw new Error(`Image reference must include an explicit tag: ${reference}`);
-  }
+  return lastColon > lastSlash ? lastColon : -1;
+};
 
-  const name = reference.slice(0, lastColon);
-  const tag = reference.slice(lastColon + 1);
-  if (!name || !tagPattern.test(tag)) {
-    throw new Error(`Invalid image tag in reference: ${reference}`);
-  }
-
+const validateImageRepositoryName = (name: string, reference: string): { registry?: string } => {
   const components = name.split('/');
   let registry: string | undefined;
   const first = components[0];
@@ -145,6 +132,89 @@ export const validateImageReference = (reference: string): ValidatedImageReferen
   if (repositoryComponents.length === 0 || repositoryComponents.some((component) => !repositoryComponentPattern.test(component))) {
     throw new Error(`Invalid image repository in reference: ${reference}`);
   }
+
+  return registry !== undefined ? { registry } : {};
+};
+
+const validateAllowedPushPrefix = (prefix: string): string => {
+  if (typeof prefix !== 'string' || prefix.length === 0 || prefix.length > MAX_IMAGE_REFERENCE_LENGTH) {
+    throw new Error('Allowed image push prefixes must be non-empty strings within length limits');
+  }
+  if (imageReferenceHasUnsupportedCharacters(prefix)) {
+    throw new Error(`Allowed image push prefix contains unsupported characters: ${JSON.stringify(prefix)}`);
+  }
+  if (prefix.includes('@')) {
+    throw new Error('Allowed image push prefix must use repository or tag prefixes, not digests');
+  }
+
+  const tagSeparator = getImageTagSeparatorIndex(prefix);
+  if (tagSeparator >= 0) {
+    const name = prefix.slice(0, tagSeparator);
+    const tagPrefix = prefix.slice(tagSeparator + 1);
+    if (!tagPrefix || !tagPattern.test(tagPrefix)) {
+      throw new Error(`Invalid image tag prefix in allowed push policy: ${prefix}`);
+    }
+    validateImageRepositoryName(name, prefix);
+    return prefix;
+  }
+
+  const namePrefix = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  if (!namePrefix) {
+    throw new Error(`Invalid image repository prefix in allowed push policy: ${prefix}`);
+  }
+  validateImageRepositoryName(namePrefix, prefix);
+  return prefix;
+};
+
+const isTagPrefixBoundary = (tagPrefix: string, nextChar: string): boolean => {
+  const lastPrefixChar = tagPrefix.charAt(tagPrefix.length - 1);
+  return tagPrefixBoundaryPattern.test(lastPrefixChar) || tagPrefixBoundaryPattern.test(nextChar);
+};
+
+const matchesAllowedPushPrefix = (reference: string, rawPrefix: string): boolean => {
+  const prefix = validateAllowedPushPrefix(rawPrefix);
+  if (!reference.startsWith(prefix)) {
+    return false;
+  }
+  if (reference.length === prefix.length) {
+    return true;
+  }
+
+  const nextChar = reference.charAt(prefix.length);
+  const prefixTagSeparator = getImageTagSeparatorIndex(prefix);
+  if (prefixTagSeparator >= 0) {
+    return isTagPrefixBoundary(prefix.slice(prefixTagSeparator + 1), nextChar);
+  }
+
+  if (prefix.endsWith('/')) {
+    return true;
+  }
+  return nextChar === '/' || nextChar === ':';
+};
+
+export const validateImageReference = (reference: string): ValidatedImageReference => {
+  if (typeof reference !== 'string' || reference.length === 0 || reference.length > MAX_IMAGE_REFERENCE_LENGTH) {
+    throw new Error('Image reference must be a non-empty string within length limits');
+  }
+  if (imageReferenceHasUnsupportedCharacters(reference)) {
+    throw new Error(`Image reference contains unsupported characters: ${JSON.stringify(reference)}`);
+  }
+  if (reference.includes('@')) {
+    throw new Error('Build image reference must use a tag, not a digest');
+  }
+
+  const lastColon = getImageTagSeparatorIndex(reference);
+  if (lastColon < 0) {
+    throw new Error(`Image reference must include an explicit tag: ${reference}`);
+  }
+
+  const name = reference.slice(0, lastColon);
+  const tag = reference.slice(lastColon + 1);
+  if (!name || !tagPattern.test(tag)) {
+    throw new Error(`Invalid image tag in reference: ${reference}`);
+  }
+
+  const { registry } = validateImageRepositoryName(name, reference);
 
   return {
     reference,
@@ -164,7 +234,7 @@ export const assertPushPolicy = ({ imageRef, push, pushApproval, policy }: PushP
   if (allowedPrefixes.length === 0) {
     throw new Error('Pushing verification images is disabled until allowedPushPrefixes is configured');
   }
-  if (!allowedPrefixes.some((prefix) => imageRef.reference.startsWith(prefix))) {
+  if (!allowedPrefixes.some((prefix) => matchesAllowedPushPrefix(imageRef.reference, prefix))) {
     throw new Error(`Image reference is not allowed by container image push policy: ${imageRef.reference}`);
   }
 };

--- a/src/services/container/container-security-policy.ts
+++ b/src/services/container/container-security-policy.ts
@@ -301,12 +301,12 @@ export const resolveApprovedWorkspacePath = async ({
   let resolvedRoot: string;
   try {
     resolvedRoot = await fs.realpath(path.resolve(workspaceRoot));
-  } catch (error) {
-    throw new Error(`Approved workspace root does not exist: ${workspaceRoot}`);
+  } catch {
+    throw new Error('Approved workspace root does not exist');
   }
 
   if (isSensitiveHostPath(resolvedRoot)) {
-    throw new Error(`Approved workspace root is too broad or sensitive: ${resolvedRoot}`);
+    throw new Error('Approved workspace root is too broad or sensitive');
   }
 
   const candidate = path.isAbsolute(projectPath)
@@ -316,15 +316,15 @@ export const resolveApprovedWorkspacePath = async ({
   let resolvedProject: string;
   try {
     resolvedProject = await fs.realpath(candidate);
-  } catch (error) {
-    throw new Error(`Project path does not exist: ${projectPath}`);
+  } catch {
+    throw new Error('Project path does not exist');
   }
 
   if (!isPathInside(resolvedProject, resolvedRoot)) {
-    throw new Error(`Project path is outside approved workspace root: ${projectPath}`);
+    throw new Error('Project path is outside approved workspace root');
   }
   if (isSensitiveHostPath(resolvedProject)) {
-    throw new Error(`Project path points to a sensitive host directory: ${projectPath}`);
+    throw new Error('Project path points to a sensitive host directory');
   }
 
   return {

--- a/src/services/container/docker-engine.ts
+++ b/src/services/container/docker-engine.ts
@@ -3,7 +3,7 @@
  * Phase 3 of Issue #37: Docker container engine implementation for comparison with Podman
  */
 
-import { exec, spawn } from 'child_process';
+import { exec, execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import { ContainerEngine } from './container-engine.js';
@@ -25,6 +25,7 @@ import {
   splitUsagePair,
   toExecErrorLike
 } from './container-engine-utils.js';
+import { redactBuildArgsInMessage, redactImageBuildContext } from './container-security-policy.js';
 import type {
   DockerContainerListEntry,
   DockerImageListEntry,
@@ -33,6 +34,7 @@ import type {
 } from './container-engine-output-types.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 const getErrorMessage = (error: unknown): string => toExecErrorLike(error).message;
 
 interface DockerInfoResponse {
@@ -261,7 +263,7 @@ export class DockerEngine extends ContainerEngine {
     if (config.args) args.push(...config.args);
 
     try {
-      const result = await execAsync(`${this.dockerPath} ${args.join(' ')}`, {
+      const result = await execFileAsync(this.dockerPath, args, {
         timeout: (options?.timeout || 300) * 1000,
         maxBuffer: 10 * 1024 * 1024 // 10MB buffer
       });
@@ -524,7 +526,7 @@ export class DockerEngine extends ContainerEngine {
     args.push(buildContext.contextPath);
 
     try {
-      const result = await execAsync(`${this.dockerPath} ${args.join(' ')}`, {
+      const result = await execFileAsync(this.dockerPath, args, {
         timeout: 600000, // 10 minutes timeout for builds
         maxBuffer: 50 * 1024 * 1024 // 50MB buffer
       });
@@ -536,18 +538,19 @@ export class DockerEngine extends ContainerEngine {
       this.emit('imageBuild', {
         imageTag,
         imageId,
-        buildContext
+        buildContext: redactImageBuildContext(buildContext)
       });
 
       return imageId;
     } catch (error: unknown) {
+      const message = redactBuildArgsInMessage(getErrorMessage(error));
       this.emit('error', {
         operation: 'buildImage',
-        error: getErrorMessage(error),
+        error: message,
         imageTag,
-        buildContext
+        buildContext: redactImageBuildContext(buildContext)
       });
-      throw new Error(`Failed to build image: ${getErrorMessage(error)}`);
+      throw new Error(`Failed to build image: ${message}`);
     }
   }
 
@@ -570,7 +573,7 @@ export class DockerEngine extends ContainerEngine {
   async pushImage(image: string, tag: string = 'latest'): Promise<void> {
     try {
       const fullImage = `${image}:${tag}`;
-      await execAsync(`${this.dockerPath} push ${fullImage}`);
+      await execFileAsync(this.dockerPath, ['push', fullImage]);
       
       this.emit('imagePushed', { image: fullImage });
     } catch (error: unknown) {
@@ -858,6 +861,7 @@ export class DockerEngine extends ContainerEngine {
     volumes?: boolean;
     networks?: boolean;
     force?: boolean;
+    labelFilters?: string[];
   }): Promise<{
     containers: number;
     images: number;
@@ -874,29 +878,39 @@ export class DockerEngine extends ContainerEngine {
     };
 
     try {
+      const pruneArgs = (resource: 'container' | 'image' | 'volume' | 'network') => {
+        const args = [resource, 'prune'];
+        if (options?.force) args.push('--force');
+        for (const filter of options?.labelFilters ?? []) {
+          args.push('--filter', filter);
+        }
+        args.push('--format', 'json');
+        return args;
+      };
+
       if (options?.containers !== false) {
-        const containerResult = await execAsync(`${this.dockerPath} container prune ${options?.force ? '--force' : ''} --format json`);
+        const containerResult = await execFileAsync(this.dockerPath, pruneArgs('container'));
         const containerData = JSON.parse(containerResult.stdout);
         results.containers = containerData.ContainersDeleted?.length || 0;
         results.spaceSaved += containerData.SpaceReclaimed || 0;
       }
 
       if (options?.images !== false) {
-        const imageResult = await execAsync(`${this.dockerPath} image prune ${options?.force ? '--force' : ''} --format json`);
+        const imageResult = await execFileAsync(this.dockerPath, pruneArgs('image'));
         const imageData = JSON.parse(imageResult.stdout);
         results.images = imageData.ImagesDeleted?.length || 0;
         results.spaceSaved += imageData.SpaceReclaimed || 0;
       }
 
       if (options?.volumes !== false) {
-        const volumeResult = await execAsync(`${this.dockerPath} volume prune ${options?.force ? '--force' : ''} --format json`);
+        const volumeResult = await execFileAsync(this.dockerPath, pruneArgs('volume'));
         const volumeData = JSON.parse(volumeResult.stdout);
         results.volumes = volumeData.VolumesDeleted?.length || 0;
         results.spaceSaved += volumeData.SpaceReclaimed || 0;
       }
 
       if (options?.networks !== false) {
-        const networkResult = await execAsync(`${this.dockerPath} network prune ${options?.force ? '--force' : ''} --format json`);
+        const networkResult = await execFileAsync(this.dockerPath, pruneArgs('network'));
         const networkData = JSON.parse(networkResult.stdout);
         results.networks = networkData.NetworksDeleted?.length || 0;
       }

--- a/src/services/container/podman-engine.ts
+++ b/src/services/container/podman-engine.ts
@@ -3,7 +3,7 @@
  * Phase 3 of Issue #37: Podman-specific container engine implementation
  */
 
-import { exec, spawn } from 'child_process';
+import { exec, execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import type * as fs from 'fs/promises';
@@ -25,6 +25,7 @@ import {
   splitUsagePair,
   toExecErrorLike
 } from './container-engine-utils.js';
+import { redactBuildArgsInMessage, redactImageBuildContext } from './container-security-policy.js';
 import type {
   PodmanContainerListEntry,
   PodmanImageListEntry,
@@ -33,6 +34,7 @@ import type {
 } from './container-engine-output-types.js';
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 const getErrorMessage = (error: unknown): string => toExecErrorLike(error).message;
 
 interface PodmanInfoResponse {
@@ -257,7 +259,7 @@ export class PodmanEngine extends ContainerEngine {
     if (config.args) args.push(...config.args);
 
     try {
-      const result = await execAsync(`${this.podmanPath} ${args.join(' ')}`, {
+      const result = await execFileAsync(this.podmanPath, args, {
         timeout: (options?.timeout || 300) * 1000,
         maxBuffer: 10 * 1024 * 1024 // 10MB buffer
       });
@@ -518,7 +520,7 @@ export class PodmanEngine extends ContainerEngine {
     args.push(buildContext.contextPath);
 
     try {
-      const result = await execAsync(`${this.podmanPath} ${args.join(' ')}`, {
+      const result = await execFileAsync(this.podmanPath, args, {
         timeout: 600000, // 10 minutes timeout for builds
         maxBuffer: 50 * 1024 * 1024 // 50MB buffer
       });
@@ -530,18 +532,19 @@ export class PodmanEngine extends ContainerEngine {
       this.emit('imageBuild', {
         imageTag,
         imageId,
-        buildContext
+        buildContext: redactImageBuildContext(buildContext)
       });
 
       return imageId;
     } catch (error: unknown) {
+      const message = redactBuildArgsInMessage(getErrorMessage(error));
       this.emit('error', {
         operation: 'buildImage',
-        error: getErrorMessage(error),
+        error: message,
         imageTag,
-        buildContext
+        buildContext: redactImageBuildContext(buildContext)
       });
-      throw new Error(`Failed to build image: ${getErrorMessage(error)}`);
+      throw new Error(`Failed to build image: ${message}`);
     }
   }
 
@@ -564,7 +567,7 @@ export class PodmanEngine extends ContainerEngine {
   async pushImage(image: string, tag: string = 'latest'): Promise<void> {
     try {
       const fullImage = `${image}:${tag}`;
-      await execAsync(`${this.podmanPath} push ${fullImage}`);
+      await execFileAsync(this.podmanPath, ['push', fullImage]);
       
       this.emit('imagePushed', { image: fullImage });
     } catch (error: unknown) {
@@ -847,6 +850,7 @@ export class PodmanEngine extends ContainerEngine {
     volumes?: boolean;
     networks?: boolean;
     force?: boolean;
+    labelFilters?: string[];
   }): Promise<{
     containers: number;
     images: number;
@@ -863,29 +867,39 @@ export class PodmanEngine extends ContainerEngine {
     };
 
     try {
+      const pruneArgs = (resource: 'container' | 'image' | 'volume' | 'network') => {
+        const args = [resource, 'prune'];
+        if (options?.force) args.push('--force');
+        for (const filter of options?.labelFilters ?? []) {
+          args.push('--filter', filter);
+        }
+        args.push('--format', 'json');
+        return args;
+      };
+
       if (options?.containers !== false) {
-        const containerResult = await execAsync(`${this.podmanPath} container prune ${options?.force ? '--force' : ''} --format json`);
+        const containerResult = await execFileAsync(this.podmanPath, pruneArgs('container'));
         const containerData = JSON.parse(containerResult.stdout);
         results.containers = containerData.ContainersDeleted?.length || 0;
         results.spaceSaved += containerData.SpaceReclaimed || 0;
       }
 
       if (options?.images !== false) {
-        const imageResult = await execAsync(`${this.podmanPath} image prune ${options?.force ? '--force' : ''} --format json`);
+        const imageResult = await execFileAsync(this.podmanPath, pruneArgs('image'));
         const imageData = JSON.parse(imageResult.stdout);
         results.images = imageData.ImagesDeleted?.length || 0;
         results.spaceSaved += imageData.SpaceReclaimed || 0;
       }
 
       if (options?.volumes !== false) {
-        const volumeResult = await execAsync(`${this.podmanPath} volume prune ${options?.force ? '--force' : ''} --format json`);
+        const volumeResult = await execFileAsync(this.podmanPath, pruneArgs('volume'));
         const volumeData = JSON.parse(volumeResult.stdout);
         results.volumes = volumeData.VolumesDeleted?.length || 0;
         results.spaceSaved += volumeData.SpaceReclaimed || 0;
       }
 
       if (options?.networks !== false) {
-        const networkResult = await execAsync(`${this.podmanPath} network prune ${options?.force ? '--force' : ''} --format json`);
+        const networkResult = await execFileAsync(this.podmanPath, pruneArgs('network'));
         const networkData = JSON.parse(networkResult.stdout);
         results.networks = networkData.NetworksDeleted?.length || 0;
       }

--- a/tests/unit/container/container-engine-security-boundary.test.ts
+++ b/tests/unit/container/container-engine-security-boundary.test.ts
@@ -1,0 +1,38 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const readSource = (name: string) => fs.readFileSync(path.resolve(process.cwd(), 'src/services/container', name), 'utf8');
+
+const methodBody = (source: string, signature: string) => {
+  const start = source.indexOf(signature);
+  if (start < 0) throw new Error(`method not found: ${signature}`);
+  const next = source.indexOf('\n  async ', start + signature.length);
+  return source.slice(start, next < 0 ? source.length : next);
+};
+
+describe('container engine security boundaries', () => {
+  for (const [file, executable] of [
+    ['docker-engine.ts', 'this.dockerPath'],
+    ['podman-engine.ts', 'this.podmanPath'],
+  ] as const) {
+    it(`${file} uses argv-safe execution for caller-influenced run/build/push/cleanup paths`, () => {
+      const source = readSource(file);
+      expect(source).toContain('execFileAsync');
+
+      for (const signature of ['async runContainer', 'async buildImage', 'async pushImage', 'async cleanup']) {
+        const body = methodBody(source, signature);
+        expect(body).toContain(`execFileAsync(${executable}`);
+        expect(body).not.toMatch(/execAsync\(`\$\{this\.(?:dockerPath|podmanPath)\} \$\{args\.join\(' '\)\}`/);
+        expect(body).not.toMatch(/execAsync\(`\$\{this\.(?:dockerPath|podmanPath)\} push/);
+        expect(body).not.toMatch(/(?:container|image|volume|network) prune \$\{/);
+      }
+    });
+
+    it(`${file} redacts build args from build-image events and errors`, () => {
+      const body = methodBody(readSource(file), 'async buildImage');
+      expect(body).toContain('redactImageBuildContext(buildContext)');
+      expect(body).not.toContain('buildContext\n');
+    });
+  }
+});

--- a/tests/unit/container/container-security-policy.test.ts
+++ b/tests/unit/container/container-security-policy.test.ts
@@ -109,6 +109,43 @@ describe('container security policy', () => {
       pushApproval: CONTAINER_PUSH_APPROVAL,
       policy: { allowedPushPrefixes: ['ghcr.io/example/ae-framework/'] },
     })).not.toThrow();
+
+    expect(() => assertPushPolicy({
+      imageRef,
+      push: true,
+      pushApproval: CONTAINER_PUSH_APPROVAL,
+      policy: { allowedPushPrefixes: ['ghcr.io/example/ae-framework'] },
+    })).not.toThrow();
+    expect(() => assertPushPolicy({
+      imageRef: validateImageReference('ghcr.io/example/ae-framework:v1'),
+      push: true,
+      pushApproval: CONTAINER_PUSH_APPROVAL,
+      policy: { allowedPushPrefixes: ['ghcr.io/example/ae-framework'] },
+    })).not.toThrow();
+    expect(() => assertPushPolicy({
+      imageRef: validateImageReference('ghcr.io/example/ae-framework-evil:v1'),
+      push: true,
+      pushApproval: CONTAINER_PUSH_APPROVAL,
+      policy: { allowedPushPrefixes: ['ghcr.io/example/ae-framework'] },
+    })).toThrow(/not allowed/);
+    expect(() => assertPushPolicy({
+      imageRef: validateImageReference('ghcr.io/example/ae-framework:release-2026'),
+      push: true,
+      pushApproval: CONTAINER_PUSH_APPROVAL,
+      policy: { allowedPushPrefixes: ['ghcr.io/example/ae-framework:release'] },
+    })).not.toThrow();
+    expect(() => assertPushPolicy({
+      imageRef: validateImageReference('ghcr.io/example/ae-framework:releasecandidate'),
+      push: true,
+      pushApproval: CONTAINER_PUSH_APPROVAL,
+      policy: { allowedPushPrefixes: ['ghcr.io/example/ae-framework:release'] },
+    })).toThrow(/not allowed/);
+    expect(() => assertPushPolicy({
+      imageRef,
+      push: true,
+      pushApproval: CONTAINER_PUSH_APPROVAL,
+      policy: { allowedPushPrefixes: ['ghcr.io/example/ae-framework;id'] },
+    })).toThrow(/unsupported characters/);
   });
 
   it('defaults cleanup to dry-run and requires destructive confirmation tokens', () => {

--- a/tests/unit/container/container-security-policy.test.ts
+++ b/tests/unit/container/container-security-policy.test.ts
@@ -1,0 +1,150 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  BuildVerificationImageArgsSchema,
+  CleanupArgsSchema,
+  RunContainerVerificationArgsSchema,
+} from '../../../src/mcp-server/schemas.js';
+import {
+  AE_CONTAINER_LABEL_FILTER,
+  CONTAINER_CLEANUP_CONFIRM,
+  CONTAINER_FORCE_CLEANUP_CONFIRM,
+  CONTAINER_PUSH_APPROVAL,
+  assertCleanupConfirmation,
+  assertPushPolicy,
+  redactBuildArgsInMessage,
+  redactImageBuildContext,
+  resolveApprovedWorkspacePath,
+  validateBuildArgs,
+  validateContainerTools,
+  validateContainerToolsForLanguage,
+  validateImageReference,
+} from '../../../src/services/container/container-security-policy.js';
+
+const sandboxRoot = path.resolve(process.cwd(), '.codex-local/tmp/container-security-policy-test');
+
+describe('container security policy', () => {
+  beforeEach(async () => {
+    await fs.rm(sandboxRoot, { recursive: true, force: true });
+    await fs.mkdir(sandboxRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(sandboxRoot, { recursive: true, force: true });
+  });
+
+  it('accepts safe image references and rejects shell-shaped references', () => {
+    expect(validateImageReference('ae-framework/verify-rust:latest')).toMatchObject({
+      reference: 'ae-framework/verify-rust:latest',
+      name: 'ae-framework/verify-rust',
+      tag: 'latest',
+    });
+    expect(validateImageReference('localhost:5000/ae-framework/verify-rust:v1')).toMatchObject({
+      registry: 'localhost:5000',
+      tag: 'v1',
+    });
+
+    expect(() => validateImageReference('ae-framework/verify-rust')).toThrow(/explicit tag/);
+    expect(() => validateImageReference('ae-framework/verify-rust:latest;id')).toThrow(/unsupported characters/);
+    expect(() => validateImageReference('AE/verify:latest')).toThrow(/Invalid image repository/);
+  });
+
+
+
+  it('applies the same validation at the Container MCP argument boundary', () => {
+    expect(RunContainerVerificationArgsSchema.parse({
+      projectPath: 'project',
+      language: 'rust',
+      tools: ['cargo'],
+    }).tools).toEqual(['cargo']);
+    expect(() => RunContainerVerificationArgsSchema.parse({
+      projectPath: 'project',
+      language: 'rust',
+      tools: ['cargo;id'],
+    })).toThrow(/tool names/);
+
+    expect(BuildVerificationImageArgsSchema.parse({
+      language: 'rust',
+      tools: ['cargo'],
+      buildArgs: { SAFE_KEY: 'value' },
+    })).toMatchObject({ push: false, pushApproval: 'none' });
+    expect(() => BuildVerificationImageArgsSchema.parse({
+      language: 'rust',
+      tools: ['cargo'],
+      buildArgs: { SAFE_KEY: 'line1\nline2' },
+    })).toThrow(/URL\/version-safe/);
+
+    expect(CleanupArgsSchema.parse({})).toMatchObject({ dryRun: true, force: false });
+  });
+
+  it('validates verification tools and build arguments before they reach container engines', () => {    expect(validateContainerTools(['cargo', 'miri', 'tool+extra@1'])).toEqual(['cargo', 'miri', 'tool+extra@1']);
+    expect(validateContainerToolsForLanguage('rust', ['cargo', 'miri'])).toEqual(['cargo', 'miri']);
+    expect(() => validateContainerTools(['cargo;id'])).toThrow(/Invalid verification tool/);
+    expect(() => validateContainerToolsForLanguage('elixir', ['cargo'])).toThrow(/Unsupported verification tools/);
+
+    expect(validateBuildArgs({ FEATURE_FLAG: 'enabled', cache_bust: 'https://example.test/v1,abc=123' })).toEqual({
+      FEATURE_FLAG: 'enabled',
+      cache_bust: 'https://example.test/v1,abc=123',
+    });
+    expect(() => validateBuildArgs({ 'BAD-KEY': 'value' })).toThrow(/Invalid build argument key/);
+    expect(() => validateBuildArgs({ SAFE_KEY: 'line1\nline2' })).toThrow(/Invalid build argument value/);
+    expect(() => validateBuildArgs({ SAFE_KEY: 'value with spaces' })).toThrow(/Invalid build argument value/);
+  });
+
+  it('requires both per-request approval and configured push prefixes before image push', () => {
+    const imageRef = validateImageReference('ghcr.io/example/ae-framework/verify-rust:v1');
+    expect(() => assertPushPolicy({ imageRef, push: true })).toThrow(/pushApproval/);
+    expect(() => assertPushPolicy({ imageRef, push: true, pushApproval: CONTAINER_PUSH_APPROVAL })).toThrow(/disabled/);
+    expect(() => assertPushPolicy({
+      imageRef,
+      push: true,
+      pushApproval: CONTAINER_PUSH_APPROVAL,
+      policy: { allowedPushPrefixes: ['ghcr.io/other/'] },
+    })).toThrow(/not allowed/);
+
+    expect(() => assertPushPolicy({
+      imageRef,
+      push: true,
+      pushApproval: CONTAINER_PUSH_APPROVAL,
+      policy: { allowedPushPrefixes: ['ghcr.io/example/ae-framework/'] },
+    })).not.toThrow();
+  });
+
+  it('defaults cleanup to dry-run and requires destructive confirmation tokens', () => {
+    expect(AE_CONTAINER_LABEL_FILTER).toBe('label=ae-framework.managed=true');
+    expect(assertCleanupConfirmation()).toEqual({ dryRun: true });
+    expect(assertCleanupConfirmation({ dryRun: true, force: true })).toEqual({ dryRun: true });
+    expect(() => assertCleanupConfirmation({ dryRun: false })).toThrow(CONTAINER_CLEANUP_CONFIRM);
+    expect(() => assertCleanupConfirmation({ dryRun: false, force: true, confirm: CONTAINER_CLEANUP_CONFIRM })).toThrow(CONTAINER_FORCE_CLEANUP_CONFIRM);
+    expect(assertCleanupConfirmation({ dryRun: false, confirm: CONTAINER_CLEANUP_CONFIRM })).toEqual({ dryRun: false });
+    expect(assertCleanupConfirmation({ dryRun: false, force: true, confirm: CONTAINER_FORCE_CLEANUP_CONFIRM })).toEqual({ dryRun: false });
+  });
+
+  it('resolves project paths under the approved workspace and rejects symlink escapes', async () => {
+    const workspace = path.join(sandboxRoot, 'workspace');
+    const project = path.join(workspace, 'project');
+    const outside = path.join(sandboxRoot, 'outside');
+    await fs.mkdir(project, { recursive: true });
+    await fs.mkdir(outside, { recursive: true });
+    await fs.symlink(outside, path.join(workspace, 'escape'));
+
+    await expect(resolveApprovedWorkspacePath({ workspaceRoot: workspace, projectPath: 'project' }))
+      .resolves.toMatchObject({ projectPath: await fs.realpath(project) });
+    await expect(resolveApprovedWorkspacePath({ workspaceRoot: workspace, projectPath: path.join(workspace, 'escape') }))
+      .rejects.toThrow(/outside approved workspace/);
+    await expect(resolveApprovedWorkspacePath({ workspaceRoot: workspace, projectPath: path.join(workspace, 'missing') }))
+      .rejects.toThrow(/does not exist/);
+  });
+
+  it('redacts build argument values before build contexts and error messages are emitted or logged', () => {
+    expect(redactImageBuildContext({
+      contextPath: 'containers',
+      buildArgs: { TOKEN: 'secret', VERIFICATION_TOOLS: 'cargo' },
+    })).toMatchObject({
+      buildArgs: { TOKEN: '<redacted>', VERIFICATION_TOOLS: '<redacted>' },
+    });
+    expect(redactBuildArgsInMessage('docker build --build-arg TOKEN=secret --build-arg VERIFICATION_TOOLS=cargo'))
+      .toBe('docker build --build-arg <redacted> --build-arg <redacted>');
+  });
+});

--- a/tests/unit/container/container-security-policy.test.ts
+++ b/tests/unit/container/container-security-policy.test.ts
@@ -22,16 +22,20 @@ import {
   validateImageReference,
 } from '../../../src/services/container/container-security-policy.js';
 
-const sandboxRoot = path.resolve(process.cwd(), '.codex-local/tmp/container-security-policy-test');
+const sandboxParent = path.resolve(process.cwd(), '.codex-local/tmp');
+let sandboxRoot = '';
 
 describe('container security policy', () => {
   beforeEach(async () => {
-    await fs.rm(sandboxRoot, { recursive: true, force: true });
-    await fs.mkdir(sandboxRoot, { recursive: true });
+    await fs.mkdir(sandboxParent, { recursive: true });
+    sandboxRoot = await fs.mkdtemp(path.join(sandboxParent, 'container-security-policy-test-'));
   });
 
   afterEach(async () => {
-    await fs.rm(sandboxRoot, { recursive: true, force: true });
+    if (sandboxRoot) {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+      sandboxRoot = '';
+    }
   });
 
   it('accepts safe image references and rejects shell-shaped references', () => {
@@ -164,14 +168,14 @@ describe('container security policy', () => {
     const outside = path.join(sandboxRoot, 'outside');
     await fs.mkdir(project, { recursive: true });
     await fs.mkdir(outside, { recursive: true });
-    await fs.symlink(outside, path.join(workspace, 'escape'));
+    await fs.symlink(outside, path.join(workspace, 'escape'), process.platform === 'win32' ? 'junction' : 'dir');
 
     await expect(resolveApprovedWorkspacePath({ workspaceRoot: workspace, projectPath: 'project' }))
       .resolves.toMatchObject({ projectPath: await fs.realpath(project) });
     await expect(resolveApprovedWorkspacePath({ workspaceRoot: workspace, projectPath: path.join(workspace, 'escape') }))
-      .rejects.toThrow(/outside approved workspace/);
+      .rejects.toThrow(/^Project path is outside approved workspace root$/);
     await expect(resolveApprovedWorkspacePath({ workspaceRoot: workspace, projectPath: path.join(workspace, 'missing') }))
-      .rejects.toThrow(/does not exist/);
+      .rejects.toThrow(/^Project path does not exist$/);
   });
 
   it('redacts build argument values before build contexts and error messages are emitted or logged', () => {


### PR DESCRIPTION
## Summary

Fixes #3344.
Fixes #3345.
Fixes #3346.

This PR hardens the container MCP trust boundary across image builds, resource cleanup, and verification workspace mounts.

## Changes

- Add a container security policy module for:
  - safe verification tool-name validation;
  - safe image-reference validation;
  - build-argument key/value validation;
  - explicit image-push approval and configured push-prefix policy;
  - cleanup confirmation tokens;
  - approved workspace realpath containment checks;
  - build-argument redaction before event/error logging.
- Restrict `run_container_verification` to an approved workspace root using canonical `realpath` containment checks before mounting `/workspace`.
- Validate container MCP build inputs before reaching Docker/Podman:
  - reject unsupported tool names and language/tool combinations;
  - reject unsafe image tags and build args;
  - require `pushApproval=approved-container-image-push` plus configured `imagePolicy.allowedPushPrefixes` before registry push.
- Switch caller-influenced Docker/Podman `run`, `build`, `push`, and cleanup-prune paths to argv-safe `execFile` calls.
- Scope cleanup to `ae-framework.managed=true` labels, default cleanup to dry-run, require confirmation tokens for destructive cleanup, and avoid forced shutdown cleanup unless `allowShutdownCleanup` is explicitly configured.
- Add unit/static regression tests for policy validation, workspace symlink escape rejection, redaction, argv-safe engine paths, and MCP schema defaults.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm -s run types:check`
- `pnpm -s exec vitest run tests/unit/container/container-security-policy.test.ts tests/unit/container/container-engine-security-boundary.test.ts --reporter dot`
- `CI=1 pnpm -s exec vitest run tests/container/container-agent.test.ts tests/unit/container/container-security-policy.test.ts tests/unit/container/container-engine-security-boundary.test.ts --reporter dot`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `pnpm -s exec eslint --quiet src/services/container/container-security-policy.ts src/services/container/container-manager.ts src/services/container/container-engine.ts src/services/container/docker-engine.ts src/services/container/podman-engine.ts src/mcp-server/schemas.ts src/mcp-server/container-server.ts`
- `git diff --check`

## Acceptance

- #3344: image build inputs are validated, push is policy-gated, caller-influenced build/push execution is argv-safe, and build args are redacted from emitted contexts/errors.
- #3345: cleanup is ae-framework label-scoped, dry-run by default, requires destructive confirmation, and shutdown forced cleanup requires explicit trusted configuration.
- #3346: verification mounts require approved-workspace realpath containment and reject symlink escapes/sensitive roots before mounting.

## Rollback

Revert this PR to restore the prior container MCP behavior. No schema migration or persistent data migration is required.