### PR TITLE
fix(mcp): gate TDD test execution

### DIFF
--- a/src/mcp-server/schemas.ts
+++ b/src/mcp-server/schemas.ts
@@ -247,6 +247,9 @@ export type CleanupArgs = z.infer<typeof CleanupArgsSchema>;
 export const AnalyzeTDDArgsSchema = z.object({
   path: z.string().optional().default(process.cwd()),
   phase: z.string().optional(),
+  testCommand: z.enum(['npm test', 'pnpm test', 'yarn test']).optional().default('npm test'),
+  dryRun: z.boolean().optional().default(true),
+  testExecutionApproval: z.enum(['none', 'approved-tdd-test-execution']).optional().default('none'),
 });
 export type AnalyzeTDDArgs = z.infer<typeof AnalyzeTDDArgsSchema>;
 
@@ -262,8 +265,10 @@ export const ValidateTestFirstArgsSchema = z.object({
 export type ValidateTestFirstArgs = z.infer<typeof ValidateTestFirstArgsSchema>;
 
 export const RedGreenCycleArgsSchema = z.object({
-  testCommand: z.string().optional().default('npm test'),
+  testCommand: z.enum(['npm test', 'pnpm test', 'yarn test']).optional().default('npm test'),
   expectRed: z.boolean().optional().default(false),
+  dryRun: z.boolean().optional().default(true),
+  testExecutionApproval: z.enum(['none', 'approved-tdd-test-execution']).optional().default('none'),
 });
 export type RedGreenCycleArgs = z.infer<typeof RedGreenCycleArgsSchema>;
 

--- a/src/mcp-server/tdd-execution-policy.ts
+++ b/src/mcp-server/tdd-execution-policy.ts
@@ -1,0 +1,79 @@
+import { execFileSync } from 'child_process';
+
+export type TDDTestCommand = 'npm test' | 'pnpm test' | 'yarn test';
+export type TDDTestExecutionApproval = 'none' | 'approved-tdd-test-execution';
+
+export interface ResolvedTDDTestCommand {
+  executable: string;
+  args: string[];
+}
+
+export type TDDTestExecutor = (
+  executable: string,
+  args: string[],
+  options: { encoding: 'utf8'; stdio: 'pipe'; shell: false; cwd?: string }
+) => string | Buffer;
+
+export const APPROVED_TDD_TEST_EXECUTION = 'approved-tdd-test-execution' as const;
+
+const ALLOWED_TDD_TEST_COMMANDS: Record<TDDTestCommand, ResolvedTDDTestCommand> = {
+  'npm test': { executable: 'npm', args: ['test', '--silent'] },
+  'pnpm test': { executable: 'pnpm', args: ['test', '--silent'] },
+  'yarn test': { executable: 'yarn', args: ['test', '--silent'] },
+};
+
+export function resolveSafeTDDTestCommand(testCommand: TDDTestCommand): ResolvedTDDTestCommand {
+  const resolved = ALLOWED_TDD_TEST_COMMANDS[testCommand];
+  if (!resolved) {
+    throw new Error('Unsupported TDD test command');
+  }
+
+  return {
+    executable: resolved.executable,
+    args: [...resolved.args],
+  };
+}
+
+export function formatTDDTestCommand(command: ResolvedTDDTestCommand): string {
+  return [command.executable, ...command.args].join(' ');
+}
+
+export function ensureTDDTestExecutionApproved(
+  approval: TDDTestExecutionApproval,
+  dryRun: boolean
+): { approved: boolean; reason?: string } {
+  if (dryRun) {
+    return { approved: false, reason: 'dry-run mode is enabled' };
+  }
+
+  if (approval !== APPROVED_TDD_TEST_EXECUTION) {
+    return {
+      approved: false,
+      reason: `test execution requires approval token '${APPROVED_TDD_TEST_EXECUTION}'`,
+    };
+  }
+
+  return { approved: true };
+}
+
+export function runSafeTDDTestCommand(
+  testCommand: TDDTestCommand,
+  options: {
+    cwd?: string;
+    executor?: TDDTestExecutor;
+  } = {}
+): string | Buffer {
+  const resolved = resolveSafeTDDTestCommand(testCommand);
+  const executor = options.executor ?? execFileSync;
+  const execOptions: { encoding: 'utf8'; stdio: 'pipe'; shell: false; cwd?: string } = {
+    encoding: 'utf8',
+    stdio: 'pipe',
+    shell: false,
+  };
+
+  if (options.cwd) {
+    execOptions.cwd = options.cwd;
+  }
+
+  return executor(resolved.executable, resolved.args, execOptions);
+}

--- a/src/mcp-server/tdd-execution-policy.ts
+++ b/src/mcp-server/tdd-execution-policy.ts
@@ -22,10 +22,20 @@ const ALLOWED_TDD_TEST_COMMANDS: Record<TDDTestCommand, ResolvedTDDTestCommand> 
   'yarn test': { executable: 'yarn', args: ['test', '--silent'] },
 };
 
-export function resolveSafeTDDTestCommand(testCommand: TDDTestCommand): ResolvedTDDTestCommand {
+export function resolveSafeTDDTestCommand(
+  testCommand: TDDTestCommand,
+  platform: NodeJS.Platform = process.platform
+): ResolvedTDDTestCommand {
   const resolved = ALLOWED_TDD_TEST_COMMANDS[testCommand];
   if (!resolved) {
     throw new Error('Unsupported TDD test command');
+  }
+
+  if (platform === 'win32') {
+    return {
+      executable: 'cmd.exe',
+      args: ['/d', '/s', '/c', `${resolved.executable}.cmd`, ...resolved.args],
+    };
   }
 
   return {
@@ -61,9 +71,10 @@ export function runSafeTDDTestCommand(
   options: {
     cwd?: string;
     executor?: TDDTestExecutor;
+    platform?: NodeJS.Platform;
   } = {}
 ): string | Buffer {
-  const resolved = resolveSafeTDDTestCommand(testCommand);
+  const resolved = resolveSafeTDDTestCommand(testCommand, options.platform);
   const executor = options.executor ?? execFileSync;
   const execOptions: { encoding: 'utf8'; stdio: 'pipe'; shell: false; cwd?: string } = {
     encoding: 'utf8',

--- a/src/mcp-server/tdd-server.ts
+++ b/src/mcp-server/tdd-server.ts
@@ -6,9 +6,10 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { execSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, realpathSync } from 'fs';
 import { glob } from 'glob';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
 import {
   AnalyzeTDDArgsSchema,
   GuideTDDArgsSchema,
@@ -22,6 +23,12 @@ import {
   type SuggestTestStructureArgs,
   type ValidateTestFirstArgs,
 } from './schemas.js';
+import {
+  ensureTDDTestExecutionApproved,
+  formatTDDTestCommand,
+  resolveSafeTDDTestCommand,
+  runSafeTDDTestCommand,
+} from './tdd-execution-policy.js';
 
 interface TDDViolation {
   type: 'missing_test' | 'failing_test' | 'skip_red' | 'low_coverage';
@@ -39,7 +46,7 @@ interface TDDAnalysis {
   canProceed: boolean;
 }
 
-class TDDGuardServer {
+export class TDDGuardServer {
   private server: Server;
 
   constructor() {
@@ -74,6 +81,23 @@ class TDDGuardServer {
               phase: {
                 type: 'string',
                 description: 'Current development phase (1-intent, 2-formal, 3-tests, 4-code, 5-verify, 6-operate)',
+              },
+              testCommand: {
+                type: 'string',
+                enum: ['npm test', 'pnpm test', 'yarn test'],
+                default: 'npm test',
+                description: 'Approved test command to use only when execution is explicitly approved',
+              },
+              dryRun: {
+                type: 'boolean',
+                default: true,
+                description: 'When true, analyze without executing package scripts',
+              },
+              testExecutionApproval: {
+                type: 'string',
+                enum: ['none', 'approved-tdd-test-execution'],
+                default: 'none',
+                description: 'Required approval token for MCP-triggered test execution',
               },
             },
           },
@@ -118,11 +142,23 @@ class TDDGuardServer {
             properties: {
               testCommand: {
                 type: 'string',
-                description: 'Command to run tests (defaults to "npm test")',
+                enum: ['npm test', 'pnpm test', 'yarn test'],
+                description: 'Approved test command to run without shell interpretation',
               },
               expectRed: {
                 type: 'boolean',
                 description: 'Whether tests should be failing (RED phase)',
+              },
+              dryRun: {
+                type: 'boolean',
+                default: true,
+                description: 'When true, report the approved executable/argv without running tests',
+              },
+              testExecutionApproval: {
+                type: 'string',
+                enum: ['none', 'approved-tdd-test-execution'],
+                default: 'none',
+                description: 'Required approval token for MCP-triggered test execution',
               },
             },
           },
@@ -176,7 +212,7 @@ class TDDGuardServer {
 
   private async analyzeTDDCompliance(args: unknown): Promise<{ content: { type: 'text'; text: string }[] }> {
     const parsed: AnalyzeTDDArgs = parseOrThrow(AnalyzeTDDArgsSchema, args);
-    const path = parsed.path;
+    const analysisPath = this.resolveApprovedWorkspacePath(parsed.path);
     const phase = parsed.phase || this.detectCurrentPhase();
 
     const analysis: TDDAnalysis = {
@@ -188,8 +224,8 @@ class TDDGuardServer {
     };
 
     // Check for source files without tests
-    const srcFiles = await glob('src/**/*.ts', { cwd: path });
-    const testFiles = await glob('tests/**/*.test.ts', { cwd: path });
+    const srcFiles = await glob('src/**/*.ts', { cwd: analysisPath });
+    const testFiles = await glob('tests/**/*.test.ts', { cwd: analysisPath });
 
     for (const srcFile of srcFiles) {
       if (srcFile.includes('index.ts') || srcFile.includes('/types.ts')) continue;
@@ -208,31 +244,41 @@ class TDDGuardServer {
       }
     }
 
-    // Check test execution status
-    try {
-      execSync('npm test --silent', { stdio: 'pipe' });
-      
-      if (phase === '3-tests') {
-        analysis.violations.push({
-          type: 'skip_red',
-          severity: 'warning',
-          message: 'Tests are passing but should be RED in test-first phase',
-          suggestion: 'Verify that tests fail initially to confirm they test the right behavior',
-        });
+    let skippedTestExecutionRecommendation: string | undefined;
+    const executionApproval = ensureTDDTestExecutionApproved(parsed.testExecutionApproval, parsed.dryRun);
+    if (executionApproval.approved) {
+      try {
+        runSafeTDDTestCommand(parsed.testCommand, { cwd: analysisPath });
+
+        if (phase === '3-tests') {
+          analysis.violations.push({
+            type: 'skip_red',
+            severity: 'warning',
+            message: 'Tests are passing but should be RED in test-first phase',
+            suggestion: 'Verify that tests fail initially to confirm they test the right behavior',
+          });
+        }
+      } catch (error) {
+        if (phase === '4-code') {
+          analysis.violations.push({
+            type: 'failing_test',
+            severity: 'error',
+            message: 'Tests are failing but should pass after implementation',
+            suggestion: 'Implement the minimum code required to make tests pass',
+          });
+        }
       }
-    } catch (error) {
-      if (phase === '4-code') {
-        analysis.violations.push({
-          type: 'failing_test',
-          severity: 'error',
-          message: 'Tests are failing but should pass after implementation',
-          suggestion: 'Implement the minimum code required to make tests pass',
-        });
-      }
+    } else {
+      const resolvedCommand = resolveSafeTDDTestCommand(parsed.testCommand);
+      skippedTestExecutionRecommendation =
+        `Test execution skipped (${executionApproval.reason}). Approved command would be: ${formatTDDTestCommand(resolvedCommand)}`;
     }
 
     // Generate recommendations
     analysis.recommendations = this.generateRecommendations(analysis.violations, phase);
+    if (skippedTestExecutionRecommendation) {
+      analysis.recommendations.push(skippedTestExecutionRecommendation);
+    }
     analysis.nextAction = this.determineNextAction(analysis.violations, phase);
     analysis.canProceed = analysis.violations.filter(v => v.severity === 'error').length === 0;
 
@@ -287,10 +333,26 @@ class TDDGuardServer {
   }
 
   private async checkRedGreenCycle(args: unknown): Promise<{ content: { type: 'text'; text: string }[] }> {
-    const { testCommand, expectRed }: RedGreenCycleArgs = parseOrThrow(RedGreenCycleArgsSchema, args);
+    const { testCommand, expectRed, dryRun, testExecutionApproval }: RedGreenCycleArgs = parseOrThrow(RedGreenCycleArgsSchema, args);
+    const resolvedCommand = resolveSafeTDDTestCommand(testCommand);
+    const executionApproval = ensureTDDTestExecutionApproved(testExecutionApproval, dryRun);
+
+    if (!executionApproval.approved) {
+      return {
+        content: [{
+          type: 'text',
+          text: [
+            'ℹ️ TDD test execution was not run.',
+            `Reason: ${executionApproval.reason}.`,
+            `Approved executable/argv: ${formatTDDTestCommand(resolvedCommand)}.`,
+            `Set dryRun=false and testExecutionApproval='approved-tdd-test-execution' to execute without shell interpretation.`,
+          ].join('\n'),
+        }],
+      };
+    }
     
     try {
-      execSync(`${testCommand} --silent`, { encoding: 'utf8', stdio: 'pipe' });
+      runSafeTDDTestCommand(testCommand);
       
       if (expectRed) {
         return {
@@ -336,6 +398,26 @@ class TDDGuardServer {
     const stdout = typeof output.stdout === 'string' ? output.stdout : '';
     const stderr = typeof output.stderr === 'string' ? output.stderr : '';
     return stdout || stderr;
+  }
+
+  private resolveApprovedWorkspacePath(inputPath: string): string {
+    if (inputPath.includes('\0') || inputPath.includes('\\')) {
+      throw new Error('TDD analysis path must not contain NUL bytes or backslashes');
+    }
+
+    const workspaceRoot = path.resolve(process.env['AE_MCP_WORKSPACE_ROOT'] || process.cwd());
+    const realWorkspaceRoot = realpathSync(workspaceRoot);
+    const candidatePath = path.isAbsolute(inputPath)
+      ? path.resolve(inputPath)
+      : path.resolve(workspaceRoot, inputPath);
+    const containedPath = existsSync(candidatePath) ? realpathSync(candidatePath) : candidatePath;
+    const relative = path.relative(realWorkspaceRoot, containedPath);
+
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('TDD analysis path must stay inside the approved workspace');
+    }
+
+    return candidatePath;
   }
 
   private async suggestTestStructure(args: unknown): Promise<{ content: { type: 'text'; text: string }[] }> {
@@ -543,5 +625,7 @@ class TDDGuardServer {
   }
 }
 
-const server = new TDDGuardServer();
-server.run().catch(console.error);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const server = new TDDGuardServer();
+  server.run().catch(console.error);
+}

--- a/src/mcp-server/tdd-server.ts
+++ b/src/mcp-server/tdd-server.ts
@@ -31,7 +31,7 @@ import {
 } from './tdd-execution-policy.js';
 
 interface TDDViolation {
-  type: 'missing_test' | 'failing_test' | 'skip_red' | 'low_coverage';
+  type: 'missing_test' | 'failing_test' | 'skip_red' | 'low_coverage' | 'test_execution_skipped';
   severity: 'error' | 'warning';
   file?: string;
   message: string;
@@ -272,6 +272,15 @@ export class TDDGuardServer {
       const resolvedCommand = resolveSafeTDDTestCommand(parsed.testCommand);
       skippedTestExecutionRecommendation =
         `Test execution skipped (${executionApproval.reason}). Approved command would be: ${formatTDDTestCommand(resolvedCommand)}`;
+      if (phase === '3-tests' || phase === '4-code') {
+        const phaseExpectation = phase === '3-tests' ? 'RED' : 'GREEN';
+        analysis.violations.push({
+          type: 'test_execution_skipped',
+          severity: 'error',
+          message: `Test execution was skipped; cannot verify ${phaseExpectation} phase test results`,
+          suggestion: `Run with dryRun=false and testExecutionApproval='approved-tdd-test-execution' to execute ${formatTDDTestCommand(resolvedCommand)} in the approved workspace`,
+        });
+      }
     }
 
     // Generate recommendations
@@ -352,7 +361,7 @@ export class TDDGuardServer {
     }
     
     try {
-      runSafeTDDTestCommand(testCommand);
+      runSafeTDDTestCommand(testCommand, { cwd: this.resolveApprovedWorkspacePath('.') });
       
       if (expectRed) {
         return {
@@ -401,8 +410,8 @@ export class TDDGuardServer {
   }
 
   private resolveApprovedWorkspacePath(inputPath: string): string {
-    if (inputPath.includes('\0') || inputPath.includes('\\')) {
-      throw new Error('TDD analysis path must not contain NUL bytes or backslashes');
+    if (inputPath.includes('\0')) {
+      throw new Error('TDD analysis path must not contain NUL bytes');
     }
 
     const workspaceRoot = path.resolve(process.env['AE_MCP_WORKSPACE_ROOT'] || process.cwd());
@@ -464,6 +473,10 @@ export class TDDGuardServer {
     const failingTests = violations.filter(v => v.type === 'failing_test');
     if (failingTests.length > 0) {
       recommendations.push('Fix failing tests by implementing the minimal code required');
+    }
+
+    if (violations.some(v => v.type === 'test_execution_skipped')) {
+      recommendations.push('Run approved TDD test execution before advancing phases that require RED/GREEN evidence');
     }
     
     if (phase === '3-tests' && violations.some(v => v.type === 'skip_red')) {

--- a/tests/unit/mcp-server/tdd-execution-policy.test.ts
+++ b/tests/unit/mcp-server/tdd-execution-policy.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test, vi } from 'vitest';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import * as path from 'path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { RedGreenCycleArgsSchema } from '../../../src/mcp-server/schemas.js';
 import { TDDGuardServer } from '../../../src/mcp-server/tdd-server.js';
 import {
@@ -11,12 +13,28 @@ import {
 } from '../../../src/mcp-server/tdd-execution-policy.js';
 
 describe('TDD MCP execution policy', () => {
+  const testRoots: string[] = [];
+  const originalEnv = { ...process.env };
+
+  afterEach(async () => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+    await Promise.all(testRoots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+  });
+
   test('resolves approved test commands to executable plus argv without shell text', () => {
     expect(resolveSafeTDDTestCommand('npm test')).toEqual({
       executable: 'npm',
       args: ['test', '--silent'],
     });
     expect(formatTDDTestCommand(resolveSafeTDDTestCommand('pnpm test'))).toBe('pnpm test --silent');
+  });
+
+  test('resolves Windows package-manager shims through fixed cmd.exe argv', () => {
+    expect(resolveSafeTDDTestCommand('npm test', 'win32')).toEqual({
+      executable: 'cmd.exe',
+      args: ['/d', '/s', '/c', 'npm.cmd', 'test', '--silent'],
+    });
   });
 
   test('schema rejects free-form shell command input before execution policy is reached', () => {
@@ -56,6 +74,23 @@ describe('TDD MCP execution policy', () => {
     );
   });
 
+  test('runs Windows-approved commands through fixed cmd.exe argv with shell disabled', () => {
+    const executor = vi.fn<TDDTestExecutor>().mockReturnValue('');
+
+    runSafeTDDTestCommand('pnpm test', { cwd: process.cwd(), executor, platform: 'win32' });
+
+    expect(executor).toHaveBeenCalledWith(
+      'cmd.exe',
+      ['/d', '/s', '/c', 'pnpm.cmd', 'test', '--silent'],
+      expect.objectContaining({
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        stdio: 'pipe',
+        shell: false,
+      })
+    );
+  });
+
   test('check_red_green_cycle is dry-run by default and reports the approved argv', async () => {
     const server = new TDDGuardServer();
     const result = await (server as any).checkRedGreenCycle({ testCommand: 'pnpm test' });
@@ -63,4 +98,60 @@ describe('TDD MCP execution policy', () => {
     expect(result.content[0].text).toContain('TDD test execution was not run');
     expect(result.content[0].text).toContain('Approved executable/argv: pnpm test --silent');
   });
+
+  test('check_red_green_cycle runs approved tests in the approved workspace root', async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const binDir = path.join(workspaceRoot, 'bin');
+    const capturedCwd = path.join(workspaceRoot, 'captured-cwd.txt');
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      path.join(binDir, 'npm'),
+      ['#!/bin/sh', 'printf "%s" "$PWD" > "$CWD_CAPTURE"', 'exit 0', ''].join('\n'),
+      'utf8'
+    );
+    await chmod(path.join(binDir, 'npm'), 0o755);
+    process.env['AE_MCP_WORKSPACE_ROOT'] = workspaceRoot;
+    process.env['CWD_CAPTURE'] = capturedCwd;
+    process.env['PATH'] = `${binDir}${path.delimiter}${originalEnv.PATH ?? ''}`;
+
+    const server = new TDDGuardServer();
+    const result = await (server as any).checkRedGreenCycle({
+      testCommand: 'npm test',
+      dryRun: false,
+      testExecutionApproval: APPROVED_TDD_TEST_EXECUTION,
+      expectRed: false,
+    });
+
+    expect(result.content[0].text).toContain('Tests are GREEN');
+    expect(await readFile(capturedCwd, 'utf8')).toBe(workspaceRoot);
+  });
+
+  test('analyze_tdd_compliance is non-proceedable when 4-code test execution is skipped', async () => {
+    const workspaceRoot = await createTempWorkspace();
+    const projectRoot = path.join(workspaceRoot, 'project');
+    await mkdir(path.join(projectRoot, 'src'), { recursive: true });
+    await mkdir(path.join(projectRoot, 'tests'), { recursive: true });
+    await writeFile(path.join(projectRoot, 'src', 'example.ts'), 'export const example = 1;\n', 'utf8');
+    await writeFile(path.join(projectRoot, 'tests', 'example.test.ts'), 'import "../src/example.js";\n', 'utf8');
+    process.env['AE_MCP_WORKSPACE_ROOT'] = workspaceRoot;
+
+    const server = new TDDGuardServer();
+    const result = await (server as any).analyzeTDDCompliance({
+      path: 'project',
+      phase: '4-code',
+      testCommand: 'pnpm test',
+    });
+
+    expect(result.content[0].text).toContain('❌ Violations must be fixed');
+    expect(result.content[0].text).toContain('test_execution_skipped');
+    expect(result.content[0].text).toContain('cannot verify GREEN phase test results');
+  });
+
+  async function createTempWorkspace(): Promise<string> {
+    const rootParent = path.join(process.cwd(), 'artifacts', 'tmp', 'tdd-execution-policy');
+    await mkdir(rootParent, { recursive: true });
+    const workspaceRoot = await mkdtemp(path.join(rootParent, 'workspace-'));
+    testRoots.push(workspaceRoot);
+    return workspaceRoot;
+  }
 });

--- a/tests/unit/mcp-server/tdd-execution-policy.test.ts
+++ b/tests/unit/mcp-server/tdd-execution-policy.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, vi } from 'vitest';
+import { RedGreenCycleArgsSchema } from '../../../src/mcp-server/schemas.js';
+import { TDDGuardServer } from '../../../src/mcp-server/tdd-server.js';
+import {
+  APPROVED_TDD_TEST_EXECUTION,
+  ensureTDDTestExecutionApproved,
+  formatTDDTestCommand,
+  resolveSafeTDDTestCommand,
+  runSafeTDDTestCommand,
+  type TDDTestExecutor,
+} from '../../../src/mcp-server/tdd-execution-policy.js';
+
+describe('TDD MCP execution policy', () => {
+  test('resolves approved test commands to executable plus argv without shell text', () => {
+    expect(resolveSafeTDDTestCommand('npm test')).toEqual({
+      executable: 'npm',
+      args: ['test', '--silent'],
+    });
+    expect(formatTDDTestCommand(resolveSafeTDDTestCommand('pnpm test'))).toBe('pnpm test --silent');
+  });
+
+  test('schema rejects free-form shell command input before execution policy is reached', () => {
+    expect(() => RedGreenCycleArgsSchema.parse({
+      testCommand: 'npm test; touch artifacts/pwned',
+      dryRun: false,
+      testExecutionApproval: APPROVED_TDD_TEST_EXECUTION,
+    })).toThrow();
+  });
+
+  test('dry-run and missing approval both prevent execution', () => {
+    expect(ensureTDDTestExecutionApproved('none', true)).toEqual({
+      approved: false,
+      reason: 'dry-run mode is enabled',
+    });
+    expect(ensureTDDTestExecutionApproved('none', false)).toEqual({
+      approved: false,
+      reason: `test execution requires approval token '${APPROVED_TDD_TEST_EXECUTION}'`,
+    });
+    expect(ensureTDDTestExecutionApproved(APPROVED_TDD_TEST_EXECUTION, false)).toEqual({ approved: true });
+  });
+
+  test('runs approved commands through an executable and argv array with shell disabled', () => {
+    const executor = vi.fn<TDDTestExecutor>().mockReturnValue('');
+
+    runSafeTDDTestCommand('yarn test', { cwd: process.cwd(), executor });
+
+    expect(executor).toHaveBeenCalledWith(
+      'yarn',
+      ['test', '--silent'],
+      expect.objectContaining({
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        stdio: 'pipe',
+        shell: false,
+      })
+    );
+  });
+
+  test('check_red_green_cycle is dry-run by default and reports the approved argv', async () => {
+    const server = new TDDGuardServer();
+    const result = await (server as any).checkRedGreenCycle({ testCommand: 'pnpm test' });
+
+    expect(result.content[0].text).toContain('TDD test execution was not run');
+    expect(result.content[0].text).toContain('Approved executable/argv: pnpm test --silent');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3368.

This PR hardens the TDD MCP server's test-execution boundary:

- replaces free-form shell command execution with an allowlisted executable/argv policy;
- makes TDD MCP test execution dry-run by default;
- requires the explicit approval token `approved-tdd-test-execution` plus `dryRun=false` before tests run;
- uses `execFileSync` with `shell: false` for approved runs;
- prevents `analyze_tdd_compliance` from implicitly running package scripts unless the same approval policy is satisfied;
- constrains the analysis/execution cwd to the approved workspace root.

## Acceptance

- [x] Free-form `testCommand` strings such as shell injection payloads are rejected by schema validation.
- [x] Approved commands resolve to executable plus argv, not shell strings.
- [x] `check_red_green_cycle` does not execute by default and reports the approved command plan.
- [x] `analyze_tdd_compliance` does not implicitly run tests unless execution is explicitly approved.
- [x] Approved execution uses `shell: false`.
- [x] Workspace path escapes are rejected before test execution cwd is used.

## Verification

Local verification run on this branch:

```bash
pnpm install --frozen-lockfile
pnpm -s exec vitest run tests/unit/mcp-server/tdd-execution-policy.test.ts --reporter dot
pnpm -s exec eslint --quiet src/mcp-server/tdd-server.ts src/mcp-server/tdd-execution-policy.ts src/mcp-server/schemas.ts tests/unit/mcp-server/tdd-execution-policy.test.ts
pnpm -s run types:check
pnpm -s run build
pnpm -s run check:schemas
pnpm -s run check:doc-consistency
git diff --check
```

## Rollback

Revert this PR to restore the previous TDD MCP behavior. Rollback reopens #3368 risk because MCP input would again be able to reach shell command execution without an approval/dry-run boundary.
