### PR TITLE
fix(security): harden production compose defaults

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -67,10 +67,10 @@ services:
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
-    ports:
-      - "4317:4317"   # OTLP gRPC receiver
-      - "4318:4318"   # OTLP HTTP receiver
-      - "8889:8889"   # Prometheus metrics
+    expose:
+      - "4317"   # OTLP gRPC receiver, internal network only
+      - "4318"   # OTLP HTTP receiver, internal network only
+      - "8889"   # Prometheus metrics, internal network only
     environment:
       - OTEL_LOG_LEVEL=warn
     healthcheck:
@@ -90,8 +90,8 @@ services:
   # Redis for caching and session storage (production)
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
+    expose:
+      - "6379"   # Redis is internal network only; publish via an explicit operator override if needed.
     command: ["redis-server", "--appendonly", "yes", "--requirepass-file", "/run/secrets/redis_password"]
     volumes:
       - redis_data:/data

--- a/podman/README.md
+++ b/podman/README.md
@@ -28,3 +28,21 @@ pnpm podman:smoke
 
 必要に応じて `CONTAINER_ENGINE=podman` を指定することで、
 `scripts/docker/analyze-optimization.sh` からも Podman を利用できます。
+
+## 本番シークレットと内部ポート
+
+`podman/compose.prod.yaml` は本番相当の実行を想定しており、サンプルのデータベース認証情報を含めません。スタック起動前に、PostgreSQL の値を外部シークレットソースから設定してください。
+
+```bash
+export POSTGRES_USER='ae_framework_app'
+export POSTGRES_PASSWORD="$(cat /path/to/secret/postgres-password)"
+export POSTGRES_DB='ae_framework'
+podman compose -f podman/compose.prod.yaml up --build -d
+```
+
+推奨運用:
+
+- シークレットファイルはリポジトリ外に配置し、`0600` など所有者のみが読める権限にする。
+- デプロイホストまたは運用者認証情報の露出が疑われる場合は `POSTGRES_PASSWORD` をローテーションする。
+- サンプル認証情報は `compose.dev.yaml` のみに置く。
+- `db` と `otel` は Compose 内部ネットワークに留める。診断目的でホストからのアクセスが必要な場合は、`127.0.0.1` に bind する明示的な operator override を別途用意し、firewall / authentication control を文書化する。

--- a/podman/compose.prod.yaml
+++ b/podman/compose.prod.yaml
@@ -55,13 +55,13 @@ services:
   db:
     image: docker.io/library/postgres:16-alpine
     environment:
-      POSTGRES_USER: app
-      POSTGRES_PASSWORD: app
-      POSTGRES_DB: app
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER for production database access}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD from an external secret}
+      POSTGRES_DB: ${POSTGRES_DB:?set POSTGRES_DB for production database access}
     volumes:
       - pgdata:/var/lib/postgresql/data:Z
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -71,9 +71,9 @@ services:
     image: docker.io/otel/opentelemetry-collector:0.106.1
     volumes:
       - ../observability/otel-collector.yaml:/etc/otelcol/config.yaml:ro,Z
-    ports:
-      - "4317:4317"
-      - "4318:4318"
+    expose:
+      - "4317"
+      - "4318"
     restart: unless-stopped
 
 volumes:

--- a/scripts/podman/smoke-test.sh
+++ b/scripts/podman/smoke-test.sh
@@ -113,6 +113,18 @@ compose_run() {
   container::compose "$@"
 }
 
+compose_config() {
+  local file="$1"
+  if [[ "$file" == "podman/compose.prod.yaml" ]]; then
+    POSTGRES_USER="${POSTGRES_USER:-ae_framework_smoke}" \
+    POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-ae_framework_smoke_password}" \
+    POSTGRES_DB="${POSTGRES_DB:-ae_framework_smoke}" \
+      compose_run -f "$file" config
+    return
+  fi
+  compose_run -f "$file" config
+}
+
 cleanup() {
   local status=$?
   if [[ "$DO_COMPOSE_UP" == true ]]; then
@@ -160,7 +172,7 @@ if [[ "$SKIP_COMPOSE" == false ]]; then
       continue
     fi
     log "validating compose file: $file"
-    compose_run -f "$file" config >/dev/null || fail "Compose validation failed for $file"
+    compose_config "$file" >/dev/null || fail "Compose validation failed for $file"
   done
 else
   log "skipping compose validation (--skip-compose)"

--- a/tests/unit/security/production-compose-security.test.ts
+++ b/tests/unit/security/production-compose-security.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+type ComposeService = {
+  environment?: Record<string, unknown> | string[];
+  expose?: Array<string | number>;
+  ports?: Array<string | number | Record<string, unknown>>;
+};
+
+type ComposeFile = {
+  services?: Record<string, ComposeService>;
+};
+
+const PROD_COMPOSE_FILES = [
+  'docker/docker-compose.prod.yml',
+  'podman/compose.prod.yaml',
+] as const;
+
+const readCompose = (filePath: string): ComposeFile => YAML.parse(readFileSync(filePath, 'utf8')) as ComposeFile;
+
+const environmentEntries = (environment: ComposeService['environment']): Array<[string, string]> => {
+  if (!environment) return [];
+  if (Array.isArray(environment)) {
+    return environment.map((entry) => {
+      const [key, ...valueParts] = String(entry).split('=');
+      return [key, valueParts.join('=')];
+    });
+  }
+  return Object.entries(environment).map(([key, value]) => [key, String(value)]);
+};
+
+const isVariableExpansion = (value: string): boolean => /^\$\{[A-Z0-9_]+(?::[-?][^}]*)?\}$/.test(value);
+
+const portBindingHost = (binding: string | number | Record<string, unknown>): string => {
+  if (typeof binding === 'number') return '0.0.0.0';
+  if (typeof binding === 'object') {
+    const hostIp = binding.host_ip ?? binding.hostIp ?? binding.ip;
+    return hostIp ? String(hostIp) : '0.0.0.0';
+  }
+  const value = String(binding);
+  if (value.startsWith('[')) {
+    const closing = value.indexOf(']');
+    return closing >= 0 && value[closing + 1] === ':' ? value.slice(1, closing) : '0.0.0.0';
+  }
+  const parts = value.split(':');
+  if (parts.length >= 3) return parts[0];
+  return '0.0.0.0';
+};
+
+const isLoopbackHost = (host: string): boolean => ['127.0.0.1', 'localhost', '::1'].includes(host);
+
+describe('production compose security', () => {
+  it('requires externalized Podman production PostgreSQL settings', () => {
+    const compose = readCompose('podman/compose.prod.yaml');
+    const db = compose.services?.db;
+    expect(db).toBeDefined();
+    const env = Object.fromEntries(environmentEntries(db?.environment));
+
+    expect(env.POSTGRES_USER).toMatch(/^\$\{POSTGRES_USER:\?/);
+    expect(env.POSTGRES_PASSWORD).toMatch(/^\$\{POSTGRES_PASSWORD:\?/);
+    expect(env.POSTGRES_DB).toMatch(/^\$\{POSTGRES_DB:\?/);
+    expect(env.POSTGRES_PASSWORD).not.toBe('app');
+  });
+
+  it('does not keep literal production database credential-like values in prod compose files', () => {
+    const credentialKey = /(?:POSTGRES_(?:USER|PASSWORD|DB)|DATABASE_URL|.*(?:PASSWORD|SECRET|TOKEN|API_KEY).*)/i;
+
+    for (const filePath of PROD_COMPOSE_FILES) {
+      const compose = readCompose(filePath);
+      for (const [serviceName, service] of Object.entries(compose.services ?? {})) {
+        for (const [key, value] of environmentEntries(service.environment)) {
+          if (!credentialKey.test(key)) continue;
+          expect(isVariableExpansion(value), `${filePath}:${serviceName}.${key} must use environment expansion`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('keeps internal production data and telemetry services off non-loopback host ports', () => {
+    const internalServices = new Set(['db', 'redis', 'otel', 'otel-collector']);
+
+    for (const filePath of PROD_COMPOSE_FILES) {
+      const compose = readCompose(filePath);
+      for (const [serviceName, service] of Object.entries(compose.services ?? {})) {
+        if (!internalServices.has(serviceName)) continue;
+        for (const binding of service.ports ?? []) {
+          expect(isLoopbackHost(portBindingHost(binding)), `${filePath}:${serviceName} publishes ${JSON.stringify(binding)} to a non-loopback host`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('documents internal-only production service ports through expose', () => {
+    const docker = readCompose('docker/docker-compose.prod.yml');
+    expect(docker.services?.['otel-collector']?.expose).toEqual(expect.arrayContaining(['4317', '4318', '8889']));
+    expect(docker.services?.redis?.expose).toEqual(expect.arrayContaining(['6379']));
+
+    const podman = readCompose('podman/compose.prod.yaml');
+    expect(podman.services?.otel?.expose).toEqual(expect.arrayContaining(['4317', '4318']));
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces checked-in Podman production PostgreSQL values with required environment expansion for `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB`.
- Keeps Podman smoke compose validation usable by providing validation-only placeholder PostgreSQL values when the caller has not supplied production secrets.
- Removes non-loopback host publishing for internal production Redis and OpenTelemetry services by converting those mappings to internal `expose` entries.
- Documents production secret-file handling, password rotation expectations, and the internal-only port posture.
- Adds static production compose security regression tests.

Closes #3372.
Closes #3373.

## Acceptance

- Podman production database credentials are no longer literal checked-in values.
- Production compose files do not publish `db`, `redis`, `otel`, or `otel-collector` ports to non-loopback host interfaces.
- Internal Redis and OpenTelemetry ports remain discoverable inside the Compose network through `expose`.
- Regression tests fail if production compose files reintroduce literal database credential-like values or unsafe host port publishing.

## Validation

- `bash -n scripts/podman/smoke-test.sh`
- `pnpm -s exec vitest run tests/unit/security/production-compose-security.test.ts tests/docker/optimization.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet tests/unit/security/production-compose-security.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

Environment-only validation limits:

- `POSTGRES_USER=ae_framework_smoke POSTGRES_PASSWORD=ae_framework_smoke_password POSTGRES_DB=ae_framework_smoke podman compose -f podman/compose.prod.yaml config` could not complete locally because rootless Podman failed with `cannot re-exec process to join the existing user namespace`.
- Docker Compose was not available in this local environment.

## Rollback

Revert this PR to restore the previous production compose defaults. If rollback is required, rotate any PostgreSQL password that may have been deployed from the old checked-in sample value and confirm Redis/OTel host exposure is controlled by host firewall rules before re-enabling the previous port mappings.
