### PR TITLE
fix(server): constrain OpenAPI route module keys

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,25 +1,26 @@
 import Fastify from 'fastify'
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath, pathToFileURL } from 'url'
 import yaml from 'yaml'
+import {
+  collectOpenApiRouteDescriptors,
+  OpenApiRouteRegistrationError,
+  resolveRouteModulePath,
+  type OpenApiLikeSpec,
+} from './server/openapi-route-security.js'
 import { handler as postReservation } from './routes/reservations-post.js'
 import { handler as deleteReservation } from './routes/reservations-id-delete.js'
 import { handler as getInventory } from './routes/inventory-sku-get.js'
 
 const server = Fastify({ logger: true })
+const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+const routesDir = path.resolve(moduleDir, 'routes')
 
 type PlainObject = Record<string, unknown>
 
 interface RouteHandlerModule {
   handler: (input: unknown) => Promise<unknown>
-}
-
-interface OpenApiLikeSpec {
-  paths?: Record<string, unknown>
-}
-
-function safeName(p: string) {
-  return String(p).replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '')
 }
 
 function toPlainObject(value: unknown): PlainObject {
@@ -59,20 +60,38 @@ function isOpenApiLikeSpec(value: unknown): value is OpenApiLikeSpec {
   return value !== null && typeof value === 'object'
 }
 
-async function loadRouteModule(key: string): Promise<RouteHandlerModule | null> {
-  const file = path.join(__dirname, 'routes', `${key}.ts`)
-  const fileJs = path.join(__dirname, 'routes', `${key}.js`)
+function isPathWithin(baseDir: string, candidatePath: string): boolean {
+  const relative = path.relative(baseDir, candidatePath)
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+}
 
+function resolveExistingRouteModulePath(key: string, extension: 'js' | 'ts'): string | null {
+  const candidate = resolveRouteModulePath(key, extension, routesDir)
+  if (!fs.existsSync(candidate)) return null
+
+  const realBase = fs.realpathSync(routesDir)
+  const realCandidate = fs.realpathSync(candidate)
+  if (!isPathWithin(realBase, realCandidate)) {
+    throw new OpenApiRouteRegistrationError(`Route module realpath escaped routes directory: ${key}.${extension}`)
+  }
+  return realCandidate
+}
+
+async function loadRouteModule(key: string): Promise<RouteHandlerModule | null> {
   try {
-    if (fs.existsSync(fileJs)) {
-      const mod: unknown = await import(`./routes/${key}.js`)
+    const fileJs = resolveExistingRouteModulePath(key, 'js')
+    if (fileJs) {
+      const mod: unknown = await import(pathToFileURL(fileJs).href)
       return isRouteHandlerModule(mod) ? mod : null
     }
-    if (fs.existsSync(file)) {
-      const mod: unknown = await import(`./routes/${key}.ts`)
+
+    const fileTs = resolveExistingRouteModulePath(key, 'ts')
+    if (fileTs) {
+      const mod: unknown = await import(pathToFileURL(fileTs).href)
       return isRouteHandlerModule(mod) ? mod : null
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof OpenApiRouteRegistrationError) throw error
     // Optional route module may not exist for every operation.
   }
 
@@ -93,51 +112,48 @@ async function tryAutoRegisterFromOpenAPI() {
       if (isOpenApiLikeSpec(parsed)) spec = parsed
     }
     if (!spec || !spec.paths) return false
-    for (const [p, methods] of Object.entries(spec.paths)) {
-      const methodMap = toPlainObject(methods)
-      for (const [m] of Object.entries(methodMap)) {
-        const key = `${safeName(p)}-${String(m).toLowerCase()}`
-        const mod = await loadRouteModule(key)
-        if (mod?.handler) {
-          const routePath = p.replace(/\{([^}]+)\}/g, ':$1')
-          switch (String(m).toLowerCase()) {
-            case 'get':
-              server.get(routePath, async (req, rep) => {
-                const r = await mod.handler({ ...toPlainObject(req.params), ...toPlainObject(req.query) })
-                rep.code(getResponseStatus(r, 200)).send(r)
-              })
-              break
-            case 'post':
-              server.post(routePath, async (req, rep) => {
-                const r = await mod.handler(req.body)
-                rep.code(getResponseStatus(r, 200)).send(r)
-              })
-              break
-            case 'delete':
-              server.delete(routePath, async (req, rep) => {
-                const r = await mod.handler(toPlainObject(req.params))
-                rep.code(getResponseStatus(r, 204)).send(r)
-              })
-              break
-            case 'put':
-              server.put(routePath, async (req, rep) => {
-                const r = await mod.handler(req.body)
-                rep.code(getResponseStatus(r, 200)).send(r)
-              })
-              break
-            case 'patch':
-              server.patch(routePath, async (req, rep) => {
-                const r = await mod.handler(req.body)
-                rep.code(getResponseStatus(r, 200)).send(r)
-              })
-              break
-          }
-          server.log.info({ route: routePath, method: String(m).toUpperCase() }, 'auto-registered route')
+    const routeDescriptors = collectOpenApiRouteDescriptors(spec)
+    for (const descriptor of routeDescriptors) {
+      const mod = await loadRouteModule(descriptor.moduleKey)
+      if (mod?.handler) {
+        switch (descriptor.method) {
+          case 'get':
+            server.get(descriptor.fastifyPath, async (req, rep) => {
+              const r = await mod.handler({ ...toPlainObject(req.params), ...toPlainObject(req.query) })
+              rep.code(getResponseStatus(r, 200)).send(r)
+            })
+            break
+          case 'post':
+            server.post(descriptor.fastifyPath, async (req, rep) => {
+              const r = await mod.handler(req.body)
+              rep.code(getResponseStatus(r, 200)).send(r)
+            })
+            break
+          case 'delete':
+            server.delete(descriptor.fastifyPath, async (req, rep) => {
+              const r = await mod.handler(toPlainObject(req.params))
+              rep.code(getResponseStatus(r, 204)).send(r)
+            })
+            break
+          case 'put':
+            server.put(descriptor.fastifyPath, async (req, rep) => {
+              const r = await mod.handler(req.body)
+              rep.code(getResponseStatus(r, 200)).send(r)
+            })
+            break
+          case 'patch':
+            server.patch(descriptor.fastifyPath, async (req, rep) => {
+              const r = await mod.handler(req.body)
+              rep.code(getResponseStatus(r, 200)).send(r)
+            })
+            break
         }
+        server.log.info({ route: descriptor.fastifyPath, method: descriptor.method.toUpperCase() }, 'auto-registered route')
       }
     }
     return true
   } catch (e) {
+    if (e instanceof OpenApiRouteRegistrationError) throw e
     server.log.warn({ err: e }, 'OpenAPI auto-register skipped')
     return false
   }
@@ -185,6 +201,6 @@ export async function start() {
   }
 }
 
-if (require.main === module) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   void start()
 }

--- a/src/server/openapi-route-security.ts
+++ b/src/server/openapi-route-security.ts
@@ -1,0 +1,129 @@
+import path from 'path'
+
+const OPENAPI_ALLOWED_METHODS = ['get', 'post', 'delete', 'put', 'patch'] as const
+export type OpenApiMethod = (typeof OPENAPI_ALLOWED_METHODS)[number]
+
+const OPENAPI_PATH_ITEM_METADATA_FIELDS = new Set(['$ref', 'summary', 'description', 'servers', 'parameters'])
+
+export interface OpenApiLikeSpec {
+  paths?: Record<string, unknown>
+}
+
+export interface OpenApiRouteDescriptor {
+  method: OpenApiMethod
+  openApiPath: string
+  fastifyPath: string
+  moduleKey: string
+}
+
+const OPENAPI_ROUTE_MANIFEST: ReadonlyArray<OpenApiRouteDescriptor> = [
+  { method: 'post', openApiPath: '/reservations', fastifyPath: '/reservations', moduleKey: 'reservations-post' },
+  { method: 'delete', openApiPath: '/reservations/{id}', fastifyPath: '/reservations/:id', moduleKey: 'reservations-id-delete' },
+  { method: 'get', openApiPath: '/inventory/{sku}', fastifyPath: '/inventory/:sku', moduleKey: 'inventory-sku-get' },
+]
+
+const routeManifestBySpecKey = new Map(
+  OPENAPI_ROUTE_MANIFEST.map((route) => [openApiRouteSpecKey(route.openApiPath, route.method), route] as const),
+)
+
+const routeModuleKeyPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+export class OpenApiRouteRegistrationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'OpenApiRouteRegistrationError'
+  }
+}
+
+function toPlainObject(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function openApiRouteSpecKey(openApiPath: string, method: OpenApiMethod): string {
+  return `${method} ${openApiPath}`
+}
+
+function isAllowedOpenApiMethod(method: string): method is OpenApiMethod {
+  return (OPENAPI_ALLOWED_METHODS as readonly string[]).includes(method)
+}
+
+function isOpenApiPathItemMetadataField(field: string): boolean {
+  return OPENAPI_PATH_ITEM_METADATA_FIELDS.has(field)
+}
+
+function isSafeOpenApiPath(openApiPath: string): boolean {
+  if (!openApiPath.startsWith('/') || openApiPath.includes('\\') || openApiPath.includes('\0')) {
+    return false
+  }
+  const segments = openApiPath.split('/').slice(1)
+  if (segments.length === 0) return false
+  return segments.every((segment) => {
+    if (!segment || segment === '.' || segment === '..') return false
+    return /^[A-Za-z0-9_-]+$/.test(segment) || /^\{[A-Za-z][A-Za-z0-9_]*\}$/.test(segment)
+  })
+}
+
+export function resolveOpenApiRouteDescriptor(openApiPath: string, rawMethod: string): OpenApiRouteDescriptor {
+  if (!isAllowedOpenApiMethod(rawMethod)) {
+    throw new OpenApiRouteRegistrationError(`Unsupported OpenAPI method for route registration: ${rawMethod}`)
+  }
+  if (!isSafeOpenApiPath(openApiPath)) {
+    throw new OpenApiRouteRegistrationError(`Unsafe OpenAPI path for route registration: ${openApiPath}`)
+  }
+
+  const descriptor = routeManifestBySpecKey.get(openApiRouteSpecKey(openApiPath, rawMethod))
+  if (!descriptor) {
+    throw new OpenApiRouteRegistrationError(`Unexpected OpenAPI route: ${rawMethod.toUpperCase()} ${openApiPath}`)
+  }
+  assertSafeRouteModuleKey(descriptor.moduleKey)
+  return descriptor
+}
+
+export function collectOpenApiRouteDescriptors(spec: OpenApiLikeSpec): OpenApiRouteDescriptor[] {
+  const descriptors: OpenApiRouteDescriptor[] = []
+  const seenRoutes = new Set<string>()
+  const seenModuleKeys = new Set<string>()
+
+  for (const [openApiPath, methods] of Object.entries(spec.paths ?? {})) {
+    const methodMap = toPlainObject(methods)
+    for (const [rawMethod] of Object.entries(methodMap)) {
+      if (isOpenApiPathItemMetadataField(rawMethod)) continue
+      const descriptor = resolveOpenApiRouteDescriptor(openApiPath, rawMethod)
+      const routeKey = `${descriptor.method} ${descriptor.fastifyPath}`
+      if (seenRoutes.has(routeKey)) {
+        throw new OpenApiRouteRegistrationError(`Duplicate OpenAPI route registration: ${routeKey}`)
+      }
+      if (seenModuleKeys.has(descriptor.moduleKey)) {
+        throw new OpenApiRouteRegistrationError(`Duplicate OpenAPI route module registration: ${descriptor.moduleKey}`)
+      }
+      seenRoutes.add(routeKey)
+      seenModuleKeys.add(descriptor.moduleKey)
+      descriptors.push(descriptor)
+    }
+  }
+
+  return descriptors
+}
+
+function assertSafeRouteModuleKey(key: string): void {
+  if (!routeModuleKeyPattern.test(key)) {
+    throw new OpenApiRouteRegistrationError(`Unsafe route module key: ${key}`)
+  }
+}
+
+function isPathWithin(baseDir: string, candidatePath: string): boolean {
+  const relative = path.relative(baseDir, candidatePath)
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+export function resolveRouteModulePath(key: string, extension: 'js' | 'ts', baseRoutesDir: string): string {
+  assertSafeRouteModuleKey(key)
+  const resolvedBase = path.resolve(baseRoutesDir)
+  const candidate = path.resolve(resolvedBase, `${key}.${extension}`)
+  if (!isPathWithin(resolvedBase, candidate)) {
+    throw new OpenApiRouteRegistrationError(`Route module path escaped routes directory: ${key}.${extension}`)
+  }
+  return candidate
+}

--- a/tests/unit/server/openapi-route-security.test.ts
+++ b/tests/unit/server/openapi-route-security.test.ts
@@ -1,0 +1,95 @@
+import path from 'path'
+import { describe, expect, it } from 'vitest'
+import {
+  collectOpenApiRouteDescriptors,
+  OpenApiRouteRegistrationError,
+  resolveOpenApiRouteDescriptor,
+  resolveRouteModulePath,
+} from '../../../src/server/openapi-route-security.js'
+
+describe('OpenAPI route registration security', () => {
+  it('maps only explicit manifest routes to route modules', () => {
+    expect(resolveOpenApiRouteDescriptor('/inventory/{sku}', 'get')).toEqual({
+      method: 'get',
+      openApiPath: '/inventory/{sku}',
+      fastifyPath: '/inventory/:sku',
+      moduleKey: 'inventory-sku-get',
+    })
+    expect(resolveOpenApiRouteDescriptor('/reservations/{id}', 'delete')).toMatchObject({
+      method: 'delete',
+      fastifyPath: '/reservations/:id',
+      moduleKey: 'reservations-id-delete',
+    })
+  })
+
+  it('rejects unsupported method names before route-key construction', () => {
+    expect(() => resolveOpenApiRouteDescriptor('/inventory/{sku}', 'GET')).toThrow(OpenApiRouteRegistrationError)
+    expect(() => resolveOpenApiRouteDescriptor('/inventory/{sku}', '../get')).toThrow(OpenApiRouteRegistrationError)
+    expect(() => resolveOpenApiRouteDescriptor('/inventory/{sku}', 'get/../../secrets')).toThrow(OpenApiRouteRegistrationError)
+  })
+
+  it('rejects unsafe or unexpected OpenAPI paths instead of using lossy path-derived keys', () => {
+    for (const unsafePath of [
+      '/inventory/../{sku}',
+      '/inventory//{sku}',
+      '/inventory/{bad-name}',
+      '/inventory\\{sku}',
+      '/inventory/%2e%2e/{sku}',
+    ]) {
+      expect(() => resolveOpenApiRouteDescriptor(unsafePath, 'get')).toThrow(OpenApiRouteRegistrationError)
+    }
+
+    expect(() => resolveOpenApiRouteDescriptor('/inventory-sku', 'get')).toThrow(OpenApiRouteRegistrationError)
+    expect(() => resolveOpenApiRouteDescriptor('/inventory/{sku}/details', 'get')).toThrow(OpenApiRouteRegistrationError)
+  })
+
+  it('collects valid descriptors from an OpenAPI-like spec', () => {
+    expect(
+      collectOpenApiRouteDescriptors({
+        paths: {
+          '/reservations': { description: 'Reservation collection', parameters: [], post: {} },
+          '/reservations/{id}': { delete: {}, summary: 'Reservation by id' },
+          '/inventory/{sku}': { get: {}, servers: [] },
+        },
+      }).map((descriptor) => descriptor.moduleKey),
+    ).toEqual(['reservations-post', 'reservations-id-delete', 'inventory-sku-get'])
+  })
+
+  it('still rejects unsupported OpenAPI operation method keys', () => {
+    expect(() =>
+      collectOpenApiRouteDescriptors({
+        paths: {
+          '/inventory/{sku}': { head: {} },
+        },
+      }),
+    ).toThrow(OpenApiRouteRegistrationError)
+  })
+
+  it('fails closed when a spec contains any unexpected public route', () => {
+    expect(() =>
+      collectOpenApiRouteDescriptors({
+        paths: {
+          '/reservations': { post: {} },
+          '/admin/{id}': { get: {} },
+        },
+      }),
+    ).toThrow(OpenApiRouteRegistrationError)
+  })
+
+  it('resolves route modules under the configured routes directory only', () => {
+    const routesDir = path.join(process.cwd(), 'src', 'routes')
+    expect(resolveRouteModulePath('inventory-sku-get', 'ts', routesDir)).toBe(
+      path.resolve(routesDir, 'inventory-sku-get.ts'),
+    )
+
+    for (const unsafeKey of [
+      '',
+      '../inventory-sku-get',
+      'inventory-sku-get/../../evil',
+      'inventory.sku.get',
+      'inventory_sku_get',
+    ]) {
+      expect(() => resolveRouteModulePath(unsafeKey, 'ts', routesDir)).toThrow(OpenApiRouteRegistrationError)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Replace path-derived OpenAPI route-module keys with an explicit allowlisted route manifest.
- Validate OpenAPI methods and path segments before any route key or dynamic import is resolved.
- Resolve route modules through contained filesystem paths under `src/routes` and import via file URLs.
- Add unit coverage for unsafe methods, unsafe paths, unexpected routes, and route-module path containment.

Closes #3357

## Acceptance
- OpenAPI auto-registration only accepts the known public route/method combinations for reservations and inventory.
- Unsupported methods, unsafe paths, and unexpected route definitions fail closed before module-key construction.
- Dynamic route imports are resolved under `src/routes` and reject unsafe module keys or path escapes.
- Regression tests cover the route manifest and path-containment behavior.

## Verification
- `pnpm -s exec vitest run tests/unit/server/openapi-route-security.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet src/server.ts src/server/openapi-route-security.ts tests/unit/server/openapi-route-security.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback
- Revert this PR to restore the previous OpenAPI auto-registration behavior. If reverted, avoid using untrusted OpenAPI artifacts for route auto-registration until an equivalent allowlist/path-containment control is in place.
