### PR TITLE
fix(mcp): constrain spec codegen paths

### DIFF
--- a/src/cli/codegen-cli.ts
+++ b/src/cli/codegen-cli.ts
@@ -15,6 +15,7 @@ import { toMessage } from '../utils/error-utils.js';
 import { safeExit } from '../utils/safe-exit.js';
 import { DriftDetector } from '../codegen/drift-detector.js';
 import type { DriftConfig } from '../codegen/drift-detector.js';
+import { resolveWorkspacePath, resolveWorkspaceRoot } from '../utils/workspace-path-policy.js';
 
 type GenerateCommandOptions = {
   input: string;
@@ -70,15 +71,18 @@ export function createCodegenCommand(): Command {
         console.log(chalk.gray(`   Output: ${options.output}`));
         console.log(chalk.gray(`   Target: ${options.target}`));
 
+        const workspaceRoot = resolveWorkspaceRoot({ envVar: 'AE_CODEGEN_WORKSPACE_ROOT' });
         const genOptions: CodegenOptions = {
-          inputPath: resolve(options.input),
-          outputDir: resolve(options.output),
+          inputPath: resolveWorkspacePath(options.input, { workspaceRoot, label: 'codegen input' }),
+          outputDir: resolveWorkspacePath(options.output, { workspaceRoot, label: 'codegen output' }),
           target: options.target,
           enableDriftDetection: options.driftDetection,
           preserveManualChanges: options.preserveChanges,
           hashAlgorithm: options.hashAlgorithm,
         };
-        if (options.templateDir) genOptions.templateDir = resolve(options.templateDir);
+        if (options.templateDir) {
+          genOptions.templateDir = resolveWorkspacePath(options.templateDir, { workspaceRoot, label: 'codegen templateDir' });
+        }
         const generator = new DeterministicCodeGenerator(genOptions);
 
         const manifest = await generator.generate();
@@ -212,15 +216,17 @@ export function createCodegenCommand(): Command {
         const regenerate = async () => {
           try {
             console.log(chalk.blue('\n🔄 Specification changed, regenerating...'));
-            
+            const workspaceRoot = resolveWorkspaceRoot({ envVar: 'AE_CODEGEN_WORKSPACE_ROOT' });
             const regenOptions: CodegenOptions = {
-              inputPath: resolve(options.input),
-              outputDir: resolve(options.output),
+              inputPath: resolveWorkspacePath(options.input, { workspaceRoot, label: 'codegen watch input' }),
+              outputDir: resolveWorkspacePath(options.output, { workspaceRoot, label: 'codegen watch output' }),
               target: options.target,
               enableDriftDetection: true,
               preserveManualChanges: true,
             };
-            if (options.templateDir) regenOptions.templateDir = resolve(options.templateDir);
+            if (options.templateDir) {
+              regenOptions.templateDir = resolveWorkspacePath(options.templateDir, { workspaceRoot, label: 'codegen watch templateDir' });
+            }
             const generator = new DeterministicCodeGenerator(regenOptions);
 
             const manifest = await generator.generate();
@@ -230,7 +236,8 @@ export function createCodegenCommand(): Command {
             console.error(chalk.red(`❌ Regeneration failed: ${toMessage(error)}`));
           }
         };
-        const watchTargets = [resolve(options.input)];
+        const workspaceRoot = resolveWorkspaceRoot({ envVar: 'AE_CODEGEN_WORKSPACE_ROOT' });
+        const watchTargets = [resolveWorkspacePath(options.input, { workspaceRoot, label: 'codegen watch input' })];
         const watcher = watchFn(watchTargets, { ignoreInitial: true });
         const scheduleRegenerate = () => {
           if (timeout) clearTimeout(timeout);

--- a/src/codegen/deterministic-generator.ts
+++ b/src/codegen/deterministic-generator.ts
@@ -5,12 +5,15 @@
 
 import { createHash } from 'crypto';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname } from 'path';
 import type { AEIR } from '@ae-framework/spec-compiler';
+import { resolveContainedWorkspacePath } from '../utils/workspace-path-policy.js';
 
 type AEIRDomainEntity = AEIR['domain'][number];
 type AEIRDomainField = AEIRDomainEntity['fields'][number];
 type AEIRApiEndpoint = NonNullable<AEIR['api']>[number];
+
+const codegenIdentifierPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
 
 export interface CodegenOptions {
   /** Input AE-IR file path */
@@ -84,7 +87,7 @@ export class DeterministicCodeGenerator {
       preserveManualChanges: true,
       ...options,
     };
-    this.manifestPath = join(this.options.outputDir, '.codegen-manifest.json');
+    this.manifestPath = this.resolveOutputFile('.codegen-manifest.json');
   }
 
   /**
@@ -93,6 +96,7 @@ export class DeterministicCodeGenerator {
   async generate(): Promise<CodegenManifest> {
     // Load and validate AE-IR
     const ir = this.loadAEIR();
+    this.validateAEIRIdentifiers(ir);
     const specHash = this.calculateHash(JSON.stringify(ir, null, 2));
 
     // Perform drift detection if enabled
@@ -145,7 +149,7 @@ export class DeterministicCodeGenerator {
     if (manifest.metadata.specHash !== currentSpecHash) {
       // All files are potentially drifted due to spec changes
       for (const file of manifest.files) {
-        const filePath = join(this.options.outputDir, file.filePath);
+        const filePath = this.resolveOutputFile(file.filePath);
         if (existsSync(filePath)) {
           const currentContent = readFileSync(filePath, 'utf-8');
           const currentHash = this.calculateHash(currentContent);
@@ -164,7 +168,7 @@ export class DeterministicCodeGenerator {
     } else {
       // Check individual file modifications
       for (const file of manifest.files) {
-        const filePath = join(this.options.outputDir, file.filePath);
+        const filePath = this.resolveOutputFile(file.filePath);
         if (existsSync(filePath)) {
           const currentContent = readFileSync(filePath, 'utf-8');
           const currentHash = this.calculateHash(currentContent);
@@ -220,7 +224,7 @@ export class DeterministicCodeGenerator {
 
     // Write generated files in deterministic order
     for (const file of sortedFiles) {
-      const fullPath = join(this.options.outputDir, file.filePath);
+      const fullPath = this.resolveOutputFile(file.filePath);
       mkdirSync(dirname(fullPath), { recursive: true });
       writeFileSync(fullPath, file.content, 'utf-8');
     }
@@ -621,6 +625,30 @@ ${entity.fields.filter((field) => field.name !== 'id').map((field) => `
   private writeManifest(manifest: CodegenManifest): void {
     mkdirSync(dirname(this.manifestPath), { recursive: true });
     writeFileSync(this.manifestPath, JSON.stringify(manifest, null, 2), 'utf-8');
+  }
+
+  private resolveOutputFile(relativePath: string): string {
+    return resolveContainedWorkspacePath(this.options.outputDir, relativePath, 'generated code file');
+  }
+
+  private validateAEIRIdentifiers(ir: AEIR): void {
+    for (const entity of ir.domain) {
+      this.assertCodegenIdentifier(entity.name, 'domain entity name');
+      for (const field of entity.fields) {
+        this.assertCodegenIdentifier(field.name, `field name for ${entity.name}`);
+      }
+    }
+
+    const apis = ir.api ?? [];
+    for (const api of apis) {
+      this.assertCodegenIdentifier(api.method, `API method for ${api.path}`);
+    }
+  }
+
+  private assertCodegenIdentifier(value: string, label: string): void {
+    if (!codegenIdentifierPattern.test(value)) {
+      throw new Error(`Invalid AE-IR ${label} for deterministic codegen: ${JSON.stringify(value)}`);
+    }
   }
 
   private calculateHash(content: string): string {

--- a/src/mcp-server/spec-synthesis-path-policy.ts
+++ b/src/mcp-server/spec-synthesis-path-policy.ts
@@ -1,0 +1,120 @@
+import {
+  resolveContainedWorkspacePath,
+  resolveWorkspacePath,
+  resolveWorkspaceRoot,
+  toWorkspaceRelativePath,
+} from '../utils/workspace-path-policy.js';
+import type { SpawnSyncOptions } from 'node:child_process';
+
+export type SpecCodegenTarget = 'typescript' | 'api' | 'database' | 'react';
+
+export interface ResolvedSpecCompilePaths {
+  workspaceRoot: string;
+  inputPath: string;
+  outputPath?: string;
+}
+
+export interface ResolvedSpecCodegenPaths {
+  workspaceRoot: string;
+  irPath: string;
+  irPathArg: string;
+  outBase: string;
+  outBaseArg: string;
+  targetOutDirs: Record<SpecCodegenTarget, string>;
+  targetOutDirArgs: Record<SpecCodegenTarget, string>;
+}
+
+export function createSpecCodegenChildProcessOptions(workspaceRoot: string): SpawnSyncOptions {
+  return {
+    stdio: 'inherit',
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      AE_CODEGEN_WORKSPACE_ROOT: workspaceRoot,
+    },
+  };
+}
+
+export function resolveSpecSynthesisWorkspaceRoot(): string {
+  return resolveWorkspaceRoot({ envVar: 'AE_MCP_WORKSPACE_ROOT' });
+}
+
+export function resolveSpecCompilePaths(
+  inputPath: string,
+  outputPath?: string,
+  workspaceRoot = resolveSpecSynthesisWorkspaceRoot(),
+): ResolvedSpecCompilePaths {
+  const resolvedInputPath = resolveWorkspacePath(inputPath, {
+    workspaceRoot,
+    label: 'ae_spec_compile inputPath',
+  });
+  const resolvedOutputPath = outputPath !== undefined
+    ? resolveWorkspacePath(outputPath, {
+      workspaceRoot,
+      label: 'ae_spec_compile outputPath',
+    })
+    : undefined;
+
+  return {
+    workspaceRoot,
+    inputPath: resolvedInputPath,
+    ...(resolvedOutputPath !== undefined ? { outputPath: resolvedOutputPath } : {}),
+  };
+}
+
+export function resolveSpecValidateInputPath(
+  inputPath: string,
+  workspaceRoot = resolveSpecSynthesisWorkspaceRoot(),
+): string {
+  return resolveWorkspacePath(inputPath, {
+    workspaceRoot,
+    label: 'ae_spec_validate inputPath',
+  });
+}
+
+export function resolveSpecCodegenPaths(
+  irPath: string,
+  targets: readonly SpecCodegenTarget[],
+  outDir?: string,
+  workspaceRoot = resolveSpecSynthesisWorkspaceRoot(),
+): ResolvedSpecCodegenPaths {
+  const resolvedIrPath = resolveWorkspacePath(irPath, {
+    workspaceRoot,
+    label: 'ae_spec_codegen irPath',
+  });
+  const irPathArg = toWorkspaceRelativePath(resolvedIrPath, {
+    workspaceRoot,
+    label: 'ae_spec_codegen irPath',
+  });
+
+  const outBase = outDir || 'generated';
+  const outBasePath = resolveWorkspacePath(outBase, {
+    workspaceRoot,
+    label: 'ae_spec_codegen outDir',
+  });
+  const outBaseArg = toWorkspaceRelativePath(outBasePath, {
+    workspaceRoot,
+    label: 'ae_spec_codegen outDir',
+  });
+
+  const targetOutDirs = {} as Record<SpecCodegenTarget, string>;
+  const targetOutDirArgs = {} as Record<SpecCodegenTarget, string>;
+  for (const target of targets) {
+    const targetDir = resolveContainedWorkspacePath(outBasePath, target, `ae_spec_codegen ${target} outDir`);
+    targetOutDirs[target] = targetDir;
+    targetOutDirArgs[target] = toWorkspaceRelativePath(targetDir, {
+      workspaceRoot,
+      label: `ae_spec_codegen ${target} outDir`,
+    });
+  }
+
+  return {
+    workspaceRoot,
+    irPath: resolvedIrPath,
+    irPathArg,
+    outBase: outBasePath,
+    outBaseArg,
+    targetOutDirs,
+    targetOutDirArgs,
+  };
+}

--- a/src/mcp-server/spec-synthesis-server.ts
+++ b/src/mcp-server/spec-synthesis-server.ts
@@ -8,8 +8,13 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
-import { resolve } from 'path';
 import type { SpecLintIssue } from '../../packages/spec-compiler/src/types.js';
+import {
+  createSpecCodegenChildProcessOptions,
+  resolveSpecCodegenPaths,
+  resolveSpecCompilePaths,
+  resolveSpecValidateInputPath,
+} from './spec-synthesis-path-policy.js';
 
 type LintIssueSummary = {
   severity: SpecLintIssue['severity'];
@@ -118,14 +123,15 @@ async function start() {
       switch (name) {
         case 'ae_spec_compile': {
           const parsed = CompileArgs.parse(args);
+          const paths = resolveSpecCompilePaths(parsed.inputPath, parsed.outputPath);
           const { AESpecCompiler } = await import('../..//packages/spec-compiler/src/index.js');
           const compiler = new AESpecCompiler();
           const prev = process.env['AE_SPEC_RELAXED'];
           if (parsed.relaxed) process.env['AE_SPEC_RELAXED'] = '1';
           try {
             const ir = await compiler.compile({
-              inputPath: resolve(parsed.inputPath),
-              ...(parsed.outputPath !== undefined ? { outputPath: resolve(parsed.outputPath) } : {}),
+              inputPath: paths.inputPath,
+              ...(paths.outputPath !== undefined ? { outputPath: paths.outputPath } : {}),
               ...(parsed.validate !== undefined ? { validate: parsed.validate } : {}),
             });
             const lint = await compiler.lint(ir);
@@ -160,12 +166,13 @@ async function start() {
 
         case 'ae_spec_validate': {
           const parsed = ValidateArgs.parse(args);
+          const inputPath = resolveSpecValidateInputPath(parsed.inputPath);
           const { AESpecCompiler } = await import('../..//packages/spec-compiler/src/index.js');
           const compiler = new AESpecCompiler();
           const prev = process.env['AE_SPEC_RELAXED'];
           if (parsed.relaxed) process.env['AE_SPEC_RELAXED'] = '1';
           try {
-            const ir = await compiler.compile({ inputPath: resolve(parsed.inputPath), validate: false });
+            const ir = await compiler.compile({ inputPath, validate: false });
             const lint = await compiler.lint(ir);
             const rawIssues: unknown[] = Array.isArray(lint.issues) ? lint.issues : [];
             const issues = rawIssues
@@ -182,24 +189,32 @@ async function start() {
         case 'ae_spec_codegen': {
           const parsed = CodegenArgs.parse(args);
           const { readFileSync } = await import('fs');
-          const irPath = resolve(parsed.irPath);
+          const paths = resolveSpecCodegenPaths(parsed.irPath, parsed.targets, parsed.outDir);
           type IRLike = { domain?: unknown[]; api?: unknown[] };
-          const ir = JSON.parse(readFileSync(irPath, 'utf-8')) as unknown as IRLike;
+          const ir = JSON.parse(readFileSync(paths.irPath, 'utf-8')) as unknown as IRLike;
           const { spawnSync } = await import('child_process');
-          const outBase = parsed.outDir || 'generated';
-          const run = (t: string, dir: string) =>
-            spawnSync(process.execPath, ['dist/src/cli/index.js', 'codegen', 'generate', '-i', irPath, '-o', resolve(dir), '-t', t], { stdio: 'inherit' });
+          const run = (t: string, dir: string) => {
+            const result = spawnSync(
+              process.execPath,
+              ['dist/src/cli/index.js', 'codegen', 'generate', '-i', paths.irPathArg, '-o', dir, '-t', t],
+              createSpecCodegenChildProcessOptions(paths.workspaceRoot),
+            );
+            if (result.error) throw result.error;
+            if (result.status !== 0) {
+              throw new Error(`Code generation failed for target ${t} with exit code ${result.status ?? 'unknown'}`);
+            }
+          };
           const results: Record<string, string> = {};
           for (const t of parsed.targets) {
-            const dir = `${outBase}/${t}`;
-            run(t, dir);
-            results[t] = dir;
+            const targetDirArg = paths.targetOutDirArgs[t];
+            run(t, targetDirArg);
+            results[t] = targetDirArg;
           }
           return {
             content: [
               {
                 type: 'text',
-                text: JSON.stringify({ outBase, results, counts: { entities: ir.domain?.length || 0, apis: ir.api?.length || 0 } }, null, 2),
+                text: JSON.stringify({ outBase: paths.outBaseArg, results, counts: { entities: ir.domain?.length || 0, apis: ir.api?.length || 0 } }, null, 2),
               },
             ],
           };

--- a/src/utils/workspace-path-policy.ts
+++ b/src/utils/workspace-path-policy.ts
@@ -1,0 +1,112 @@
+import path from 'node:path';
+import { existsSync, realpathSync } from 'node:fs';
+
+export interface WorkspaceRootOptions {
+  envVar?: string;
+  defaultRoot?: string;
+}
+
+export interface WorkspacePathOptions {
+  workspaceRoot?: string;
+  label?: string;
+}
+
+export class WorkspacePathPolicyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorkspacePathPolicyError';
+  }
+}
+
+const hasWindowsAbsolutePrefix = (value: string): boolean =>
+  path.win32.isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value);
+
+const isPathWithin = (baseDir: string, candidatePath: string): boolean => {
+  const relative = path.relative(baseDir, candidatePath);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
+const pathPolicyLabel = (label: string | undefined): string => label ?? 'workspace path';
+
+const splitInputPath = (value: string): string[] => value.replace(/\\/g, '/').split('/');
+
+const nearestExistingAncestor = (resolvedPath: string): string | null => {
+  let current = path.resolve(resolvedPath);
+  while (!existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return current;
+};
+
+const assertExistingAncestorWithin = (workspaceRoot: string, resolvedPath: string, label: string): void => {
+  if (!existsSync(workspaceRoot)) return;
+  const ancestor = nearestExistingAncestor(resolvedPath);
+  if (!ancestor) return;
+
+  const realRoot = realpathSync(workspaceRoot);
+  const realAncestor = realpathSync(ancestor);
+  if (!isPathWithin(realRoot, realAncestor)) {
+    throw new WorkspacePathPolicyError(`${label} resolves through a filesystem entry outside the approved workspace`);
+  }
+};
+
+export function resolveWorkspaceRoot(options: WorkspaceRootOptions = {}): string {
+  const envVar = options.envVar ?? 'AE_WORKSPACE_ROOT';
+  const fromEnv = process.env[envVar]?.trim();
+  return path.resolve(fromEnv && fromEnv.length > 0 ? fromEnv : (options.defaultRoot ?? process.cwd()));
+}
+
+export function resolveWorkspacePath(input: string, options: WorkspacePathOptions = {}): string {
+  const label = pathPolicyLabel(options.label);
+  const raw = String(input).trim();
+  if (!raw) {
+    throw new WorkspacePathPolicyError(`${label} must be a non-empty workspace-relative path`);
+  }
+  if (raw.includes('\0')) {
+    throw new WorkspacePathPolicyError(`${label} must not contain NUL bytes`);
+  }
+  if (raw.includes('\\')) {
+    throw new WorkspacePathPolicyError(`${label} must use POSIX-style '/' separators`);
+  }
+  if (raw.startsWith('//') || path.isAbsolute(raw) || hasWindowsAbsolutePrefix(raw)) {
+    throw new WorkspacePathPolicyError(`${label} must be relative to the approved workspace`);
+  }
+
+  const segments = splitInputPath(raw);
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new WorkspacePathPolicyError(`${label} must not contain dot-segment path components`);
+  }
+
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? resolveWorkspaceRoot());
+  const resolved = path.resolve(workspaceRoot, raw);
+  if (!isPathWithin(workspaceRoot, resolved)) {
+    throw new WorkspacePathPolicyError(`${label} escaped the approved workspace`);
+  }
+  assertExistingAncestorWithin(workspaceRoot, resolved, label);
+  return resolved;
+}
+
+export function resolveContainedWorkspacePath(baseDir: string, relativePath: string, label?: string): string {
+  const base = path.resolve(baseDir);
+  const resolved = resolveWorkspacePath(relativePath, {
+    workspaceRoot: base,
+    label: label ?? 'contained path',
+  });
+  if (!isPathWithin(base, resolved)) {
+    throw new WorkspacePathPolicyError(`${pathPolicyLabel(label)} escaped the approved base directory`);
+  }
+  return resolved;
+}
+
+export function toWorkspaceRelativePath(resolvedPath: string, options: WorkspacePathOptions = {}): string {
+  const label = pathPolicyLabel(options.label);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? resolveWorkspaceRoot());
+  const absolutePath = path.resolve(resolvedPath);
+  if (!isPathWithin(workspaceRoot, absolutePath)) {
+    throw new WorkspacePathPolicyError(`${label} is outside the approved workspace`);
+  }
+  const relative = path.relative(workspaceRoot, absolutePath);
+  return relative === '' ? '.' : relative.replace(/\\/g, '/');
+}

--- a/tests/unit/codegen/deterministic-generator-path-policy.test.ts
+++ b/tests/unit/codegen/deterministic-generator-path-policy.test.ts
@@ -1,0 +1,84 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DeterministicCodeGenerator } from '../../../src/codegen/deterministic-generator.js';
+
+const testRoot = path.join(process.cwd(), 'artifacts', 'codegen-path-policy-test');
+
+const validAeir = {
+  version: '1.0.0',
+  metadata: {
+    name: 'PathPolicyTest',
+    created: '2025-01-01T00:00:00.000Z',
+    updated: '2025-01-01T00:00:00.000Z',
+  },
+  glossary: [],
+  domain: [
+    {
+      name: 'Product',
+      fields: [
+        { name: 'id', type: 'string', required: true },
+        { name: 'name', type: 'string', required: true },
+      ],
+    },
+  ],
+  invariants: [],
+  usecases: [],
+  api: [],
+};
+
+describe('DeterministicCodeGenerator path policy', () => {
+  beforeEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+    mkdirSync(testRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('writes generated files only under the configured output directory', async () => {
+    const inputPath = path.join(testRoot, 'ae-ir.json');
+    const outputDir = path.join(testRoot, 'generated');
+    writeFileSync(inputPath, JSON.stringify(validAeir, null, 2), 'utf8');
+
+    const generator = new DeterministicCodeGenerator({
+      inputPath,
+      outputDir,
+      target: 'react',
+      enableDriftDetection: false,
+    });
+
+    const manifest = await generator.generate();
+
+    expect(manifest.files.map((file) => file.filePath).sort()).toEqual([
+      'components/ProductForm.tsx',
+      'components/ProductList.tsx',
+    ]);
+    expect(existsSync(path.join(outputDir, 'components', 'ProductForm.tsx'))).toBe(true);
+    expect(existsSync(path.join(outputDir, '.codegen-manifest.json'))).toBe(true);
+  });
+
+  it('rejects IR-derived entity names that could become path traversal components', async () => {
+    const inputPath = path.join(testRoot, 'bad-ae-ir.json');
+    const outputDir = path.join(testRoot, 'generated');
+    writeFileSync(
+      inputPath,
+      JSON.stringify({
+        ...validAeir,
+        domain: [{ ...validAeir.domain[0], name: '../Escape' }],
+      }),
+      'utf8',
+    );
+
+    const generator = new DeterministicCodeGenerator({
+      inputPath,
+      outputDir,
+      target: 'database',
+      enableDriftDetection: false,
+    });
+
+    await expect(generator.generate()).rejects.toThrow('Invalid AE-IR domain entity name');
+    expect(existsSync(path.join(testRoot, 'Escape.ts'))).toBe(false);
+  });
+});

--- a/tests/unit/mcp-server/spec-synthesis-path-policy.test.ts
+++ b/tests/unit/mcp-server/spec-synthesis-path-policy.test.ts
@@ -1,0 +1,63 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  createSpecCodegenChildProcessOptions,
+  resolveSpecCodegenPaths,
+  resolveSpecCompilePaths,
+} from '../../../src/mcp-server/spec-synthesis-path-policy.js';
+import { WorkspacePathPolicyError } from '../../../src/utils/workspace-path-policy.js';
+
+describe('spec synthesis MCP path policy', () => {
+  const workspaceRoot = path.resolve(process.cwd(), 'artifacts', 'spec-synthesis-path-policy');
+
+  it('resolves compile input/output paths under the MCP workspace', () => {
+    const paths = resolveSpecCompilePaths('specs/sample.md', 'artifacts/spec-synthesis/ae-ir.json', workspaceRoot);
+
+    expect(paths.inputPath).toBe(path.join(workspaceRoot, 'specs', 'sample.md'));
+    expect(paths.outputPath).toBe(path.join(workspaceRoot, 'artifacts', 'spec-synthesis', 'ae-ir.json'));
+  });
+
+  it('rejects compile output traversal before the compiler write sink', () => {
+    expect(() => resolveSpecCompilePaths('specs/sample.md', '../outside.json', workspaceRoot)).toThrow(
+      WorkspacePathPolicyError,
+    );
+    expect(() => resolveSpecCompilePaths('/absolute/spec.md', 'artifacts/ae-ir.json', workspaceRoot)).toThrow(
+      WorkspacePathPolicyError,
+    );
+  });
+
+  it('keeps codegen child-process arguments workspace-relative', () => {
+    const paths = resolveSpecCodegenPaths(
+      '.ae/ae-ir.json',
+      ['typescript', 'react'],
+      'artifacts/generated',
+      workspaceRoot,
+    );
+
+    expect(paths.irPath).toBe(path.join(workspaceRoot, '.ae', 'ae-ir.json'));
+    expect(paths.irPathArg).toBe('.ae/ae-ir.json');
+    expect(paths.outBaseArg).toBe('artifacts/generated');
+    expect(paths.targetOutDirArgs).toEqual({
+      typescript: 'artifacts/generated/typescript',
+      react: 'artifacts/generated/react',
+    });
+  });
+
+  it('pins spawned codegen CLI execution to the MCP workspace', () => {
+    const options = createSpecCodegenChildProcessOptions(workspaceRoot);
+
+    expect(options.cwd).toBe(workspaceRoot);
+    expect(options.env).toMatchObject({
+      AE_CODEGEN_WORKSPACE_ROOT: workspaceRoot,
+    });
+  });
+
+  it('rejects codegen path escapes before spawnSync receives paths', () => {
+    expect(() => resolveSpecCodegenPaths('../ae-ir.json', ['typescript'], 'generated', workspaceRoot)).toThrow(
+      WorkspacePathPolicyError,
+    );
+    expect(() => resolveSpecCodegenPaths('.ae/ae-ir.json', ['typescript'], '/var/tmp/generated', workspaceRoot)).toThrow(
+      WorkspacePathPolicyError,
+    );
+  });
+});

--- a/tests/unit/utils/workspace-path-policy.test.ts
+++ b/tests/unit/utils/workspace-path-policy.test.ts
@@ -1,0 +1,76 @@
+import path from 'node:path';
+import { mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  resolveContainedWorkspacePath,
+  resolveWorkspacePath,
+  toWorkspaceRelativePath,
+  WorkspacePathPolicyError,
+} from '../../../src/utils/workspace-path-policy.js';
+
+describe('workspace path policy', () => {
+  const workspaceRoot = path.resolve(process.cwd(), 'artifacts', 'workspace-path-policy');
+
+  it('resolves workspace-relative paths under the approved root', () => {
+    const resolved = resolveWorkspacePath('generated/typescript', {
+      workspaceRoot,
+      label: 'test output',
+    });
+
+    expect(resolved).toBe(path.join(workspaceRoot, 'generated', 'typescript'));
+    expect(toWorkspaceRelativePath(resolved, { workspaceRoot })).toBe('generated/typescript');
+  });
+
+  it('rejects absolute paths and dot-segment traversal before filesystem access', () => {
+    for (const candidate of [
+      path.join(workspaceRoot, 'generated'),
+      '/var/tmp/generated',
+      '../generated',
+      'generated/../outside',
+      'generated/./typescript',
+      'C:\\temp\\generated',
+      'generated\\typescript',
+      '//server/share/generated',
+    ]) {
+      expect(() => resolveWorkspacePath(candidate, { workspaceRoot, label: 'test path' })).toThrow(
+        WorkspacePathPolicyError,
+      );
+    }
+  });
+
+  it('contains generated relative files under their output directory', () => {
+    const outputDir = path.join(workspaceRoot, 'generated');
+
+    expect(resolveContainedWorkspacePath(outputDir, 'components/ProductForm.tsx')).toBe(
+      path.join(outputDir, 'components', 'ProductForm.tsx'),
+    );
+    expect(() => resolveContainedWorkspacePath(outputDir, '../ProductForm.tsx')).toThrow(WorkspacePathPolicyError);
+    expect(() => resolveContainedWorkspacePath(outputDir, 'components/../../ProductForm.tsx')).toThrow(
+      WorkspacePathPolicyError,
+    );
+  });
+
+  it('rejects existing symlink ancestors that resolve outside the workspace', () => {
+    const root = path.join(workspaceRoot, `symlink-${Date.now()}`);
+    const outside = path.join(process.cwd(), 'artifacts', `workspace-path-policy-outside-${Date.now()}`);
+    mkdirSync(root, { recursive: true });
+    mkdirSync(outside, { recursive: true });
+
+    try {
+      symlinkSync(outside, path.join(root, 'linked-outside'), 'dir');
+    } catch {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+      return;
+    }
+
+    try {
+      expect(() => resolveWorkspacePath('linked-outside/generated', { workspaceRoot: root })).toThrow(
+        WorkspacePathPolicyError,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared workspace path policy for MCP/CLI codegen paths, rejecting absolute paths, dot-segment escapes, backslash separators, and symlink ancestors that resolve outside the approved workspace.
- Apply the policy to `ae_spec_compile`, `ae_spec_validate`, and `ae_spec_codegen` before compiler writes or codegen child-process spawning.
- Apply the same workspace-relative policy to codegen CLI generate/watch inputs and outputs.
- Contain deterministic generator file writes under the configured output directory and validate IR-derived identifiers before using them in generated filenames/code.

Closes #3358
Closes #3360

## Acceptance
- MCP `ae_spec_compile` output paths are resolved only under the approved MCP workspace before `AESpecCompiler.compile()` can write.
- MCP `ae_spec_codegen` `irPath`/`outDir` are resolved only under the approved workspace, and child-process arguments remain workspace-relative.
- Codegen CLI rejects absolute or dot-segment input/output paths instead of resolving them into arbitrary filesystem locations.
- Generated files and manifests are contained under the configured output directory, and unsafe IR-derived entity/field/API method identifiers fail closed.
- Regression tests cover valid paths, traversal/absolute rejection, symlink ancestor rejection, child-process argument shaping, and IR-derived path traversal prevention.

## Verification
- `pnpm -s exec vitest run tests/unit/utils/workspace-path-policy.test.ts tests/unit/mcp-server/spec-synthesis-path-policy.test.ts tests/unit/codegen/deterministic-generator-path-policy.test.ts --reporter dot`
- `pnpm -s run types:check`
- `pnpm -s exec eslint --quiet src/utils/workspace-path-policy.ts src/mcp-server/spec-synthesis-path-policy.ts src/mcp-server/spec-synthesis-server.ts src/cli/codegen-cli.ts src/codegen/deterministic-generator.ts tests/unit/utils/workspace-path-policy.test.ts tests/unit/mcp-server/spec-synthesis-path-policy.test.ts tests/unit/codegen/deterministic-generator-path-policy.test.ts`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`
- CLI smoke: relative codegen generate succeeds; absolute input path is rejected with the workspace-relative policy error.

## Rollback
- Revert this PR to restore the previous MCP/CLI codegen path handling. If reverted, do not expose `ae_spec_compile` or `ae_spec_codegen` to untrusted MCP clients until equivalent workspace containment is restored.
