### PR TITLE
fix(release): attest official release assets

### DIFF
--- a/.github/workflows/release-quality-artifacts.yml
+++ b/.github/workflows/release-quality-artifacts.yml
@@ -9,6 +9,9 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 jobs:
   upload:
     runs-on: ubuntu-latest
@@ -20,22 +23,49 @@ jobs:
         shell: bash
         run: |
           mkdir -p dist-quality
-          [ -d artifacts ] && cp -r artifacts dist-quality/ || true
-          [ -f artifacts/summary/combined.json ] && mkdir -p dist-quality/artifacts/summary && cp artifacts/summary/combined.json dist-quality/artifacts/summary/ || true
+          if [ -d artifacts ]; then
+            cp -r artifacts dist-quality/
+          fi
+          if [ -f artifacts/summary/combined.json ]; then
+            mkdir -p dist-quality/artifacts/summary
+            cp artifacts/summary/combined.json dist-quality/artifacts/summary/
+          fi
           printf "%s\n" "Bundled files:"
           find dist-quality -type f -maxdepth 3 -print
-          [ -f formal/summary.json ] && mkdir -p dist-quality/formal && cp formal/summary.json dist-quality/formal/ || true
-          [ -f artifacts/summary/PR_SUMMARY.md ] && cp artifacts/summary/PR_SUMMARY.md dist-quality/ || true
-          [ -f coverage/coverage-summary.json ] && mkdir -p dist-quality/coverage && cp coverage/coverage-summary.json dist-quality/coverage/ || true
+          if [ -f formal/summary.json ]; then
+            mkdir -p dist-quality/formal
+            cp formal/summary.json dist-quality/formal/
+          fi
+          if [ -f artifacts/summary/PR_SUMMARY.md ]; then
+            cp artifacts/summary/PR_SUMMARY.md dist-quality/
+          fi
+          if [ -f coverage/coverage-summary.json ]; then
+            mkdir -p dist-quality/coverage
+            cp coverage/coverage-summary.json dist-quality/coverage/
+          fi
           tar -czf quality-artifacts.tgz -C dist-quality .
+      - name: Attest quality artifact bundle
+        id: attest_quality
+        uses: actions/attest@v4
+        with:
+          subject-path: quality-artifacts.tgz
+      - name: Stage quality attestation bundle
+        shell: bash
+        run: |
+          mkdir -p security/sigstore
+          cp "${{ steps.attest_quality.outputs.bundle-path }}" security/sigstore/quality-artifacts.intoto.jsonl
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         if: github.event_name != 'workflow_dispatch'
         with:
-          files: quality-artifacts.tgz
+          files: |
+            quality-artifacts.tgz
+            security/sigstore/quality-artifacts.intoto.jsonl
       - name: Upload artifacts (manual)
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: quality-artifacts
-          path: quality-artifacts.tgz
+          path: |
+            quality-artifacts.tgz
+            security/sigstore/quality-artifacts.intoto.jsonl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@v4
       - name: Detect container manifest
@@ -59,6 +62,15 @@ jobs:
           tar -xzf "${SYFT_TAR}" syft
           ./syft packages dir:. -o cyclonedx-json > sbom.json
           rm -f "${SYFT_TAR}" "${SYFT_CHECKSUMS}" syft
+      - name: Attest SBOM release asset
+        id: attest_sbom
+        uses: actions/attest@v4
+        with:
+          subject-path: sbom.json
+      - name: Stage SBOM attestation bundle
+        run: |
+          mkdir -p security/sigstore
+          cp "${{ steps.attest_sbom.outputs.bundle-path }}" security/sigstore/sbom.intoto.jsonl
       - name: Install Podman
         if: steps.container_manifest.outputs.skip != 'true'
         run: |
@@ -70,17 +82,12 @@ jobs:
         run: |
           podman build -f "${{ steps.container_manifest.outputs.dockerfile }}" -t ${{ github.repository }}:${{ github.ref_name }} .
       
-      - name: Sign with Sigstore
-        run: |
-          # Placeholder for Sigstore signing
-          printf "%s\n" "Signing artifacts with Sigstore..."
-      
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             sbom.json
-            security/sigstore/*
+            security/sigstore/sbom.intoto.jsonl
           generate_release_notes: true
       
       - name: Deploy Canary
@@ -94,4 +101,7 @@ jobs:
     uses: ./.github/workflows/release-quality-artifacts.yml
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     secrets: inherit

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking') }}
     steps:
       - uses: actions/checkout@v4
-      - uses: rhysd/actionlint@v1.7.1
+      - uses: rhysd/actionlint@v1.7.12
       - name: Check for unresolved merge markers in workflows
         run: |
           set -e

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -17,6 +17,7 @@ type WorkflowDocument = {
       workflows?: string[];
     };
   };
+  permissions?: Record<string, string>;
   jobs?: Record<string, any>;
 };
 
@@ -219,5 +220,91 @@ describe('workflow permission boundaries', () => {
     expect(workflow).toContain('Download verify-lite assurance artifacts');
     expect(workflow).toContain('name: verify-lite-report');
     expect(workflow).toContain('run-id: ${{ steps.assurance-policy.outputs.verify_lite_run_id }}');
+  });
+
+  it('release workflows attest official SBOM and quality release assets before upload', () => {
+    const release = parseWorkflow('release.yml');
+    const releaseRaw = readWorkflow('release.yml');
+    const releaseJob = release.jobs?.release;
+    const releaseSteps = Array.isArray(releaseJob?.steps) ? releaseJob.steps : [];
+    const releaseQualityJob = release.jobs?.['release-quality-artifacts'];
+
+    expect(releaseJob?.permissions).toMatchObject({
+      contents: 'write',
+      packages: 'write',
+      'id-token': 'write',
+      attestations: 'write',
+      'artifact-metadata': 'write',
+    });
+    expect(releaseQualityJob?.permissions).toMatchObject({
+      contents: 'write',
+      'id-token': 'write',
+      attestations: 'write',
+      'artifact-metadata': 'write',
+    });
+
+    const generateSbomIndex = releaseSteps.findIndex((step: any) => step?.name === 'Generate SBOM');
+    const attestSbomIndex = releaseSteps.findIndex((step: any) => step?.name === 'Attest SBOM release asset');
+    const stageSbomIndex = releaseSteps.findIndex((step: any) => step?.name === 'Stage SBOM attestation bundle');
+    const createReleaseIndex = releaseSteps.findIndex((step: any) => step?.name === 'Create Release');
+    const attestSbomStep = releaseSteps[attestSbomIndex];
+    const stageSbomStep = releaseSteps[stageSbomIndex];
+    const createReleaseStep = releaseSteps[createReleaseIndex];
+
+    expect(generateSbomIndex).toBeGreaterThanOrEqual(0);
+    expect(attestSbomIndex).toBeGreaterThan(generateSbomIndex);
+    expect(stageSbomIndex).toBeGreaterThan(attestSbomIndex);
+    expect(createReleaseIndex).toBeGreaterThan(stageSbomIndex);
+    expect(attestSbomStep?.uses).toBe('actions/attest@v4');
+    expect(attestSbomStep?.with?.['subject-path']).toBe('sbom.json');
+    expect(stageSbomStep?.run).toContain('steps.attest_sbom.outputs.bundle-path');
+    expect(stageSbomStep?.run).toContain('security/sigstore/sbom.intoto.jsonl');
+    expect(createReleaseStep?.with?.files).toContain('sbom.json');
+    expect(createReleaseStep?.with?.files).toContain('security/sigstore/sbom.intoto.jsonl');
+    expect(releaseRaw).not.toContain('Placeholder for Sigstore signing');
+    expect(releaseRaw).not.toContain('security/sigstore/*');
+
+    const workflowLint = parseWorkflow('workflow-lint.yml');
+    const actionlintSteps = Array.isArray(workflowLint.jobs?.actionlint?.steps)
+      ? workflowLint.jobs.actionlint.steps
+      : [];
+    expect(actionlintSteps.some((step: any) => step?.uses === 'rhysd/actionlint@v1.7.12')).toBe(true);
+
+    const quality = parseWorkflow('release-quality-artifacts.yml');
+    const qualityRaw = readWorkflow('release-quality-artifacts.yml');
+    const qualityJob = quality.jobs?.upload;
+    const qualitySteps = Array.isArray(qualityJob?.steps) ? qualityJob.steps : [];
+
+    expect(quality.permissions).toMatchObject({
+      contents: 'write',
+      'id-token': 'write',
+      attestations: 'write',
+      'artifact-metadata': 'write',
+    });
+
+    const prepareBundleIndex = qualitySteps.findIndex((step: any) => step?.name === 'Prepare bundle (include combined.json if present)');
+    const attestQualityIndex = qualitySteps.findIndex((step: any) => step?.name === 'Attest quality artifact bundle');
+    const stageQualityIndex = qualitySteps.findIndex((step: any) => step?.name === 'Stage quality attestation bundle');
+    const uploadReleaseIndex = qualitySteps.findIndex((step: any) => step?.name === 'Upload release assets');
+    const uploadManualIndex = qualitySteps.findIndex((step: any) => step?.name === 'Upload artifacts (manual)');
+    const attestQualityStep = qualitySteps[attestQualityIndex];
+    const stageQualityStep = qualitySteps[stageQualityIndex];
+    const uploadReleaseStep = qualitySteps[uploadReleaseIndex];
+    const uploadManualStep = qualitySteps[uploadManualIndex];
+
+    expect(prepareBundleIndex).toBeGreaterThanOrEqual(0);
+    expect(attestQualityIndex).toBeGreaterThan(prepareBundleIndex);
+    expect(stageQualityIndex).toBeGreaterThan(attestQualityIndex);
+    expect(uploadReleaseIndex).toBeGreaterThan(stageQualityIndex);
+    expect(uploadManualIndex).toBeGreaterThan(stageQualityIndex);
+    expect(attestQualityStep?.uses).toBe('actions/attest@v4');
+    expect(attestQualityStep?.with?.['subject-path']).toBe('quality-artifacts.tgz');
+    expect(stageQualityStep?.run).toContain('steps.attest_quality.outputs.bundle-path');
+    expect(stageQualityStep?.run).toContain('security/sigstore/quality-artifacts.intoto.jsonl');
+    expect(uploadReleaseStep?.with?.files).toContain('quality-artifacts.tgz');
+    expect(uploadReleaseStep?.with?.files).toContain('security/sigstore/quality-artifacts.intoto.jsonl');
+    expect(uploadManualStep?.with?.path).toContain('quality-artifacts.tgz');
+    expect(uploadManualStep?.with?.path).toContain('security/sigstore/quality-artifacts.intoto.jsonl');
+    expect(qualityRaw).toContain('actions/attest@v4');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3347.

This PR adds provenance attestations for the release assets published by the tag-triggered release workflow:

- grants the release jobs the least-privilege attestation permissions required for `actions/attest@v4` (`id-token: write`, `attestations: write`, and `artifact-metadata: write`);
- replaces the placeholder Sigstore step with a real SBOM release-asset attestation for `sbom.json`;
- stages and uploads the generated SBOM attestation bundle as `security/sigstore/sbom.intoto.jsonl`;
- attests the `quality-artifacts.tgz` bundle before release upload and includes `security/sigstore/quality-artifacts.intoto.jsonl` in both release and manual workflow artifacts;
- updates the workflow-lint action to a version that recognizes the current `artifact-metadata` permission scope;
- adds a workflow-boundary regression test that verifies permissions, attestation step ordering, workflow-lint compatibility, and upload coverage for both release workflows.

## Impact

Release consumers can verify that the official SBOM and quality bundle were produced by the expected GitHub Actions workflow identity for the release commit. The previous placeholder signing step no longer gives a false impression of provenance coverage.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot`
- `/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint-bin .github/workflows/release.yml .github/workflows/release-quality-artifacts.yml .github/workflows/workflow-lint.yml`
- `pnpm -s exec eslint --quiet tests/unit/ci/workflow-permission-boundary.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Acceptance

- [x] `release.yml` requests attestation/OIDC permissions before publishing release assets.
- [x] `release.yml` attests `sbom.json` before `softprops/action-gh-release` uploads it.
- [x] `release-quality-artifacts.yml` requests attestation/OIDC permissions and attests `quality-artifacts.tgz` before release upload.
- [x] Workflow lint recognizes the `artifact-metadata` permission scope used by the release workflows.
- [x] Regression coverage fails if official release assets are uploaded without matching attestation steps.

## Rollback

Revert this PR to restore the prior release upload behavior. The rollback removes release-asset attestations and should only be used if `actions/attest@v4` blocks releases unexpectedly.