### PR TITLE
fix(release): address attestation review follow-up

### DIFF
--- a/.github/workflows/release-quality-artifacts.yml
+++ b/.github/workflows/release-quality-artifacts.yml
@@ -31,7 +31,7 @@ jobs:
             cp artifacts/summary/combined.json dist-quality/artifacts/summary/
           fi
           printf "%s\n" "Bundled files:"
-          find dist-quality -type f -maxdepth 3 -print
+          find dist-quality -maxdepth 3 -type f -print
           if [ -f formal/summary.json ]; then
             mkdir -p dist-quality/formal
             cp formal/summary.json dist-quality/formal/

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -17,7 +17,7 @@ type WorkflowDocument = {
       workflows?: string[];
     };
   };
-  permissions?: Record<string, string>;
+  permissions?: Record<string, string> | 'read-all' | 'write-all';
   jobs?: Record<string, any>;
 };
 


### PR DESCRIPTION
## Summary

Follow-up to #3349 review comments.

This PR addresses the two Copilot review findings that arrived on #3349 after it was merged:

- broadens the workflow test document type so `permissions: read-all` / `write-all` scalar permissions are represented correctly;
- reorders the `find` options in `release-quality-artifacts.yml` so `-maxdepth` is specified before path tests.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot`
- `/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint-bin .github/workflows/release-quality-artifacts.yml .github/workflows/release.yml .github/workflows/workflow-lint.yml`
- `pnpm -s exec eslint --quiet tests/unit/ci/workflow-permission-boundary.test.ts`
- `pnpm -s run types:check`
- `git diff --check`

## Acceptance

- [x] PR #3349 review comment on workflow permissions typing is addressed.
- [x] PR #3349 review comment on `find` option ordering is addressed.

## Rollback

Revert this PR to restore the exact #3349 merged content. This would reintroduce the two review nits, so rollback should only be used if the test typing or workflow shell portability adjustment causes an unexpected issue.