### PR TITLE
fix(security): redact runtime telemetry and LLM cassettes

### DIFF
--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -2,7 +2,7 @@
 docRole: derived
 canonicalSource:
   - .github/workflows/agent-commands.yml
-lastVerified: '2026-06-01'
+lastVerified: '2026-06-02'
 ---
 
 # Agent Commands Catalog

--- a/docs/reference/CLI-COMMANDS-REFERENCE.md
+++ b/docs/reference/CLI-COMMANDS-REFERENCE.md
@@ -483,7 +483,7 @@ ae setup list
  ae status
  ae board
 
-# Agent completion (LLM)
+# Agent completion (LLM; --record writes redacted local cassettes with restrictive permissions)
  ae agent:complete --prompt "Summarize failures" --record
 
 # CI scaffold

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -6,6 +6,7 @@ import { enhancedTelemetry, TELEMETRY_ATTRIBUTES } from "../telemetry/enhanced-t
 import { trace } from '@opentelemetry/api';
 import { registerHealthEndpoint } from '../health/health-endpoint.js';
 import { requireAdminDiagnosticsAuth } from '../security/admin-diagnostics-auth.js';
+import { redactSensitiveData, safeUrlPath } from '../security/sensitive-redaction.js';
 import { IdempotencyConflictError, InsufficientStockError } from '../domain/entities.js';
 import { InMemoryInventoryRepository, InventoryServiceImpl } from '../domain/services.js';
 import type { InventoryService } from '../domain/services.js';
@@ -13,6 +14,14 @@ import type { InventoryService } from '../domain/services.js';
 interface CreateServerOptions {
   inventoryService?: InventoryService;
   adminDiagnosticsToken?: string;
+}
+
+interface FastifyRequestLogEntry {
+  method?: string;
+  url?: string;
+  hostname?: string;
+  remoteAddress?: string;
+  remotePort?: number;
 }
 
 const createFallbackInventoryService = (): InventoryService =>
@@ -23,12 +32,49 @@ const createFallbackInventoryService = (): InventoryService =>
     }),
   );
 
+const getTelemetryRoute = (request: { url: string }): string => {
+  const routeOptions = (request as unknown as { routeOptions?: { url?: string } }).routeOptions;
+  if (typeof routeOptions?.url === 'string' && routeOptions.url.length > 0) {
+    return routeOptions.url;
+  }
+  const routerPath = (request as unknown as { routerPath?: string }).routerPath;
+  if (typeof routerPath === 'string' && routerPath.length > 0) {
+    return routerPath;
+  }
+  return safeUrlPath(request.url);
+};
+
+export const sanitizeFastifyRequestLog = (request: FastifyRequestLogEntry): Record<string, unknown> => {
+  const logged: Record<string, unknown> = {
+    url: safeUrlPath(request.url),
+  };
+  if (typeof request.method === 'string') {
+    logged['method'] = request.method;
+  }
+  if (typeof request.hostname === 'string') {
+    logged['host'] = request.hostname;
+  }
+  if (typeof request.remoteAddress === 'string') {
+    logged['remoteAddress'] = request.remoteAddress;
+  }
+  if (typeof request.remotePort === 'number') {
+    logged['remotePort'] = request.remotePort;
+  }
+  return logged;
+};
+
+const apiServerLoggerOptions = {
+  serializers: {
+    req: (request: unknown) => sanitizeFastifyRequestLog(request as FastifyRequestLogEntry),
+  },
+};
+
 /**
  * Create and configure Fastify server instance
  */
 export async function createServer(options: CreateServerOptions = {}): Promise<FastifyInstance> {
   const app = Fastify({ 
-    logger: true,
+    logger: apiServerLoggerOptions,
     genReqId: () => `req_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
   });
 
@@ -56,13 +102,14 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
 
   // Add request tracing hook
   app.addHook('onRequest', async (request, reply) => {
-    const span = tracer.startSpan(`${request.method} ${request.url}`, {
+    const telemetryRoute = getTelemetryRoute(request);
+    const span = tracer.startSpan(`${request.method} ${telemetryRoute}`, {
       attributes: {
         [TELEMETRY_ATTRIBUTES.REQUEST_ID]: request.id,
         [TELEMETRY_ATTRIBUTES.SERVICE_COMPONENT]: 'api-server',
-        [TELEMETRY_ATTRIBUTES.SERVICE_OPERATION]: `${request.method} ${request.url}`,
+        [TELEMETRY_ATTRIBUTES.SERVICE_OPERATION]: `${request.method} ${telemetryRoute}`,
         'http.method': request.method,
-        'http.url': request.url,
+        'http.route': telemetryRoute,
         'http.user_agent': request.headers['user-agent'] || 'unknown',
       },
     });
@@ -71,15 +118,16 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
     request.startTime = Date.now();
     enhancedTelemetry.recordCounter('api.requests.total', 1, {
       method: request.method,
-      endpoint: request.url,
+      endpoint: telemetryRoute,
     });
   });
 
   // Add response timing hook
   app.addHook('onResponse', async (request, reply) => {
+    const telemetryRoute = getTelemetryRoute(request);
     const responseMetadata = {
       method: request.method,
-      endpoint: request.url,
+      endpoint: telemetryRoute,
       status_code: reply.statusCode.toString(),
     };
 
@@ -168,7 +216,7 @@ export async function createServer(options: CreateServerOptions = {}): Promise<F
         },
       );
       if (!validation.valid) {
-        console.error('Reservation error response validation failed:', validation.violations);
+        console.error('Reservation error response validation failed:', redactSensitiveData(validation.violations));
       }
       return validation.valid ? 'success' : 'failure';
     };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -767,9 +767,9 @@ program
   .description('LLM completion for quick verification')
   .option('--prompt <prompt>', 'Prompt to send to LLM (required)')
   .option('--system <system>', 'System message for LLM (optional)')
-  .option('--record', 'Record LLM I/O to cassettes')
+  .option('--record', 'Record redacted LLM cassettes with restrictive local permissions')
   .option('--replay', 'Replay from cassettes (no network)')
-  .option('--cassette-dir <dir>', 'Cassette directory (default: artifacts/cassettes)')
+  .option('--cassette-dir <dir>', 'Cassette directory for local redacted fixtures (default: artifacts/cassettes)')
   .action(async (options) => {
     if (!options.prompt) {
       console.error(chalk.red('❌ --prompt is required'));

--- a/src/commands/agent/complete.ts
+++ b/src/commands/agent/complete.ts
@@ -2,6 +2,7 @@ import { loadLLM } from '../../providers/index.js';
 import { withRecorder } from '../../providers/recorder.js';
 import { formatAppError, toExecAppError } from '../../core/command-errors.js';
 import type { AppError } from '../../core/errors.js';
+import { redactSensitiveString } from '../../security/sensitive-redaction.js';
 
 export async function agentComplete(prompt: string, system?: string, flags?: { record?: boolean; replay?: boolean; dir?: string }) {
   // Enhanced flag interpretation
@@ -37,7 +38,8 @@ export async function agentComplete(prompt: string, system?: string, flags?: { r
   const cassetteDir = flags?.dir ?? 'artifacts/cassettes';
   
   // Start execution log with prompt summary
-  const promptSummary = prompt.length > 100 ? `${prompt.slice(0, 100)}...` : prompt;
+  const redactedPrompt = redactSensitiveString(prompt);
+  const promptSummary = redactedPrompt.length > 100 ? `${redactedPrompt.slice(0, 100)}...` : redactedPrompt;
   console.log(`[ae][agent] Starting completion: "${promptSummary}"`);
   
   if (wantRecord) {
@@ -52,7 +54,7 @@ export async function agentComplete(prompt: string, system?: string, flags?: { r
     let llm = await loadLLM();
     
     if (wantReplay || wantRecord) {
-      llm = withRecorder(llm, { dir: cassetteDir, replay: wantReplay });
+      llm = withRecorder(llm, { dir: cassetteDir, replay: wantReplay, record: wantRecord });
     }
     
     console.log(`[ae][agent] Provider: ${llm.name}`);

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,7 +1,8 @@
 import type { LLM } from './index.js';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import * as path from 'node:path';
+import { safeErrorForLogging, safeStringForCassette } from '../security/sensitive-redaction.js';
 
 // Cache echo provider to avoid repeated imports
 let echoProviderPromise: Promise<{ default: LLM }> | null = null;
@@ -16,15 +17,21 @@ const isErrnoException = (value: unknown): value is { code: string } => {
   return typeof (value as { code?: unknown }).code === 'string';
 };
 
-export function withRecorder(base: LLM, opts?: { dir?: string; replay?: boolean }) : LLM {
+const hashValue = (value: string | undefined): string | undefined => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+};
+
+export function withRecorder(base: LLM, opts?: { dir?: string; replay?: boolean; record?: boolean }) : LLM {
   const dir = opts?.dir ?? 'artifacts/cassettes';
   const replay = opts?.replay ?? false;
+  const record = opts?.record ?? false;
   
   return {
     name: `rec(${base.name})`,
     async complete(input) {
-      await mkdir(dir, { recursive: true });
-      
       // Generate hash-based key for better reliability
       const hashKey = createHash('sha1')
         .update(JSON.stringify({ system: input.system, prompt: input.prompt }))
@@ -49,7 +56,7 @@ export function withRecorder(base: LLM, opts?: { dir?: string; replay?: boolean 
               return parsed;
             } catch (innerError) {
               if (innerError instanceof SyntaxError) {
-                throw new Error(`Cassette file is invalid JSON: ${filePath}`);
+                throw new Error('Cassette file is invalid JSON');
               }
               throw innerError;
             }
@@ -64,6 +71,9 @@ export function withRecorder(base: LLM, opts?: { dir?: string; replay?: boolean 
             }
           }
           const hit = content as { output: string };
+          if (typeof hit.output !== 'string') {
+            throw new Error(`Cassette file is missing a string output: ${hashFile}`);
+          }
           return hit.output;
         } catch (error) {
           if (isErrnoException(error) && error.code === 'ENOENT') {
@@ -73,13 +83,27 @@ export function withRecorder(base: LLM, opts?: { dir?: string; replay?: boolean 
           }
         }
       }
+
+      if (!record) {
+        return await base.complete(input);
+      }
+
+      await mkdir(dir, { recursive: true, mode: 0o700 });
+      if (process.platform !== 'win32') {
+        await chmod(dir, 0o700);
+      }
+
+      console.warn(
+        `[recorder] RECORD mode persists redacted LLM cassettes in ${dir}. ` +
+          'Review retention policy and do not publish cassette artifacts containing sensitive context.'
+      );
       
       let out: string;
       try {
         out = await base.complete(input);
       } catch (error) {
         // If base provider fails (including timeout), use echo as fallback
-        console.warn(`[recorder] Base provider failed, using echo fallback:`, error instanceof Error ? error.message : 'Unknown error');
+        console.warn('[recorder] Base provider failed, using echo fallback:', safeErrorForLogging(error));
         if (!echoProviderPromise) {
           echoProviderPromise = import('./llm-echo.js');
         }
@@ -87,8 +111,23 @@ export function withRecorder(base: LLM, opts?: { dir?: string; replay?: boolean 
         out = await echoProvider.complete(input);
       }
       
-      // Always save with hash-based filename for new recordings
-      await writeFile(hashFile, JSON.stringify({ input, output: out }, null, 2));
+      const cassette = {
+        schemaVersion: 1,
+        redacted: true,
+        inputHash: hashKey,
+        input: {
+          promptHash: hashValue(input.prompt),
+          systemHash: hashValue(input.system),
+          ...(typeof input.temperature === 'number' ? { temperature: input.temperature } : {}),
+        },
+        output: safeStringForCassette(out),
+      };
+
+      // Always save with hash-based filename for new recordings.
+      await writeFile(hashFile, JSON.stringify(cassette, null, 2), { mode: 0o600 });
+      if (process.platform !== 'win32') {
+        await chmod(hashFile, 0o600);
+      }
       return out;
     }
   };

--- a/src/runner/main.ts
+++ b/src/runner/main.ts
@@ -53,9 +53,9 @@ export async function main() {
   cli.command('agent:complete', 'LLM completion with record/replay support')
     .option('--prompt <text>', 'Prompt text')
     .option('--system <text>', 'System message')
-    .option('--record', 'Record mode')
+    .option('--record', 'Record redacted cassette mode')
     .option('--replay', 'Replay mode') 
-    .option('--cassette-dir <dir>', 'Cassette directory')
+    .option('--cassette-dir <dir>', 'Cassette directory for local redacted fixtures')
     .action((opts) => agentComplete(opts.prompt, opts.system, opts));
 
   cli.command('tests:suggest', 'Generate tests-first prompt after intent capture')

--- a/src/runtime/conformance-guards.ts
+++ b/src/runtime/conformance-guards.ts
@@ -10,6 +10,7 @@ import { trace, metrics as otMetrics, SpanStatusCode } from '@opentelemetry/api'
 import type { Attributes, Span } from '@opentelemetry/api';
 import type { FailureLocation } from '../cegis/failure-artifact-schema.js';
 import { FailureArtifactFactory } from '../cegis/failure-artifact-schema.js';
+import { redactSensitiveData, safeErrorForLogging, safeJsonForLogging, safeUrlPath } from '../security/sensitive-redaction.js';
 
 // Telemetry instances (safe for partially mocked @opentelemetry/api)
 const tracer = trace.getTracer('ae-framework-runtime-conformance');
@@ -20,6 +21,7 @@ type MiddlewareRequest = {
   params: unknown;
   method: string;
   originalUrl: string;
+  route?: { path?: string } | null;
   ip?: string;
   get: (name: string) => string | undefined;
 };
@@ -178,6 +180,7 @@ export class ConformanceGuard<T> {
     context?: ConformanceContext
   ): ConformanceResult<T> {
     const mergedContext = mergeContext(this.config.context, context);
+    const redactedContext = safeJsonForLogging(mergedContext) as ConformanceContext | undefined;
 
     if (!this.config.enabled) {
       return {
@@ -189,7 +192,7 @@ export class ConformanceGuard<T> {
           schemaName: this.schemaName,
           duration: 0,
           timestamp: new Date().toISOString(),
-          ...(mergedContext ? { context: mergedContext } : {}),
+          ...(redactedContext ? { context: redactedContext } : {}),
         },
       };
     }
@@ -255,7 +258,7 @@ export class ConformanceGuard<T> {
             schemaName: this.schemaName,
             duration,
             timestamp: new Date().toISOString(),
-            ...(mergedContext ? { context: mergedContext } : {}),
+            ...(redactedContext ? { context: redactedContext } : {}),
           },
         };
       } else {
@@ -263,6 +266,7 @@ export class ConformanceGuard<T> {
         const errors = result.error.errors.map(err => 
           `${err.path.join('.')}: ${err.message}`
         );
+        const redactedData = safeJsonForLogging(data);
 
         if (span) {
           span.setStatus({
@@ -295,14 +299,14 @@ export class ConformanceGuard<T> {
         if (this.config.logViolations) {
           console.warn(`🚨 Conformance violation in ${this.schemaName} (${direction}):`, {
             errors,
-            data: this.sanitizeForLogging(data),
+            data: redactedData,
             duration,
           });
         }
 
         // Generate failure artifact if configured
         if (this.config.generateArtifacts) {
-          this.generateFailureArtifact(errors, data, direction, mergedContext);
+          this.generateFailureArtifact(errors, redactedData, direction, redactedContext);
         }
 
         // Throw error if configured to fail on violation
@@ -312,7 +316,7 @@ export class ConformanceGuard<T> {
             this.schemaName,
             direction,
             errors,
-            data
+            redactedData
           );
         }
 
@@ -324,7 +328,7 @@ export class ConformanceGuard<T> {
             schemaName: this.schemaName,
             duration,
             timestamp: new Date().toISOString(),
-            ...(mergedContext ? { context: mergedContext } : {}),
+            ...(redactedContext ? { context: redactedContext } : {}),
           },
         };
       }
@@ -359,7 +363,7 @@ export class ConformanceGuard<T> {
       const artifact = FailureArtifactFactory.fromContractViolation(
         `${this.schemaName} (${direction})`,
         'Schema validation',
-        data,
+        safeJsonForLogging(data),
         context?.location
       );
 
@@ -370,7 +374,7 @@ export class ConformanceGuard<T> {
       if (context) {
         let serializedContext: string | undefined;
         try {
-          serializedContext = JSON.stringify(context);
+          serializedContext = JSON.stringify(safeJsonForLogging(context));
         } catch {
           serializedContext = undefined;
         }
@@ -386,53 +390,8 @@ export class ConformanceGuard<T> {
       // In a real implementation, this would store the artifact
       console.debug('📝 Generated failure artifact:', artifact.id);
     } catch (error) {
-      console.error('Failed to generate failure artifact:', error);
+      console.error('Failed to generate failure artifact:', safeErrorForLogging(error));
     }
-  }
-
-  /**
-   * Sanitize data for logging (remove sensitive information)
-   */
-  private sanitizeForLogging(data: unknown): unknown {
-    if (data === null || typeof data !== 'object') {
-      return data;
-    }
-
-    const sensitiveFragments = ['password', 'token', 'secret', 'key', 'authorization'];
-
-    let clone: unknown;
-    try {
-      clone = JSON.parse(JSON.stringify(data));
-    } catch {
-      return '[Unserializable payload]';
-    }
-
-    const sanitizeInPlace = (value: unknown): unknown => {
-      if (Array.isArray(value)) {
-        const arrayValue = value as unknown[];
-        for (let index = 0; index < arrayValue.length; index += 1) {
-          arrayValue[index] = sanitizeInPlace(arrayValue[index]);
-        }
-        return arrayValue;
-      }
-
-      if (value && typeof value === 'object') {
-        const record = value as Record<string, unknown>;
-        for (const [key, nestedValue] of Object.entries(record)) {
-          const lowerKey = key.toLowerCase();
-          if (sensitiveFragments.some((fragment) => lowerKey.includes(fragment))) {
-            record[key] = '[REDACTED]';
-          } else {
-            record[key] = sanitizeInPlace(nestedValue);
-          }
-        }
-        return record;
-      }
-
-      return value;
-    };
-
-    return sanitizeInPlace(clone);
   }
 
   /**
@@ -458,15 +417,23 @@ export class ConformanceGuard<T> {
  * Conformance Violation Error
  */
 export class ConformanceViolationError extends Error {
+  public readonly data: unknown;
+
   constructor(
     message: string,
     public schemaName: string,
     public direction: 'input' | 'output',
     public validationErrors: string[],
-    public data: unknown
+    data: unknown
   ) {
     super(message);
     this.name = 'ConformanceViolationError';
+    Object.defineProperty(this, 'data', {
+      value: redactSensitiveData(data),
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
   }
 }
 
@@ -698,7 +665,9 @@ export function createExpressMiddleware<T>(
 
       const result = await guard.validateInput(data, {
         method: req.method,
-        url: req.originalUrl,
+        path: typeof req.route?.path === 'string' && req.route.path.length > 0
+          ? req.route.path
+          : safeUrlPath(req.originalUrl),
         userAgent: req.get('User-Agent'),
         ip: req.ip,
       });
@@ -730,7 +699,7 @@ export function createExpressMiddleware<T>(
 
       next();
     } catch (error) {
-      console.error('Conformance middleware error:', error);
+      console.error('Conformance middleware error:', safeErrorForLogging(error));
       if (guard.getConfig().failOnViolation) {
         res.status(500).json({
           error: 'Internal validation error',

--- a/src/runtime/runtime-middleware.ts
+++ b/src/runtime/runtime-middleware.ts
@@ -10,6 +10,7 @@ import { z, type ZodRawShape, type ZodTypeAny } from 'zod';
 import { GuardFactory } from './conformance-guards.js';
 import type { ConformanceResult } from './conformance-guards.js';
 import { trace, SpanStatusCode } from '@opentelemetry/api';
+import { safeErrorForLogging, safeUrlPath } from '../security/sensitive-redaction.js';
 
 /**
  * Minimal request/response types that remain compatible with Express but keep
@@ -51,6 +52,13 @@ type ExpressMiddleware = (
 type ResponseInvoker = (payload: unknown) => ExpressResponseLike;
 
 const tracer = trace.getTracer('ae-framework-runtime-middleware');
+
+const extractExpressRouteTemplate = (req: ExpressRequestLike): string => {
+  if (typeof req.route?.path === 'string' && req.route.path.length > 0) {
+    return req.route.path;
+  }
+  return safeUrlPath(req.path);
+};
 
 // Middleware configuration
 export interface MiddlewareConfig {
@@ -128,7 +136,7 @@ export class ExpressConformanceMiddleware {
 
         span.setAttributes({
           'http.method': req.method,
-          'http.route': req.route?.path || req.path,
+          'http.route': extractExpressRouteTemplate(req),
           'conformance.operation_id': operationId,
           'conformance.validation_result': result.success ? 'success' : 'failure',
         });
@@ -174,7 +182,7 @@ export class ExpressConformanceMiddleware {
 
         span.setAttributes({
           'http.method': req.method,
-          'http.route': req.route?.path || req.path,
+          'http.route': extractExpressRouteTemplate(req),
           'conformance.operation_id': operationId,
           'conformance.validation_result': result.success ? 'success' : 'failure',
         });
@@ -219,7 +227,7 @@ export class ExpressConformanceMiddleware {
 
         span.setAttributes({
           'http.method': req.method,
-          'http.route': req.route?.path || req.path,
+          'http.route': extractExpressRouteTemplate(req),
           'conformance.operation_id': operationId,
           'conformance.validation_result': result.success ? 'success' : 'failure',
         });
@@ -260,7 +268,7 @@ export class ExpressConformanceMiddleware {
         const span = tracer.startSpan(`validate_response_${operationId}`);
         span.setAttributes({
           'http.method': req.method,
-          'http.route': req.route?.path || req.path,
+          'http.route': extractExpressRouteTemplate(req),
           'conformance.operation_id': operationId,
           'http.status_code': res.statusCode,
         });
@@ -288,7 +296,7 @@ export class ExpressConformanceMiddleware {
             span.setStatus({ code: SpanStatusCode.ERROR });
 
             if (this.config.logErrors) {
-              console.error(`Response validation error for ${operationId}:`, error);
+              console.error(`Response validation error for ${operationId}:`, safeErrorForLogging(error));
             }
           })
           .finally(() => {
@@ -335,7 +343,7 @@ export class ExpressConformanceMiddleware {
     const context: ValidationContext = {
       operationId,
       method: req.method,
-      path: req.path,
+      path: extractExpressRouteTemplate(req),
       timestamp: new Date().toISOString(),
     };
 
@@ -383,7 +391,7 @@ export class ExpressConformanceMiddleware {
       message: `${target} validation failed`,
       details: result.errors,
       timestamp: result.metadata.timestamp,
-      path: req.path,
+      path: extractExpressRouteTemplate(req),
       method: req.method,
     };
 
@@ -414,7 +422,7 @@ export class ExpressConformanceMiddleware {
     }
 
     if (this.config.logErrors) {
-      console.error('Conformance middleware error:', error);
+      console.error('Conformance middleware error:', safeErrorForLogging(error));
     }
 
     if (this.config.strictMode) {
@@ -445,6 +453,18 @@ const extractOperationId = (request: FastifyRequest): string | undefined => {
   return candidate?.operationId;
 };
 
+const extractRouteTemplate = (request: FastifyRequest): string => {
+  const routeOptions = (request as unknown as { routeOptions?: { url?: string } }).routeOptions;
+  if (typeof routeOptions?.url === 'string' && routeOptions.url.length > 0) {
+    return routeOptions.url;
+  }
+  const routerPath = (request as unknown as { routerPath?: string }).routerPath;
+  if (typeof routerPath === 'string' && routerPath.length > 0) {
+    return routerPath;
+  }
+  return safeUrlPath(request.url);
+};
+
 /**
  * Fastify Plugin for Runtime Conformance
  */
@@ -470,14 +490,15 @@ export function fastifyConformancePlugin(
   fastify.addHook('preHandler', (request: FastifyRequest) => {
     if (!config.enabled) return;
 
-    const operationId = extractOperationId(request) ?? `${request.method}_${request.url}`;
+    const routeTemplate = extractRouteTemplate(request);
+    const operationId = extractOperationId(request) ?? `${request.method}_${routeTemplate}`;
 
     const span = tracer.startSpan(`fastify_validate_${operationId}`);
 
     try {
       span.setAttributes({
         'http.method': request.method,
-        'http.url': request.url,
+        'http.route': routeTemplate,
         'conformance.operation_id': operationId,
       });
 
@@ -499,14 +520,15 @@ export function fastifyConformancePlugin(
   fastify.addHook('onSend', (request: FastifyRequest, reply: FastifyReply, payload: unknown) => {
     if (!config.enabled) return payload;
 
-    const operationId = extractOperationId(request) ?? `${request.method}_${request.url}`;
+    const routeTemplate = extractRouteTemplate(request);
+    const operationId = extractOperationId(request) ?? `${request.method}_${routeTemplate}`;
 
     const span = tracer.startSpan(`fastify_validate_response_${operationId}`);
 
     try {
       span.setAttributes({
         'http.method': request.method,
-        'http.url': request.url,
+        'http.route': routeTemplate,
         'http.status_code': reply.statusCode,
         'conformance.operation_id': operationId,
       });
@@ -521,7 +543,7 @@ export function fastifyConformancePlugin(
       span.setStatus({ code: SpanStatusCode.ERROR });
       
       if (config.logErrors) {
-        console.error('Fastify response validation error:', error);
+        console.error('Fastify response validation error:', safeErrorForLogging(error));
       }
     } finally {
       span.end();

--- a/src/security/sensitive-redaction.ts
+++ b/src/security/sensitive-redaction.ts
@@ -1,0 +1,82 @@
+export const REDACTED_VALUE = '[REDACTED]';
+
+const SENSITIVE_KEY_PATTERN = /(?:^key$|authorization|cookie|set-cookie|password|passwd|passphrase|secret|token|api[_-]?key|apikey|access[_-]?key|private[_-]?key|public[_-]?key|ssh[_-]?key|signing[_-]?key|encryption[_-]?key|decryption[_-]?key|client[_-]?secret|session(?:id)?|jwt|dsn|database[_-]?url|connection[_-]?string|credential|refresh[_-]?token|id[_-]?token|sig(?:nature)?)/i;
+
+const STRING_REDACTIONS: Array<[RegExp, string]> = [
+  [/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]'],
+  [/\bBasic\s+[A-Za-z0-9+/=-]+/gi, 'Basic [REDACTED]'],
+  [
+    /([?&](?:access[_-]?token|api[_-]?key|apikey|authorization|client[_-]?secret|code|cookie|database[_-]?url|dsn|id[_-]?token|jwt|key|password|refresh[_-]?token|secret|session(?:id)?|sig(?:nature)?|token)=)([^&#\s]+)/gi,
+    '$1[REDACTED]',
+  ],
+  [
+    /\b(access[_-]?token|api[_-]?key|apikey|authorization|client[_-]?secret|cookie|database[_-]?url|dsn|id[_-]?token|jwt|key|password|refresh[_-]?token|secret|session(?:id)?|sig(?:nature)?|token)=([^&\s]+)/gi,
+    '$1=[REDACTED]',
+  ],
+  [/\b((?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp|https?):\/\/)([^:@/\s]+):([^@/\s]+)@/gi, '$1[REDACTED]@'],
+  [/\b(Cookie:\s*)[^\r\n]+/gi, '$1[REDACTED]'],
+  [/\b(Set-Cookie:\s*)[^\r\n]+/gi, '$1[REDACTED]'],
+];
+
+export function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERN.test(key);
+}
+
+export function redactSensitiveString(value: string): string {
+  return STRING_REDACTIONS.reduce((current, [pattern, replacement]) => current.replace(pattern, replacement), value);
+}
+
+export function redactSensitiveData(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === 'string') {
+    return redactSensitiveString(value);
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveData(entry, seen));
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+    redacted[key] = isSensitiveKey(key) ? REDACTED_VALUE : redactSensitiveData(nested, seen);
+  }
+  return redacted;
+}
+
+export function safeJsonForLogging(value: unknown): unknown {
+  try {
+    return redactSensitiveData(value);
+  } catch {
+    return '[Unserializable payload]';
+  }
+}
+
+export function safeUrlPath(value: string | undefined): string {
+  if (!value) return '/';
+  try {
+    const parsed = new URL(value, 'http://local.invalid');
+    return parsed.pathname || '/';
+  } catch {
+    return value.split('?')[0] || '/';
+  }
+}
+
+export function safeErrorForLogging(error: unknown): unknown {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: redactSensitiveString(error.message),
+    };
+  }
+  return redactSensitiveData(error);
+}
+
+export function safeStringForCassette(value: string): string {
+  return redactSensitiveString(value);
+}

--- a/src/telemetry/runtime-guards.ts
+++ b/src/telemetry/runtime-guards.ts
@@ -7,6 +7,30 @@ import { z } from 'zod';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import { enhancedTelemetry, TELEMETRY_ATTRIBUTES } from './enhanced-telemetry.js';
 import { trace } from '@opentelemetry/api';
+import { redactSensitiveData, safeUrlPath } from '../security/sensitive-redaction.js';
+
+const sanitizeEndpoint = (endpoint?: string): string | undefined => {
+  if (!endpoint) {
+    return undefined;
+  }
+  const methodPathMatch = endpoint.match(/^([A-Z]+)\s+(.+)$/);
+  if (methodPathMatch) {
+    return `${methodPathMatch[1]} ${safeUrlPath(methodPathMatch[2])}`;
+  }
+  return safeUrlPath(endpoint);
+};
+
+const getFastifyRoute = (request: FastifyRequest): string => {
+  const routeOptions = (request as unknown as { routeOptions?: { url?: string } }).routeOptions;
+  if (typeof routeOptions?.url === 'string' && routeOptions.url.length > 0) {
+    return routeOptions.url;
+  }
+  const routerPath = (request as unknown as { routerPath?: string }).routerPath;
+  if (typeof routerPath === 'string' && routerPath.length > 0) {
+    return routerPath;
+  }
+  return safeUrlPath(request.url);
+};
 
 // Contract violation types
 export enum ViolationType {
@@ -59,12 +83,23 @@ export class RuntimeGuard {
       operation?: string;
     } = {}
   ): ValidationResult<T> {
+    const sanitizedEndpoint = sanitizeEndpoint(context.endpoint);
+    const violationContext: {
+      requestId?: string;
+      endpoint?: string;
+      operation?: string;
+    } = { ...context };
+    if (typeof sanitizedEndpoint === 'string') {
+      violationContext.endpoint = sanitizedEndpoint;
+    } else {
+      delete violationContext.endpoint;
+    }
     const span = this.tracer.startSpan('runtime_guard.validate_request', {
       attributes: {
         [TELEMETRY_ATTRIBUTES.SERVICE_COMPONENT]: 'runtime-guard',
         [TELEMETRY_ATTRIBUTES.SERVICE_OPERATION]: context.operation || 'validate_request',
         [TELEMETRY_ATTRIBUTES.REQUEST_ID]: context.requestId || 'unknown',
-        endpoint: context.endpoint || 'unknown',
+        endpoint: sanitizedEndpoint || 'unknown',
       },
     });
 
@@ -73,7 +108,7 @@ export class RuntimeGuard {
       const result = schema.safeParse(data);
       const duration = timer.end({
         validation_type: 'request',
-        endpoint: context.endpoint,
+        endpoint: sanitizedEndpoint,
       });
 
       if (result.success) {
@@ -84,7 +119,7 @@ export class RuntimeGuard {
         
         enhancedTelemetry.recordCounter('runtime_guard.validations.success', 1, {
           validation_type: 'request',
-          endpoint: context.endpoint,
+          endpoint: sanitizedEndpoint,
         });
 
         span.end();
@@ -96,7 +131,7 @@ export class RuntimeGuard {
       } else {
         const violation = this.createValidationViolation(
           result.error,
-          context,
+          violationContext,
           ViolationSeverity.MEDIUM
         );
 
@@ -140,12 +175,23 @@ export class RuntimeGuard {
       statusCode?: number;
     } = {}
   ): ValidationResult<T> {
+    const sanitizedEndpoint = sanitizeEndpoint(context.endpoint);
+    const violationContext: {
+      requestId?: string;
+      endpoint?: string;
+      statusCode?: number;
+    } = { ...context };
+    if (typeof sanitizedEndpoint === 'string') {
+      violationContext.endpoint = sanitizedEndpoint;
+    } else {
+      delete violationContext.endpoint;
+    }
     const span = this.tracer.startSpan('runtime_guard.validate_response', {
       attributes: {
         [TELEMETRY_ATTRIBUTES.SERVICE_COMPONENT]: 'runtime-guard',
         [TELEMETRY_ATTRIBUTES.SERVICE_OPERATION]: 'validate_response',
         [TELEMETRY_ATTRIBUTES.REQUEST_ID]: context.requestId || 'unknown',
-        endpoint: context.endpoint || 'unknown',
+        endpoint: sanitizedEndpoint || 'unknown',
         status_code: context.statusCode || 0,
       },
     });
@@ -155,7 +201,7 @@ export class RuntimeGuard {
       const result = schema.safeParse(data);
       const duration = timer.end({
         validation_type: 'response',
-        endpoint: context.endpoint,
+        endpoint: sanitizedEndpoint,
       });
 
       if (result.success) {
@@ -166,7 +212,7 @@ export class RuntimeGuard {
 
         enhancedTelemetry.recordCounter('runtime_guard.validations.success', 1, {
           validation_type: 'response',
-          endpoint: context.endpoint,
+          endpoint: sanitizedEndpoint,
         });
 
         span.end();
@@ -178,7 +224,7 @@ export class RuntimeGuard {
       } else {
         const violation = this.createValidationViolation(
           result.error,
-          context,
+          violationContext,
           ViolationSeverity.HIGH // Response validation failures are more serious
         );
 
@@ -264,7 +310,7 @@ export class RuntimeGuard {
     return async (request: FastifyRequest, reply: FastifyReply) => {
       const result = this.validateRequest(schema, request.body, {
         requestId: request.id,
-        endpoint: `${request.method} ${request.url}`,
+        endpoint: `${request.method} ${getFastifyRoute(request)}`,
         operation: 'request_validation',
       });
 
@@ -293,7 +339,7 @@ export class RuntimeGuard {
     return async (request: FastifyRequest, reply: FastifyReply, payload: unknown) => {
       const result = this.validateResponse(schema, payload, {
         requestId: request.id,
-        endpoint: `${request.method} ${request.url}`,
+        endpoint: `${request.method} ${getFastifyRoute(request)}`,
         statusCode: reply.statusCode,
       });
 
@@ -301,7 +347,7 @@ export class RuntimeGuard {
         // Log the violation but don't modify the response in production
         // to avoid breaking the API contract
         const violation = result.violations[0];
-        console.error('Response validation failed:', violation);
+        console.error('Response validation failed:', redactSensitiveData(violation));
         
         if (process.env['NODE_ENV'] === 'development') {
           return {
@@ -309,7 +355,7 @@ export class RuntimeGuard {
             message: 'Response payload validation failed',
             details: violation?.details || 'Unknown validation error',
             violation_id: violation?.id || 'unknown',
-            original_payload: payload,
+            redacted_payload: redactSensitiveData(payload),
           };
         }
       }

--- a/tests/api/server.instrumentation.test.ts
+++ b/tests/api/server.instrumentation.test.ts
@@ -5,7 +5,7 @@ import { trace } from '@opentelemetry/api';
 import { formatGWT } from '../utils/gwt-format';
 import * as SecurityHeaders from '../../src/api/middleware/security-headers.js';
 import { TELEMETRY_ATTRIBUTES } from '../../src/telemetry/enhanced-telemetry.js';
-import getServer, { createServer } from '../../src/api/server.js';
+import getServer, { createServer, sanitizeFastifyRequestLog } from '../../src/api/server.js';
 const {
   timerEndSpy,
   createTimerSpy,
@@ -162,7 +162,7 @@ describe('Server instrumentation telemetry', () => {
               [TELEMETRY_ATTRIBUTES.SERVICE_COMPONENT]: 'api-server',
               [TELEMETRY_ATTRIBUTES.SERVICE_OPERATION]: 'GET /health',
               'http.method': 'GET',
-              'http.url': '/health',
+              'http.route': '/health',
               'http.user_agent': 'lightMyRequest',
             }),
           }),
@@ -200,6 +200,69 @@ describe('Server instrumentation telemetry', () => {
             status_code: '200',
           }),
         );
+      } finally {
+        await app.close();
+        tracerSpy?.mockRestore();
+        tracerSpy = undefined;
+      }
+    },
+  );
+
+  it(
+    formatGWT(
+      'Fastify request logger serializer',
+      'receives a request with secret-bearing query parameters',
+      'logs a query-stripped URL without raw secrets',
+    ),
+    () => {
+      const logged = sanitizeFastifyRequestLog({
+        method: 'GET',
+        url: '/health?token=raw-logger-query-token&password=raw-logger-query-password',
+        hostname: 'localhost:80',
+        remoteAddress: '127.0.0.1',
+      });
+
+      const serialized = JSON.stringify(logged);
+      expect(logged.url).toBe('/health');
+      expect(serialized).not.toContain('raw-logger-query-token');
+      expect(serialized).not.toContain('raw-logger-query-password');
+    },
+  );
+
+  it(
+    formatGWT(
+      'request tracing with secret-bearing query parameters',
+      'handles a traced API request',
+      'records sanitized route metadata instead of raw URL query values',
+    ),
+    async () => {
+      const spanStub = {
+        setAttributes: vi.fn(),
+        recordException: vi.fn(),
+        end: vi.fn(),
+      };
+      const startSpan = vi.fn(() => spanStub);
+      tracerSpy = vi.spyOn(trace, 'getTracer').mockReturnValue({ startSpan } as any);
+
+      const app: FastifyInstance = await createServer();
+      await app.ready();
+
+      try {
+        const response = await app.inject({
+          method: 'GET',
+          url: '/health?token=raw-api-query-token&password=raw-api-query-password',
+        });
+
+        expect(response.statusCode).toBe(200);
+        const startSpanPayload = JSON.stringify(startSpan.mock.calls);
+        const counterPayload = JSON.stringify(recordCounterSpy.mock.calls);
+
+        expect(startSpanPayload).toContain('GET /health');
+        expect(startSpanPayload).not.toContain('raw-api-query-token');
+        expect(startSpanPayload).not.toContain('raw-api-query-password');
+        expect(startSpanPayload).not.toContain('http.url');
+        expect(counterPayload).not.toContain('raw-api-query-token');
+        expect(counterPayload).not.toContain('raw-api-query-password');
       } finally {
         await app.close();
         tracerSpy?.mockRestore();

--- a/tests/providers/recorder.test.ts
+++ b/tests/providers/recorder.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, readdir, readFile, rm, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { withRecorder } from '../../src/providers/recorder.js';
+import type { LLM } from '../../src/providers/index.js';
+
+const tmpRoot = path.join(process.cwd(), '.codex-local', 'tmp', 'recorder-tests');
+
+async function makeCassetteDir(name: string): Promise<string> {
+  await mkdir(tmpRoot, { recursive: true });
+  return path.join(tmpRoot, `${name}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+}
+
+async function readOnlyCassette(dir: string): Promise<{ file: string; text: string }> {
+  const files = await readdir(dir);
+  expect(files).toHaveLength(1);
+  const file = path.join(dir, files[0]!);
+  return {
+    file,
+    text: await readFile(file, 'utf8'),
+  };
+}
+
+describe('LLM recorder', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    warnSpy.mockRestore();
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('does not write cassettes unless record mode is explicitly enabled', async () => {
+    const dir = await makeCassetteDir('default-off');
+    const base: LLM = {
+      name: 'base',
+      complete: vi.fn().mockResolvedValue('live output'),
+    };
+
+    const recorder = withRecorder(base, { dir });
+    const output = await recorder.complete({ prompt: 'token=raw-prompt-token' });
+
+    expect(output).toBe('live output');
+    await expect(readdir(dir)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('RECORD mode'));
+  });
+
+  it('persists redacted cassettes with restrictive file permissions in explicit record mode', async () => {
+    const dir = await makeCassetteDir('record-redacted');
+    const base: LLM = {
+      name: 'base',
+      complete: vi.fn().mockResolvedValue('provider output Bearer raw-output-token token=raw-output-query'),
+    };
+
+    const recorder = withRecorder(base, { dir, record: true });
+    const output = await recorder.complete({
+      system: 'Cookie: sid=raw-system-cookie',
+      prompt: 'use password=raw-prompt-password and api_key=raw-prompt-api-key',
+      temperature: 0,
+    });
+
+    expect(output).toContain('raw-output-token');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('RECORD mode persists redacted LLM cassettes'));
+
+    const { file, text } = await readOnlyCassette(dir);
+    const cassette = JSON.parse(text) as {
+      redacted: boolean;
+      inputHash: string;
+      input: { promptHash: string; systemHash: string; temperature: number };
+      output: string;
+    };
+
+    expect(cassette.redacted).toBe(true);
+    expect(cassette.inputHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(cassette.input.promptHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(cassette.input.systemHash).toMatch(/^[a-f0-9]{16}$/);
+    expect(cassette.input.temperature).toBe(0);
+    expect(text).toContain('[REDACTED]');
+    expect(text).not.toContain('raw-system-cookie');
+    expect(text).not.toContain('raw-prompt-password');
+    expect(text).not.toContain('raw-prompt-api-key');
+    expect(text).not.toContain('raw-output-token');
+    expect(text).not.toContain('raw-output-query');
+
+    if (process.platform !== 'win32') {
+      expect((await stat(dir)).mode & 0o777).toBe(0o700);
+      expect((await stat(file)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('redacts echo fallback output before cassette persistence', async () => {
+    const dir = await makeCassetteDir('fallback-redacted');
+    const base: LLM = {
+      name: 'base',
+      complete: vi.fn().mockRejectedValue(new Error('provider failed with token=raw-provider-error-token')),
+    };
+
+    const recorder = withRecorder(base, { dir, record: true });
+    const output = await recorder.complete({
+      system: 'system token=raw-system-token',
+      prompt: 'prompt token=raw-fallback-token',
+    });
+
+    expect(output).toContain('raw-fallback-token');
+    const { text } = await readOnlyCassette(dir);
+    const serializedWarnings = JSON.stringify(warnSpy.mock.calls);
+
+    expect(text).toContain('[REDACTED]');
+    expect(text).not.toContain('raw-system-token');
+    expect(text).not.toContain('raw-fallback-token');
+    expect(text).not.toContain('raw-provider-error-token');
+    expect(serializedWarnings).not.toContain('raw-provider-error-token');
+  });
+
+  it('replays a recorded cassette output without calling the base provider', async () => {
+    const dir = await makeCassetteDir('replay');
+    const input = { prompt: 'prompt token=raw-replay-token' };
+    const recordBase: LLM = {
+      name: 'record-base',
+      complete: vi.fn().mockResolvedValue('recorded output token=raw-replay-output-token'),
+    };
+    const replayBase: LLM = {
+      name: 'replay-base',
+      complete: vi.fn().mockResolvedValue('should not be called'),
+    };
+
+    await withRecorder(recordBase, { dir, record: true }).complete(input);
+    const replayed = await withRecorder(replayBase, { dir, replay: true }).complete(input);
+
+    expect(replayed).toContain('[REDACTED]');
+    expect(replayed).not.toContain('raw-replay-output-token');
+    expect(replayBase.complete).not.toHaveBeenCalled();
+  });
+});

--- a/tests/runtime/conformance-guards.test.ts
+++ b/tests/runtime/conformance-guards.test.ts
@@ -37,6 +37,7 @@ import {
   ValidateInput,
   ValidateOutput,
 } from '../../src/runtime/conformance-guards.js';
+import { FailureArtifactFactory } from '../../src/cegis/failure-artifact-schema.js';
 
 describe('ConformanceGuard', () => {
   const userSchema = z.object({
@@ -208,6 +209,7 @@ describe('ConformanceGuard', () => {
         expect((error as ConformanceViolationError).direction).toBe('input');
         expect((error as ConformanceViolationError).validationErrors).toBeDefined();
         expect((error as ConformanceViolationError).data).toEqual(invalidData);
+        expect(Object.keys(error as ConformanceViolationError)).not.toContain('data');
       }
     });
   });
@@ -526,5 +528,66 @@ describe('Edge Cases and Error Handling', () => {
     // Should either succeed or fail gracefully without performance issues
     expect(typeof result.success).toBe('boolean');
     expect(Array.isArray(result.errors)).toBe(true);
+  });
+
+  it('redacts validation logs, failure artifacts, and non-enumerable thrown error data', async () => {
+    const secretGuard = new ConformanceGuard(z.object({ id: z.number() }), 'secret-schema', {
+      failOnViolation: true,
+      logViolations: true,
+      generateArtifacts: true,
+      telemetryEnabled: false,
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    const artifactSpy = vi.spyOn(FailureArtifactFactory, 'fromContractViolation');
+
+    const invalidData = {
+      id: 'not-a-number',
+      password: 'raw-password-secret',
+      key: 'raw-generic-key-secret',
+      sshKey: 'raw-ssh-key-secret',
+      nested: {
+        cookie: 'sid=raw-cookie-secret',
+        connectionString: 'postgres://app:raw-db-secret@example.test/app',
+      },
+      note: 'Authorization: Bearer raw-bearer-secret',
+      url: 'https://example.test/callback?token=raw-query-token',
+    };
+
+    let thrown: unknown;
+    try {
+      await secretGuard.validateInput(invalidData, {
+        source: 'test',
+        path: '/api/widgets?token=raw-context-token',
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ConformanceViolationError);
+    const error = thrown as ConformanceViolationError;
+    expect(Object.keys(error)).not.toContain('data');
+
+    const serializedEvidence = JSON.stringify({
+      warnCalls: warnSpy.mock.calls,
+      artifactActual: artifactSpy.mock.calls[0]?.[2],
+      artifactContext: artifactSpy.mock.calls[0]?.[3],
+      errorData: error.data,
+      serializedError: JSON.stringify(error),
+    });
+
+    expect(serializedEvidence).toContain('[REDACTED]');
+    expect(serializedEvidence).not.toContain('raw-password-secret');
+    expect(serializedEvidence).not.toContain('raw-generic-key-secret');
+    expect(serializedEvidence).not.toContain('raw-ssh-key-secret');
+    expect(serializedEvidence).not.toContain('raw-cookie-secret');
+    expect(serializedEvidence).not.toContain('raw-db-secret');
+    expect(serializedEvidence).not.toContain('raw-bearer-secret');
+    expect(serializedEvidence).not.toContain('raw-query-token');
+    expect(serializedEvidence).not.toContain('raw-context-token');
+
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+    artifactSpy.mockRestore();
   });
 });

--- a/tests/runtime/runtime-middleware.test.ts
+++ b/tests/runtime/runtime-middleware.test.ts
@@ -6,20 +6,36 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { z } from 'zod';
 import {
   ExpressConformanceMiddleware,
+  fastifyConformancePlugin,
   MiddlewareRegistry,
   OpenAPIConformanceIntegration,
 } from '../../src/runtime/runtime-middleware.js';
+
+const otelMock = vi.hoisted(() => ({
+  spans: [] as Array<{
+    name: string;
+    setStatus: ReturnType<typeof vi.fn>;
+    setAttributes: ReturnType<typeof vi.fn>;
+    recordException: ReturnType<typeof vi.fn>;
+    end: ReturnType<typeof vi.fn>;
+  }>,
+}));
 
 // Mock OpenTelemetry
 vi.mock('@opentelemetry/api', () => ({
   trace: {
     getTracer: () => ({
-      startSpan: () => ({
-        setStatus: vi.fn(),
-        setAttributes: vi.fn(),
-        recordException: vi.fn(),
-        end: vi.fn(),
-      }),
+      startSpan: (name: string) => {
+        const span = {
+          name,
+          setStatus: vi.fn(),
+          setAttributes: vi.fn(),
+          recordException: vi.fn(),
+          end: vi.fn(),
+        };
+        otelMock.spans.push(span);
+        return span;
+      },
     }),
   },
   SpanStatusCode: {
@@ -63,6 +79,7 @@ describe('ExpressConformanceMiddleware', () => {
   });
 
   beforeEach(() => {
+    otelMock.spans = [];
     middleware = new ExpressConformanceMiddleware({
       enabled: true,
       strictMode: false,
@@ -391,6 +408,42 @@ describe('ExpressConformanceMiddleware', () => {
       expect(mockNext).toHaveBeenCalledOnce();
       expect(mockRes.status).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('Fastify conformance telemetry redaction', () => {
+  it('uses route templates instead of raw request URLs for request and response spans', () => {
+    const hooks: Record<string, (...args: unknown[]) => unknown> = {};
+    const fastify = {
+      addSchema: vi.fn(),
+      addHook: vi.fn((name: string, handler: (...args: unknown[]) => unknown) => {
+        hooks[name] = handler;
+      }),
+    };
+
+    fastifyConformancePlugin(fastify as any, { config: { enabled: true } });
+
+    const request = {
+      method: 'GET',
+      url: '/users/123?token=raw-query-token&password=raw-query-password',
+      routeOptions: { url: '/users/:id' },
+    };
+    const reply = { statusCode: 200 };
+
+    hooks['preHandler']?.(request);
+    hooks['onSend']?.(request, reply, '{"ok":true}');
+
+    const attributes = otelMock.spans.flatMap((span) =>
+      span.setAttributes.mock.calls.map(([attrs]) => attrs as Record<string, unknown>)
+    );
+
+    expect(attributes).toHaveLength(2);
+    for (const attrs of attributes) {
+      expect(attrs['http.route']).toBe('/users/:id');
+      expect(attrs).not.toHaveProperty('http.url');
+      expect(JSON.stringify(attrs)).not.toContain('raw-query-token');
+      expect(JSON.stringify(attrs)).not.toContain('raw-query-password');
+    }
   });
 });
 

--- a/tests/telemetry/runtime-guards.test.ts
+++ b/tests/telemetry/runtime-guards.test.ts
@@ -3,7 +3,7 @@
  * Tests for request/response validation and contract violation tracking
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { z } from 'zod';
 import { RuntimeGuard, ViolationType, ViolationSeverity, CommonSchemas } from '../../src/telemetry/runtime-guards.js';
 
@@ -67,6 +67,26 @@ describe('Runtime Guards', () => {
       expect(violation.severity).toBe(ViolationSeverity.MEDIUM);
       expect(violation.requestId).toBe('test-req-456');
       expect(violation.endpoint).toBe('POST /users');
+    });
+
+    it('sanitizes secret-bearing endpoint query parameters in violations', () => {
+      const invalidData = {
+        name: '',
+        age: -5,
+        email: 'invalid-email',
+      };
+
+      const result = guard.validateRequest(testSchema, invalidData, {
+        requestId: 'test-req-secret',
+        endpoint: 'POST /users?token=raw-runtime-token&password=raw-runtime-password',
+        operation: 'create_user',
+      });
+
+      expect(result.valid).toBe(false);
+      const serialized = JSON.stringify(result.violations);
+      expect(result.violations[0]?.endpoint).toBe('POST /users');
+      expect(serialized).not.toContain('raw-runtime-token');
+      expect(serialized).not.toContain('raw-runtime-password');
     });
 
     it('should handle missing required fields', () => {
@@ -134,6 +154,48 @@ describe('Runtime Guards', () => {
       expect(violation.type).toBe(ViolationType.SCHEMA_VALIDATION);
       expect(violation.severity).toBe(ViolationSeverity.HIGH); // Response failures are high severity
       expect(violation.statusCode).toBeUndefined(); // statusCode not stored in violation
+    });
+
+    it('redacts development response-validator payloads and logs', async () => {
+      const originalNodeEnv = process.env['NODE_ENV'];
+      process.env['NODE_ENV'] = 'development';
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        const validator = guard.createResponseValidator(responseSchema);
+        const response = await validator(
+          {
+            id: 'req-redacted',
+            method: 'GET',
+            url: '/status?token=raw-response-query-token',
+            routeOptions: { url: '/status' },
+          } as any,
+          { statusCode: 200 } as any,
+          {
+            id: 123,
+            success: 'yes',
+            password: 'raw-response-password',
+            nested: {
+              connectionString: 'postgres://app:raw-response-db-secret@example.test/app',
+            },
+          },
+        );
+
+        const serialized = JSON.stringify({ response, logs: errorSpy.mock.calls });
+        expect(serialized).toContain('redacted_payload');
+        expect(serialized).not.toContain('original_payload');
+        expect(serialized).not.toContain('raw-response-query-token');
+        expect(serialized).not.toContain('raw-response-password');
+        expect(serialized).not.toContain('raw-response-db-secret');
+        expect(serialized).toContain('[REDACTED]');
+      } finally {
+        if (typeof originalNodeEnv === 'string') {
+          process.env['NODE_ENV'] = originalNodeEnv;
+        } else {
+          delete process.env['NODE_ENV'];
+        }
+        errorSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/unit/security/sensitive-redaction.test.ts
+++ b/tests/unit/security/sensitive-redaction.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REDACTED_VALUE,
+  redactSensitiveData,
+  redactSensitiveString,
+  safeErrorForLogging,
+  safeUrlPath,
+} from '../../../src/security/sensitive-redaction.js';
+
+describe('sensitive redaction policy', () => {
+  it('redacts sensitive keys, nested values, bearer tokens, cookies, and connection URLs', () => {
+    const input = {
+      password: 'raw-password-secret',
+      key: 'raw-generic-key-secret',
+      sshKey: 'raw-ssh-key-secret',
+      headers: {
+        Authorization: 'Bearer raw-bearer-secret',
+        cookie: 'sid=raw-cookie-secret',
+      },
+      nested: {
+        databaseUrl: 'postgres://app:raw-db-secret@example.test/app',
+        message: 'call https://example.test/callback?token=raw-query-token&code=raw-oauth-code',
+        detail: 'key=raw-inline-key-secret',
+      },
+      events: [
+        {
+          connectionString: 'redis://cache:raw-redis-secret@example.test/0',
+          note: 'Cookie: session=raw-cookie-header',
+        },
+      ],
+    };
+
+    const redacted = redactSensitiveData(input);
+    const serialized = JSON.stringify(redacted);
+
+    expect(serialized).toContain(REDACTED_VALUE);
+    expect(serialized).not.toContain('raw-password-secret');
+    expect(serialized).not.toContain('raw-generic-key-secret');
+    expect(serialized).not.toContain('raw-ssh-key-secret');
+    expect(serialized).not.toContain('raw-bearer-secret');
+    expect(serialized).not.toContain('raw-cookie-secret');
+    expect(serialized).not.toContain('raw-db-secret');
+    expect(serialized).not.toContain('raw-query-token');
+    expect(serialized).not.toContain('raw-oauth-code');
+    expect(serialized).not.toContain('raw-inline-key-secret');
+    expect(serialized).not.toContain('raw-redis-secret');
+    expect(serialized).not.toContain('raw-cookie-header');
+  });
+
+  it('sanitizes URL paths without retaining query parameters', () => {
+    expect(safeUrlPath('/api/users?token=raw-token&password=raw-password')).toBe('/api/users');
+    expect(safeUrlPath('https://example.test/api/users?token=raw-token')).toBe('/api/users');
+  });
+
+  it('redacts sensitive error messages before logging', () => {
+    const logged = safeErrorForLogging(new Error('failed with token=raw-error-token and Bearer raw-bearer-token'));
+    const serialized = JSON.stringify(logged);
+
+    expect(serialized).toContain('[REDACTED]');
+    expect(serialized).not.toContain('raw-error-token');
+    expect(serialized).not.toContain('raw-bearer-token');
+  });
+
+  it('redacts sensitive standalone strings', () => {
+    const value = redactSensitiveString('dsn=postgres://app:raw-dsn-secret@example.test/app; api_key=raw-api-key');
+
+    expect(value).not.toContain('raw-dsn-secret');
+    expect(value).not.toContain('raw-api-key');
+    expect(value).toContain('[REDACTED]');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3374 and fixes #3375.

This PR hardens runtime validation telemetry/logging and LLM cassette recording against secret exposure:

- adds a shared recursive sensitive-data redaction policy for authorization data, cookies, tokens, API keys, DSNs, database/connection URLs, session identifiers, and credential-bearing strings;
- replaces raw runtime/Fastify URL telemetry with route-template or query-stripped path metadata;
- redacts validation-failure logs, failure artifacts, runtime guard development payloads, and error logging paths;
- makes `withRecorder()` non-recording by default unless explicit record mode is provided;
- records cassette input as hashes only, stores redacted output only, emits an operator-visible retention warning, and writes cassette directories/files with restrictive POSIX permissions where supported;
- updates CLI/help/docs to describe redacted local cassette behavior.

## Acceptance

- Validation failure logs/artifacts/errors do not retain secret-like nested payload fields or secret-bearing query strings.
- Runtime/Fastify telemetry uses `http.route` or query-stripped endpoint values instead of `http.url: request.url`.
- `ConformanceViolationError.data` is redacted and non-enumerable.
- `withRecorder()` does not create cassettes unless record mode is explicitly enabled.
- Recorded cassette input is minimized to hashes and output is redacted before persistence.
- Recorded cassette directory/file permissions are `0700` / `0600` on non-Windows platforms.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -s exec vitest run tests/unit/security/sensitive-redaction.test.ts tests/runtime/conformance-guards.test.ts tests/runtime/runtime-middleware.test.ts tests/providers/recorder.test.ts tests/telemetry/runtime-guards.test.ts tests/api/server.instrumentation.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet src/security/sensitive-redaction.ts src/runtime/conformance-guards.ts src/runtime/runtime-middleware.ts src/providers/recorder.ts src/commands/agent/complete.ts src/api/server.ts src/telemetry/runtime-guards.ts src/cli/index.ts src/runner/main.ts tests/unit/security/sensitive-redaction.test.ts tests/runtime/conformance-guards.test.ts tests/runtime/runtime-middleware.test.ts tests/providers/recorder.test.ts tests/telemetry/runtime-guards.test.ts tests/api/server.instrumentation.test.ts tests/api/server.instrumentation.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

Revert this PR to restore the previous runtime telemetry and cassette behavior. If rollback is needed only for cassette compatibility, retain the redaction helper and route-template telemetry changes while reverting `src/providers/recorder.ts` and CLI help updates.
