### PR TITLE
fix(mcp): constrain plugin paths and templates

### DIFF
--- a/src/utils/mcp-plugin-manager.ts
+++ b/src/utils/mcp-plugin-manager.ts
@@ -5,6 +5,8 @@
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { constants as fsConstants } from 'fs';
+import { pathToFileURL } from 'url';
 import type { MCPPlugin, MCPServer } from '../services/mcp-server.js';
 
 export interface PluginManifest {
@@ -45,6 +47,15 @@ export interface PluginDiscoveryOptions {
   includeDevPlugins: boolean;
   skipValidation: boolean;
 }
+
+interface PluginScanEntry {
+  manifest: PluginManifest;
+  manifestPath: string;
+}
+
+const SAFE_PLUGIN_NAME_PATTERN = /^[a-z][a-z0-9_-]*(?:\.[a-z0-9_-]+)*$/;
+const SAFE_PLUGIN_TEMPLATE_NAME_PATTERN = /^[a-z][a-z0-9-]{0,63}$/;
+const MAX_PLUGIN_NAME_LENGTH = 80;
 
 export class MCPPluginManager {
   private plugins: Map<string, PluginRegistration> = new Map();
@@ -118,8 +129,9 @@ export class MCPPluginManager {
         };
       }
 
-      // Load plugin module
-      const pluginModulePath = path.join(path.dirname(filePath), manifest.main);
+      // Load plugin module only after manifest-controlled paths have been
+      // constrained to the scanned plugin directory.
+      const pluginModulePath = await this.resolvePluginModulePath(manifest, filePath);
       const pluginModule = await this.loadPluginModule(pluginModulePath);
 
       if (!pluginModule || typeof pluginModule.initialize !== 'function') {
@@ -176,15 +188,14 @@ export class MCPPluginManager {
     const results: PluginLoadResult[] = [];
 
     try {
-      const plugins = await this.scanPluginDirectory(directoryPath, {
+      const plugins = await this.scanPluginDirectoryEntries(directoryPath, {
         searchPaths: [directoryPath],
         includeDevPlugins: true,
-        skipValidation: false
+        skipValidation: true
       });
 
-      for (const manifest of plugins) {
-        const manifestPath = path.join(directoryPath, manifest.name, 'plugin.json');
-        const result = await this.loadPlugin(manifest, manifestPath);
+      for (const plugin of plugins) {
+        const result = await this.loadPlugin(plugin.manifest, plugin.manifestPath);
         results.push(result);
       }
 
@@ -294,8 +305,16 @@ export class MCPPluginManager {
    * Create a new plugin template
    */
   async createPluginTemplate(name: string, targetDir: string): Promise<void> {
-    const pluginDir = path.join(targetDir, name);
+    const nameError = this.validatePluginTemplateName(name);
+    if (nameError) {
+      throw new Error(nameError);
+    }
+
+    const safeTargetDir = await this.resolvePluginTemplateTargetDirectory(targetDir);
+    const pluginDir = path.resolve(safeTargetDir, name);
+    this.assertPathInside(pluginDir, safeTargetDir, 'Plugin template directory escapes the target directory');
     await fs.mkdir(pluginDir, { recursive: true });
+    await this.assertRealPathInsideProject(pluginDir, 'Plugin template directory escapes the project root');
 
     // Create plugin manifest
     const manifest: PluginManifest = {
@@ -311,10 +330,13 @@ export class MCPPluginManager {
       }
     };
 
-    await fs.writeFile(
-      path.join(pluginDir, 'plugin.json'),
-      JSON.stringify(manifest, null, 2)
-    );
+    await this.writePluginTemplateFile(pluginDir, 'plugin.json', JSON.stringify(manifest, null, 2));
+
+    const initMessage = JSON.stringify(`${name} plugin initialized`);
+    const terminateMessage = JSON.stringify(`${name} plugin terminated`);
+    const endpointPath = JSON.stringify(`/${encodeURIComponent(name)}/hello`);
+    const helloMessage = JSON.stringify(`Hello from ${name} plugin!`);
+    const endpointDescription = JSON.stringify(`Test endpoint for ${name} plugin`);
 
     // Create plugin implementation
     const pluginCode = `/**
@@ -325,17 +347,17 @@ export class MCPPluginManager {
  * Initialize plugin
  */
 async function initialize(server) {
-  console.log('${name} plugin initialized');
+  console.log(${initMessage});
   
   // Register plugin endpoints
   server.registerEndpoint({
-    path: '/${name}/hello',
+    path: ${endpointPath},
     method: 'GET',
     handler: async (request) => ({
       status: 200,
-      data: { message: 'Hello from ${name} plugin!' }
+      data: { message: ${helloMessage} }
     }),
-    description: 'Test endpoint for ${name} plugin'
+    description: ${endpointDescription}
   });
 }
 
@@ -343,7 +365,7 @@ async function initialize(server) {
  * Terminate plugin
  */
 async function terminate(server) {
-  console.log('${name} plugin terminated');
+  console.log(${terminateMessage});
 }
 
 module.exports = {
@@ -352,7 +374,7 @@ module.exports = {
 };
 `;
 
-    await fs.writeFile(path.join(pluginDir, 'index.js'), pluginCode);
+    await this.writePluginTemplateFile(pluginDir, 'index.js', pluginCode);
 
     // Create README
     const readme = `# ${name} Plugin
@@ -374,7 +396,7 @@ This plugin provides the following endpoints:
 No additional configuration required.
 `;
 
-    await fs.writeFile(path.join(pluginDir, 'README.md'), readme);
+    await this.writePluginTemplateFile(pluginDir, 'README.md', readme);
   }
 
   // Private methods
@@ -383,14 +405,23 @@ No additional configuration required.
     directoryPath: string, 
     options: PluginDiscoveryOptions
   ): Promise<PluginManifest[]> {
-    const plugins: PluginManifest[] = [];
+    const entries = await this.scanPluginDirectoryEntries(directoryPath, options);
+    return entries.map((entry) => entry.manifest);
+  }
+
+  private async scanPluginDirectoryEntries(
+    directoryPath: string,
+    options: PluginDiscoveryOptions
+  ): Promise<PluginScanEntry[]> {
+    const plugins: PluginScanEntry[] = [];
 
     try {
       const entries = await fs.readdir(directoryPath, { withFileTypes: true });
 
       for (const entry of entries) {
         if (entry.isDirectory()) {
-          const pluginManifestPath = path.join(directoryPath, entry.name, 'plugin.json');
+          const pluginDirectory = path.join(directoryPath, entry.name);
+          const pluginManifestPath = path.join(pluginDirectory, 'plugin.json');
           
           try {
             const manifestContent = await fs.readFile(pluginManifestPath, 'utf-8');
@@ -401,7 +432,14 @@ No additional configuration required.
               continue;
             }
 
-            plugins.push(manifest);
+            if (!options.skipValidation && this.validateManifest(manifest)) {
+              continue;
+            }
+
+            plugins.push({
+              manifest,
+              manifestPath: pluginManifestPath
+            });
           } catch (error) {
             // Skip directories without valid plugin.json
             continue;
@@ -420,12 +458,22 @@ No additional configuration required.
       return 'Plugin name is required and must be a string';
     }
 
+    const pluginNameError = this.validatePluginManifestName(manifest.name);
+    if (pluginNameError) {
+      return pluginNameError;
+    }
+
     if (!manifest.version || typeof manifest.version !== 'string') {
       return 'Plugin version is required and must be a string';
     }
 
     if (!manifest.main || typeof manifest.main !== 'string') {
       return 'Plugin main file is required and must be a string';
+    }
+
+    const pluginMainError = this.validatePluginMainPath(manifest.main);
+    if (pluginMainError) {
+      return pluginMainError;
     }
 
     // Validate version format (basic semver check)
@@ -435,6 +483,206 @@ No additional configuration required.
     }
 
     return null;
+  }
+
+  private validatePluginManifestName(name: string): string | null {
+    if (name.length > MAX_PLUGIN_NAME_LENGTH) {
+      return `Plugin name must be ${MAX_PLUGIN_NAME_LENGTH} characters or fewer`;
+    }
+
+    if (this.hasUnsafePathCharacters(name)) {
+      return 'Plugin name must not contain path separators, control characters, or NUL bytes';
+    }
+
+    if (!SAFE_PLUGIN_NAME_PATTERN.test(name)) {
+      return 'Plugin name must be a safe lowercase plugin identifier';
+    }
+
+    return null;
+  }
+
+  private validatePluginTemplateName(name: string): string | null {
+    if (!name || typeof name !== 'string') {
+      return 'Plugin template name is required and must be a string';
+    }
+
+    if (this.hasUnsafePathCharacters(name)) {
+      return 'Plugin template name must not contain path separators, control characters, or NUL bytes';
+    }
+
+    if (!SAFE_PLUGIN_TEMPLATE_NAME_PATTERN.test(name)) {
+      return 'Plugin template name must be a lowercase slug using only letters, digits, and hyphens';
+    }
+
+    return null;
+  }
+
+  private validatePluginMainPath(main: string): string | null {
+    if (main.length === 0 || main.trim() !== main) {
+      return 'Plugin main file must be a non-empty relative path without surrounding whitespace';
+    }
+
+    if (this.hasControlOrNullByte(main) || main.includes('\\')) {
+      return 'Plugin main file must not contain backslashes, control characters, or NUL bytes';
+    }
+
+    if (path.isAbsolute(main) || /^[A-Za-z]:/.test(main) || main.startsWith('//')) {
+      return 'Plugin main file must be a relative path';
+    }
+
+    const parts = main.split('/');
+    if (parts.some((part) => part === '' || part === '.' || part === '..')) {
+      return 'Plugin main file must not contain empty, current-directory, or parent-directory segments';
+    }
+
+    const extension = path.posix.extname(main);
+    if (extension !== '.js' && extension !== '.mjs') {
+      return 'Plugin main file must be a JavaScript module ending in .js or .mjs';
+    }
+
+    return null;
+  }
+
+  private hasUnsafePathCharacters(value: string): boolean {
+    return this.hasControlOrNullByte(value) || value.includes('/') || value.includes('\\');
+  }
+
+  private hasControlOrNullByte(value: string): boolean {
+    for (let index = 0; index < value.length; index += 1) {
+      const codePoint = value.charCodeAt(index);
+      if (codePoint <= 0x1f || codePoint === 0x7f) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private async resolvePluginModulePath(manifest: PluginManifest, manifestPath: string): Promise<string> {
+    const pluginDirectory = path.dirname(manifestPath);
+    const candidateModulePath = path.resolve(pluginDirectory, manifest.main);
+    this.assertPathInside(candidateModulePath, pluginDirectory, 'Plugin main file escapes the plugin directory');
+
+    let realPluginDirectory: string;
+    let realModulePath: string;
+
+    try {
+      realPluginDirectory = await fs.realpath(pluginDirectory);
+      realModulePath = await fs.realpath(candidateModulePath);
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') {
+        throw new Error(`Plugin module file not found: ${candidateModulePath}`);
+      }
+      throw error;
+    }
+
+    this.assertPathInside(realModulePath, realPluginDirectory, 'Plugin main file resolves outside the plugin directory');
+    return realModulePath;
+  }
+
+  private async resolvePluginTemplateTargetDirectory(targetDir: string): Promise<string> {
+    if (!targetDir || typeof targetDir !== 'string') {
+      throw new Error('Plugin template target directory is required and must be a string');
+    }
+
+    if (this.hasControlOrNullByte(targetDir) || targetDir.includes('\\') || /^[A-Za-z]:/.test(targetDir)) {
+      throw new Error('Plugin template target directory must not contain control characters, NUL bytes, backslashes, or Windows drive prefixes');
+    }
+
+    const resolvedProjectRoot = path.resolve(this.projectRoot);
+    const realProjectRoot = await fs.realpath(resolvedProjectRoot);
+    const resolvedTargetDir = path.isAbsolute(targetDir)
+      ? path.resolve(targetDir)
+      : path.resolve(resolvedProjectRoot, targetDir);
+
+    this.assertPathInside(resolvedTargetDir, resolvedProjectRoot, 'Plugin template target directory escapes the project root');
+
+    const realNearestAncestor = await this.realpathNearestExistingAncestor(resolvedTargetDir);
+    this.assertPathInside(realNearestAncestor, realProjectRoot, 'Plugin template target directory resolves outside the project root');
+
+    return resolvedTargetDir;
+  }
+
+  private async resolvePluginTemplateOutputPath(pluginDir: string, fileName: string): Promise<string> {
+    const candidatePath = path.resolve(pluginDir, fileName);
+    this.assertPathInside(candidatePath, pluginDir, 'Plugin template output file escapes the plugin directory');
+
+    const realPluginDir = await fs.realpath(pluginDir);
+    const realParentDir = await fs.realpath(path.dirname(candidatePath));
+    this.assertPathInside(realParentDir, realPluginDir, 'Plugin template output parent resolves outside the plugin directory');
+
+    try {
+      const existingOutput = await fs.lstat(candidatePath);
+      if (existingOutput.isSymbolicLink()) {
+        throw new Error('Plugin template output file must not be a symbolic link');
+      }
+
+      if (!existingOutput.isFile()) {
+        throw new Error('Plugin template output path must be a regular file when it already exists');
+      }
+
+      const realExistingOutput = await fs.realpath(candidatePath);
+      this.assertPathInside(realExistingOutput, realPluginDir, 'Plugin template output file resolves outside the plugin directory');
+    } catch (error: any) {
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+
+    return candidatePath;
+  }
+
+  private async writePluginTemplateFile(pluginDir: string, fileName: string, content: string): Promise<void> {
+    const outputPath = await this.resolvePluginTemplateOutputPath(pluginDir, fileName);
+    const noFollowFlag = fsConstants.O_NOFOLLOW ?? 0;
+    const handle = await fs.open(
+      outputPath,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlag,
+      0o666
+    );
+
+    try {
+      await handle.writeFile(content);
+    } finally {
+      await handle.close();
+    }
+  }
+
+  private async assertRealPathInsideProject(targetPath: string, message: string): Promise<void> {
+    const realProjectRoot = await fs.realpath(this.projectRoot);
+    const realTargetPath = await fs.realpath(targetPath);
+    this.assertPathInside(realTargetPath, realProjectRoot, message);
+  }
+
+  private async realpathNearestExistingAncestor(targetPath: string): Promise<string> {
+    let current = path.resolve(targetPath);
+
+    while (true) {
+      try {
+        return await fs.realpath(current);
+      } catch (error: any) {
+        if (error?.code !== 'ENOENT') {
+          throw error;
+        }
+      }
+
+      const parent = path.dirname(current);
+      if (parent === current) {
+        throw new Error(`No existing ancestor found for ${targetPath}`);
+      }
+      current = parent;
+    }
+  }
+
+  private assertPathInside(candidatePath: string, parentPath: string, message: string): void {
+    const relative = path.relative(parentPath, candidatePath);
+    if (relative === '') {
+      return;
+    }
+
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error(message);
+    }
   }
 
   private async loadPluginModule(modulePath: string): Promise<any> {
@@ -449,7 +697,7 @@ No additional configuration required.
         case '.mjs':
           try {
             // Dynamic import for ES modules
-            const module = await import(modulePath);
+            const module = await import(pathToFileURL(modulePath).href);
             return module.default || module;
           } catch (importError: any) {
             // Fallback to require for CommonJS modules

--- a/tests/unit/utils/mcp-plugin-manager-security.test.ts
+++ b/tests/unit/utils/mcp-plugin-manager-security.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { MCPPluginManager, type PluginManifest } from '../../../src/utils/mcp-plugin-manager.js';
+
+const fileSymlinkType = process.platform === 'win32' ? 'file' : undefined;
+const directorySymlinkType = process.platform === 'win32' ? 'junction' : 'dir';
+
+describe('MCPPluginManager path safety', () => {
+  let workspaceRoot: string;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = path.join(
+      process.cwd(),
+      'artifacts',
+      'testing',
+      'test-tmp',
+      `mcp-plugin-manager-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+    );
+    projectRoot = path.join(workspaceRoot, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  async function writePlugin(
+    pluginsRoot: string,
+    directoryName: string,
+    manifest: Partial<PluginManifest>,
+    moduleContent = 'export async function initialize() {}\n'
+  ): Promise<string> {
+    const pluginDirectory = path.join(pluginsRoot, directoryName);
+    await fs.mkdir(pluginDirectory, { recursive: true });
+
+    const completeManifest: PluginManifest = {
+      name: 'safe-plugin',
+      version: '1.0.0',
+      main: 'index.mjs',
+      ...manifest
+    };
+
+    await fs.writeFile(path.join(pluginDirectory, 'plugin.json'), JSON.stringify(completeManifest, null, 2));
+    await fs.writeFile(path.join(pluginDirectory, 'index.mjs'), moduleContent);
+    return path.join(pluginDirectory, 'plugin.json');
+  }
+
+  test('loads plugins from the actual scanned directory instead of recomputing paths from manifest.name', async () => {
+    const pluginsRoot = path.join(projectRoot, 'plugins');
+    const manifestPath = await writePlugin(pluginsRoot, 'actual-directory', {
+      name: 'safe-plugin',
+      main: 'index.mjs'
+    });
+
+    const manager = new MCPPluginManager(projectRoot);
+    const results = await manager.loadPluginsFromDirectory(pluginsRoot);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.success).toBe(true);
+    expect(results[0]?.plugin?.filePath).toBe(manifestPath);
+    expect(manager.getPlugin('safe-plugin')?.filePath).toBe(manifestPath);
+  });
+
+  test('discovery filters invalid manifests by default but can expose them when validation is skipped', async () => {
+    const pluginsRoot = path.join(projectRoot, 'plugins');
+    await writePlugin(pluginsRoot, 'valid-plugin', {
+      name: 'valid-plugin',
+      main: 'index.mjs'
+    });
+    await writePlugin(pluginsRoot, 'invalid-plugin', {
+      name: '../invalid',
+      main: 'index.mjs'
+    });
+
+    const manager = new MCPPluginManager(projectRoot);
+
+    const defaultDiscovery = await manager.discoverPlugins({ searchPaths: [pluginsRoot], includeDevPlugins: true });
+    expect(defaultDiscovery.map((plugin) => plugin.name).sort()).toEqual(['valid-plugin']);
+
+    const skipValidationDiscovery = await manager.discoverPlugins({
+      searchPaths: [pluginsRoot],
+      includeDevPlugins: true,
+      skipValidation: true
+    });
+    expect(skipValidationDiscovery.map((plugin) => plugin.name).sort()).toEqual(['../invalid', 'valid-plugin']);
+  });
+
+  test('directory loading returns per-plugin load errors for invalid manifests instead of silently skipping them', async () => {
+    const pluginsRoot = path.join(projectRoot, 'plugins');
+    await writePlugin(pluginsRoot, 'invalid-plugin', {
+      name: '../invalid',
+      main: 'index.mjs'
+    });
+
+    const manager = new MCPPluginManager(projectRoot);
+    const results = await manager.loadPluginsFromDirectory(pluginsRoot);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.success).toBe(false);
+    expect(results[0]?.error).toContain('Invalid plugin manifest');
+  });
+
+  test('allows nested manifest main paths when they remain inside the plugin directory', async () => {
+    const pluginsRoot = path.join(projectRoot, 'plugins');
+    const pluginDirectory = path.join(pluginsRoot, 'nested-main-plugin');
+    await fs.mkdir(path.join(pluginDirectory, 'dist'), { recursive: true });
+    const manifestPath = path.join(pluginDirectory, 'plugin.json');
+    await fs.writeFile(
+      manifestPath,
+      JSON.stringify({ name: 'nested-main-plugin', version: '1.0.0', main: 'dist/index.mjs' }, null, 2)
+    );
+    await fs.writeFile(path.join(pluginDirectory, 'dist', 'index.mjs'), 'export async function initialize() {}\n');
+
+    const manager = new MCPPluginManager(projectRoot);
+    const result = await manager.loadPlugin(
+      { name: 'nested-main-plugin', version: '1.0.0', main: 'dist/index.mjs' },
+      manifestPath
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.plugin?.manifest.name).toBe('nested-main-plugin');
+  });
+
+  test.each([
+    '../evil',
+    'bad/name',
+    'bad\\name',
+    'BadName',
+    'bad name',
+    '.hidden',
+    'a'.repeat(81)
+  ])('rejects unsafe manifest plugin name %s before module loading', async (unsafeName) => {
+    const pluginsRoot = path.join(projectRoot, 'plugins');
+    const manifestPath = await writePlugin(pluginsRoot, 'unsafe-name-plugin', {
+      name: unsafeName,
+      main: 'index.mjs'
+    });
+
+    const manager = new MCPPluginManager(projectRoot);
+    const result = await manager.loadPlugin(
+      { name: unsafeName, version: '1.0.0', main: 'index.mjs' },
+      manifestPath
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid plugin manifest');
+  });
+
+  test.each([
+    '../outside.mjs',
+    './index.mjs',
+    '/absolute/index.mjs',
+    'C:\\temp\\plugin.js',
+    'nested/../index.mjs',
+    'index.ts',
+    'index.json'
+  ])('rejects unsafe manifest main path %s before module loading', async (unsafeMain) => {
+    const pluginsRoot = path.join(projectRoot, 'plugins');
+    const manifestPath = await writePlugin(pluginsRoot, 'unsafe-main-plugin', {
+      name: 'unsafe-main-plugin',
+      main: unsafeMain
+    });
+
+    const manager = new MCPPluginManager(projectRoot);
+    const result = await manager.loadPlugin(
+      { name: 'unsafe-main-plugin', version: '1.0.0', main: unsafeMain },
+      manifestPath
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid plugin manifest');
+  });
+
+  test('rejects symlinked plugin main files that resolve outside the plugin directory', async () => {
+    const pluginsRoot = path.join(projectRoot, 'plugins');
+    const pluginDirectory = path.join(pluginsRoot, 'symlink-plugin');
+    const outsideDirectory = path.join(workspaceRoot, 'outside');
+    await fs.mkdir(pluginDirectory, { recursive: true });
+    await fs.mkdir(outsideDirectory, { recursive: true });
+
+    const outsideModule = path.join(outsideDirectory, 'outside.mjs');
+    await fs.writeFile(outsideModule, 'export async function initialize() {}\n');
+    await fs.writeFile(
+      path.join(pluginDirectory, 'plugin.json'),
+      JSON.stringify({ name: 'symlink-plugin', version: '1.0.0', main: 'index.mjs' }, null, 2)
+    );
+    await fs.symlink(outsideModule, path.join(pluginDirectory, 'index.mjs'), fileSymlinkType);
+
+    const manager = new MCPPluginManager(projectRoot);
+    const result = await manager.loadPlugin(
+      { name: 'symlink-plugin', version: '1.0.0', main: 'index.mjs' },
+      path.join(pluginDirectory, 'plugin.json')
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('resolves outside the plugin directory');
+  });
+
+  test('creates plugin templates only inside the approved project tree and serializes generated code strings', async () => {
+    const targetDir = path.join(projectRoot, 'plugins');
+    const manager = new MCPPluginManager(projectRoot);
+
+    await manager.createPluginTemplate('new-plugin', targetDir);
+
+    const pluginDirectory = path.join(targetDir, 'new-plugin');
+    await expect(fs.stat(path.join(pluginDirectory, 'plugin.json'))).resolves.toBeDefined();
+    await expect(fs.stat(path.join(pluginDirectory, 'README.md'))).resolves.toBeDefined();
+
+    const generatedCode = await fs.readFile(path.join(pluginDirectory, 'index.js'), 'utf8');
+    expect(generatedCode).toContain('console.log("new-plugin plugin initialized");');
+    expect(generatedCode).toContain('path: "/new-plugin/hello"');
+    expect(generatedCode).toContain('message: "Hello from new-plugin plugin!"');
+  });
+
+  test('allows relative template target directories inside the project root', async () => {
+    const manager = new MCPPluginManager(projectRoot);
+
+    await manager.createPluginTemplate('relative-plugin', 'plugins');
+
+    await expect(fs.stat(path.join(projectRoot, 'plugins', 'relative-plugin', 'plugin.json'))).resolves.toBeDefined();
+  });
+
+  test.each(['../evil', 'bad/name', 'bad\\name', "bad'name", 'BadName', 'bad name'])(
+    'rejects unsafe template plugin name %s before writing files',
+    async (unsafeName) => {
+      const targetDir = path.join(projectRoot, 'plugins');
+      const manager = new MCPPluginManager(projectRoot);
+
+      await expect(manager.createPluginTemplate(unsafeName, targetDir)).rejects.toThrow(/Plugin template name/);
+
+      const entries = await fs.readdir(targetDir).catch(() => []);
+      expect(entries).toEqual([]);
+    }
+  );
+
+  test('rejects plugin template target directories outside the project root', async () => {
+    const manager = new MCPPluginManager(projectRoot);
+    const outsideTarget = path.join(workspaceRoot, 'outside-target');
+
+    await expect(manager.createPluginTemplate('safe-plugin', outsideTarget)).rejects.toThrow(/project root/);
+
+    await expect(fs.stat(path.join(outsideTarget, 'safe-plugin'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  test('rejects plugin template target symlinks that resolve outside the project root', async () => {
+    const outsideTarget = path.join(workspaceRoot, 'outside-target');
+    const symlinkTarget = path.join(projectRoot, 'plugins-link');
+    await fs.mkdir(outsideTarget, { recursive: true });
+    await fs.symlink(outsideTarget, symlinkTarget, directorySymlinkType);
+
+    const manager = new MCPPluginManager(projectRoot);
+
+    await expect(manager.createPluginTemplate('safe-plugin', symlinkTarget)).rejects.toThrow(/outside the project root/);
+
+    const entries = await fs.readdir(outsideTarget);
+    expect(entries).toEqual([]);
+  });
+
+  test('rejects pre-existing symlinked plugin template output files before overwriting them', async () => {
+    const targetDir = path.join(projectRoot, 'plugins');
+    const pluginDirectory = path.join(targetDir, 'safe-plugin');
+    const outsideTarget = path.join(workspaceRoot, 'outside-plugin-json');
+    await fs.mkdir(pluginDirectory, { recursive: true });
+    await fs.writeFile(outsideTarget, 'outside content');
+    await fs.symlink(outsideTarget, path.join(pluginDirectory, 'plugin.json'), fileSymlinkType);
+
+    const manager = new MCPPluginManager(projectRoot);
+
+    await expect(manager.createPluginTemplate('safe-plugin', targetDir)).rejects.toThrow(/symbolic link|ELOOP/);
+    await expect(fs.readFile(outsideTarget, 'utf8')).resolves.toBe('outside content');
+  });
+
+  test('rejects symlinked implementation output files without following the final symlink', async () => {
+    const targetDir = path.join(projectRoot, 'plugins');
+    const pluginDirectory = path.join(targetDir, 'safe-plugin');
+    const outsideTarget = path.join(workspaceRoot, 'outside-index');
+    await fs.mkdir(pluginDirectory, { recursive: true });
+    await fs.writeFile(outsideTarget, 'outside content');
+    await fs.symlink(outsideTarget, path.join(pluginDirectory, 'index.js'), fileSymlinkType);
+
+    const manager = new MCPPluginManager(projectRoot);
+
+    await expect(manager.createPluginTemplate('safe-plugin', targetDir)).rejects.toThrow(/symbolic link|ELOOP/);
+    await expect(fs.readFile(outsideTarget, 'utf8')).resolves.toBe('outside content');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3361.
Closes #3362.

This PR hardens MCP plugin loading and plugin template generation:

- preserves the actual scanned `plugin.json` path instead of recomputing it from `manifest.name`;
- validates plugin manifest names and `manifest.main` before module loading;
- resolves plugin modules with realpath-based containment before dynamic import / CommonJS fallback;
- validates plugin template names as lowercase slugs;
- constrains template output targets to the project root and checks symlink escapes before write sinks;
- serializes generated JavaScript string literals for template code.

## Acceptance

- [x] Unsafe `manifest.name` values are rejected before module loading.
- [x] Unsafe `manifest.main` values, absolute paths, dot segments, backslashes, and non-JS module paths are rejected before import/require.
- [x] Symlinked plugin main files that resolve outside the plugin directory fail closed.
- [x] Plugin template names reject traversal, separators, whitespace, uppercase, and quote/control-style injection inputs before writes.
- [x] Plugin template target directories are constrained to the project root, including symlink ancestor checks.
- [x] Existing MCP command happy-path behavior remains covered.

## Verification

Local verification run on this branch:

```bash
pnpm install --frozen-lockfile
pnpm -s exec vitest run tests/unit/utils/mcp-plugin-manager-security.test.ts tests/commands/mcp-command.test.ts --reporter dot
pnpm -s exec eslint --quiet src/utils/mcp-plugin-manager.ts tests/unit/utils/mcp-plugin-manager-security.test.ts tests/commands/mcp-command.test.ts
pnpm -s run types:check
pnpm -s run build
pnpm -s run check:schemas
pnpm -s run check:doc-consistency
git diff --check
```

## Rollback

Revert this PR to restore the previous MCP plugin loading and template generation behavior. Rollback reopens #3361/#3362 risk because manifest-controlled paths and template names would again reach import/write/code-generation sinks without these containment checks.
