### PR TITLE
fix(ci): guard PR automation write targets

### DIFF
--- a/.github/workflows/ci-auto-rerun-failed.yml
+++ b/.github/workflows/ci-auto-rerun-failed.yml
@@ -19,7 +19,7 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   rerun-failed:
@@ -35,19 +35,56 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const runId = context.payload.workflow_run.id;
-            const workflowName = context.payload.workflow_run.name;
+            const workflowRun = context.payload.workflow_run;
+            const runId = workflowRun.id;
+            const workflowName = workflowRun.name;
+            const pr = (context.payload.workflow_run.pull_requests || [])[0];
+            if (!pr || !pr.number) {
+              core.notice('No PR context available for rerun; skipping.');
+              return;
+            }
+
+            let currentPr = null;
+            try {
+              const { data } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pr.number
+              });
+              currentPr = data;
+            } catch (error) {
+              const message = error && error.message ? error.message : String(error);
+              core.warning(`Failed to fetch PR #${pr.number}; skipping rerun: ${message}`);
+              return;
+            }
+
+            const expectedRepo = `${owner}/${repo}`;
+            const headRepo = currentPr.head?.repo?.full_name || '';
+            const headSha = currentPr.head?.sha || '';
+            const workflowHeadSha = workflowRun.head_sha || '';
+            const workflowHeadRepo = workflowRun.head_repository?.full_name || '';
+            if (currentPr.state !== 'open') {
+              core.notice(`PR #${pr.number} state=${currentPr.state}; skipping rerun.`);
+              return;
+            }
+            if (currentPr.head?.repo?.fork || headRepo !== expectedRepo) {
+              core.notice(`PR #${pr.number} head repository is not ${expectedRepo}; skipping rerun.`);
+              return;
+            }
+            if (!workflowHeadSha || headSha !== workflowHeadSha) {
+              core.notice(`Workflow run head SHA does not match current PR #${pr.number} head; skipping rerun.`);
+              return;
+            }
+            if (workflowHeadRepo && workflowHeadRepo !== expectedRepo) {
+              core.notice(`Workflow run head repository is not ${expectedRepo}; skipping rerun.`);
+              return;
+            }
+
             try {
               await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: runId });
             } catch (error) {
               const message = error && error.message ? error.message : String(error);
               core.setFailed(`Failed to rerun failed jobs for workflow run ${runId}: ${message}`);
-              return;
-            }
-
-            const pr = (context.payload.workflow_run.pull_requests || [])[0];
-            if (!pr || !pr.number) {
-              core.notice('No PR context available for rerun comment.');
               return;
             }
 

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -20,6 +20,9 @@ on:
       pr_number:
         description: "PR number (required for eligibility or update-branch)"
         required: false
+      expected_head_sha:
+        description: "Expected current PR head SHA for update-branch dispatches"
+        required: false
       enable_auto_merge:
         description: "Enable auto-merge if eligible (eligibility mode only)"
         required: false
@@ -61,12 +64,14 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const inputNumber = context.payload.inputs?.pr_number ?? core.getInput('pr_number');
+            const expectedHeadSha = String(context.payload.inputs?.expected_head_sha ?? core.getInput('expected_head_sha') ?? '').trim();
             const parsedInput = inputNumber ? Number(inputNumber) : null;
             const prNumber = context.payload.pull_request?.number ?? parsedInput;
             if (!Number.isFinite(prNumber)) {
               core.notice('No PR number provided; skipping.');
               return;
             }
+            const isDispatchUpdate = context.eventName === 'workflow_dispatch';
 
             const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
             const maxAttempts = 3;
@@ -121,6 +126,25 @@ jobs:
                 core.notice('PR is draft; skipping update.');
                 return;
               }
+              const expectedRepo = `${owner}/${repo}`;
+              const headRepo = pr.head?.repo?.full_name || '';
+              const headSha = pr.head?.sha || '';
+              if (pr.state !== 'open') {
+                core.notice(`PR #${prNumber} state=${pr.state}; skipping update.`);
+                return;
+              }
+              if (pr.head?.repo?.fork || headRepo !== expectedRepo) {
+                core.notice(`PR #${prNumber} head repository is not ${expectedRepo}; skipping update.`);
+                return;
+              }
+              if (isDispatchUpdate && !expectedHeadSha) {
+                core.setFailed('workflow_dispatch update-branch requires expected_head_sha.');
+                return;
+              }
+              if (expectedHeadSha && headSha !== expectedHeadSha) {
+                core.notice(`PR #${prNumber} head SHA changed; expected ${expectedHeadSha}, current ${headSha}. Skipping update.`);
+                return;
+              }
               mergeableState = pr.mergeable_state || 'unknown';
               if (mergeableState !== 'unknown') {
                 break;
@@ -145,7 +169,8 @@ jobs:
               await github.rest.pulls.updateBranch({
                 owner,
                 repo,
-                pull_number: prNumber
+                pull_number: prNumber,
+                expected_head_sha: expectedHeadSha || pr.head.sha
               });
             } catch (error) {
               const message = error?.message ?? String(error);

--- a/.github/workflows/pr-self-heal.yml
+++ b/.github/workflows/pr-self-heal.yml
@@ -37,7 +37,7 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   self-heal:
@@ -95,6 +95,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
           PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || '' }}
           WORKFLOW_RUN_PR_NUMBERS: ${{ github.event_name == 'workflow_run' && join(github.event.workflow_run.pull_requests.*.number, ',') || '' }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
+          WORKFLOW_RUN_HEAD_REPOSITORY: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_repository.full_name || '' }}
           AE_SELF_HEAL_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || vars.AE_SELF_HEAL_DRY_RUN || 'false' }}
           AE_SELF_HEAL_MAX_ROUNDS: ${{ github.event_name == 'workflow_dispatch' && inputs.max_rounds || vars.AE_SELF_HEAL_MAX_ROUNDS || '3' }}
           AE_SELF_HEAL_MAX_AGE_MINUTES: ${{ vars.AE_SELF_HEAL_MAX_AGE_MINUTES || '180' }}

--- a/scripts/ci/copilot-auto-fix.mjs
+++ b/scripts/ci/copilot-auto-fix.mjs
@@ -18,6 +18,7 @@ import {
   resolveReviewActors,
   toActorSet,
 } from './lib/automation-guards.mjs';
+import { collectResolvableReviewThreadIds } from './lib/review-thread-resolution.mjs';
 import { buildActionTaskFromComment, summarizeActionTasks } from './lib/review-comment-classifier.mjs';
 
 const repo = process.env.GITHUB_REPOSITORY;
@@ -535,23 +536,29 @@ const main = async () => {
     }
   }
 
-  // Resolve threads where all Copilot comments were handled (applied or already-applied).
+  // Resolve only automation-only threads where every automation comment was handled
+  // (applied or already-applied). Mixed human/automation threads stay unresolved.
   const [owner, name] = repo.split('/');
   let resolvedThreads = 0;
   try {
-    const query = `query($owner:String!, $repo:String!, $number:Int!) {\n  repository(owner:$owner, name:$repo) {\n    pullRequest(number:$number) {\n      reviewThreads(first: 100) {\n        nodes {\n          id\n          isResolved\n          comments(first: 100) {\n            nodes {\n              author { login }\n              databaseId\n            }\n          }\n        }\n      }\n    }\n  }\n}`;
-    const data = await graphqlQuery(query, { owner, repo: name, number: prNumber });
-    const threads = data?.data?.repository?.pullRequest?.reviewThreads?.nodes || [];
-    for (const thread of threads) {
-      const comments = thread?.comments?.nodes || [];
-      const copilotComments = comments.filter(
-        (c) => c?.author?.login && reviewActorSet.has(String(c.author.login).toLowerCase())
-      );
-      if (copilotComments.length === 0) continue;
-      const allHandled = copilotComments.every((c) => handledCommentIds.has(Number(c.databaseId)));
-      if (!allHandled) continue;
-      if (thread.isResolved) continue;
-      await resolveReviewThread(thread.id);
+    const fetchReviewThreadPage = async (cursor) => {
+      const afterClause = cursor ? ', after:$cursor' : '';
+      const query = `query($owner:String!, $repo:String!, $number:Int!${cursor ? ', $cursor:String!' : ''}) {\n  repository(owner:$owner, name:$repo) {\n    pullRequest(number:$number) {\n      reviewThreads(first: 100${afterClause}) {\n        pageInfo { hasNextPage endCursor }\n        nodes {\n          id\n          isResolved\n          comments(first: 100) {\n            pageInfo { hasNextPage }\n            nodes {\n              author { login }\n              databaseId\n            }\n          }\n        }\n      }\n    }\n  }\n}`;
+      const variables = cursor
+        ? { owner, repo: name, number: prNumber, cursor }
+        : { owner, repo: name, number: prNumber };
+      const data = await graphqlQuery(query, variables);
+      return data?.data?.repository?.pullRequest?.reviewThreads || { nodes: [], pageInfo: { hasNextPage: false } };
+    };
+
+    const resolvableThreadIds = await collectResolvableReviewThreadIds({
+      fetchPage: fetchReviewThreadPage,
+      handledCommentIds,
+      reviewActorSet,
+    });
+
+    for (const threadId of resolvableThreadIds) {
+      await resolveReviewThread(threadId);
       resolvedThreads += 1;
       await sleep(COPILOT_AUTO_FIX_THREAD_RESOLVE_SLEEP_MS_DEFAULT);
     }

--- a/scripts/ci/lib/review-thread-resolution.mjs
+++ b/scripts/ci/lib/review-thread-resolution.mjs
@@ -1,0 +1,64 @@
+const normalizeActorLogin = (value) => String(value || '').trim().toLowerCase();
+
+const normalizeCommentId = (value) => {
+  const id = Number(value);
+  return Number.isFinite(id) ? id : null;
+};
+
+export const shouldResolveAutomationOnlyThread = (thread, {
+  handledCommentIds,
+  reviewActorSet,
+} = {}) => {
+  if (!thread || thread.isResolved) return false;
+
+  const handled = handledCommentIds instanceof Set ? handledCommentIds : new Set();
+  const actors = reviewActorSet instanceof Set ? reviewActorSet : new Set();
+  if (thread.comments?.pageInfo?.hasNextPage === true) return false;
+
+  const comments = Array.isArray(thread.comments?.nodes) ? thread.comments.nodes : [];
+  if (comments.length === 0) return false;
+
+  const automationComments = [];
+  for (const comment of comments) {
+    const author = normalizeActorLogin(comment?.author?.login);
+    if (!author || !actors.has(author)) {
+      return false;
+    }
+    const id = normalizeCommentId(comment?.databaseId);
+    if (!id) return false;
+    automationComments.push(id);
+  }
+
+  return automationComments.length > 0 && automationComments.every((id) => handled.has(id));
+};
+
+export const collectResolvableReviewThreadIds = async ({
+  fetchPage,
+  handledCommentIds,
+  reviewActorSet,
+} = {}) => {
+  if (typeof fetchPage !== 'function') {
+    throw new Error('fetchPage is required');
+  }
+
+  const threadIds = [];
+  let cursor = null;
+
+  while (true) {
+    const page = await fetchPage(cursor);
+    const nodes = Array.isArray(page?.nodes) ? page.nodes : [];
+    for (const thread of nodes) {
+      if (thread?.id && shouldResolveAutomationOnlyThread(thread, { handledCommentIds, reviewActorSet })) {
+        threadIds.push(thread.id);
+      }
+    }
+
+    if (!page?.pageInfo?.hasNextPage) break;
+    cursor = page.pageInfo.endCursor || null;
+    if (!cursor) {
+      throw new Error('review thread pagination cursor is missing');
+    }
+  }
+
+  return threadIds;
+};

--- a/scripts/ci/pr-self-heal.mjs
+++ b/scripts/ci/pr-self-heal.mjs
@@ -10,6 +10,8 @@ const FAILURE_CONCLUSIONS = new Set(['FAILURE', 'CANCELLED', 'TIMED_OUT', 'ACTIO
 
 const repo = String(process.env.GITHUB_REPOSITORY || '').trim();
 const eventName = String(process.env.GITHUB_EVENT_NAME || '').trim();
+const workflowRunHeadSha = String(process.env.WORKFLOW_RUN_HEAD_SHA || '').trim();
+const workflowRunHeadRepository = String(process.env.WORKFLOW_RUN_HEAD_REPOSITORY || '').trim();
 
 const maxRounds = readIntEnv('AE_SELF_HEAL_MAX_ROUNDS', 3, 1);
 const maxAgeMinutes = readIntEnv('AE_SELF_HEAL_MAX_AGE_MINUTES', 180, 1);
@@ -44,6 +46,60 @@ function toBool(value) {
 function parseRunId(detailsUrl) {
   const match = String(detailsUrl || '').match(/\/actions\/runs\/([0-9]+)/);
   return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function normalizeRepositoryFullName(value) {
+  if (!value) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value.nameWithOwner === 'string') return value.nameWithOwner.trim();
+  if (typeof value.fullName === 'string') return value.fullName.trim();
+  if (typeof value.full_name === 'string') return value.full_name.trim();
+  const owner = value.owner?.login || value.owner?.name || value.owner;
+  const name = value.name;
+  if (owner && name) return `${owner}/${name}`;
+  return '';
+}
+
+function validatePrWriteTarget(view, context) {
+  const expectedRepo = normalizeRepositoryFullName(context.repo);
+  const headRepo = normalizeRepositoryFullName(view.headRepository);
+  const state = String(view.state || '').toUpperCase();
+  const headSha = String(view.headRefOid || '').trim();
+  const workflowHeadSha = String(context.workflowRunHeadSha || '').trim();
+  const workflowHeadRepo = normalizeRepositoryFullName(context.workflowRunHeadRepository);
+  const isCrossRepository = view.isCrossRepository === true;
+
+  if (!expectedRepo) {
+    return { ok: false, reason: 'base repository could not be verified' };
+  }
+  if (state !== 'OPEN') {
+    return { ok: false, reason: `PR is not open (state=${state || 'UNKNOWN'})` };
+  }
+  if (isCrossRepository) {
+    return { ok: false, reason: 'PR head is cross-repository' };
+  }
+  if (!headRepo) {
+    return { ok: false, reason: 'PR head repository could not be verified' };
+  }
+  if (headRepo !== expectedRepo) {
+    return { ok: false, reason: `PR head repository is not ${expectedRepo}` };
+  }
+  if (context.eventName === 'workflow_run') {
+    if (!workflowHeadSha) {
+      return { ok: false, reason: 'workflow_run head SHA is missing' };
+    }
+    if (!headSha) {
+      return { ok: false, reason: 'current PR head SHA could not be verified' };
+    }
+    if (headSha !== workflowHeadSha) {
+      return { ok: false, reason: 'workflow_run head SHA does not match current PR head' };
+    }
+    if (workflowHeadRepo && workflowHeadRepo !== expectedRepo) {
+      return { ok: false, reason: `workflow_run head repository is not ${expectedRepo}` };
+    }
+  }
+
+  return { ok: true, reason: '' };
 }
 
 function summarizeCheckRollup(rollup, { nowMs, maxAgeMs, rerunBlacklist }) {
@@ -266,11 +322,11 @@ function fetchPrView(prNumber) {
     '--repo',
     repo,
     '--json',
-    'number,title,url,isDraft,mergeable,mergeStateStatus,statusCheckRollup',
+    'number,title,url,state,isDraft,mergeable,mergeStateStatus,statusCheckRollup,headRefOid,headRepository,isCrossRepository',
   ]);
 }
 
-function dispatchUpdateBranch(prNumber) {
+function dispatchUpdateBranch(prNumber, expectedHeadSha) {
   execText([
     'workflow',
     'run',
@@ -281,6 +337,8 @@ function dispatchUpdateBranch(prNumber) {
     'mode=update-branch',
     '-f',
     `pr_number=${prNumber}`,
+    '-f',
+    `expected_head_sha=${expectedHeadSha}`,
   ]);
 }
 
@@ -334,6 +392,26 @@ async function processPr(prNumber) {
       maxAgeMinutes,
       rerunBlacklist,
     });
+    const guard = validatePrWriteTarget(view, {
+      repo,
+      eventName,
+      workflowRunHeadSha,
+      workflowRunHeadRepository,
+    });
+    if (!guard.ok) {
+      return {
+        number: state.number,
+        title: state.title,
+        status: 'skip',
+        reason: guard.reason,
+        rounds: round,
+        mergeable: state.mergeable,
+        mergeState: state.mergeState,
+        checks: state.checkSummary.counts,
+        failures: state.checkSummary.failureNames,
+        actions: [],
+      };
+    }
     finalState = state;
     const plan = planActions(state);
 
@@ -352,7 +430,7 @@ async function processPr(prNumber) {
       if (action.type === 'update-branch') {
         actionsTaken.push(`round${round}: update-branch dispatch`);
         if (!dryRun) {
-          dispatchUpdateBranch(prNumber);
+          dispatchUpdateBranch(prNumber, view.headRefOid);
         }
       }
       if (action.type === 'rerun-failed') {
@@ -580,4 +658,4 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   main();
 }
 
-export { parseRunId, summarizeCheckRollup, classifyPr, planActions };
+export { parseRunId, summarizeCheckRollup, classifyPr, planActions, validatePrWriteTarget };

--- a/tests/unit/ci/pr-self-heal.test.ts
+++ b/tests/unit/ci/pr-self-heal.test.ts
@@ -4,6 +4,7 @@ import {
   summarizeCheckRollup,
   classifyPr,
   planActions,
+  validatePrWriteTarget,
 } from '../../../scripts/ci/pr-self-heal.mjs';
 
 describe('pr-self-heal helpers', () => {
@@ -138,5 +139,45 @@ describe('pr-self-heal helpers', () => {
     const plan = planActions(state);
     expect(plan.status).toBe('blocked');
     expect(plan.reason).toContain('conflict');
+  });
+
+  it('validates same-repository current-head write targets for workflow_run automation', () => {
+    const view = {
+      number: 3,
+      state: 'OPEN',
+      isCrossRepository: false,
+      headRefOid: 'abc123',
+      headRepository: { nameWithOwner: 'itdojp/ae-framework' },
+    };
+
+    expect(validatePrWriteTarget(view, {
+      repo: 'itdojp/ae-framework',
+      eventName: 'workflow_run',
+      workflowRunHeadSha: 'abc123',
+      workflowRunHeadRepository: 'itdojp/ae-framework',
+    })).toEqual({ ok: true, reason: '' });
+    expect(validatePrWriteTarget({
+      ...view,
+      headRepository: { nameWithOwner: 'fork/ae-framework' },
+      isCrossRepository: true,
+    }, {
+      repo: 'itdojp/ae-framework',
+      eventName: 'workflow_run',
+      workflowRunHeadSha: 'abc123',
+      workflowRunHeadRepository: 'fork/ae-framework',
+    }).reason).toContain('cross-repository');
+    expect(validatePrWriteTarget(view, {
+      repo: 'itdojp/ae-framework',
+      eventName: 'workflow_run',
+      workflowRunHeadSha: 'def456',
+      workflowRunHeadRepository: 'itdojp/ae-framework',
+    }).reason).toContain('does not match current PR head');
+    expect(validatePrWriteTarget({
+      ...view,
+      state: 'CLOSED',
+    }, {
+      repo: 'itdojp/ae-framework',
+      eventName: 'schedule',
+    }).reason).toContain('not open');
   });
 });

--- a/tests/unit/ci/review-thread-resolution.test.ts
+++ b/tests/unit/ci/review-thread-resolution.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectResolvableReviewThreadIds,
+  shouldResolveAutomationOnlyThread,
+} from '../../../scripts/ci/lib/review-thread-resolution.mjs';
+
+const actors = new Set(['copilot-pull-request-reviewer', 'chatgpt-codex-connector']);
+const handled = new Set([101, 102, 201]);
+
+const thread = (overrides: Record<string, any> = {}) => ({
+  id: 'thread-1',
+  isResolved: false,
+  comments: {
+    nodes: [
+      { databaseId: 101, author: { login: 'copilot-pull-request-reviewer' } },
+      { databaseId: 102, author: { login: 'chatgpt-codex-connector' } },
+    ],
+  },
+  ...overrides,
+});
+
+describe('review thread resolution guard', () => {
+  it('resolves only unresolved automation-only threads with all comments handled', () => {
+    expect(shouldResolveAutomationOnlyThread(thread(), {
+      handledCommentIds: handled,
+      reviewActorSet: actors,
+    })).toBe(true);
+
+    expect(shouldResolveAutomationOnlyThread(thread({ isResolved: true }), {
+      handledCommentIds: handled,
+      reviewActorSet: actors,
+    })).toBe(false);
+
+    expect(shouldResolveAutomationOnlyThread(thread({
+      comments: {
+        nodes: [
+          { databaseId: 101, author: { login: 'copilot-pull-request-reviewer' } },
+          { databaseId: 999, author: { login: 'human-reviewer' } },
+        ],
+      },
+    }), {
+      handledCommentIds: handled,
+      reviewActorSet: actors,
+    })).toBe(false);
+
+    expect(shouldResolveAutomationOnlyThread(thread({
+      comments: {
+        nodes: [
+          { databaseId: 101, author: { login: 'copilot-pull-request-reviewer' } },
+          { databaseId: 999, author: { login: 'chatgpt-codex-connector' } },
+        ],
+      },
+    }), {
+      handledCommentIds: handled,
+      reviewActorSet: actors,
+    })).toBe(false);
+
+    expect(shouldResolveAutomationOnlyThread(thread({
+      comments: {
+        pageInfo: { hasNextPage: true },
+        nodes: [
+          { databaseId: 101, author: { login: 'copilot-pull-request-reviewer' } },
+        ],
+      },
+    }), {
+      handledCommentIds: handled,
+      reviewActorSet: actors,
+    })).toBe(false);
+  });
+
+  it('collects resolvable thread ids across paginated thread responses', async () => {
+    const pages = [
+      {
+        nodes: [
+          thread({ id: 'thread-1' }),
+          thread({
+            id: 'mixed-human-thread',
+            comments: {
+              nodes: [
+                { databaseId: 101, author: { login: 'copilot-pull-request-reviewer' } },
+                { databaseId: 301, author: { login: 'human-reviewer' } },
+              ],
+            },
+          }),
+        ],
+        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+      },
+      {
+        nodes: [
+          thread({
+            id: 'thread-2',
+            comments: {
+              nodes: [
+                { databaseId: 201, author: { login: 'copilot-pull-request-reviewer' } },
+              ],
+            },
+          }),
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    ];
+    const seenCursors: Array<string | null> = [];
+
+    const ids = await collectResolvableReviewThreadIds({
+      fetchPage: async (cursor) => {
+        seenCursors.push(cursor);
+        return pages.shift();
+      },
+      handledCommentIds: handled,
+      reviewActorSet: actors,
+    });
+
+    expect(seenCursors).toEqual([null, 'cursor-1']);
+    expect(ids).toEqual(['thread-1', 'thread-2']);
+  });
+});

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -22,6 +22,11 @@ type WorkflowDocument = {
 };
 
 const parseWorkflow = (name: string) => yaml.load(readWorkflow(name)) as WorkflowDocument;
+const workflowPermission = (workflow: WorkflowDocument, key: string) => (
+  workflow.permissions && typeof workflow.permissions === 'object'
+    ? workflow.permissions[key]
+    : undefined
+);
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -184,10 +189,38 @@ describe('workflow permission boundaries', () => {
   it('pr-maintenance update-branch enforces fork guard, explicit mode, and global kill-switch', () => {
     const workflow = readWorkflow('pr-ci-status-comment.yml');
     const updateBranch = extractJobBlock(workflow, 'update-branch');
+    const parsed = parseWorkflow('pr-ci-status-comment.yml');
+    const inputs = parsed.on?.workflow_dispatch?.inputs ?? {};
     expect(updateBranch).toContain("github.event.pull_request.head.repo.fork == false");
     expect(updateBranch).toContain("inputs.mode == 'update-branch'");
     expect(updateBranch).toContain('AE_AUTOMATION_GLOBAL_DISABLE');
     expect(updateBranch).toContain('github-token: ${{ github.token }}');
+    expect(inputs.expected_head_sha).toBeDefined();
+    expect(updateBranch).toContain('expectedHeadSha');
+    expect(updateBranch).toContain("workflow_dispatch update-branch requires expected_head_sha");
+    expect(updateBranch).toContain("pr.head?.repo?.fork || headRepo !== expectedRepo");
+    expect(updateBranch).toContain('headSha !== expectedHeadSha');
+    expect(updateBranch).toContain('expected_head_sha: expectedHeadSha || pr.head.sha');
+  });
+
+  it('write-capable workflow_run maintenance validates same-repo current-head PRs before mutation', () => {
+    const selfHealWorkflow = readWorkflow('pr-self-heal.yml');
+    const autoRerunWorkflow = readWorkflow('ci-auto-rerun-failed.yml');
+    const selfHealJob = extractJobBlock(selfHealWorkflow, 'self-heal');
+    const autoRerunJob = extractJobBlock(autoRerunWorkflow, 'rerun-failed');
+
+    expect(selfHealJob).toContain('WORKFLOW_RUN_HEAD_SHA');
+    expect(selfHealJob).toContain('github.event.workflow_run.head_sha');
+    expect(selfHealJob).toContain('WORKFLOW_RUN_HEAD_REPOSITORY');
+    expect(selfHealJob).toContain('github.event.workflow_run.head_repository.full_name');
+    expect(workflowPermission(parseWorkflow('pr-self-heal.yml'), 'pull-requests')).toBe('read');
+    expect(workflowPermission(parseWorkflow('ci-auto-rerun-failed.yml'), 'pull-requests')).toBe('read');
+
+    expect(autoRerunJob.indexOf('github.rest.pulls.get')).toBeGreaterThanOrEqual(0);
+    expect(autoRerunJob.indexOf('github.rest.pulls.get')).toBeLessThan(autoRerunJob.indexOf('github.rest.actions.reRunWorkflowFailedJobs'));
+    expect(autoRerunJob).toContain("currentPr.head?.repo?.fork || headRepo !== expectedRepo");
+    expect(autoRerunJob).toContain('headSha !== workflowHeadSha');
+    expect(autoRerunJob).toContain('workflowHeadRepo && workflowHeadRepo !== expectedRepo');
   });
 
   it('keeps pull-request DoD report-only while preserving push/main enforcement', () => {


### PR DESCRIPTION
## Summary

Fixes #3351.
Fixes #3352.

This PR hardens two write-capable PR automation paths:

- Copilot auto-fix now resolves only unresolved automation-only review threads where every automation comment is known to be handled. Mixed human/automation review threads and threads with unverified comment pagination stay unresolved.
- PR self-heal / auto-rerun / PR Maintenance update-branch paths now validate same-repository, open PR, current-head targets before write actions. workflow_run automation is bound to the workflow run head SHA and repository, and update-branch dispatches pass an expected head SHA.

## Acceptance

- [x] Mixed human/AI review threads are not auto-resolved by Copilot auto-fix.
- [x] All-AI handled review threads can still be resolved.
- [x] Review thread pagination is handled, and unverified comment pagination fails closed.
- [x] workflow_run self-heal validates open state, same repo, cross-repo status, and current head SHA before labels/comments/reruns/update dispatches.
- [x] PR Maintenance workflow_dispatch update-branch requires an expected head SHA and passes it to `updateBranch`.
- [x] auto-rerun failed workflow validates the current PR before rerunning failed jobs.
- [x] Pull-request token permissions are reduced to read where the workflow only needs PR metadata.

## Validation

Local validation performed:

```bash
node --check scripts/ci/copilot-auto-fix.mjs
node --check scripts/ci/pr-self-heal.mjs
node --check scripts/ci/lib/review-thread-resolution.mjs
git diff --check
/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint-bin \
  .github/workflows/pr-self-heal.yml \
  .github/workflows/pr-ci-status-comment.yml \
  .github/workflows/ci-auto-rerun-failed.yml
pnpm -s exec vitest run \
  tests/unit/ci/pr-self-heal.test.ts \
  tests/unit/ci/review-thread-resolution.test.ts \
  tests/unit/ci/workflow-permission-boundary.test.ts \
  --reporter dot
pnpm -s exec eslint --quiet \
  scripts/ci/copilot-auto-fix.mjs \
  scripts/ci/pr-self-heal.mjs \
  scripts/ci/lib/review-thread-resolution.mjs \
  tests/unit/ci/pr-self-heal.test.ts \
  tests/unit/ci/review-thread-resolution.test.ts \
  tests/unit/ci/workflow-permission-boundary.test.ts
pnpm -s run types:check
pnpm -s run check:schemas
pnpm -s run check:doc-consistency
```

## Rollback

Revert this PR to restore the previous automation behavior. If rollback is required, also disable the affected automation via `AE_AUTOMATION_GLOBAL_DISABLE` while evaluating whether mixed review-thread resolution or workflow_run write actions are safe to re-enable.
