### PR TITLE
fix(api): protect diagnostic endpoints

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -20,6 +20,9 @@ services:
       # Security configuration
       - HELMET_ENABLED=true
       - RATE_LIMIT_ENABLED=true
+      # Optional: set to enable authenticated /health/detailed and /api/runtime-guard/stats.
+      # Leave empty to keep detailed diagnostics disabled on the published app port.
+      - AE_ADMIN_TOKEN=${AE_ADMIN_TOKEN:-}
     volumes:
       # Production state directory (read-only filesystem except for app data)
       - ae_prod_data:/app/.ae

--- a/docs/observability/runtime-guard-dashboard.md
+++ b/docs/observability/runtime-guard-dashboard.md
@@ -31,7 +31,8 @@ hour,count
 - Verify Lite ワークフローで `export-runtime-guard-timeseries.mjs` を実行し、CSV をアーティファクトとして保存するタスクを追加予定。
 
 ## データソース
-- API: `/api/runtime-guard/stats` が最新違反状況を返却。Verify Lite pipeline ではこのエンドポイントを呼び出して `artifacts/runtime-guard/runtime-guard-stats.json` を生成する。
+- API: `/api/runtime-guard/stats` が最新違反状況を返却。Detailed diagnostics と同じ管理者向け endpoint のため、`AE_ADMIN_TOKEN`（または `AE_DIAGNOSTICS_ADMIN_TOKEN`）を設定し、`Authorization: Bearer <token>` または `x-ae-admin-token: <token>` で呼び出す。トークン未設定時は fail-closed で `403` を返す。
+- Verify Lite pipeline でこの API を使う場合は、公開ネットワークから直接叩かず、内部ネットワークまたは認証済み proxy 経由で `artifacts/runtime-guard/runtime-guard-stats.json` を生成する。
 - Step Summary: `scripts/telemetry/render-runtime-guard-summary.mjs` で Markdown を生成し、Gate から参照できるようにする。
 - 時系列変換: `scripts/telemetry/export-runtime-guard-timeseries.mjs` で 24h の hourly bucket を CSV 化し、Grafana や Observable notebook から参照可能にする。
 

--- a/podman/compose.prod.yaml
+++ b/podman/compose.prod.yaml
@@ -11,6 +11,9 @@ services:
       PORT: "3000"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel:4317
       OTEL_RESOURCE_ATTRIBUTES: service.name=ae-framework,service.version=1.0.0
+      # Optional: set to enable authenticated /health/detailed and /api/runtime-guard/stats.
+      # Leave empty to keep detailed diagnostics disabled on the published app port.
+      AE_ADMIN_TOKEN: ${AE_ADMIN_TOKEN:-}
     ports:
       - "3000:3000"
     user: "1001:1001"

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -5,12 +5,14 @@ import { runtimeGuard, CommonSchemas, ViolationSeverity } from "../telemetry/run
 import { enhancedTelemetry, TELEMETRY_ATTRIBUTES } from "../telemetry/enhanced-telemetry.js";
 import { trace } from '@opentelemetry/api';
 import { registerHealthEndpoint } from '../health/health-endpoint.js';
+import { requireAdminDiagnosticsAuth } from '../security/admin-diagnostics-auth.js';
 import { IdempotencyConflictError, InsufficientStockError } from '../domain/entities.js';
 import { InMemoryInventoryRepository, InventoryServiceImpl } from '../domain/services.js';
 import type { InventoryService } from '../domain/services.js';
 
 interface CreateServerOptions {
   inventoryService?: InventoryService;
+  adminDiagnosticsToken?: string;
 }
 
 const createFallbackInventoryService = (): InventoryService =>
@@ -32,6 +34,9 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
 
   const tracer = trace.getTracer('ae-framework-api');
   const inventoryService = options.inventoryService ?? createFallbackInventoryService();
+  const adminDiagnosticsAuthOptions = options.adminDiagnosticsToken
+    ? { token: options.adminDiagnosticsToken }
+    : {};
 
   // Register security headers middleware with development config for testing
   const securityConfig = process.env['NODE_ENV'] === 'test' 
@@ -308,6 +313,10 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
   // Runtime guard statistics endpoint
   app.get("/api/runtime-guard/stats", async (req, reply) => {
     try {
+      if (!requireAdminDiagnosticsAuth(req, reply, adminDiagnosticsAuthOptions)) {
+        return;
+      }
+
       const stats = runtimeGuard.getViolationStats();
       return reply.code(200).send({
         violations: stats,
@@ -326,7 +335,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
   });
 
   // Register health check endpoints for Docker/Kubernetes
-  await registerHealthEndpoint(app);
+  await registerHealthEndpoint(app, adminDiagnosticsAuthOptions);
 
   return app;
 }

--- a/src/health/health-endpoint.ts
+++ b/src/health/health-endpoint.ts
@@ -58,7 +58,8 @@ export async function registerHealthEndpoint(
   if (!fastify.hasRoute({ method: 'GET', url: '/health' })) {
     fastify.get('/health', async (_request: FastifyRequest, reply: FastifyReply) => {
       reply.status(200).send({
-        status: 'ok',
+        status: 'healthy',
+        service: 'ae-framework-api',
         timestamp: new Date().toISOString(),
       });
     });

--- a/src/health/health-endpoint.ts
+++ b/src/health/health-endpoint.ts
@@ -8,6 +8,10 @@ import { telemetryService } from '../telemetry/telemetry-service.js';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import {
+  type AdminDiagnosticsAuthOptions,
+  requireAdminDiagnosticsAuth,
+} from '../security/admin-diagnostics-auth.js';
 
 // Read version from package.json at startup
 const __filename = fileURLToPath(import.meta.url);
@@ -46,22 +50,27 @@ export interface HealthStatus {
   };
 }
 
-export async function registerHealthEndpoint(fastify: FastifyInstance): Promise<void> {
+export async function registerHealthEndpoint(
+  fastify: FastifyInstance,
+  options: AdminDiagnosticsAuthOptions = {},
+): Promise<void> {
   // Simple health check endpoint
   if (!fastify.hasRoute({ method: 'GET', url: '/health' })) {
-    fastify.get('/health', async (request: FastifyRequest, reply: FastifyReply) => {
-      const healthStatus = await getHealthStatus();
-      
-      const httpStatus = healthStatus.status === 'healthy' ? 200 :
-                         healthStatus.status === 'degraded' ? 200 : 503;
-      
-      reply.status(httpStatus).send(healthStatus);
+    fastify.get('/health', async (_request: FastifyRequest, reply: FastifyReply) => {
+      reply.status(200).send({
+        status: 'ok',
+        timestamp: new Date().toISOString(),
+      });
     });
   }
 
   // Detailed health check for monitoring
   if (!fastify.hasRoute({ method: 'GET', url: '/health/detailed' })) {
     fastify.get('/health/detailed', async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!requireAdminDiagnosticsAuth(request, reply, options)) {
+        return;
+      }
+
       const healthStatus = await getDetailedHealthStatus();
       
       const httpStatus = healthStatus.status === 'healthy' ? 200 :
@@ -87,12 +96,11 @@ export async function registerHealthEndpoint(fastify: FastifyInstance): Promise<
 
   // Liveness probe for Kubernetes/Docker orchestration
   if (!fastify.hasRoute({ method: 'GET', url: '/alive' })) {
-    fastify.get('/alive', async (request: FastifyRequest, reply: FastifyReply) => {
+    fastify.get('/alive', async (_request: FastifyRequest, reply: FastifyReply) => {
       // Simple liveness check - if we can respond, we're alive
       reply.status(200).send({ 
         status: 'alive', 
-        timestamp: new Date().toISOString(),
-        pid: process.pid
+        timestamp: new Date().toISOString()
       });
     });
   }
@@ -156,20 +164,18 @@ async function getHealthStatus(): Promise<HealthStatus> {
 async function getDetailedHealthStatus(): Promise<HealthStatus & { 
   detailed: {
     process: {
-      pid: number;
-      ppid: number;
-      title: string;
-      argv: string[];
+      uptimeSeconds: number;
+      nodeVersion: string;
+      platform: string;
     };
     memory: {
-      rss: number;
-      heapTotal: number;
-      heapUsed: number;
-      external: number;
-      arrayBuffers: number;
+      heapUsedBytes: number;
+      heapTotalBytes: number;
+      usagePercent: number;
     };
     cpu: {
-      usage: NodeJS.CpuUsage;
+      userMicroseconds: number;
+      systemMicroseconds: number;
     };
   }
 }> {
@@ -181,14 +187,18 @@ async function getDetailedHealthStatus(): Promise<HealthStatus & {
     ...basicHealth,
     detailed: {
       process: {
-        pid: process.pid,
-        ppid: process.ppid,
-        title: process.title,
-        argv: process.argv
+        uptimeSeconds: Math.floor(process.uptime()),
+        nodeVersion: process.version,
+        platform: process.platform
       },
-      memory: memoryUsage,
+      memory: {
+        heapUsedBytes: memoryUsage.heapUsed,
+        heapTotalBytes: memoryUsage.heapTotal,
+        usagePercent: basicHealth.checks.memory.percentage
+      },
       cpu: {
-        usage: cpuUsage
+        userMicroseconds: cpuUsage.user,
+        systemMicroseconds: cpuUsage.system
       }
     }
   };

--- a/src/security/admin-diagnostics-auth.ts
+++ b/src/security/admin-diagnostics-auth.ts
@@ -1,0 +1,65 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+export interface AdminDiagnosticsAuthOptions {
+  token?: string;
+}
+
+const normalizeToken = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const configuredAdminToken = (options: AdminDiagnosticsAuthOptions = {}): string =>
+  normalizeToken(options.token || process.env['AE_ADMIN_TOKEN'] || process.env['AE_DIAGNOSTICS_ADMIN_TOKEN']);
+
+const firstHeaderValue = (value: string | string[] | undefined): string => {
+  if (Array.isArray(value)) {
+    return normalizeToken(value[0]);
+  }
+  return normalizeToken(value);
+};
+
+const extractCredential = (request: FastifyRequest): string => {
+  const headerToken = firstHeaderValue(request.headers['x-ae-admin-token']);
+  if (headerToken) {
+    return headerToken;
+  }
+
+  const authorization = firstHeaderValue(request.headers.authorization);
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return normalizeToken(match?.[1]);
+};
+
+const constantTimeEquals = (actual: string, expected: string): boolean => {
+  if (!actual || !expected) return false;
+  const actualBuffer = Buffer.from(actual);
+  const expectedBuffer = Buffer.from(expected);
+  if (actualBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+};
+
+export const requireAdminDiagnosticsAuth = (
+  request: FastifyRequest,
+  reply: FastifyReply,
+  options: AdminDiagnosticsAuthOptions = {},
+): boolean => {
+  const expectedToken = configuredAdminToken(options);
+  if (!expectedToken) {
+    reply.code(403).send({
+      error: 'DIAGNOSTICS_DISABLED',
+      message: 'Detailed diagnostics require an admin diagnostics token.',
+    });
+    return false;
+  }
+
+  if (!constantTimeEquals(extractCredential(request), expectedToken)) {
+    reply
+      .header('www-authenticate', 'Bearer realm="ae-framework diagnostics"')
+      .code(401)
+      .send({
+        error: 'UNAUTHORIZED',
+        message: 'Admin credentials are required for diagnostics.',
+      });
+    return false;
+  }
+
+  return true;
+};

--- a/tests/api/diagnostics-auth.test.ts
+++ b/tests/api/diagnostics-auth.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import Fastify from 'fastify';
 import type { FastifyInstance } from 'fastify';
 import { formatGWT } from '../utils/gwt-format';
 import { createServer } from '../../src/api/server.js';
+import { registerHealthEndpoint } from '../../src/health/health-endpoint.js';
 
 const closeApp = async (app: FastifyInstance) => {
   await app.close();
@@ -65,6 +67,34 @@ describe('diagnostic endpoint authorization', () => {
         });
         expect(aliveBody).not.toHaveProperty('pid');
         expect(aliveBody).not.toHaveProperty('argv');
+      } finally {
+        await closeApp(app);
+      }
+    },
+  );
+
+  it(
+    formatGWT(
+      'standalone health endpoint bundle',
+      'registerHealthEndpoint provides /health directly',
+      'uses the same minimal public health contract as the API server',
+    ),
+    async () => {
+      const app = Fastify({ logger: false });
+      await registerHealthEndpoint(app);
+      await app.ready();
+
+      try {
+        const health = await app.inject({ method: 'GET', url: '/health' });
+        const detailed = await app.inject({ method: 'GET', url: '/health/detailed' });
+
+        expect(health.statusCode).toBe(200);
+        expect(JSON.parse(health.body)).toEqual({
+          status: 'healthy',
+          service: 'ae-framework-api',
+          timestamp: expect.any(String),
+        });
+        expect(detailed.statusCode).toBe(403);
       } finally {
         await closeApp(app);
       }

--- a/tests/api/diagnostics-auth.test.ts
+++ b/tests/api/diagnostics-auth.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { formatGWT } from '../utils/gwt-format';
+import { createServer } from '../../src/api/server.js';
+
+const closeApp = async (app: FastifyInstance) => {
+  await app.close();
+};
+
+describe('diagnostic endpoint authorization', () => {
+  it(
+    formatGWT(
+      'anonymous diagnostics request',
+      'GET /health/detailed and /api/runtime-guard/stats',
+      'fails closed when no admin diagnostics token is configured',
+    ),
+    async () => {
+      const app = await createServer();
+      await app.ready();
+
+      try {
+        const detailed = await app.inject({ method: 'GET', url: '/health/detailed' });
+        const stats = await app.inject({ method: 'GET', url: '/api/runtime-guard/stats' });
+
+        expect(detailed.statusCode).toBe(403);
+        expect(JSON.parse(detailed.body)).toEqual(expect.objectContaining({
+          error: 'DIAGNOSTICS_DISABLED',
+        }));
+        expect(stats.statusCode).toBe(403);
+        expect(JSON.parse(stats.body)).toEqual(expect.objectContaining({
+          error: 'DIAGNOSTICS_DISABLED',
+        }));
+      } finally {
+        await closeApp(app);
+      }
+    },
+  );
+
+  it(
+    formatGWT(
+      'public liveness request',
+      'GET /health and /alive',
+      'returns only minimal unauthenticated health data',
+    ),
+    async () => {
+      const app = await createServer();
+      await app.ready();
+
+      try {
+        const health = await app.inject({ method: 'GET', url: '/health' });
+        const alive = await app.inject({ method: 'GET', url: '/alive' });
+
+        expect(health.statusCode).toBe(200);
+        expect(JSON.parse(health.body)).toEqual(expect.objectContaining({
+          status: 'healthy',
+          service: 'ae-framework-api',
+          timestamp: expect.any(String),
+        }));
+
+        expect(alive.statusCode).toBe(200);
+        const aliveBody = JSON.parse(alive.body);
+        expect(aliveBody).toEqual({
+          status: 'alive',
+          timestamp: expect.any(String),
+        });
+        expect(aliveBody).not.toHaveProperty('pid');
+        expect(aliveBody).not.toHaveProperty('argv');
+      } finally {
+        await closeApp(app);
+      }
+    },
+  );
+
+  it(
+    formatGWT(
+      'configured admin diagnostics token',
+      'GET /health/detailed and /api/runtime-guard/stats',
+      'requires the token and avoids process argument disclosure',
+    ),
+    async () => {
+      const app = await createServer({ adminDiagnosticsToken: 'diagnostics-secret' });
+      await app.ready();
+
+      try {
+        const missing = await app.inject({ method: 'GET', url: '/health/detailed' });
+        const wrong = await app.inject({
+          method: 'GET',
+          url: '/api/runtime-guard/stats',
+          headers: { authorization: 'Bearer wrong-secret' },
+        });
+        const detailed = await app.inject({
+          method: 'GET',
+          url: '/health/detailed',
+          headers: { 'x-ae-admin-token': 'diagnostics-secret' },
+        });
+        const stats = await app.inject({
+          method: 'GET',
+          url: '/api/runtime-guard/stats',
+          headers: { authorization: 'Bearer diagnostics-secret' },
+        });
+
+        expect(missing.statusCode).toBe(401);
+        expect(missing.headers['www-authenticate']).toContain('Bearer');
+        expect(wrong.statusCode).toBe(401);
+
+        expect(detailed.statusCode).toBe(200);
+        const detailedBody = JSON.parse(detailed.body);
+        expect(detailedBody.detailed.process).toEqual(expect.objectContaining({
+          uptimeSeconds: expect.any(Number),
+          nodeVersion: expect.any(String),
+          platform: expect.any(String),
+        }));
+        expect(detailedBody.detailed.process).not.toHaveProperty('argv');
+        expect(detailedBody.detailed.process).not.toHaveProperty('pid');
+        expect(detailedBody.detailed.process).not.toHaveProperty('ppid');
+        expect(detailedBody.detailed.process).not.toHaveProperty('title');
+
+        expect(stats.statusCode).toBe(200);
+        expect(JSON.parse(stats.body)).toEqual(expect.objectContaining({
+          violations: expect.any(Object),
+          timestamp: expect.any(String),
+        }));
+      } finally {
+        await closeApp(app);
+      }
+    },
+  );
+});

--- a/tests/api/runtime-guard.reservations.test.ts
+++ b/tests/api/runtime-guard.reservations.test.ts
@@ -512,13 +512,14 @@ describe('Reservations API telemetry integration', () => {
       };
       runtimeGuardMocks.getViolationStats.mockReturnValue(mockStats);
 
-      const app: FastifyInstance = await createServer();
+      const app: FastifyInstance = await createServer({ adminDiagnosticsToken: 'test-admin-token' });
       await app.ready();
 
       try {
         const response = await app.inject({
           method: 'GET',
           url: '/api/runtime-guard/stats',
+          headers: { 'x-ae-admin-token': 'test-admin-token' },
         });
 
         expect(response.statusCode).toBe(200);
@@ -543,7 +544,7 @@ describe('Reservations API telemetry integration', () => {
         throw new Error('stats failed');
       });
 
-      const app: FastifyInstance = await createServer();
+      const app: FastifyInstance = await createServer({ adminDiagnosticsToken: 'test-admin-token' });
       const spanSpy = vi.fn();
       app.addHook('preHandler', (request, _reply, done) => {
         const span: any = request.span;
@@ -562,6 +563,7 @@ describe('Reservations API telemetry integration', () => {
         const response = await app.inject({
           method: 'GET',
           url: '/api/runtime-guard/stats',
+          headers: { 'x-ae-admin-token': 'test-admin-token' },
         });
 
         expect(response.statusCode).toBe(500);
@@ -583,7 +585,7 @@ describe('Reservations API telemetry integration', () => {
         throw new Error('stats failed');
       });
 
-      const app: FastifyInstance = await createServer();
+      const app: FastifyInstance = await createServer({ adminDiagnosticsToken: 'test-admin-token' });
       app.addHook('preHandler', (request, _reply, done) => {
         // @ts-expect-error span is cleared to simulate missing instrumentation
         delete request.span;
@@ -595,6 +597,7 @@ describe('Reservations API telemetry integration', () => {
         const response = await app.inject({
           method: 'GET',
           url: '/api/runtime-guard/stats',
+          headers: { 'x-ae-admin-token': 'test-admin-token' },
         });
 
         expect(response.statusCode).toBe(500);


### PR DESCRIPTION
## Summary

Fixes #3353.

This PR protects detailed health/runtime diagnostics from anonymous access while keeping minimal liveness endpoints available:

- adds an admin diagnostics auth helper using `AE_ADMIN_TOKEN`, `AE_DIAGNOSTICS_ADMIN_TOKEN`, or an explicit server option;
- requires admin diagnostics authentication for `/health/detailed` and `/api/runtime-guard/stats`;
- keeps `/health` and `/alive` unauthenticated but minimal, and removes `pid` from `/alive`;
- removes process `argv`, pid/ppid, and process title from the detailed health process payload;
- documents the runtime-guard stats token requirement and adds production compose placeholders that leave diagnostics disabled unless an operator supplies a token.

## Acceptance

- [x] `/health` remains available without credentials for liveness.
- [x] `/alive` remains available without credentials and no longer exposes process identifiers.
- [x] `/health/detailed` fails closed without a configured admin diagnostics token.
- [x] `/health/detailed` and `/api/runtime-guard/stats` return 401 for missing/invalid credentials when a token is configured.
- [x] Authenticated detailed health responses do not expose `process.argv`, `pid`, `ppid`, or `process.title`.
- [x] Existing runtime-guard stats tests cover the authenticated path.
- [x] Production compose docs make diagnostics opt-in via `AE_ADMIN_TOKEN`.

## Validation

Local validation performed:

```bash
pnpm install --frozen-lockfile
git diff --check
pnpm -s exec vitest run \
  tests/api/diagnostics-auth.test.ts \
  tests/api/security-headers.test.ts \
  tests/api/runtime-guard.reservations.test.ts \
  --reporter dot
pnpm -s exec eslint --quiet \
  src/security/admin-diagnostics-auth.ts \
  src/health/health-endpoint.ts \
  src/api/server.ts \
  tests/api/diagnostics-auth.test.ts \
  tests/api/runtime-guard.reservations.test.ts
pnpm -s run types:check
node -e "const fs=require('fs'); const yaml=require('js-yaml'); for (const f of ['docker/docker-compose.prod.yml','podman/compose.prod.yaml']) yaml.load(fs.readFileSync(f,'utf8'))"
pnpm -s run check:schemas
pnpm -s run check:doc-consistency
```

## Rollback

Revert this PR to restore the previous unauthenticated diagnostic behavior. If rollback is required in production, keep detailed diagnostic paths blocked at an upstream proxy until a replacement authorization control is available.
