### PR TITLE
fix(ci): require trusted issue command actors

### DIFF
--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -520,46 +520,73 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const actor = context.actor;
+            const cmd = body.split(/\s+/)[0];
+            const association = context.payload.comment.author_association || '';
+            const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            const isTrusted = trustedAssociations.includes(association);
+            const trustedAssociationText = trustedAssociations.join(' / ');
+            const mutatingIssueCommands = new Set([
+              '/start',
+              '/ready-for-review',
+              '/done',
+              '/block',
+              '/unblock',
+              '/assign',
+              '/handoff',
+              '/plan'
+            ]);
+            const assertTrustedForIssueMutation = (operation) => {
+              if (isTrusted) return;
+              throw new Error(`Refusing ${operation} for untrusted issue commenter (association: ${association || 'NONE'}, command: ${cmd || '(none)'})`);
+            };
+            const requireTrustedIssueCommand = () => {
+              if (isTrusted) return true;
+              core.notice(`Permission denied for ${cmd || 'command'} (association: ${association || 'NONE'}). Mutating issue commands require ${trustedAssociationText}.`);
+              return false;
+            };
 
             async function add(labels){
               if (!labels || labels.length===0) return;
+              assertTrustedForIssueMutation('addLabels');
               await github.rest.issues.addLabels({ owner, repo, issue_number, labels });
             }
             async function remove(name){
+              assertTrustedForIssueMutation('removeLabel');
               try { await github.rest.issues.removeLabel({ owner, repo, issue_number, name }); } catch {}
             }
             async function assign(user){
+              assertTrustedForIssueMutation('addAssignees');
               try { await github.rest.issues.addAssignees({ owner, repo, issue_number, assignees: [user] }); } catch {}
             }
 
-            if (body.startsWith('/start')) {
+            if (mutatingIssueCommands.has(cmd) && !requireTrustedIssueCommand()) {
+              return;
+            }
+
+            switch (cmd) {
+            case '/start':
               await remove('status:ready');
               await add(['status:in-progress']);
               await assign(actor);
               return core.notice(`Moved to in-progress and assigned to ${actor}`);
-            }
-            if (body.startsWith('/ready-for-review')) {
+            case '/ready-for-review':
               await remove('status:in-progress');
               await add(['status:review']);
               return core.notice('Moved to review');
-            }
-            if (body.startsWith('/done')) {
+            case '/done':
               await remove('status:review');
               await remove('status:in-progress');
               await add(['status:done']);
               return core.notice('Marked as done');
-            }
-            if (body.startsWith('/block')) {
+            case '/block':
               await add(['status:blocked']);
               return core.notice('Marked as blocked');
-            }
-            if (body.startsWith('/unblock')) {
+            case '/unblock':
               await remove('status:blocked');
               await add(['status:in-progress']);
               return core.notice('Unblocked');
-            }
-            // /assign @user or /assign user
-            if (body.startsWith('/assign')) {
+            case '/assign': {
+              // /assign @user or /assign user
               const m = body.match(/^\/assign\s+@?([A-Za-z0-9-]+)/);
               if (m && m[1]) {
                 await assign(m[1]);
@@ -567,9 +594,9 @@ jobs:
               }
               return core.info('No assignee parsed');
             }
-            // /handoff @user → assign and set status:review
-            // NOTE: PR comments use /handoff A|B|C for agent handoff; issues use /handoff @user.
-            if (body.startsWith('/handoff')) {
+            case '/handoff': {
+              // /handoff @user → assign and set status:review
+              // NOTE: PR comments use /handoff A|B|C for agent handoff; issues use /handoff @user.
               const m = body.match(/^\/handoff\s+@?([A-Za-z0-9-]+)/);
               if (m && m[1]) {
                 await assign(m[1]);
@@ -579,8 +606,8 @@ jobs:
               }
               return core.info('No handoff target parsed');
             }
-            // /plan → post a standard checklist as a comment
-            if (body.startsWith('/plan')) {
+            case '/plan': {
+              // /plan → post a standard checklist as a comment
               const plan = [
                 '## Plan Checklist',
                 '',
@@ -591,7 +618,10 @@ jobs:
                 '- [ ] CI policy noted: fix PR-caused failures here; global failures in separate PR',
                 '- [ ] Stop: leave in review and await automation rollout',
               ].join('\n');
+              assertTrustedForIssueMutation('createComment');
               await github.rest.issues.createComment({ owner, repo, issue_number, body: plan });
               return core.notice('Posted plan checklist');
             }
-            core.info('No recognized slash command');
+            default:
+              core.info('No recognized slash command');
+            }

--- a/docs/ci/OPT-IN-CONTROLS.md
+++ b/docs/ci/OPT-IN-CONTROLS.md
@@ -154,7 +154,7 @@ These call workflow-dispatch entry points directly when the repository wants the
 Dual entrypoints exist:
 - `.github/workflows/agent-commands.yml`
   - always enabled
-  - no `author_association` restriction
+  - mutating Issue commands require trusted actors (`MEMBER` / `OWNER` / `COLLABORATOR`) before label changes, assignee changes, or plan-comment creation
 - `.github/workflows/slash-commands.yml`
   - enabled only when `AE_SLASH_COMMANDS_ISSUE=1`
   - restricted to `MEMBER` / `OWNER` / `COLLABORATOR`
@@ -318,7 +318,7 @@ Codex Autopilot Lane を使う場合:
 ## 5. Issue向け Slash コマンド（Issueコメント）
 
 > 入口（2系統）:  
-> - `.github/workflows/agent-commands.yml`（常時有効 / `author_association` 制限なし）  
+> - `.github/workflows/agent-commands.yml`（常時有効 / Issue metadata変更・assignee変更・planコメント作成は `MEMBER/OWNER/COLLABORATOR` のみ）
 > - `.github/workflows/slash-commands.yml`（`AE_SLASH_COMMANDS_ISSUE=1` かつ `MEMBER/OWNER/COLLABORATOR` のみ）
 
 - `/start` → `status:in-progress` 付与（commenter をアサイン）

--- a/docs/ci/automation-permission-boundaries.md
+++ b/docs/ci/automation-permission-boundaries.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-06-01'
+lastVerified: '2026-06-02'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -27,6 +27,7 @@ Primary sources:
 | Workflow | Trigger | Boundary condition | Intent |
 | --- | --- | --- | --- |
 | agent-commands (`PR slash command mutations`) | `issue_comment` | requires a comment attached to a PR plus trusted `author_association` (`MEMBER` / `OWNER` / `COLLABORATOR`) before label mutation or workflow dispatch commands execute | prevent arbitrary PR commenters from changing control labels or starting privileged workflows |
+| agent-commands (`Issue slash command mutations`) | `issue_comment` | requires a non-PR Issue comment plus trusted `author_association` (`MEMBER` / `OWNER` / `COLLABORATOR`) before label mutation, assignee mutation, or plan-comment creation executes | prevent arbitrary Issue commenters from changing triage metadata or posting bot-authored plan comments |
 | agent-commands (`copilot-review-gate dispatch`) | `issue_comment` | requires a comment attached to a PR plus `github-actions[bot]` and `<!-- AE-COPILOT-AUTO-FIX v1 -->` marker | prevent arbitrary comment-driven dispatch |
 | Copilot Review Gate (`gate`) | `workflow_dispatch` | on the default branch, manual runs must provide `pr_number`; otherwise the gate skips or errors | prevent accidental execution against unrelated branches |
 | Copilot Auto Fix | `pull_request_review` | excludes fork PRs, limits actors to Copilot identities, and respects the global kill switch | constrain write permission and apply authority |
@@ -39,7 +40,7 @@ Primary sources:
 ### 2. Implementation notes
 
 - the global kill switch (`AE_AUTOMATION_GLOBAL_DISABLE`) is enforced in automation lanes that mutate or dispatch follow-up work (`Codex Autopilot Lane`, `PR Maintenance`, `Copilot Auto Fix`); `Copilot Review Gate` does not currently use that kill switch
-- `issue_comment` entrypoints must first prove that the comment is attached to a PR, then add actor or marker validation before repository mutations such as label changes or workflow dispatches
+- `issue_comment` entrypoints must first distinguish PR comments from non-PR Issue comments, then add actor or marker validation before repository mutations such as label changes, assignee changes, plan-comment creation, or workflow dispatches
 - `workflow_dispatch` entrypoints must require or default critical inputs such as `pr_number` or `mode` so operators do not accidentally target the wrong PR or lane
 - ADMIN_TOKEN-backed manual workflows must keep the mutation token in the protected environment secret `BRANCH_PROTECTION_ADMIN_TOKEN`, validate allowlisted inputs before exporting admin-token API paths, avoid direct dispatch-input interpolation in shell `run` blocks, and use protected environments for approval
 
@@ -66,6 +67,7 @@ The purpose of this test is to guarantee the presence of the boundary policy. It
 | Workflow | Trigger | 境界条件 | 意図 |
 | --- | --- | --- | --- |
 | agent-commands（`PR slash command mutations`） | `issue_comment` | PRに紐づくコメントのみ、ラベル変更または workflow dispatch の前に trusted `author_association`（`MEMBER` / `OWNER` / `COLLABORATOR`）を要求 | 任意のPRコメント投稿者による制御ラベル変更や特権workflow起動を防止 |
+| agent-commands（`Issue slash command mutations`） | `issue_comment` | 非PR Issueコメントのみ、ラベル変更・assignee変更・planコメント作成の前に trusted `author_association`（`MEMBER` / `OWNER` / `COLLABORATOR`）を要求 | 任意のIssueコメント投稿者によるtriage metadata変更やbot-authored planコメント投稿を防止 |
 | agent-commands (`copilot-review-gate dispatch`) | `issue_comment` | PRに紐づくコメントのみ、`github-actions[bot]` + `<!-- AE-COPILOT-AUTO-FIX v1 -->` を要求 | 任意コメントからのdispatch起動を防止 |
 | Copilot Review Gate (`gate`) | `workflow_dispatch` | default branch 上の手動実行では `pr_number` が必要。未指定なら gate は skip または error になる | 無関係ブランチでの誤起動を防止 |
 | Copilot Auto Fix | `pull_request_review` | fork PR除外、Copilot actor限定、global kill-switch考慮 | 書き込み権限と適用主体を制限 |
@@ -78,7 +80,7 @@ The purpose of this test is to guarantee the presence of the boundary policy. It
 ## 2. 実装上の補足
 
 - global kill-switch (`AE_AUTOMATION_GLOBAL_DISABLE`) は、更新系 / follow-up dispatch 系の lane（`Codex Autopilot Lane`, `PR Maintenance`, `Copilot Auto Fix`）で workflow 条件とスクリプト内部の両方からガードします。`Copilot Review Gate` 自体は現時点ではこの kill-switch の対象外です。
-- `issue_comment` 起点は「PRに紐づいているか」を必須条件とし、ラベル変更や workflow dispatch などの repository mutation の前に actor または marker を検証します。
+- `issue_comment` 起点は PRコメントと非PR Issueコメントを分離し、ラベル変更・assignee変更・planコメント作成・workflow dispatch などの repository mutation の前に actor または marker を検証します。
 - `workflow_dispatch` 起点は `pr_number` や `mode` のような重要入力を必須化または既定化し、誤対象への実行を避けます。
 - `ADMIN_TOKEN` 相当の手動 workflow は protected environment secret `BRANCH_PROTECTION_ADMIN_TOKEN` に mutation token を限定し、admin token の API path を出力する前に allowlist 入力検証を行い、shell `run` block で dispatch input を直接展開せず、protected environment を approval boundary とします。
 

--- a/scripts/docs/check-agent-commands-doc-sync.mjs
+++ b/scripts/docs/check-agent-commands-doc-sync.mjs
@@ -53,11 +53,16 @@ function extractPrCommands(prSection) {
 
 function extractIssueCommands(issueSection) {
   const commands = [];
-  const pattern = /body\.startsWith\('([^']+)'\)/g;
-  for (const match of issueSection.matchAll(pattern)) {
-    const command = String(match[1] || '').trim();
-    if (!command.startsWith('/')) continue;
-    commands.push(command);
+  const patterns = [
+    /body\.startsWith\('([^']+)'\)/g,
+    /case\s+'([^']+)':/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of issueSection.matchAll(pattern)) {
+      const command = String(match[1] || '').trim();
+      if (!command.startsWith('/')) continue;
+      commands.push(command);
+    }
   }
   return toSortedUnique(commands);
 }

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -44,10 +44,32 @@ const extractAgentCommandsPrScript = () => {
   return script;
 };
 
+const extractAgentCommandsIssueScript = () => {
+  const workflow = parseWorkflow('agent-commands.yml');
+  const steps = workflow.jobs?.handle_issue?.steps;
+  if (!Array.isArray(steps)) {
+    throw new Error('agent-commands handle_issue steps not found');
+  }
+  const scriptStep = steps.find((step) => step?.uses === 'actions/github-script@v7');
+  const script = scriptStep?.with?.script;
+  if (typeof script !== 'string' || script.length === 0) {
+    throw new Error('agent-commands handle_issue github-script body not found');
+  }
+  return script;
+};
+
 const extractMutatingCommandSet = (prSection: string) => {
   const match = prSection.match(/const mutatingCommands = new Set\(\[([\s\S]*?)\]\);/);
   if (!match) {
     throw new Error('mutatingCommands set not found');
+  }
+  return new Set([...match[1].matchAll(/'([^']+)'/g)].map((item) => item[1]));
+};
+
+const extractMutatingIssueCommandSet = (issueSection: string) => {
+  const match = issueSection.match(/const mutatingIssueCommands = new Set\(\[([\s\S]*?)\]\);/);
+  if (!match) {
+    throw new Error('mutatingIssueCommands set not found');
   }
   return new Set([...match[1].matchAll(/'([^']+)'/g)].map((item) => item[1]));
 };
@@ -69,6 +91,35 @@ const detectPrCommandsThatReachMutationSinks = (script: string) => {
       continue;
     }
     if (/(await\s+addLabels|await\s+removeLabel|await\s+removeLabelsByPrefix|await\s+dispatchWorkflow|dispatchWithResult\(|github\.rest\.issues\.addLabels|github\.rest\.issues\.removeLabel|github\.rest\.actions\.createWorkflowDispatch)/.test(line)) {
+      for (const command of activeCases) {
+        mutating.add(command);
+      }
+    }
+    if (/^\s*return\b/.test(line)) {
+      activeCases = [];
+    }
+  }
+
+  return mutating;
+};
+
+const detectIssueCommandsThatReachMutationSinks = (script: string) => {
+  const switchStart = script.indexOf('switch (cmd) {');
+  const switchEnd = script.indexOf('default:', switchStart);
+  if (switchStart < 0 || switchEnd < 0 || switchEnd <= switchStart) {
+    throw new Error('agent-commands issue switch not found');
+  }
+  const switchBody = script.slice(switchStart, switchEnd);
+  const mutating = new Set<string>();
+  let activeCases: string[] = [];
+
+  for (const line of switchBody.split('\n')) {
+    const caseMatch = line.match(/case '([^']+)':/);
+    if (caseMatch) {
+      activeCases.push(caseMatch[1]);
+      continue;
+    }
+    if (/(await\s+add\(|await\s+remove\(|await\s+assign\(|github\.rest\.issues\.addLabels|github\.rest\.issues\.removeLabel|github\.rest\.issues\.addAssignees|github\.rest\.issues\.createComment)/.test(line)) {
       for (const command of activeCases) {
         mutating.add(command);
       }
@@ -140,6 +191,28 @@ describe('workflow permission boundaries', () => {
     expect([...mutatingCommands].sort()).toEqual([...commandsThatReachMutationSinks].sort());
     expect(mutatingCommands.has('/formal-help')).toBe(false);
     expect(mutatingCommands.has('/formal-quickstart')).toBe(false);
+  });
+
+  it('agent-commands requires trusted issue commenters before label, assignee, or plan-comment mutations', () => {
+    const issueScript = extractAgentCommandsIssueScript();
+    const mutatingIssueCommands = extractMutatingIssueCommandSet(issueScript);
+    const commandsThatReachMutationSinks = detectIssueCommandsThatReachMutationSinks(issueScript);
+
+    expect(issueScript).toContain("const trustedAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR']");
+    expect(issueScript).toContain('const isTrusted = trustedAssociations.includes(association)');
+    expect(issueScript).toContain('assertTrustedForIssueMutation');
+    expect(issueScript).toContain("assertTrustedForIssueMutation('addLabels')");
+    expect(issueScript).toContain("assertTrustedForIssueMutation('removeLabel')");
+    expect(issueScript).toContain("assertTrustedForIssueMutation('addAssignees')");
+    expect(issueScript).toContain("assertTrustedForIssueMutation('createComment')");
+    expect(issueScript.indexOf('if (mutatingIssueCommands.has(cmd)')).toBeGreaterThanOrEqual(0);
+    expect(issueScript.indexOf('if (mutatingIssueCommands.has(cmd)')).toBeLessThan(issueScript.indexOf('switch (cmd)'));
+    expect(issueScript).toContain('Mutating issue commands require ${trustedAssociationText}');
+
+    for (const command of commandsThatReachMutationSinks) {
+      expect(mutatingIssueCommands.has(command), `${command} must require trusted association`).toBe(true);
+    }
+    expect([...mutatingIssueCommands].sort()).toEqual([...commandsThatReachMutationSinks].sort());
   });
 
   it('branch-protection admin workflow validates allowlisted inputs before ADMIN_TOKEN use', () => {

--- a/tests/unit/docs/check-agent-commands-doc-sync.test.ts
+++ b/tests/unit/docs/check-agent-commands-doc-sync.test.ts
@@ -46,6 +46,13 @@ jobs:
               await add(['status:done']);
               return;
             }
+            switch (cmd) {
+              case '/block':
+                await add(['status:blocked']);
+                return;
+              default:
+                return;
+            }
 `;
 
 describe('check-agent-commands-doc-sync', () => {
@@ -58,13 +65,13 @@ describe('check-agent-commands-doc-sync', () => {
   it('extracts PR and issue commands', () => {
     const sections = splitWorkflowSections(SAMPLE_WORKFLOW);
     expect(extractPrCommands(sections.prSection)).toEqual(['/coverage', '/handoff', '/run-qa']);
-    expect(extractIssueCommands(sections.issueSection)).toEqual(['/done', '/start']);
+    expect(extractIssueCommands(sections.issueSection)).toEqual(['/block', '/done', '/start']);
   });
 
   it('extracts static and dynamic label metadata', () => {
     const labels = extractLabelMetadata(SAMPLE_WORKFLOW);
     expect(labels.prLabels).toEqual(['run-qa']);
-    expect(labels.issueLabels).toEqual(['status:done', 'status:in-progress']);
+    expect(labels.issueLabels).toEqual(['status:blocked', 'status:done', 'status:in-progress']);
     expect(labels.dynamicLabels).toEqual(['coverage:<0-100>', 'handoff:agent-{a|b|c}']);
   });
 


### PR DESCRIPTION
## Summary

- Require trusted `author_association` (`MEMBER` / `OWNER` / `COLLABORATOR`) before non-PR Issue slash commands mutate labels, assignees, or plan comments.
- Convert the Issue command handler to exact command dispatch, preventing prefix matches such as `/started` from reaching `/start` behavior.
- Extend workflow permission-boundary tests and agent-command doc sync parsing for the updated Issue command switch structure.
- Update CI permission-boundary documentation and opt-in controls docs.

Fixes #3383.

## Validation

- `pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts tests/unit/docs/check-agent-commands-doc-sync.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet scripts/docs/check-agent-commands-doc-sync.mjs tests/unit/ci/workflow-permission-boundary.test.ts tests/unit/docs/check-agent-commands-doc-sync.test.ts`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run types:check`
- `pnpm -s run check:schemas`
- `git diff --check`

## Acceptance

- Untrusted non-PR Issue commenters cannot trigger Issue label mutation, assignee mutation, or bot-authored plan comments through `.github/workflows/agent-commands.yml`.
- Trusted Issue commenters retain existing `/start`, `/ready-for-review`, `/done`, `/block`, `/unblock`, `/assign`, `/handoff`, and `/plan` behavior.
- Regression tests fail if Issue command mutation sinks are no longer covered by the trusted-author command gate.

## Rollback

Revert this PR to restore the previous unguarded non-PR Issue command behavior.
