### PR TITLE
fix(security): constrain outbound integration URLs

### DIFF
--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -185,21 +185,53 @@ jobs:
       env:
         DT_API_KEY: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
         DT_BASE_URL: ${{ vars.DEPENDENCY_TRACK_URL }}
+        DT_ALLOWED_HOSTS: ${{ vars.DEPENDENCY_TRACK_ALLOWED_HOSTS }}
         DT_PROJECT_UUID: ${{ vars.DEPENDENCY_TRACK_PROJECT_UUID }}
       run: |
+        validate_dependency_track_url() {
+          node --input-type=module - "$DT_BASE_URL" "$DT_ALLOWED_HOSTS" <<'NODE'
+        const [rawUrl, rawAllowedHosts] = process.argv.slice(2);
+        const allowedHosts = new Set(String(rawAllowedHosts || '').split(/[\s,]+/).filter(Boolean).map((value) => {
+          try {
+            const parsed = new URL(value);
+            return parsed.host.toLowerCase();
+          } catch {
+            return value.toLowerCase();
+          }
+        }));
+        try {
+          const url = new URL(rawUrl);
+          if (url.protocol !== 'https:') throw new Error('Dependency Track URL must use HTTPS');
+          if (url.username || url.password) throw new Error('Dependency Track URL must not contain userinfo');
+          if (!url.hostname) throw new Error('Dependency Track URL must include a hostname');
+          const hostname = url.hostname.toLowerCase();
+          const host = url.host.toLowerCase();
+          if (!allowedHosts.has(hostname) && !allowedHosts.has(host)) {
+            throw new Error('Dependency Track host must be allowlisted via DEPENDENCY_TRACK_ALLOWED_HOSTS');
+          }
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error(`::error::${message}`);
+          process.exit(1);
+        }
+        NODE
+        }
+
         if [[ -n "$DT_API_KEY" && -n "$DT_BASE_URL" ]]; then
+          validate_dependency_track_url
           printf -- "%s\n" "Uploading SBOM to Dependency Track..."
+          DT_BOM_URL="${DT_BASE_URL%/}/api/v1/bom"
           
           # Upload to specific project if UUID is provided
           if [[ -n "$DT_PROJECT_UUID" ]]; then
-            curl -X "PUT" "$DT_BASE_URL/api/v1/bom" \
+            curl --fail --show-error --silent --proto '=https' --tlsv1.2 -X "PUT" "$DT_BOM_URL" \
               -H "X-API-Key: $DT_API_KEY" \
               -H "Content-Type: application/json" \
               -F "project=$DT_PROJECT_UUID" \
               -F "bom=@sbom.json"
           else
             # Auto-create project from SBOM metadata
-            curl -X "PUT" "$DT_BASE_URL/api/v1/bom" \
+            curl --fail --show-error --silent --proto '=https' --tlsv1.2 -X "PUT" "$DT_BOM_URL" \
               -H "X-API-Key: $DT_API_KEY" \
               -H "Content-Type: application/json" \
               -d @sbom.json

--- a/scripts/trace/export-dashboard.mjs
+++ b/scripts/trace/export-dashboard.mjs
@@ -107,11 +107,13 @@ function loadDashboardConfig(configPath) {
 }
 
 async function exportDashboard({ host, uid, token, output, dryRun }) {
-  const grafanaBaseUrl = validateTokenBearingUrl(host, {
-    serviceName: 'Grafana',
-    allowedHostsEnv: 'GRAFANA_ALLOWED_HOSTS',
-    allowLocalhostHttp: true,
-  });
+  const grafanaBaseUrl = token
+    ? validateTokenBearingUrl(host, {
+      serviceName: 'Grafana',
+      allowedHostsEnv: 'GRAFANA_ALLOWED_HOSTS',
+      allowLocalhostHttp: true,
+    })
+    : new URL(host);
   const url = new URL(`/api/dashboards/uid/${encodeURIComponent(uid)}`, grafanaBaseUrl).toString();
   const headers = { 'Content-Type': 'application/json' };
   if (token) {

--- a/scripts/trace/export-dashboard.mjs
+++ b/scripts/trace/export-dashboard.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
+import { sanitizeExternalResponseText, validateTokenBearingUrl } from './outbound-url-policy.mjs';
 
 function isErrnoException(value) {
   if (!value || typeof value !== 'object') return false;
@@ -55,6 +56,7 @@ function parseArgs(argv) {
 
 Options:
   -h, --host <url>     Grafana base URL (default: http://localhost:3000)
+                        Remote hosts require HTTPS and GRAFANA_ALLOWED_HOSTS allowlisting.
   -u, --uid <uid>      Dashboard UID to export (required if --config is absent)
   -t, --token <token>  Grafana API token with dashboard:read scope
   -o, --output <file>  Output JSON path (default: docs/trace/grafana/tempo-dashboard.json)
@@ -105,16 +107,21 @@ function loadDashboardConfig(configPath) {
 }
 
 async function exportDashboard({ host, uid, token, output, dryRun }) {
-  const url = new URL(`/api/dashboards/uid/${encodeURIComponent(uid)}`, host).toString();
+  const grafanaBaseUrl = validateTokenBearingUrl(host, {
+    serviceName: 'Grafana',
+    allowedHostsEnv: 'GRAFANA_ALLOWED_HOSTS',
+    allowLocalhostHttp: true,
+  });
+  const url = new URL(`/api/dashboards/uid/${encodeURIComponent(uid)}`, grafanaBaseUrl).toString();
   const headers = { 'Content-Type': 'application/json' };
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
 
-  const response = await fetch(url, { headers });
+  const response = await fetch(url, { headers, redirect: 'error' });
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(`Failed to fetch dashboard (${response.status}): ${body}`);
+    throw new Error(`Failed to fetch dashboard (${response.status}): ${sanitizeExternalResponseText(body)}`);
   }
 
   const data = await response.json();

--- a/scripts/trace/import-dashboard.mjs
+++ b/scripts/trace/import-dashboard.mjs
@@ -2,6 +2,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { sanitizeExternalResponseText, validateTokenBearingUrl } from './outbound-url-policy.mjs';
 
 function isErrnoException(value) {
   if (!value || typeof value !== 'object') return false;
@@ -62,6 +63,7 @@ function parseArgs(argv) {
 Options:
   -i, --input <file>     Dashboard JSON (default: docs/trace/grafana/tempo-dashboard.json)
   -h, --host <url>       Grafana base URL (default: http://localhost:3000)
+                        Remote hosts require HTTPS and GRAFANA_ALLOWED_HOSTS allowlisting.
   -t, --token <token>    Grafana API token with dashboard:write scope
       --folder-id <id>   Target folder ID (default: 0)
       --no-overwrite     Do not overwrite existing dashboards (default: overwrite)
@@ -101,6 +103,11 @@ function readDashboard(filePath) {
 }
 
 async function importDashboard({ host, token, folderId, overwrite, input }) {
+  const grafanaBaseUrl = validateTokenBearingUrl(host, {
+    serviceName: 'Grafana',
+    allowedHostsEnv: 'GRAFANA_ALLOWED_HOSTS',
+    allowLocalhostHttp: true,
+  });
   const payload = readDashboard(input);
   const body = {
     dashboard: payload.dashboard ?? payload,
@@ -109,8 +116,9 @@ async function importDashboard({ host, token, folderId, overwrite, input }) {
   };
 
   // codeql[js/file-access-to-http] Uploading dashboards (including the payload) is an explicit CLI action.
-  const response = await fetch(new URL('/api/dashboards/db', host), {
+  const response = await fetch(new URL('/api/dashboards/db', grafanaBaseUrl), {
     method: 'POST',
+    redirect: 'error',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
@@ -120,7 +128,7 @@ async function importDashboard({ host, token, folderId, overwrite, input }) {
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Grafana import failed (${response.status}): ${text}`);
+    throw new Error(`Grafana import failed (${response.status}): ${sanitizeExternalResponseText(text)}`);
   }
 
   console.log('[import-dashboard] dashboard imported successfully');

--- a/scripts/trace/outbound-url-policy.mjs
+++ b/scripts/trace/outbound-url-policy.mjs
@@ -1,0 +1,83 @@
+const LOCALHOST_NAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+function toAllowedHostEntries(rawAllowedHosts) {
+  if (!rawAllowedHosts) return new Set();
+  const entries = new Set();
+  for (const rawEntry of String(rawAllowedHosts).split(/[\s,]+/)) {
+    const entry = rawEntry.trim().toLowerCase();
+    if (!entry) continue;
+    try {
+      const parsed = new URL(entry);
+      if (parsed.hostname) entries.add(parsed.hostname.toLowerCase());
+      if (parsed.host) entries.add(parsed.host.toLowerCase());
+      continue;
+    } catch {
+      // Plain host or host:port allowlist entries are accepted below.
+    }
+    entries.add(entry);
+  }
+  return entries;
+}
+
+function isLocalhost(url) {
+  return LOCALHOST_NAMES.has(url.hostname.toLowerCase());
+}
+
+function matchesAllowedHost(url, allowedHosts) {
+  const hostname = url.hostname.toLowerCase();
+  const host = url.host.toLowerCase();
+  return allowedHosts.has(hostname) || allowedHosts.has(host);
+}
+
+export function validateTokenBearingUrl(rawUrl, {
+  serviceName,
+  allowedHostsEnv,
+  allowedHosts,
+  allowLocalhostHttp = false,
+} = {}) {
+  const label = serviceName ?? 'outbound integration';
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(`${label} URL is malformed`);
+  }
+
+  if (url.username || url.password) {
+    throw new Error(`${label} URL must not contain userinfo`);
+  }
+  if (!url.hostname) {
+    throw new Error(`${label} URL must include a hostname`);
+  }
+  if (url.protocol !== 'https:' && !(allowLocalhostHttp && url.protocol === 'http:' && isLocalhost(url))) {
+    throw new Error(`${label} URL must use HTTPS${allowLocalhostHttp ? ' unless it is localhost HTTP for development' : ''}`);
+  }
+
+  if (allowLocalhostHttp && isLocalhost(url)) {
+    return url;
+  }
+
+  const allowed = allowedHosts ?? toAllowedHostEntries(allowedHostsEnv ? process.env[allowedHostsEnv] : '');
+  if (!matchesAllowedHost(url, allowed)) {
+    const envMessage = allowedHostsEnv ? ` via ${allowedHostsEnv}` : '';
+    throw new Error(`${label} host must be explicitly allowlisted${envMessage}`);
+  }
+
+  return url;
+}
+
+export function sanitizeExternalResponseText(value, maxLength = 500) {
+  const normalized = String(value ?? '')
+    .replace(/[\u0000-\u001f\u007f]+/g, ' ')
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]')
+    .replace(/(api[_-]?key|token|password|secret|authorization)=([^&\s]+)/gi, '$1=[REDACTED]')
+    .trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength)}…[truncated]`;
+}
+
+export const __test__ = {
+  toAllowedHostEntries,
+};

--- a/src/cli/sbom-cli.ts
+++ b/src/cli/sbom-cli.ts
@@ -430,9 +430,12 @@ jobs:
       env:
         DT_API_KEY: \${{ secrets.DEPENDENCY_TRACK_API_KEY }}
         DT_BASE_URL: \${{ secrets.DEPENDENCY_TRACK_URL }}
+        DT_ALLOWED_HOSTS: \${{ vars.DEPENDENCY_TRACK_ALLOWED_HOSTS }}
       run: |
         if [[ -n "\$DT_API_KEY" && -n "\$DT_BASE_URL" ]]; then
-          curl -X "PUT" "\$DT_BASE_URL/api/v1/bom" \\
+          node -e 'const [rawUrl, rawAllowedHosts] = process.argv.slice(1); const allowedHosts = new Set(String(rawAllowedHosts || "").split(/[\\s,]+/).filter(Boolean).map((value) => { try { return new URL(value).host.toLowerCase(); } catch { return value.toLowerCase(); } })); const url = new URL(rawUrl); if (url.protocol !== "https:") throw new Error("Dependency Track URL must use HTTPS"); if (url.username || url.password) throw new Error("Dependency Track URL must not contain userinfo"); if (!url.hostname) throw new Error("Dependency Track URL must include a hostname"); if (!allowedHosts.has(url.hostname.toLowerCase()) && !allowedHosts.has(url.host.toLowerCase())) throw new Error("Dependency Track host must be allowlisted via DEPENDENCY_TRACK_ALLOWED_HOSTS");' "\$DT_BASE_URL" "\$DT_ALLOWED_HOSTS"
+          DT_BOM_URL="\${DT_BASE_URL%/}/api/v1/bom"
+          curl --fail --show-error --silent --proto '=https' --tlsv1.2 -X "PUT" "\$DT_BOM_URL" \\
             -H "X-API-Key: \$DT_API_KEY" \\
             -H "Content-Type: application/json" \\
             -d @sbom.json
@@ -525,7 +528,9 @@ dependency_tracking:
   script:
     - |
       if [[ -n "\$DEPENDENCY_TRACK_API_KEY" && -n "\$DEPENDENCY_TRACK_URL" ]]; then
-        curl -X "PUT" "\$DEPENDENCY_TRACK_URL/api/v1/bom" \\
+        node -e 'const [rawUrl, rawAllowedHosts] = process.argv.slice(1); const allowedHosts = new Set(String(rawAllowedHosts || "").split(/[\\s,]+/).filter(Boolean).map((value) => { try { return new URL(value).host.toLowerCase(); } catch { return value.toLowerCase(); } })); const url = new URL(rawUrl); if (url.protocol !== "https:") throw new Error("Dependency Track URL must use HTTPS"); if (url.username || url.password) throw new Error("Dependency Track URL must not contain userinfo"); if (!url.hostname) throw new Error("Dependency Track URL must include a hostname"); if (!allowedHosts.has(url.hostname.toLowerCase()) && !allowedHosts.has(url.host.toLowerCase())) throw new Error("Dependency Track host must be allowlisted via DEPENDENCY_TRACK_ALLOWED_HOSTS");' "\$DEPENDENCY_TRACK_URL" "\$DEPENDENCY_TRACK_ALLOWED_HOSTS"
+        DEPENDENCY_TRACK_BOM_URL="\${DEPENDENCY_TRACK_URL%/}/api/v1/bom"
+        curl --fail --show-error --silent --proto '=https' --tlsv1.2 -X "PUT" "\$DEPENDENCY_TRACK_BOM_URL" \\
           -H "X-API-Key: \$DEPENDENCY_TRACK_API_KEY" \\
           -H "Content-Type: application/json" \\
           -d @sbom.json
@@ -765,7 +770,9 @@ stages:
                 script {
                     if (env.DEPENDENCY_TRACK_API_KEY && env.DEPENDENCY_TRACK_URL) {
                         sh '''
-                            curl -X "PUT" "\${DEPENDENCY_TRACK_URL}/api/v1/bom" \\
+                            node -e 'const [rawUrl, rawAllowedHosts] = process.argv.slice(1); const allowedHosts = new Set(String(rawAllowedHosts || "").split(/[\\s,]+/).filter(Boolean).map((value) => { try { return new URL(value).host.toLowerCase(); } catch { return value.toLowerCase(); } })); const url = new URL(rawUrl); if (url.protocol !== "https:") throw new Error("Dependency Track URL must use HTTPS"); if (url.username || url.password) throw new Error("Dependency Track URL must not contain userinfo"); if (!url.hostname) throw new Error("Dependency Track URL must include a hostname"); if (!allowedHosts.has(url.hostname.toLowerCase()) && !allowedHosts.has(url.host.toLowerCase())) throw new Error("Dependency Track host must be allowlisted via DEPENDENCY_TRACK_ALLOWED_HOSTS");' "\${DEPENDENCY_TRACK_URL}" "\${DEPENDENCY_TRACK_ALLOWED_HOSTS}"
+                            DEPENDENCY_TRACK_BOM_URL="\${DEPENDENCY_TRACK_URL%/}/api/v1/bom"
+                            curl --fail --show-error --silent --proto '=https' --tlsv1.2 -X "PUT" "\${DEPENDENCY_TRACK_BOM_URL}" \\
                               -H "X-API-Key: \${DEPENDENCY_TRACK_API_KEY}" \\
                               -H "Content-Type: application/json" \\
                               -d @sbom.json

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -410,8 +410,11 @@ describe('workflow permission boundaries', () => {
     expect(dependencyTrackStep?.env).toMatchObject({
       DT_ALLOWED_HOSTS: '${{ vars.DEPENDENCY_TRACK_ALLOWED_HOSTS }}',
     });
-    expect(run.indexOf('validate_dependency_track_url')).toBeGreaterThanOrEqual(0);
-    expect(run.indexOf('validate_dependency_track_url')).toBeLessThan(run.indexOf('-H "X-API-Key: $DT_API_KEY"'));
+    const runLines = String(run).split('\n');
+    const validatorInvocationIndex = runLines.findIndex((line) => line.trim() === 'validate_dependency_track_url');
+    const apiKeyHeaderIndex = runLines.findIndex((line) => line.includes('-H "X-API-Key: $DT_API_KEY"'));
+    expect(validatorInvocationIndex).toBeGreaterThanOrEqual(0);
+    expect(validatorInvocationIndex).toBeLessThan(apiKeyHeaderIndex);
     expect(run).toContain('Dependency Track URL must use HTTPS');
     expect(run).toContain('Dependency Track URL must not contain userinfo');
     expect(run).toContain('DEPENDENCY_TRACK_ALLOWED_HOSTS');

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -398,4 +398,25 @@ describe('workflow permission boundaries', () => {
     expect(sbomRaw).toContain('High-risk vulnerabilities found under enforced SBOM audit mode.');
     expect(sbomRaw).toContain('printf \'{"metadata":{"vulnerabilities":{}}}\\n\' > audit-results.json');
   });
+
+  it('dependency-track SBOM upload validates allowlisted HTTPS destinations before API-key use', () => {
+    const sbom = parseWorkflow('sbom-generation.yml');
+    const sbomSteps = sbom.jobs?.['sbom-generation']?.steps ?? [];
+    const dependencyTrackStep = Array.isArray(sbomSteps)
+      ? sbomSteps.find((step: any) => step?.name === 'Upload to Dependency Track')
+      : undefined;
+    const run = dependencyTrackStep?.run ?? '';
+
+    expect(dependencyTrackStep?.env).toMatchObject({
+      DT_ALLOWED_HOSTS: '${{ vars.DEPENDENCY_TRACK_ALLOWED_HOSTS }}',
+    });
+    expect(run.indexOf('validate_dependency_track_url')).toBeGreaterThanOrEqual(0);
+    expect(run.indexOf('validate_dependency_track_url')).toBeLessThan(run.indexOf('-H "X-API-Key: $DT_API_KEY"'));
+    expect(run).toContain('Dependency Track URL must use HTTPS');
+    expect(run).toContain('Dependency Track URL must not contain userinfo');
+    expect(run).toContain('DEPENDENCY_TRACK_ALLOWED_HOSTS');
+    expect(run).toContain('--proto \'=https\'');
+    expect(run).toContain('${DT_BASE_URL%/}/api/v1/bom');
+    expect(run).not.toContain('$DT_BASE_URL/api/v1/bom');
+  });
 });

--- a/tests/unit/security/sbom-cli-templates.test.ts
+++ b/tests/unit/security/sbom-cli-templates.test.ts
@@ -25,6 +25,8 @@ describe('SBOM CI integration templates', () => {
       expect(template).toContain('Dependency Track URL must not contain userinfo');
       expect(template).toContain('Dependency Track URL must include a hostname');
       expect(template).toContain('Dependency Track host must be allowlisted via DEPENDENCY_TRACK_ALLOWED_HOSTS');
+      expect(template.indexOf('node -e')).toBeGreaterThanOrEqual(0);
+      expect(template.indexOf('node -e')).toBeLessThan(template.indexOf('X-API-Key'));
       expect(template).toContain("--proto '=https'");
       expect(template).toContain('--fail --show-error --silent');
       expect(template).not.toMatch(/curl[^\n]+\$\{?DEPENDENCY_TRACK_URL\}?\/api\/v1\/bom/);

--- a/tests/unit/security/sbom-cli-templates.test.ts
+++ b/tests/unit/security/sbom-cli-templates.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { SBOMCLI } from '../../../src/cli/sbom-cli.js';
+
+type SBOMTemplateAccess = {
+  generateGitHubWorkflow(): string;
+  generateGitLabPipeline(): string;
+  generateJenkinsfile(): string;
+};
+
+const createTemplateAccess = (): SBOMTemplateAccess => new SBOMCLI() as unknown as SBOMTemplateAccess;
+
+describe('SBOM CI integration templates', () => {
+  it('validates Dependency Track destinations before sending API keys', () => {
+    const cli = createTemplateAccess();
+    const templates = [
+      cli.generateGitHubWorkflow(),
+      cli.generateGitLabPipeline(),
+      cli.generateJenkinsfile(),
+    ];
+
+    for (const template of templates) {
+      expect(template).toContain('DEPENDENCY_TRACK_ALLOWED_HOSTS');
+      expect(template).toContain('process.argv.slice(1)');
+      expect(template).toContain('Dependency Track URL must use HTTPS');
+      expect(template).toContain('Dependency Track URL must not contain userinfo');
+      expect(template).toContain('Dependency Track URL must include a hostname');
+      expect(template).toContain('Dependency Track host must be allowlisted via DEPENDENCY_TRACK_ALLOWED_HOSTS');
+      expect(template).toContain("--proto '=https'");
+      expect(template).toContain('--fail --show-error --silent');
+      expect(template).not.toMatch(/curl[^\n]+\$\{?DEPENDENCY_TRACK_URL\}?\/api\/v1\/bom/);
+    }
+  });
+});

--- a/tests/unit/trace/outbound-url-policy.test.ts
+++ b/tests/unit/trace/outbound-url-policy.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+const policyModule = () => import('../../../scripts/trace/outbound-url-policy.mjs');
+
+describe('outbound URL policy', () => {
+  it('allows localhost HTTP only for explicit development exceptions', async () => {
+    const { validateTokenBearingUrl } = await policyModule();
+
+    const parsed = validateTokenBearingUrl('http://localhost:3000', {
+      serviceName: 'Grafana',
+      allowLocalhostHttp: true,
+    });
+
+    expect(parsed.origin).toBe('http://localhost:3000');
+
+    const ipv6 = validateTokenBearingUrl('http://[::1]:3000', {
+      serviceName: 'Grafana',
+      allowLocalhostHttp: true,
+    });
+    expect(ipv6.origin).toBe('http://[::1]:3000');
+  });
+
+  it('requires HTTPS for remote token-bearing destinations', async () => {
+    const { validateTokenBearingUrl } = await policyModule();
+
+    expect(() => validateTokenBearingUrl('http://grafana.example.com', {
+      serviceName: 'Grafana',
+      allowedHosts: new Set(['grafana.example.com']),
+      allowLocalhostHttp: true,
+    })).toThrow(/must use HTTPS/);
+  });
+
+  it('does not read an accidental process.env.undefined allowlist', async () => {
+    const { validateTokenBearingUrl } = await policyModule();
+    const previous = process.env.undefined;
+    process.env.undefined = 'grafana.example.com';
+    try {
+      expect(() => validateTokenBearingUrl('https://grafana.example.com', {
+        serviceName: 'Grafana',
+      })).toThrow(/host must be explicitly allowlisted/);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.undefined;
+      } else {
+        process.env.undefined = previous;
+      }
+    }
+  });
+
+  it('requires explicit host allowlisting for remote HTTPS destinations', async () => {
+    const { validateTokenBearingUrl } = await policyModule();
+
+    expect(() => validateTokenBearingUrl('https://grafana.example.com', {
+      serviceName: 'Grafana',
+      allowedHosts: new Set(['other.example.com']),
+      allowLocalhostHttp: true,
+    })).toThrow(/host must be explicitly allowlisted/);
+
+    expect(validateTokenBearingUrl('https://grafana.example.com', {
+      serviceName: 'Grafana',
+      allowedHosts: new Set(['grafana.example.com']),
+      allowLocalhostHttp: true,
+    }).origin).toBe('https://grafana.example.com');
+  });
+
+  it('rejects userinfo before token-bearing requests are built', async () => {
+    const { validateTokenBearingUrl } = await policyModule();
+
+    expect(() => validateTokenBearingUrl('https://user:pass@grafana.example.com', {
+      serviceName: 'Grafana',
+      allowedHosts: new Set(['grafana.example.com']),
+      allowLocalhostHttp: true,
+    })).toThrow(/must not contain userinfo/);
+  });
+
+  it('redacts and bounds external response text', async () => {
+    const { sanitizeExternalResponseText } = await policyModule();
+
+    const sanitized = sanitizeExternalResponseText('Authorization=Bearer abc token=secret-value ' + 'x'.repeat(100), 80);
+
+    expect(sanitized).toContain('token=[REDACTED]');
+    expect(sanitized).not.toContain('secret-value');
+    expect(sanitized).toContain('[truncated]');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a shared outbound URL policy for token-bearing Grafana integrations.
- Requires remote Grafana hosts to use HTTPS and be explicitly allowlisted via `GRAFANA_ALLOWED_HOSTS`, while preserving localhost HTTP for local development.
- Adds Dependency Track upload validation in the SBOM workflow and generated GitHub/GitLab/Jenkins CI templates before API-key-bearing `curl` requests.
- Blocks userinfo, malformed/missing hosts, non-HTTPS Dependency Track URLs, and redirect following; bounds/redacts external response text in Grafana failure messages.

Closes #3371.

## Acceptance

- Grafana import/export validates the configured base URL before building token-bearing requests.
- SBOM Dependency Track uploads fail closed unless the target is HTTPS and allowlisted via `DEPENDENCY_TRACK_ALLOWED_HOSTS`.
- Generated SBOM CI templates include the same validation guard before Dependency Track API keys are used.
- Regression tests cover allowed localhost development, rejected HTTP/userinfo/non-allowlisted destinations, response redaction, workflow guard order, and generated template guards.

## Validation

- `pnpm -s exec vitest run tests/unit/trace/outbound-url-policy.test.ts tests/unit/trace/import-dashboard.test.ts tests/unit/trace/export-dashboard.test.ts tests/unit/security/sbom-cli-templates.test.ts tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot`
- `/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint-bin -color .github/workflows/sbom-generation.yml`
- `pnpm -s exec eslint --quiet scripts/trace/import-dashboard.mjs scripts/trace/export-dashboard.mjs scripts/trace/outbound-url-policy.mjs src/cli/sbom-cli.ts tests/unit/trace/outbound-url-policy.test.ts tests/unit/security/sbom-cli-templates.test.ts tests/unit/ci/workflow-permission-boundary.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`
- Manual generated Dependency Track guard smoke: allowlisted HTTPS succeeds; HTTP is rejected with `Dependency Track URL must use HTTPS`.

## Rollback

Revert this PR to restore the previous permissive Grafana and Dependency Track URL handling. If rollback is required in production CI, remove or clear `DEPENDENCY_TRACK_ALLOWED_HOSTS` only after disabling Dependency Track upload secrets so API keys are not sent to unvalidated destinations.
