### PR TITLE
fix(ci): fail closed on dependency workflow drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,8 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: 22
-      - run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+      - name: Install dependencies (frozen lockfile)
+        run: pnpm install --frozen-lockfile
       - run: pnpm run build
 
       - name: Bin smoke check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           node-version: 22
       - name: Install dependencies (frozen lockfile)
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc
+          NPM_CONFIG_GLOBALCONFIG: /dev/null
         run: pnpm install --frozen-lockfile
       - run: pnpm run build
 

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -56,6 +56,9 @@ jobs:
         node-version: '20'
         
     - name: Install dependencies
+      env:
+        NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc
+        NPM_CONFIG_GLOBALCONFIG: /dev/null
       run: pnpm install --frozen-lockfile
       
     - name: Build project

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -56,8 +56,7 @@ jobs:
         node-version: '20'
         
     - name: Install dependencies
-      # Exception: automation-generated diffs can arrive before `pnpm-lock.yaml` refresh; review when upstream lockfile updates are mandatory.
-      run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+      run: pnpm install --frozen-lockfile
       
     - name: Build project
       run: pnpm run build
@@ -135,7 +134,40 @@ jobs:
     # Security scanning
     - name: Run dependency audit
       run: |
-        pnpm audit --audit-level=moderate --json > audit-results.json || true
+        set -euo pipefail
+        ENFORCE=1
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          ENFORCE=0
+          if jq -e '.pull_request.labels[]?.name | select(.=="enforce-security")' "$GITHUB_EVENT_PATH" >/dev/null; then
+            ENFORCE=1
+          fi
+        fi
+
+        set +e
+        pnpm audit --audit-level=moderate --json > audit-results.json
+        AUDIT_EXIT=$?
+        set -e
+
+        if ! jq -e '.metadata.vulnerabilities' audit-results.json >/dev/null 2>&1; then
+          if [ "${ENFORCE}" = "1" ]; then
+            printf "%s\n" "Dependency audit did not produce parseable vulnerability metadata."
+            exit 1
+          fi
+          echo "::warning::Dependency audit did not produce parseable vulnerability metadata."
+          printf '{"metadata":{"vulnerabilities":{}}}\n' > audit-results.json
+          exit 0
+        fi
+
+        HIGH="$(jq -r '.metadata.vulnerabilities.high // 0' audit-results.json)"
+        CRITICAL="$(jq -r '.metadata.vulnerabilities.critical // 0' audit-results.json)"
+        printf "%s\n" "Dependency audit summary: high=${HIGH}, critical=${CRITICAL}, audit_exit=${AUDIT_EXIT}, enforce=${ENFORCE}"
+        if [ "${HIGH}" -gt 0 ] || [ "${CRITICAL}" -gt 0 ]; then
+          if [ "${ENFORCE}" = "1" ]; then
+            printf "%s\n" "High-risk vulnerabilities found under enforced SBOM audit mode."
+            exit 1
+          fi
+          echo "::warning::High/critical vulnerabilities detected (non-blocking without enforce-security label)."
+        fi
         
     - name: Upload security scan results
       uses: actions/upload-artifact@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -100,7 +100,7 @@ jobs:
     if: ${{ needs.gate.outputs.run_security == 'true' }}
     name: Dependency Audit
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'enforce-security') }}
     
     steps:
       - name: Checkout code
@@ -112,18 +112,11 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        # Exception: automation-generated diffs can arrive before `pnpm-lock.yaml` refresh; review when upstream lockfile updates are mandatory.
-        run: pnpm install --frozen-lockfile || pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
-      - name: Audit dependencies
-        run: pnpm audit --audit-level=moderate || true
-
-      - name: Check for high-risk packages
+      - name: Audit dependencies and enforce high-risk thresholds
         run: |
           set -euo pipefail
-          pnpm audit --audit-level=high --json > audit-results.json || true
-          HIGH="$(jq -r '.metadata.vulnerabilities.high // 0' audit-results.json 2>/dev/null || echo 0)"
-          CRITICAL="$(jq -r '.metadata.vulnerabilities.critical // 0' audit-results.json 2>/dev/null || echo 0)"
           ENFORCE=1
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             ENFORCE=0
@@ -132,13 +125,36 @@ jobs:
             fi
           fi
 
-          printf "%s\n" "Dependency audit summary: high=${HIGH}, critical=${CRITICAL}, enforce=${ENFORCE}"
+          set +e
+          pnpm audit --audit-level=moderate --json > audit-results.json
+          AUDIT_EXIT=$?
+          set -e
+
+          if ! jq -e '.metadata.vulnerabilities' audit-results.json >/dev/null 2>&1; then
+            if [ "${ENFORCE}" = "1" ]; then
+              printf "%s\n" "Dependency audit did not produce parseable vulnerability metadata."
+              exit 1
+            fi
+            echo "::warning::Dependency audit did not produce parseable vulnerability metadata."
+            exit 0
+          fi
+
+          LOW="$(jq -r '.metadata.vulnerabilities.low // 0' audit-results.json)"
+          MODERATE="$(jq -r '.metadata.vulnerabilities.moderate // 0' audit-results.json)"
+          HIGH="$(jq -r '.metadata.vulnerabilities.high // 0' audit-results.json)"
+          CRITICAL="$(jq -r '.metadata.vulnerabilities.critical // 0' audit-results.json)"
+
+          printf "%s\n" "Dependency audit summary: low=${LOW}, moderate=${MODERATE}, high=${HIGH}, critical=${CRITICAL}, audit_exit=${AUDIT_EXIT}, enforce=${ENFORCE}"
           if [ "${HIGH}" -gt 0 ] || [ "${CRITICAL}" -gt 0 ]; then
             if [ "${ENFORCE}" = "1" ]; then
               printf "%s\n" "High-risk vulnerabilities found under enforce-security mode."
               exit 1
             fi
             echo "::warning::High/critical vulnerabilities detected (non-blocking without enforce-security label)."
+          fi
+
+          if [ "${AUDIT_EXIT}" -ne 0 ] && [ "${HIGH}" -eq 0 ] && [ "${CRITICAL}" -eq 0 ]; then
+            echo "::warning::Dependency audit returned a nonzero exit code without high/critical findings."
           fi
 
   secrets-scan:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -112,6 +112,9 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc
+          NPM_CONFIG_GLOBALCONFIG: /dev/null
         run: pnpm install --frozen-lockfile
 
       - name: Audit dependencies and enforce high-risk thresholds

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -340,4 +340,45 @@ describe('workflow permission boundaries', () => {
     expect(uploadManualStep?.with?.path).toContain('security/sigstore/quality-artifacts.intoto.jsonl');
     expect(qualityRaw).toContain('actions/attest@v4');
   });
+
+  it('release and dependency security workflows fail closed on lockfile and audit failures', () => {
+    const releaseRaw = readWorkflow('release.yml');
+    const securityRaw = readWorkflow('security.yml');
+    const sbomRaw = readWorkflow('sbom-generation.yml');
+    const protectedWorkflowText = [
+      ['release.yml', releaseRaw],
+      ['security.yml', securityRaw],
+      ['sbom-generation.yml', sbomRaw],
+    ] as const;
+
+    for (const [workflowName, workflowText] of protectedWorkflowText) {
+      expect(workflowText, `${workflowName} must not allow mutable dependency installs`).not.toContain('--no-frozen-lockfile');
+      expect(workflowText, `${workflowName} must not suppress pnpm audit exits with || true`)
+        .not.toMatch(/pnpm\s+audit[^\n]*\|\|\s*true/);
+    }
+
+    const release = parseWorkflow('release.yml');
+    const releaseSteps = release.jobs?.release?.steps ?? [];
+    const releaseInstallStep = Array.isArray(releaseSteps)
+      ? releaseSteps.find((step: any) => step?.name === 'Install dependencies (frozen lockfile)')
+      : undefined;
+    expect(releaseInstallStep?.run).toBe('pnpm install --frozen-lockfile');
+
+    const security = parseWorkflow('security.yml');
+    const dependencyAudit = security.jobs?.['dependency-audit'];
+    expect(dependencyAudit?.['continue-on-error']).toBe("${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'enforce-security') }}");
+    expect(securityRaw).toContain('pnpm audit --audit-level=moderate --json > audit-results.json');
+    expect(securityRaw).toContain('Dependency audit did not produce parseable vulnerability metadata.');
+    expect(securityRaw).toContain('High-risk vulnerabilities found under enforce-security mode.');
+    expect(securityRaw).toContain('AUDIT_EXIT=$?');
+
+    const sbom = parseWorkflow('sbom-generation.yml');
+    const sbomSteps = sbom.jobs?.['sbom-generation']?.steps ?? [];
+    const sbomInstallStep = Array.isArray(sbomSteps)
+      ? sbomSteps.find((step: any) => step?.name === 'Install dependencies')
+      : undefined;
+    expect(sbomInstallStep?.run).toBe('pnpm install --frozen-lockfile');
+    expect(sbomRaw).toContain('High-risk vulnerabilities found under enforced SBOM audit mode.');
+    expect(sbomRaw).toContain('printf \'{"metadata":{"vulnerabilities":{}}}\\n\' > audit-results.json');
+  });
 });

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -363,10 +363,23 @@ describe('workflow permission boundaries', () => {
       ? releaseSteps.find((step: any) => step?.name === 'Install dependencies (frozen lockfile)')
       : undefined;
     expect(releaseInstallStep?.run).toBe('pnpm install --frozen-lockfile');
+    expect(releaseInstallStep?.env).toMatchObject({
+      NPM_CONFIG_USERCONFIG: '${{ github.workspace }}/.npmrc',
+      NPM_CONFIG_GLOBALCONFIG: '/dev/null',
+    });
 
     const security = parseWorkflow('security.yml');
     const dependencyAudit = security.jobs?.['dependency-audit'];
+    const dependencyAuditSteps = dependencyAudit?.steps ?? [];
+    const dependencyAuditInstallStep = Array.isArray(dependencyAuditSteps)
+      ? dependencyAuditSteps.find((step: any) => step?.name === 'Install dependencies')
+      : undefined;
     expect(dependencyAudit?.['continue-on-error']).toBe("${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'enforce-security') }}");
+    expect(dependencyAuditInstallStep?.run).toBe('pnpm install --frozen-lockfile');
+    expect(dependencyAuditInstallStep?.env).toMatchObject({
+      NPM_CONFIG_USERCONFIG: '${{ github.workspace }}/.npmrc',
+      NPM_CONFIG_GLOBALCONFIG: '/dev/null',
+    });
     expect(securityRaw).toContain('pnpm audit --audit-level=moderate --json > audit-results.json');
     expect(securityRaw).toContain('Dependency audit did not produce parseable vulnerability metadata.');
     expect(securityRaw).toContain('High-risk vulnerabilities found under enforce-security mode.');
@@ -378,6 +391,10 @@ describe('workflow permission boundaries', () => {
       ? sbomSteps.find((step: any) => step?.name === 'Install dependencies')
       : undefined;
     expect(sbomInstallStep?.run).toBe('pnpm install --frozen-lockfile');
+    expect(sbomInstallStep?.env).toMatchObject({
+      NPM_CONFIG_USERCONFIG: '${{ github.workspace }}/.npmrc',
+      NPM_CONFIG_GLOBALCONFIG: '/dev/null',
+    });
     expect(sbomRaw).toContain('High-risk vulnerabilities found under enforced SBOM audit mode.');
     expect(sbomRaw).toContain('printf \'{"metadata":{"vulnerabilities":{}}}\\n\' > audit-results.json');
   });


### PR DESCRIPTION
## Summary

Closes #3369.
Closes #3370.

This PR makes release/security/SBOM dependency paths fail closed when dependency resolution or enforced audit evidence is not reproducible:

- removes `pnpm install --no-frozen-lockfile` fallback from release, security, and SBOM artifact-producing workflows;
- makes the dependency-audit job blocking by default outside report-only PR mode;
- replaces `pnpm audit ... || true` suppression with explicit audit-exit capture and high/critical threshold enforcement;
- fails protected/non-PR paths when audit output is not parseable as vulnerability metadata;
- keeps PR report-only behavior explicit unless `enforce-security` is applied;
- adds workflow regression coverage for frozen-lockfile and audit fail-closed policy.

## Acceptance

- [x] Release artifact publication uses only `pnpm install --frozen-lockfile` before build/SBOM/release upload.
- [x] Security and SBOM workflows no longer fall back to mutable installs in publishing/security paths.
- [x] Dependency audit enforcement is fail-closed for non-PR/protected paths and explicit for PR report-only mode.
- [x] Audit command exits are captured and converted into threshold decisions instead of being hidden by `|| true`.
- [x] Static workflow tests reject future reintroduction of mutable installs and audit suppression in these workflows.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot
/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint-bin -color .github/workflows/release.yml .github/workflows/security.yml .github/workflows/sbom-generation.yml
pnpm -s exec eslint --quiet tests/unit/ci/workflow-permission-boundary.test.ts
pnpm -s run types:check
pnpm -s run check:schemas
pnpm -s run check:doc-consistency
git diff --check
```

Note: running `scripts/ci/actionlint.sh` without a file scope currently reports unrelated pre-existing shellcheck findings in `.github/workflows/hermetic-ci.yml` and `.github/workflows/verify-lite.yml`. The changed workflows above pass targeted `actionlint` with the workspace-local binary.

## Rollback

Revert this PR to restore the prior dependency workflow behavior. Rollback reopens #3369/#3370 risk because release/security/SBOM jobs would again permit mutable dependency installs or suppressed audit failures.
