### PR TITLE
fix(web-api): scope reservation idempotency

### DIFF
--- a/docs/changes/2025-12-05-webapi-reservation-api.md
+++ b/docs/changes/2025-12-05-webapi-reservation-api.md
@@ -1,6 +1,6 @@
 ---
 docRole: narrative
-lastVerified: '2026-03-12'
+lastVerified: '2026-06-02'
 ---
 # Web API 予約リポジトリ実装とプロパティテスト整備 (2025-12-05)
 
@@ -16,6 +16,11 @@ lastVerified: '2026-03-12'
   - `tests/integration/web-api/reservations.test.ts` で成功・冪等・在庫不足・バリデーションをカバー。
   - `tests/property/web-api/reservation.spec.ts` で fc.uuid を用いた requestId 生成、毎ケース新インスタンス生成で汚染防止。
   - `tests/property/web-api/fast-check.config.ts` で FC_WEBAPI_RUNS 等の環境変数で実行回数を調整可能に。
+
+## 2026-06-02 セキュリティ補強
+- `POST /reservations` は `buildApp(..., { resolvePrincipal })` で渡される認証済みプリンシパルを使用し、未設定時は fail-closed で 401 を返却する。
+- リクエストボディの `userId` は権威情報として使用せず、認証済みプリンシパルとの整合性チェックに限定する。
+- `requestId` の冪等性レコードはプリンシパルと正規化済み予約ペイロード（SKU/数量）のハッシュに束縛し、異なるプリンシパル・SKU・数量での再利用は既存レコードを返さず 409 `idempotency_conflict` とする。
 
 ## 影響/注意点
 - 既知警告: テスト実行時の MaxListenersExceededWarning は `tests/setup/ci-vitest.ts` で setMaxListeners(0) を設定済み。依然発生する場合は Socket などの追加対処を検討。

--- a/docs/changes/2025-12-05-webapi-reservation-api.md
+++ b/docs/changes/2025-12-05-webapi-reservation-api.md
@@ -18,7 +18,7 @@ lastVerified: '2026-06-02'
   - `tests/property/web-api/fast-check.config.ts` で FC_WEBAPI_RUNS 等の環境変数で実行回数を調整可能に。
 
 ## 2026-06-02 セキュリティ補強
-- `POST /reservations` は `buildApp(..., { resolvePrincipal })` で渡される認証済みプリンシパルを使用し、未設定時は fail-closed で 401 を返却する。
+- `POST /reservations` は `buildApp(..., { resolvePrincipal })` で渡される認証済みプリンシパルを使用し、未設定時は payload validation より前に fail-closed で 401 を返却する。
 - リクエストボディの `userId` は権威情報として使用せず、認証済みプリンシパルとの整合性チェックに限定する。
 - `requestId` の冪等性レコードはプリンシパルと正規化済み予約ペイロード（SKU/数量）のハッシュに束縛し、異なるプリンシパル・SKU・数量での再利用は既存レコードを返さず 409 `idempotency_conflict` とする。
 

--- a/src/web-api/app.ts
+++ b/src/web-api/app.ts
@@ -57,14 +57,14 @@ export function buildApp(repo: ReservationRepository = createRepo(), options: Bu
       | ConflictResponse
       | IdempotencyConflictResponse;
   }>('/reservations', async (request, reply) => {
-    const validationErrors = validateRequest(request.body);
-    if (validationErrors.length > 0) {
-      return reply.code(400).send({ error: 'invalid_request', details: validationErrors });
-    }
-
     const principalId = normalizePrincipalId(await resolvePrincipal(request));
     if (!principalId) {
       return reply.code(401).send({ error: 'unauthorized', details: ['authenticated principal is required'] });
+    }
+
+    const validationErrors = validateRequest(request.body);
+    if (validationErrors.length > 0) {
+      return reply.code(400).send({ error: 'invalid_request', details: validationErrors });
     }
     if (request.body.userId !== undefined && request.body.userId !== principalId) {
       return reply.code(403).send({

--- a/src/web-api/app.ts
+++ b/src/web-api/app.ts
@@ -1,4 +1,4 @@
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyRequest } from 'fastify';
 import { InMemoryReservationRepository, type ReservationRepository, type ReservationRecord } from './repository.js';
 
 export type ReservationRequest = {
@@ -8,8 +8,28 @@ export type ReservationRequest = {
   userId?: string;
 };
 
+type ReservationRouteRequest = FastifyRequest<{ Body: ReservationRequest }>;
+
+export type ReservationPrincipalResolver = (request: ReservationRouteRequest) => Promise<string | undefined> | string | undefined;
+
+export type BuildAppOptions = {
+  /**
+   * Resolves the authenticated principal for a reservation request.
+   * Integrations should provide this from an auth middleware or trusted upstream
+   * context. The request body userId is never used as authority.
+   */
+  resolvePrincipal?: ReservationPrincipalResolver;
+};
+
 type ValidationErrorResponse = { error: 'invalid_request'; details: string[] };
+type AuthenticationErrorResponse = { error: 'unauthorized'; details: string[] };
+type AuthorizationErrorResponse = { error: 'forbidden'; details: string[] };
 type ConflictResponse = { error: 'insufficient_stock'; record: ReservationRecord; remainingStock: number };
+type IdempotencyConflictResponse = {
+  error: 'idempotency_conflict';
+  details: string[];
+  reason: 'principal_mismatch' | 'payload_mismatch';
+};
 
 function createRepo(): ReservationRepository {
   return new InMemoryReservationRepository();
@@ -21,34 +41,61 @@ declare module 'fastify' {
   }
 }
 
-export function buildApp(repo: ReservationRepository = createRepo()): FastifyInstance {
+export function buildApp(repo: ReservationRepository = createRepo(), options: BuildAppOptions = {}): FastifyInstance {
   const app = Fastify({ logger: false });
+  const resolvePrincipal = options.resolvePrincipal ?? rejectUnauthenticatedPrincipal;
 
   app.get('/health', async () => ({ status: 'ok' }));
 
-  app.post<{ Body: ReservationRequest; Reply: ReservationRecord | ValidationErrorResponse | ConflictResponse }>(
-    '/reservations',
-    async (request, reply) => {
-      const validationErrors = validateRequest(request.body);
-      if (validationErrors.length > 0) {
-        return reply.code(400).send({ error: 'invalid_request', details: validationErrors });
-      }
+  app.post<{
+    Body: ReservationRequest;
+    Reply:
+      | ReservationRecord
+      | ValidationErrorResponse
+      | AuthenticationErrorResponse
+      | AuthorizationErrorResponse
+      | ConflictResponse
+      | IdempotencyConflictResponse;
+  }>('/reservations', async (request, reply) => {
+    const validationErrors = validateRequest(request.body);
+    if (validationErrors.length > 0) {
+      return reply.code(400).send({ error: 'invalid_request', details: validationErrors });
+    }
 
-      const result = repo.upsertReservation({
-        requestId: request.body.requestId,
-        sku: request.body.sku,
-        quantity: request.body.quantity,
+    const principalId = normalizePrincipalId(await resolvePrincipal(request));
+    if (!principalId) {
+      return reply.code(401).send({ error: 'unauthorized', details: ['authenticated principal is required'] });
+    }
+    if (request.body.userId !== undefined && request.body.userId !== principalId) {
+      return reply.code(403).send({
+        error: 'forbidden',
+        details: ['body userId must match the authenticated principal'],
       });
+    }
 
-      if (result.record.status === 'rejected') {
-        return reply
-          .code(409)
-          .send({ error: 'insufficient_stock', record: result.record, remainingStock: result.stock });
-      }
+    const result = repo.upsertReservation({
+      principalId,
+      requestId: request.body.requestId,
+      sku: request.body.sku,
+      quantity: request.body.quantity,
+    });
 
-      return reply.send(result.record);
-    },
-  );
+    if (result.kind === 'idempotency_conflict') {
+      return reply.code(409).send({
+        error: 'idempotency_conflict',
+        reason: result.conflict.reason,
+        details: ['idempotency key already exists for a different principal or payload'],
+      });
+    }
+
+    if (result.record.status === 'rejected') {
+      return reply
+        .code(409)
+        .send({ error: 'insufficient_stock', record: result.record, remainingStock: result.stock });
+    }
+
+    return reply.send(result.record);
+  });
 
   app.decorate('repo', repo);
   return app;
@@ -71,5 +118,31 @@ function validateRequest(body: ReservationRequest): string[] {
   } else if (!Number.isInteger(body.quantity) || body.quantity < 1) {
     errors.push('quantity must be an integer >= 1');
   }
+  if (body.userId !== undefined && typeof body.userId !== 'string') {
+    errors.push('userId must be a string when provided');
+  }
   return errors;
+}
+
+function rejectUnauthenticatedPrincipal(): undefined {
+  return undefined;
+}
+
+export function resolvePrincipalFromHeaders(request: ReservationRouteRequest): string | undefined {
+  return normalizeHeaderPrincipal(request.headers['x-principal-id']) ?? normalizeHeaderPrincipal(request.headers['x-user-id']);
+}
+
+function normalizeHeaderPrincipal(headerValue: string | string[] | undefined): string | undefined {
+  if (Array.isArray(headerValue)) {
+    if (headerValue.length !== 1) {
+      return undefined;
+    }
+    return normalizePrincipalId(headerValue[0]);
+  }
+  return normalizePrincipalId(headerValue);
+}
+
+function normalizePrincipalId(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized && normalized.length > 0 ? normalized : undefined;
 }

--- a/src/web-api/repository.ts
+++ b/src/web-api/repository.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 export type ReservationRecord = {
   reservationId: string;
@@ -8,14 +8,23 @@ export type ReservationRecord = {
   status: 'reserved' | 'rejected';
 };
 
+export type IdempotencyConflict = {
+  reason: 'principal_mismatch' | 'payload_mismatch';
+  requestId: string;
+};
+
 export interface ReservationRepository {
   reset(stock: Record<string, number>): void;
   getStock(sku: string): number;
   /**
    * Idempotently create or fetch a reservation for the given requestId.
-   * Implementations should ensure this operation is atomic to avoid races on stock/reservations.
+   *
+   * Idempotency keys are bound to the authenticated principal and the canonical
+   * reservation payload. Implementations must only return a duplicate record
+   * when the same principal repeats the identical request payload.
    */
   upsertReservation(input: {
+    principalId: string;
     requestId: string;
     sku: string;
     quantity: number;
@@ -25,11 +34,18 @@ export interface ReservationRepository {
 export type UpsertResult =
   | { kind: 'duplicate'; record: ReservationRecord; stock: number }
   | { kind: 'reserved'; record: ReservationRecord; stock: number }
-  | { kind: 'rejected'; record: ReservationRecord; stock: number };
+  | { kind: 'rejected'; record: ReservationRecord; stock: number }
+  | { kind: 'idempotency_conflict'; conflict: IdempotencyConflict };
+
+type ReservationEntry = {
+  principalId: string;
+  payloadHash: string;
+  record: ReservationRecord;
+};
 
 export class InMemoryReservationRepository implements ReservationRepository {
   private stock = new Map<string, number>();
-  private reservations = new Map<string, ReservationRecord>();
+  private reservations = new Map<string, ReservationEntry>();
 
   reset(stock: Record<string, number>): void {
     this.stock.clear();
@@ -43,12 +59,20 @@ export class InMemoryReservationRepository implements ReservationRepository {
     return this.stock.get(sku) ?? 0;
   }
 
-  upsertReservation(input: { requestId: string; sku: string; quantity: number }): UpsertResult {
-    const { requestId, sku, quantity } = input;
-    if (this.reservations.has(requestId)) {
-      const record = this.reservations.get(requestId)!;
-      return { kind: 'duplicate', record, stock: this.stock.get(sku) ?? 0 };
+  upsertReservation(input: { principalId: string; requestId: string; sku: string; quantity: number }): UpsertResult {
+    const { principalId, requestId, sku, quantity } = input;
+    const payloadHash = hashReservationPayload({ sku, quantity });
+    const existing = this.reservations.get(requestId);
+    if (existing) {
+      if (existing.principalId !== principalId) {
+        return { kind: 'idempotency_conflict', conflict: { reason: 'principal_mismatch', requestId } };
+      }
+      if (existing.payloadHash !== payloadHash) {
+        return { kind: 'idempotency_conflict', conflict: { reason: 'payload_mismatch', requestId } };
+      }
+      return { kind: 'duplicate', record: existing.record, stock: this.stock.get(existing.record.sku) ?? 0 };
     }
+
     const current = this.stock.get(sku) ?? 0;
     if (current < quantity) {
       const record: ReservationRecord = {
@@ -58,7 +82,7 @@ export class InMemoryReservationRepository implements ReservationRepository {
         quantity,
         status: 'rejected',
       };
-      this.reservations.set(requestId, record);
+      this.reservations.set(requestId, { principalId, payloadHash, record });
       return { kind: 'rejected', record, stock: current };
     }
     const nextStock = current - quantity;
@@ -70,7 +94,12 @@ export class InMemoryReservationRepository implements ReservationRepository {
       quantity,
       status: 'reserved',
     };
-    this.reservations.set(requestId, record);
+    this.reservations.set(requestId, { principalId, payloadHash, record });
     return { kind: 'reserved', record, stock: nextStock };
   }
+}
+
+function hashReservationPayload(payload: { sku: string; quantity: number }): string {
+  const canonicalPayload = JSON.stringify({ quantity: payload.quantity, sku: payload.sku });
+  return createHash('sha256').update(canonicalPayload).digest('hex');
 }

--- a/tests/integration/web-api/reservations.test.ts
+++ b/tests/integration/web-api/reservations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildApp, seedRepo } from '../../../src/web-api/app';
+import { buildApp, resolvePrincipalFromHeaders, seedRepo } from '../../../src/web-api/app';
 import { InMemoryReservationRepository } from '../../../src/web-api/repository';
 import {
   applyIntegrationRetry,
@@ -13,7 +13,7 @@ applyIntegrationRetry(it);
 
 async function buildTestApp() {
   const repo = new InMemoryReservationRepository();
-  const app = buildApp(repo);
+  const app = buildApp(repo, { resolvePrincipal: resolvePrincipalFromHeaders });
   await app.ready();
   registerIntegrationCleanup(async () => {
     try {
@@ -25,41 +25,184 @@ async function buildTestApp() {
   return { repo, app };
 }
 
+const principalHeaders = (userId: string) => ({ 'x-user-id': userId });
+
 describe('web api / reservations', () => {
-  it('creates a reservation when stock is sufficient', async () => {
+  it('fails closed when no authenticated principal resolver is configured', async () => {
+    const repo = new InMemoryReservationRepository();
+    const app = buildApp(repo);
+    await app.ready();
+    registerIntegrationCleanup(async () => {
+      await app.close();
+    });
+    seedRepo(repo, { 'item-1': 5 });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload: { sku: 'item-1', quantity: 1, requestId: 'default-fail-closed', userId: 'u1' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toMatchObject({ error: 'unauthorized' });
+    expect(repo.getStock('item-1')).toBe(5);
+  });
+
+  it('creates a reservation when stock is sufficient for the authenticated principal', async () => {
     const { repo, app } = await buildTestApp();
     seedRepo(repo, { 'item-1': 5 });
     const res = await app.inject({
       method: 'POST',
       url: '/reservations',
+      headers: principalHeaders('u1'),
       payload: { sku: 'item-1', quantity: 1, requestId: 'r1', userId: 'u1' },
     });
     expect(res.statusCode).toBe(200);
     expect(repo.getStock('item-1')).toBe(4);
   });
 
-  it('is idempotent for the same requestId', async () => {
+  it('is idempotent for the same principal, requestId, and payload', async () => {
     const { repo, app } = await buildTestApp();
     seedRepo(repo, { 'item-1': 5 });
     const payload = { sku: 'item-1', quantity: 1, requestId: 'r2', userId: 'u1' };
-    const first = await app.inject({ method: 'POST', url: '/reservations', payload });
-    const second = await app.inject({ method: 'POST', url: '/reservations', payload });
+    const first = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload,
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload,
+    });
     expect(first.statusCode).toBe(200);
     expect(second.statusCode).toBe(200);
     expect(first.json()).toEqual(second.json());
     expect(repo.getStock('item-1')).toBe(4);
   });
 
-  it('returns 409 when stock is insufficient and caches rejection', async () => {
+  it('returns 409 when stock is insufficient and caches same-principal rejection', async () => {
     const { repo, app } = await buildTestApp();
     seedRepo(repo, { 'item-1': 1 });
     const payload = { sku: 'item-1', quantity: 10, requestId: 'r3', userId: 'u1' };
-    const first = await app.inject({ method: 'POST', url: '/reservations', payload });
-    const second = await app.inject({ method: 'POST', url: '/reservations', payload });
+    const first = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload,
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload,
+    });
     expect(first.statusCode).toBe(409);
     expect(second.statusCode).toBe(409);
     expect(first.json()).toEqual(second.json());
     expect(repo.getStock('item-1')).toBe(1);
+  });
+
+  it('returns 409 without leaking a record when a duplicate key crosses principals', async () => {
+    const { repo, app } = await buildTestApp();
+    seedRepo(repo, { 'item-1': 5 });
+    const first = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload: { sku: 'item-1', quantity: 1, requestId: 'shared-key', userId: 'u1' },
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u2'),
+      payload: { sku: 'item-1', quantity: 1, requestId: 'shared-key', userId: 'u2' },
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(409);
+    expect(second.json()).toMatchObject({ error: 'idempotency_conflict', reason: 'principal_mismatch' });
+    expect(second.json()).not.toHaveProperty('record');
+    expect(repo.getStock('item-1')).toBe(4);
+  });
+
+  it('returns 409 when the same principal reuses a key with a different quantity', async () => {
+    const { repo, app } = await buildTestApp();
+    seedRepo(repo, { 'item-1': 5 });
+    const first = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload: { sku: 'item-1', quantity: 1, requestId: 'payload-key', userId: 'u1' },
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload: { sku: 'item-1', quantity: 2, requestId: 'payload-key', userId: 'u1' },
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(409);
+    expect(second.json()).toMatchObject({ error: 'idempotency_conflict', reason: 'payload_mismatch' });
+    expect(second.json()).not.toHaveProperty('record');
+    expect(repo.getStock('item-1')).toBe(4);
+  });
+
+  it('returns 409 when the same principal reuses a key with a different SKU', async () => {
+    const { repo, app } = await buildTestApp();
+    seedRepo(repo, { 'item-1': 5, 'item-2': 5 });
+    const first = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload: { sku: 'item-1', quantity: 1, requestId: 'sku-key', userId: 'u1' },
+    });
+    const second = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload: { sku: 'item-2', quantity: 1, requestId: 'sku-key', userId: 'u1' },
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(409);
+    expect(second.json()).toMatchObject({ error: 'idempotency_conflict', reason: 'payload_mismatch' });
+    expect(second.json()).not.toHaveProperty('record');
+    expect(repo.getStock('item-1')).toBe(4);
+    expect(repo.getStock('item-2')).toBe(5);
+  });
+
+  it('rejects body userId that does not match the authenticated principal', async () => {
+    const { repo, app } = await buildTestApp();
+    seedRepo(repo, { 'item-1': 5 });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      headers: principalHeaders('u1'),
+      payload: { sku: 'item-1', quantity: 1, requestId: 'mismatch', userId: 'u2' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toMatchObject({ error: 'forbidden' });
+    expect(repo.getStock('item-1')).toBe(5);
+  });
+
+  it('rejects unauthenticated multi-user requests instead of trusting body userId', async () => {
+    const { repo, app } = await buildTestApp();
+    seedRepo(repo, { 'item-1': 5 });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      payload: { sku: 'item-1', quantity: 1, requestId: 'unauthenticated', userId: 'u1' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toMatchObject({ error: 'unauthorized' });
+    expect(repo.getStock('item-1')).toBe(5);
   });
 
   it('returns 400 when requestId is missing', async () => {
@@ -68,6 +211,7 @@ describe('web api / reservations', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/reservations',
+      headers: principalHeaders('u1'),
       payload: { sku: 'item-1', quantity: 1, userId: 'u1' },
     });
     expect(res.statusCode).toBe(400);

--- a/tests/integration/web-api/reservations.test.ts
+++ b/tests/integration/web-api/reservations.test.ts
@@ -205,7 +205,21 @@ describe('web api / reservations', () => {
     expect(repo.getStock('item-1')).toBe(5);
   });
 
-  it('returns 400 when requestId is missing', async () => {
+  it('rejects unauthenticated malformed requests before payload validation', async () => {
+    const { repo, app } = await buildTestApp();
+    seedRepo(repo, { 'item-1': 5 });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/reservations',
+      payload: { sku: 'item-1', quantity: 1, userId: 'u1' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(res.json()).toMatchObject({ error: 'unauthorized' });
+    expect(repo.getStock('item-1')).toBe(5);
+  });
+
+  it('returns 400 when requestId is missing for an authenticated principal', async () => {
     const { repo, app } = await buildTestApp();
     seedRepo(repo, { 'item-1': 5 });
     const res = await app.inject({

--- a/tests/property/web-api/reservation.spec.ts
+++ b/tests/property/web-api/reservation.spec.ts
@@ -1,26 +1,38 @@
 import fc from 'fast-check';
 import { describe, it, expect } from 'vitest';
-import { buildApp, seedRepo } from '../../../src/web-api/app';
+import { buildApp, resolvePrincipalFromHeaders, seedRepo } from '../../../src/web-api/app';
 import { InMemoryReservationRepository } from '../../../src/web-api/repository';
 import { reservationArb, insufficientArb, defaultRuns } from './fast-check.config';
 
-// property: idempotency and non-negative stock for reservations
+// property: principal-scoped idempotency and non-negative stock for reservations
 // test:property:webapi で実行
 
+const principalHeaders = (userId: string) => ({ 'x-user-id': userId });
+
 describe('property: web api reservations', () => {
-  it('idempotent by requestId and stock decreases once', async () => {
+  it('idempotent by principal, requestId, and payload; stock decreases once', async () => {
     await fc.assert(
       fc.asyncProperty(reservationArb, async ({ requestId, sku, quantity, userId }) => {
         const repo = new InMemoryReservationRepository();
-        const app = buildApp(repo);
+        const app = buildApp(repo, { resolvePrincipal: resolvePrincipalFromHeaders });
         await app.ready();
         try {
           const initialStock = Math.max(quantity + 1, 3);
           seedRepo(repo, { [sku]: initialStock });
 
           const payload = { requestId, sku, quantity, userId };
-          const first = await app.inject({ method: 'POST', url: '/reservations', payload });
-          const second = await app.inject({ method: 'POST', url: '/reservations', payload });
+          const first = await app.inject({
+            method: 'POST',
+            url: '/reservations',
+            headers: principalHeaders(userId),
+            payload,
+          });
+          const second = await app.inject({
+            method: 'POST',
+            url: '/reservations',
+            headers: principalHeaders(userId),
+            payload,
+          });
 
           expect(first.statusCode).toBe(200);
           expect(second.statusCode).toBe(200);
@@ -34,11 +46,49 @@ describe('property: web api reservations', () => {
     );
   });
 
+  it('does not return a duplicate record when another principal reuses the same requestId', async () => {
+    await fc.assert(
+      fc.asyncProperty(reservationArb, fc.constantFrom('u1', 'u2', 'u3'), async (reservation, otherUserId) => {
+        fc.pre(otherUserId !== reservation.userId);
+        const { requestId, sku, quantity, userId } = reservation;
+        const repo = new InMemoryReservationRepository();
+        const app = buildApp(repo, { resolvePrincipal: resolvePrincipalFromHeaders });
+        await app.ready();
+        try {
+          const initialStock = Math.max(quantity + 1, 3);
+          seedRepo(repo, { [sku]: initialStock });
+
+          const first = await app.inject({
+            method: 'POST',
+            url: '/reservations',
+            headers: principalHeaders(userId),
+            payload: { requestId, sku, quantity, userId },
+          });
+          const second = await app.inject({
+            method: 'POST',
+            url: '/reservations',
+            headers: principalHeaders(otherUserId),
+            payload: { requestId, sku, quantity, userId: otherUserId },
+          });
+
+          expect(first.statusCode).toBe(200);
+          expect(second.statusCode).toBe(409);
+          expect(second.json()).toMatchObject({ error: 'idempotency_conflict', reason: 'principal_mismatch' });
+          expect(second.json()).not.toHaveProperty('record');
+          expect(repo.getStock(sku)).toBe(initialStock - quantity);
+        } finally {
+          await app.close();
+        }
+      }),
+      { numRuns: defaultRuns },
+    );
+  });
+
   it('returns 409 when stock is insufficient and does not change stock', async () => {
     await fc.assert(
       fc.asyncProperty(insufficientArb, async ({ requestId, sku, stock, userId }) => {
         const repo = new InMemoryReservationRepository();
-        const app = buildApp(repo);
+        const app = buildApp(repo, { resolvePrincipal: resolvePrincipalFromHeaders });
         await app.ready();
         try {
           seedRepo(repo, { [sku]: stock });
@@ -47,6 +97,7 @@ describe('property: web api reservations', () => {
           const res = await app.inject({
             method: 'POST',
             url: '/reservations',
+            headers: principalHeaders(userId),
             payload: { requestId, sku, quantity, userId },
           });
 


### PR DESCRIPTION
## Summary

- Bind `src/web-api` reservation idempotency records to an authenticated principal and canonical SKU/quantity payload hash.
- Fail closed when no principal resolver is configured, ignore body `userId` as authority, and reject body/principal mismatches.
- Return `409 idempotency_conflict` without the prior reservation record for cross-principal or changed-payload duplicate keys.
- Add integration/property regressions for same-principal replay, cross-principal collisions, payload conflicts, and unauthenticated multi-user requests.
- Document the reservation API security-hardening behavior.

Closes #3354

## Acceptance

- Same-principal, same-request replay returns the original reservation/rejection and does not decrement stock twice.
- Duplicate `requestId` with a different principal, SKU, or quantity returns `409 idempotency_conflict` and does not expose the previous reservation record.
- Reservation requests without an authenticated principal fail closed with `401`.
- Body `userId` is treated only as an optional consistency check and mismatches return `403`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -s exec vitest run tests/integration/web-api/reservations.test.ts tests/property/web-api/reservation.spec.ts --reporter dot`
- `pnpm -s exec eslint --quiet src/web-api/app.ts src/web-api/repository.ts tests/integration/web-api/reservations.test.ts tests/property/web-api/reservation.spec.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

Revert this PR to restore the previous sample reservation idempotency behavior. If rolled back, re-open #3354 because duplicate `requestId` records would again be global to the repository and could expose prior reservation metadata.
