### PR TITLE
fix(ci): harden formal dispatch inputs

### DIFF
--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -50,6 +50,7 @@ concurrency:
 
 env:
   APALACHE_VERSION: '0.50.3'
+  TLA_TOOLS_VERSION: '1.8.0'
   KANI_VERSION: '0.67.0'
   CSPX_REPO: 'https://github.com/itdojp/cspx'
   # Pinned for reproducibility and supply-chain hardening (immutable commit).
@@ -175,14 +176,33 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: node scripts/ci/assert-workflow-dispatch-actor.mjs
+      - name: Setup Java (TLC)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '20'
+      - name: Cache TLA+ tools jar
+        uses: actions/cache@v4
+        with:
+          path: .cache/tools/tla2tools.jar
+          key: ${{ runner.os }}-tla2tools-${{ env.TLA_TOOLS_VERSION }}
+      - name: Download TLA+ tools jar
+        run: |
+          set -euo pipefail
+          JAR_PATH="$PWD/.cache/tools/tla2tools.jar"
+          if [ ! -f "$JAR_PATH" ]; then
+            mkdir -p "$(dirname "$JAR_PATH")"
+            curl -L -sS -o "$JAR_PATH" "https://github.com/tlaplus/tlaplus/releases/download/v${TLA_TOOLS_VERSION}/tla2tools.jar"
+          fi
+          test -s "$JAR_PATH"
       - name: Run verify:tla stub
         env:
           TLA_ENGINE: ${{ github.event_name == 'workflow_dispatch' && inputs.engine || 'tlc' }}
-          TLA_TOOLS_JAR: ''
+          TLA_TOOLS_JAR: ${{ format('{0}/.cache/tools/tla2tools.jar', github.workspace) }}
           TLA_FILE: ${{ github.event_name == 'workflow_dispatch' && inputs.tlaFile || 'spec/tla/DomainSpec.tla' }}
         run: node scripts/formal/verify-tla.mjs --engine="$TLA_ENGINE" --file "$TLA_FILE" || true
       - name: Upload TLA summary (artifact)

--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -8,27 +8,39 @@ on:
       target:
         description: "Target to run (all|conformance|alloy|tla|smt|apalache|kani|spin|csp|lean)"
         required: false
+        type: choice
         default: "all"
+        options:
+          - all
+          - conformance
+          - alloy
+          - tla
+          - smt
+          - apalache
+          - kani
+          - spin
+          - csp
+          - lean
       tlaFile:
-        description: "TLA file to run (for Apalache/TLA)"
+        description: "Approved repository-relative TLA file under spec/tla"
         required: false
         default: "spec/tla/DomainSpec.tla"
       engine:
         description: "TLA+ engine (tlc|apalache)"
         required: false
+        type: choice
         default: "tlc"
+        options:
+          - tlc
+          - apalache
       solver:
         description: "SMT solver (z3|cvc5)"
         required: false
+        type: choice
         default: "z3"
-      alloyJar:
-        description: "Path to Alloy jar (optional)"
-        required: false
-        default: ""
-      tlaToolsJar:
-        description: "Path to TLA+ tla2tools.jar (optional)"
-        required: false
-        default: ""
+        options:
+          - z3
+          - cvc5
 concurrency:
   group: >-
     ${{ github.event_name == 'workflow_dispatch'
@@ -44,6 +56,9 @@ env:
   # Includes expanded cspx docs/report updates and ae-framework summary contract.
   CSPX_REF: '8a67639ea4d3f715e27feb8cd728f46866a905db'
 
+permissions:
+  contents: read
+
 jobs:
   verify-conformance:
     name: verify:conformance (stub)
@@ -51,6 +66,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'conformance'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -93,6 +115,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'alloy'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Java (Alloy)
         uses: actions/setup-java@v4
         with:
@@ -121,8 +150,7 @@ jobs:
           node -e "console.log('Alloy tooling check stub ok')"
       - name: Run verify:alloy (sample)
         env:
-          ALLOY_JAR: ${{ github.event_name == 'workflow_dispatch' && inputs.alloyJar || format('{0}/.cache/tools/alloy.jar', github.workspace) }}
-          ALLOY_RUN_CMD: java -jar $ALLOY_JAR exec -q -o - -f {file}
+          ALLOY_JAR: ${{ format('{0}/.cache/tools/alloy.jar', github.workspace) }}
           JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
         run: node scripts/formal/verify-alloy.mjs --file spec/alloy/Domain.als || true
       - name: Upload Alloy summary (artifact)
@@ -140,6 +168,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'tla'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -147,7 +182,7 @@ jobs:
       - name: Run verify:tla stub
         env:
           TLA_ENGINE: ${{ github.event_name == 'workflow_dispatch' && inputs.engine || 'tlc' }}
-          TLA_TOOLS_JAR: ${{ github.event_name == 'workflow_dispatch' && inputs.tlaToolsJar || '' }}
+          TLA_TOOLS_JAR: ''
           TLA_FILE: ${{ github.event_name == 'workflow_dispatch' && inputs.tlaFile || 'spec/tla/DomainSpec.tla' }}
         run: node scripts/formal/verify-tla.mjs --engine="$TLA_ENGINE" --file "$TLA_FILE" || true
       - name: Upload TLA summary (artifact)
@@ -165,6 +200,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'smt'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -204,6 +246,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'apalache'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Java (Apalache)
         uses: actions/setup-java@v4
         with:
@@ -234,8 +283,10 @@ jobs:
         run: |
           node scripts/formal/check-apalache.mjs || true
       - name: Run verify:apalache (summary, non-blocking)
+        env:
+          APALACHE_FILE: ${{ github.event_name == 'workflow_dispatch' && inputs.tlaFile || 'spec/tla/DomainSpec.tla' }}
         run: |
-          node scripts/formal/verify-apalache.mjs --file "${{ inputs.tlaFile || 'spec/tla/DomainSpec.tla' }}" || true
+          node scripts/formal/verify-apalache.mjs --file "$APALACHE_FILE" || true
       - name: Upload Apalache summary (artifact)
         uses: actions/upload-artifact@v4
         if: always()
@@ -274,6 +325,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'kani'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -310,6 +368,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'spin'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -338,6 +403,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'csp'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -384,6 +456,13 @@ jobs:
     if: (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-formal')) || (github.event_name == 'workflow_dispatch' && (inputs.target == 'all' || inputs.target == 'lean'))
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Authorize workflow_dispatch actor
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node scripts/ci/assert-workflow-dispatch-actor.mjs
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:

--- a/docs/quality/formal-full-run.md
+++ b/docs/quality/formal-full-run.md
@@ -26,7 +26,7 @@ This guide shows how to run **all formal verification tools** end-to-end for a s
   - `target`: `all`
   - `engine`: `tlc` or `apalache` (for TLA)
   - `solver`: `z3` or `cvc5` (for SMT)
-  - `alloyJar` / `tlaToolsJar`: optional jar path overrides
+  - `tlaFile`: approved repository-relative TLA file under `spec/tla`; jar path overrides are intentionally not exposed through `workflow_dispatch`
 
 3) **Artifacts to confirm**
 - `formal-reports` artifact (folder): `artifacts/hermetic-reports/formal/*`
@@ -60,7 +60,7 @@ pnpm run verify:formal
 ```
 
 Notes:
-- Alloy needs `ALLOY_JAR` or `ALLOY_RUN_CMD` to run (otherwise `tool_not_available`).
+- Alloy needs the `alloy` CLI or `ALLOY_JAR` to run (otherwise `tool_not_available`). `ALLOY_RUN_CMD` shell templates are rejected by `scripts/formal/verify-alloy.mjs`.
 - SMT needs an input file to run. Use the sample below.
 - SPIN/Lean/CSP are non-blocking; if tools are not installed, they will report `tool_not_available`.
 
@@ -76,7 +76,6 @@ curl -L -sS -o .cache/tools/alloy.jar \
   "https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.2.0/org.alloytools.alloy.dist.jar"
 
 ALLOY_JAR=$PWD/.cache/tools/alloy.jar \
-ALLOY_RUN_CMD='java -jar $ALLOY_JAR exec -q -o - -f {file}' \
   pnpm run verify:alloy -- --file spec/alloy/Domain.als
 ```
 
@@ -150,7 +149,7 @@ Outputs:
   - `target`: `all`
   - `engine`: `tlc` または `apalache`
   - `solver`: `z3` または `cvc5`
-  - `alloyJar` / `tlaToolsJar`: 任意（jar パスの上書き）
+  - `tlaFile`: `spec/tla` 配下の repository-relative TLA ファイル。jar パス上書きは `workflow_dispatch` では受け付けません。
 
 3) **成果物の確認**
 - `formal-reports`（`artifacts/hermetic-reports/formal/*`）
@@ -183,7 +182,7 @@ pnpm run verify:formal
 ```
 
 補足:
-- Alloy は `ALLOY_JAR` / `ALLOY_RUN_CMD` 未設定だと `tool_not_available` になります。
+- Alloy は `alloy` CLI または `ALLOY_JAR` 未設定だと `tool_not_available` になります。`scripts/formal/verify-alloy.mjs` は `ALLOY_RUN_CMD` の shell template を拒否します。
 - SMT は入力ファイル指定が必要です（次の手順）。
 - SPIN / Lean / CSP は非ブロッキングです。未導入の場合は `tool_not_available` として記録されます。
 
@@ -199,7 +198,6 @@ curl -L -sS -o .cache/tools/alloy.jar \
   "https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.2.0/org.alloytools.alloy.dist.jar"
 
 ALLOY_JAR=$PWD/.cache/tools/alloy.jar \
-ALLOY_RUN_CMD='java -jar $ALLOY_JAR exec -q -o - -f {file}' \
   pnpm run verify:alloy -- --file spec/alloy/Domain.als
 ```
 

--- a/docs/quality/formal-full-run.md
+++ b/docs/quality/formal-full-run.md
@@ -27,6 +27,7 @@ This guide shows how to run **all formal verification tools** end-to-end for a s
   - `engine`: `tlc` or `apalache` (for TLA)
   - `solver`: `z3` or `cvc5` (for SMT)
   - `tlaFile`: approved repository-relative TLA file under `spec/tla`; jar path overrides are intentionally not exposed through `workflow_dispatch`
+  - TLC uses a workflow-owned, cached `tla2tools.jar` from the pinned `TLA_TOOLS_VERSION`; operators do not provide a jar path.
 
 3) **Artifacts to confirm**
 - `formal-reports` artifact (folder): `artifacts/hermetic-reports/formal/*`
@@ -150,6 +151,7 @@ Outputs:
   - `engine`: `tlc` または `apalache`
   - `solver`: `z3` または `cvc5`
   - `tlaFile`: `spec/tla` 配下の repository-relative TLA ファイル。jar パス上書きは `workflow_dispatch` では受け付けません。
+  - TLC は workflow 管理の `TLA_TOOLS_VERSION` に基づくキャッシュ済み `tla2tools.jar` を使用します。実行者は jar パスを指定しません。
 
 3) **成果物の確認**
 - `formal-reports`（`artifacts/hermetic-reports/formal/*`）

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -207,6 +207,7 @@ jobs:
 - Example SMT run: `pnpm run verify:smt -- --solver=z3 --file spec/smt/sample.smt2`
 - Alloy / TLA jar configuration:
   - `workflow_dispatch` accepts only approved repository-relative `tlaFile` values under `spec/tla`; jar path overrides are intentionally not accepted.
+  - The `Formal Verify` workflow downloads/caches `tla2tools.jar` from its pinned `TLA_TOOLS_VERSION` and sets `TLA_TOOLS_JAR` internally for TLC.
   - set `ALLOY_JAR` / `TLA_TOOLS_JAR` locally when reproducing outside CI
 
 ### `verify:conformance` options
@@ -281,6 +282,7 @@ jobs:
 - ツール有無の確認: `pnpm run tools:formal:check`
 - Apalache（`apalache-mc` 導入済みの場合）: `pnpm run verify:tla -- --engine=apalache`
 - TLC（`TLA_TOOLS_JAR` 設定時）: `TLA_TOOLS_JAR=/path/to/tla2tools.jar pnpm run verify:tla -- --engine=tlc`
+- CI の `Formal Verify` workflow は固定された `TLA_TOOLS_VERSION` から `tla2tools.jar` を取得・キャッシュし、TLC 用の `TLA_TOOLS_JAR` を内部設定します。`workflow_dispatch` から jar パスは指定しません。
 - SMT（`z3` または `cvc5` がある場合）: `pnpm run verify:smt -- --solver=z3 --file spec/smt/sample.smt2`
 
 ### Apalache クイックスタート

--- a/docs/quality/formal-runbook.md
+++ b/docs/quality/formal-runbook.md
@@ -27,12 +27,11 @@ This runbook describes the lowest-friction way to operate formal verification in
   - `target`: `all|conformance|alloy|tla|smt|apalache|kani|spin|csp|lean`
   - `engine`: `tlc|apalache` (for TLA)
   - `solver`: `z3|cvc5` (for SMT)
-  - `alloyJar`: optional path to the Alloy jar
-  - `tlaToolsJar`: optional path to `tla2tools.jar`
+  - `tlaFile`: approved repository-relative TLA file under `spec/tla`
 
 ### CLI Runners (non-blocking)
 - `pnpm run verify:conformance` - conformance summary runner. Use together with `ae conformance verify` when you need a narrower replay/conformance check.
-- `pnpm run verify:alloy` - Alloy runner. Resolves `ALLOY_RUN_CMD`, `ALLOY_JAR`, or the `alloy` CLI.
+- `pnpm run verify:alloy` - Alloy runner. Resolves the `alloy` CLI or runs `java` with argv-safe arguments when `ALLOY_JAR` is set. Shell command templates such as `ALLOY_RUN_CMD` are not executed by this runner.
 - `pnpm run verify:tla -- --engine=apalache|tlc` - TLA runner. Resolves `TLA_TOOLS_JAR` or `apalache-mc`.
 - `pnpm run verify:smt -- --solver=z3|cvc5` - SMT runner.
 - `pnpm run verify:kani` - Kani presence summary runner.
@@ -207,8 +206,8 @@ jobs:
 - SMT sample: `spec/smt/sample.smt2`
 - Example SMT run: `pnpm run verify:smt -- --solver=z3 --file spec/smt/sample.smt2`
 - Alloy / TLA jar configuration:
-  - set `alloyJar` / `tlaToolsJar` in `workflow_dispatch`
-  - or set `ALLOY_JAR` / `TLA_TOOLS_JAR` locally
+  - `workflow_dispatch` accepts only approved repository-relative `tlaFile` values under `spec/tla`; jar path overrides are intentionally not accepted.
+  - set `ALLOY_JAR` / `TLA_TOOLS_JAR` locally when reproducing outside CI
 
 ### `verify:conformance` options
 - `-i, --in <file>` - input event JSON. Default: `samples/conformance/sample-traces.json`.
@@ -251,7 +250,7 @@ jobs:
 
 ### CLI ランナー（非ブロッキング）
 - `pnpm run verify:conformance` - conformance サマリーランナー。必要に応じて `ae conformance verify` と併用する。
-- `pnpm run verify:alloy` - Alloy ランナー。`ALLOY_RUN_CMD`、`ALLOY_JAR`、`alloy` CLI を順に解決する。
+- `pnpm run verify:alloy` - Alloy ランナー。`alloy` CLI、または `ALLOY_JAR` を使った argv-safe な `java` 実行を使う。`ALLOY_RUN_CMD` のような shell command template は実行しない。
 - `pnpm run verify:tla -- --engine=apalache|tlc` - TLA ランナー。`TLA_TOOLS_JAR` または `apalache-mc` を解決する。
 - `pnpm run verify:smt -- --solver=z3|cvc5` - SMT ランナー。
 - `pnpm run verify:kani` - Kani の presence サマリーランナー。

--- a/scripts/ci/assert-workflow-dispatch-actor.mjs
+++ b/scripts/ci/assert-workflow-dispatch-actor.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+export function parseAllowedPermissions(value = 'admin,maintain,write') {
+  return new Set(
+    String(value)
+      .split(',')
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+export function isTrustedPermission(permission, allowed = parseAllowedPermissions()) {
+  return allowed.has(String(permission || '').trim().toLowerCase());
+}
+
+export function parsePermissionResponse(stdout) {
+  const text = String(stdout || '').trim();
+  if (!text) return '';
+  try {
+    const parsed = JSON.parse(text);
+    return String(parsed?.permission || '').trim().toLowerCase();
+  } catch {
+    return text.split(/\r?\n/)[0].trim().toLowerCase();
+  }
+}
+
+export function main(env = process.env) {
+  const actor = env.GITHUB_ACTOR || env.GITHUB_TRIGGERING_ACTOR || '';
+  const repo = env.GITHUB_REPOSITORY || '';
+  const token = env.GH_TOKEN || env.GITHUB_TOKEN || '';
+  const allowed = parseAllowedPermissions(env.TRUSTED_WORKFLOW_DISPATCH_PERMISSIONS || 'admin,maintain,write');
+
+  if (!actor) {
+    throw new Error('GITHUB_ACTOR is required to authorize workflow_dispatch');
+  }
+  if (!repo) {
+    throw new Error('GITHUB_REPOSITORY is required to authorize workflow_dispatch');
+  }
+  if (!token) {
+    throw new Error('GH_TOKEN or GITHUB_TOKEN is required to authorize workflow_dispatch');
+  }
+
+  const result = spawnSync(
+    'gh',
+    ['api', `repos/${repo}/collaborators/${actor}/permission`, '--jq', '.permission'],
+    {
+      encoding: 'utf8',
+      env: {
+        ...env,
+        GH_TOKEN: token,
+      },
+    },
+  );
+  if (result.error) {
+    throw new Error(`failed to query collaborator permission: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const diagnostic = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    throw new Error(`failed to query collaborator permission for ${actor}: ${diagnostic || `exit ${result.status}`}`);
+  }
+
+  const permission = parsePermissionResponse(result.stdout);
+  if (!isTrustedPermission(permission, allowed)) {
+    throw new Error(`workflow_dispatch actor ${actor} has permission '${permission || 'unknown'}'; required one of: ${[...allowed].join(', ')}`);
+  }
+
+  console.log(`workflow_dispatch actor ${actor} authorized with permission '${permission}'`);
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exit(main());
+  } catch (error) {
+    console.error(error?.message ?? String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/ci/assert-workflow-dispatch-actor.mjs
+++ b/scripts/ci/assert-workflow-dispatch-actor.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 export function parseAllowedPermissions(value = 'admin,maintain,write') {
   return new Set(
@@ -23,6 +25,12 @@ export function parsePermissionResponse(stdout) {
   } catch {
     return text.split(/\r?\n/)[0].trim().toLowerCase();
   }
+}
+
+export function isDirectInvocation(moduleUrl = import.meta.url, argv = process.argv) {
+  const scriptPath = argv?.[1] || '';
+  if (!scriptPath) return false;
+  return pathToFileURL(path.resolve(scriptPath)).href === moduleUrl;
 }
 
 export function main(env = process.env) {
@@ -69,7 +77,7 @@ export function main(env = process.env) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectInvocation(import.meta.url, process.argv)) {
   try {
     process.exit(main());
   } catch (error) {

--- a/scripts/formal/input-policy.mjs
+++ b/scripts/formal/input-policy.mjs
@@ -1,0 +1,89 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const WINDOWS_ABSOLUTE_RE = /^[A-Za-z]:[\\/]/;
+const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f]/;
+
+function toPosixPath(value) {
+  return String(value || '').replace(/\\/g, '/');
+}
+
+function isSubpath(candidate, root) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+export function validateChoice(value, { allowed, name, defaultValue }) {
+  const selected = String(value || defaultValue || '').trim();
+  if (!allowed.includes(selected)) {
+    throw new Error(`${name} must be one of: ${allowed.join(', ')}`);
+  }
+  return selected;
+}
+
+export function resolveRepoRelativeFileInput(
+  value,
+  {
+    repoRoot = process.cwd(),
+    defaultPath,
+    allowedRoots,
+    allowedExtensions,
+    name = 'file',
+  },
+) {
+  const raw = String(value || defaultPath || '').trim();
+  if (!raw) {
+    throw new Error(`${name} must not be empty`);
+  }
+  if (CONTROL_CHARS_RE.test(raw)) {
+    throw new Error(`${name} must not contain control characters`);
+  }
+  if (raw.includes('\\')) {
+    throw new Error(`${name} must use POSIX-style repository-relative separators`);
+  }
+  if (path.isAbsolute(raw) || WINDOWS_ABSOLUTE_RE.test(raw) || raw.startsWith('//')) {
+    throw new Error(`${name} must be repository-relative`);
+  }
+
+  const normalized = path.posix.normalize(toPosixPath(raw));
+  if (normalized === '.' || normalized.startsWith('../') || normalized === '..') {
+    throw new Error(`${name} must not contain parent traversal`);
+  }
+
+  const extension = path.posix.extname(normalized);
+  if (allowedExtensions?.length && !allowedExtensions.includes(extension)) {
+    throw new Error(`${name} must use one of these extensions: ${allowedExtensions.join(', ')}`);
+  }
+
+  const normalizedAllowedRoots = allowedRoots.map((root) => path.posix.normalize(root).replace(/\/$/, ''));
+  const isAllowedRoot = normalizedAllowedRoots.some((root) => normalized === root || normalized.startsWith(`${root}/`));
+  if (!isAllowedRoot) {
+    throw new Error(`${name} must be under one of: ${normalizedAllowedRoots.join(', ')}`);
+  }
+
+  const absolutePath = path.resolve(repoRoot, normalized);
+  const absoluteRepoRoot = path.resolve(repoRoot);
+  if (!isSubpath(absolutePath, absoluteRepoRoot)) {
+    throw new Error(`${name} resolved outside the repository`);
+  }
+
+  if (fs.existsSync(absolutePath)) {
+    const realFile = fs.realpathSync(absolutePath);
+    const allowedRealRoots = normalizedAllowedRoots.map((root) => {
+      const candidate = path.resolve(absoluteRepoRoot, root);
+      return fs.existsSync(candidate) ? fs.realpathSync(candidate) : candidate;
+    });
+    if (!allowedRealRoots.some((root) => isSubpath(realFile, root))) {
+      throw new Error(`${name} resolved outside the approved directory`);
+    }
+  }
+
+  return {
+    relativePath: normalized,
+    absolutePath,
+  };
+}
+
+export const FORMAL_TARGETS = ['all', 'conformance', 'alloy', 'tla', 'smt', 'apalache', 'kani', 'spin', 'csp', 'lean'];
+export const TLA_ENGINES = ['tlc', 'apalache'];
+export const SMT_SOLVERS = ['z3', 'cvc5'];

--- a/scripts/formal/verify-alloy.mjs
+++ b/scripts/formal/verify-alloy.mjs
@@ -4,6 +4,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { resolveRepoRelativeFileInput } from './input-policy.mjs';
 
 function parseArgs(argv){
   const args = { _: [] };
@@ -32,23 +33,6 @@ function runCommand(cmd, cmdArgs){
   return { available: true, success: result.status === 0, status: result.status ?? null, output: `${stdout}${stderr}` };
 }
 
-function runShell(cmd){
-  // ALLOY_RUN_CMD is intentionally executed via shell to allow flexible commands.
-  // Only use with trusted inputs (CI/env-controlled).
-  const result = spawnSync(cmd, { shell: true, encoding: 'utf8' });
-  const stdout = result.stdout ?? '';
-  const stderr = result.stderr ?? '';
-  if (result.error) {
-    return {
-      available: false,
-      success: false,
-      status: result.status ?? null,
-      output: `${stdout}${stderr}${result.error.message ? `\n${result.error.message}` : ''}`.trim()
-    };
-  }
-  return { available: true, success: result.status === 0, status: result.status ?? null, output: `${stdout}${stderr}` };
-}
-
 function expandHome(inputPath){
   if (!inputPath || inputPath[0] !== '~') return inputPath;
   if (inputPath === '~') return os.homedir();
@@ -65,8 +49,6 @@ if (args.help){
 }
 
 const repoRoot = path.resolve(process.cwd());
-const file = args.file || path.join('spec','alloy','Domain.als');
-const absFile = path.resolve(repoRoot, file);
 const outDir = path.join(repoRoot, 'artifacts/hermetic-reports', 'formal');
 const outFile = path.join(outDir, 'alloy-summary.json');
 const outLog = path.join(outDir, 'alloy-output.txt');
@@ -79,39 +61,35 @@ let temporal = { present: false, operators: [], pastOperators: [] };
 let exitCode = null;
 let ok = null;
 let timeMs = null;
+let file = path.join('spec','alloy','Domain.als');
+let absFile = path.resolve(repoRoot, file);
 
-if (!fs.existsSync(absFile)){
+try {
+  const resolvedFile = resolveRepoRelativeFileInput(args.file, {
+    repoRoot,
+    defaultPath: path.join('spec','alloy','Domain.als'),
+    allowedRoots: ['spec/alloy'],
+    allowedExtensions: ['.als'],
+    name: 'Alloy file',
+  });
+  file = resolvedFile.relativePath;
+  absFile = resolvedFile.absolutePath;
+} catch (error) {
+  status = 'invalid_input';
+  output = error?.message ?? String(error);
+  ok = false;
+}
+
+if (status === 'invalid_input') {
+  // fail closed before invoking external formal tools
+} else if (!fs.existsSync(absFile)){
   status = 'file_not_found';
   output = `Alloy file not found: ${absFile}`;
 } else {
   const runCmd = process.env.ALLOY_RUN_CMD;
   if (runCmd) {
-    const jar = args.jar || process.env.ALLOY_JAR || '';
-    const jarPath = jar ? path.resolve(expandHome(jar)) : '';
-    if (runCmd.includes('$ALLOY_JAR') && !jarPath) {
-      status = 'jar_not_set';
-      output = 'ALLOY_RUN_CMD requires $ALLOY_JAR, but ALLOY_JAR is not set.';
-    } else if (runCmd.includes('$ALLOY_JAR') && !fs.existsSync(jarPath)) {
-      status = 'jar_not_found';
-      output = `Alloy jar not found: ${jarPath}. Set ALLOY_JAR to a valid path, use --jar /path/to/alloy.jar, or check that the file exists.`;
-    } else {
-      const cmd = runCmd
-        .replace(/{file}/g, absFile)
-        .replace(/\$ALLOY_JAR/g, jarPath);
-      const t0 = Date.now();
-      const res = runShell(cmd);
-      if (res.available) timeMs = Date.now() - t0;
-      if (!res.available) {
-        status = 'tool_not_available';
-        output = res.output || 'Failed to execute ALLOY_RUN_CMD.';
-      } else {
-        output = res.output;
-        ran = true;
-        exitCode = res.status;
-        status = res.success ? 'ran' : 'failed';
-        ok = status === 'ran';
-      }
-    }
+    status = 'run_cmd_unsupported';
+    output = 'ALLOY_RUN_CMD shell execution is disabled. Use ALLOY_JAR or the Alloy CLI so the runner can invoke java/alloy with argv-safe arguments.';
   } else {
     const t0 = Date.now();
     const alloyResult = runCommand('alloy', [absFile]);
@@ -130,7 +108,7 @@ if (!fs.existsSync(absFile)){
         output = `Alloy jar not found: ${jarPath}. Set ALLOY_JAR to a valid path, use --jar /path/to/alloy.jar, or check that the file exists.`;
       } else {
         const t1 = Date.now();
-        const javaResult = runCommand('java', ['-jar', jarPath, absFile]);
+        const javaResult = runCommand('java', ['-jar', jarPath, 'exec', '-q', '-o', '-', '-f', absFile]);
         if (!javaResult.available) {
           status = 'java_not_available';
           output = 'Java runtime not found. Ensure `java` is installed and on PATH to run the Alloy jar.';

--- a/scripts/formal/verify-apalache.mjs
+++ b/scripts/formal/verify-apalache.mjs
@@ -8,6 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { computeOkFromOutput } from './heuristics.mjs';
+import { resolveRepoRelativeFileInput } from './input-policy.mjs';
 
 function parseArgs(argv){
   const args = { _: [] };
@@ -140,12 +141,6 @@ export function main(argv = process.argv){
   }
 
   const repoRoot = path.resolve(process.cwd());
-  const file = args.file || process.env.APALACHE_FILE || path.join('spec','tla','DomainSpec.tla');
-  const absFile = path.resolve(repoRoot, file);
-  const cfgFromArg = args.config || process.env.APALACHE_CONFIG || process.env.APALACHE_CFG || '';
-  const autoCfg = path.format({ ...path.parse(absFile), base: '', ext: '.cfg' });
-  const absCfg = path.resolve(repoRoot, cfgFromArg || autoCfg);
-  const hasCfg = fs.existsSync(absCfg);
   const outDir = path.join(repoRoot, 'artifacts/hermetic-reports', 'formal');
   const outFile = path.join(outDir, 'apalache-summary.json');
   const outLog = path.join(outDir, 'apalache-output.txt');
@@ -162,8 +157,45 @@ export function main(argv = process.argv){
   let toolPath = '';
   let timeMs = 0;
   let exitCode = null;
+  let file = path.join('spec','tla','DomainSpec.tla');
+  let absFile = path.resolve(repoRoot, file);
+  let cfgFromArg = args.config || process.env.APALACHE_CONFIG || process.env.APALACHE_CFG || '';
+  let absCfg = '';
+  let hasCfg = false;
 
-  if (!fs.existsSync(absFile)){
+  try {
+    const resolvedFile = resolveRepoRelativeFileInput(args.file || process.env.APALACHE_FILE, {
+      repoRoot,
+      defaultPath: path.join('spec','tla','DomainSpec.tla'),
+      allowedRoots: ['spec/tla'],
+      allowedExtensions: ['.tla'],
+      name: 'Apalache TLA file',
+    });
+    file = resolvedFile.relativePath;
+    absFile = resolvedFile.absolutePath;
+    const autoCfg = path.format({ ...path.parse(absFile), base: '', ext: '.cfg' });
+    if (cfgFromArg) {
+      const resolvedCfg = resolveRepoRelativeFileInput(cfgFromArg, {
+        repoRoot,
+        defaultPath: path.relative(repoRoot, autoCfg),
+        allowedRoots: ['spec/tla'],
+        allowedExtensions: ['.cfg'],
+        name: 'Apalache config file',
+      });
+      cfgFromArg = resolvedCfg.relativePath;
+      absCfg = resolvedCfg.absolutePath;
+    } else {
+      absCfg = autoCfg;
+    }
+    hasCfg = fs.existsSync(absCfg);
+  } catch (error) {
+    status = 'invalid_input';
+    output = error?.message ?? String(error);
+  }
+
+  if (status === 'invalid_input') {
+    // fail closed before invoking external formal tools
+  } else if (!fs.existsSync(absFile)){
     status = 'file_not_found';
     output = `TLA file not found: ${absFile}\nSee docs/quality/formal-runbook.md (Reproduce Locally).`;
   } else if (cfgFromArg && !hasCfg) {

--- a/scripts/formal/verify-tla.mjs
+++ b/scripts/formal/verify-tla.mjs
@@ -3,6 +3,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { resolveRepoRelativeFileInput, validateChoice, TLA_ENGINES } from './input-policy.mjs';
 
 function parseArgs(argv){
   const args = { _: [] };
@@ -62,10 +63,7 @@ if (args.help){
   process.exit(0);
 }
 
-const engine = (args.engine || 'tlc').toLowerCase();
 const repoRoot = process.cwd();
-const file = args.file || path.join('spec','tla','DomainSpec.tla');
-const absFile = path.resolve(repoRoot, file);
 
 const outDir = path.join(repoRoot, 'artifacts/hermetic-reports', 'formal');
 const outFile = path.join(outDir, 'tla-summary.json');
@@ -78,8 +76,33 @@ let output = '';
 let exitCode = null;
 let ok = null;
 let timeMs = null;
+let engine = 'tlc';
+let file = path.join('spec','tla','DomainSpec.tla');
+let absFile = path.resolve(repoRoot, file);
 
-if (!fs.existsSync(absFile)){
+try {
+  engine = validateChoice((args.engine || 'tlc').toLowerCase(), {
+    allowed: TLA_ENGINES,
+    name: 'TLA engine',
+    defaultValue: 'tlc',
+  });
+  const resolvedFile = resolveRepoRelativeFileInput(args.file, {
+    repoRoot,
+    defaultPath: path.join('spec','tla','DomainSpec.tla'),
+    allowedRoots: ['spec/tla'],
+    allowedExtensions: ['.tla'],
+    name: 'TLA file',
+  });
+  file = resolvedFile.relativePath;
+  absFile = resolvedFile.absolutePath;
+} catch (error) {
+  status = 'invalid_input';
+  output = error?.message ?? String(error);
+}
+
+if (status === 'invalid_input') {
+  ok = false;
+} else if (!fs.existsSync(absFile)){
   status = 'file_not_found';
   output = `TLA file not found: ${absFile}`;
 } else if (engine === 'apalache'){

--- a/tests/unit/ci/assert-workflow-dispatch-actor.test.ts
+++ b/tests/unit/ci/assert-workflow-dispatch-actor.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isTrustedPermission,
+  parseAllowedPermissions,
+  parsePermissionResponse,
+} from '../../../scripts/ci/assert-workflow-dispatch-actor.mjs';
+
+describe('assert-workflow-dispatch-actor', () => {
+  it('parses allowed permission configuration', () => {
+    expect([...parseAllowedPermissions('admin, maintain,write')]).toEqual(['admin', 'maintain', 'write']);
+  });
+
+  it('accepts write-like collaborator permissions only', () => {
+    const allowed = parseAllowedPermissions('admin,maintain,write');
+    expect(isTrustedPermission('admin', allowed)).toBe(true);
+    expect(isTrustedPermission('maintain', allowed)).toBe(true);
+    expect(isTrustedPermission('write', allowed)).toBe(true);
+    expect(isTrustedPermission('triage', allowed)).toBe(false);
+    expect(isTrustedPermission('read', allowed)).toBe(false);
+  });
+
+  it('parses gh api permission output', () => {
+    expect(parsePermissionResponse('write\n')).toBe('write');
+    expect(parsePermissionResponse('{"permission":"maintain"}')).toBe('maintain');
+  });
+});

--- a/tests/unit/ci/assert-workflow-dispatch-actor.test.ts
+++ b/tests/unit/ci/assert-workflow-dispatch-actor.test.ts
@@ -1,6 +1,9 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import {
+  isDirectInvocation,
   isTrustedPermission,
   parseAllowedPermissions,
   parsePermissionResponse,
@@ -23,5 +26,14 @@ describe('assert-workflow-dispatch-actor', () => {
   it('parses gh api permission output', () => {
     expect(parsePermissionResponse('write\n')).toBe('write');
     expect(parsePermissionResponse('{"permission":"maintain"}')).toBe('maintain');
+  });
+
+  it('detects direct node CLI invocation using a file URL', () => {
+    const scriptPath = path.resolve(process.cwd(), 'scripts/ci/assert-workflow-dispatch-actor.mjs');
+    const moduleUrl = pathToFileURL(scriptPath).href;
+
+    expect(isDirectInvocation(moduleUrl, ['node', scriptPath])).toBe(true);
+    expect(isDirectInvocation(moduleUrl, ['node', path.resolve(process.cwd(), 'scripts/ci/other.mjs')])).toBe(false);
+    expect(isDirectInvocation(moduleUrl, ['node'])).toBe(false);
   });
 });

--- a/tests/unit/ci/formal-verify-workflow-security.test.ts
+++ b/tests/unit/ci/formal-verify-workflow-security.test.ts
@@ -48,9 +48,19 @@ describe('formal-verify workflow dispatch security', () => {
     expect(inputs.alloyJar).toBeUndefined();
     expect(inputs.tlaToolsJar).toBeUndefined();
     expect(workflow).not.toContain('ALLOY_RUN_CMD');
+    expect(workflow).not.toContain("TLA_TOOLS_JAR: ''");
     expect(workflow).not.toMatch(/run:\s*\|[\s\S]*\$\{\{\s*inputs\.tlaFile/);
     expect(workflow).toContain('TLA_FILE: ${{ github.event_name == \'workflow_dispatch\' && inputs.tlaFile || \'spec/tla/DomainSpec.tla\' }}');
     expect(workflow).toContain('APALACHE_FILE: ${{ github.event_name == \'workflow_dispatch\' && inputs.tlaFile || \'spec/tla/DomainSpec.tla\' }}');
+  });
+
+  it('restores a trusted TLC jar path without exposing a dispatch jar override', () => {
+    const workflow = rawWorkflow();
+
+    expect(workflow).toContain("TLA_TOOLS_VERSION: '1.8.0'");
+    expect(workflow).toContain('key: ${{ runner.os }}-tla2tools-${{ env.TLA_TOOLS_VERSION }}');
+    expect(workflow).toContain('https://github.com/tlaplus/tlaplus/releases/download/v${TLA_TOOLS_VERSION}/tla2tools.jar');
+    expect(workflow).toContain("TLA_TOOLS_JAR: ${{ format('{0}/.cache/tools/tla2tools.jar', github.workspace) }}");
   });
 
   it('uses least-privilege permissions and disables persisted checkout credentials', () => {

--- a/tests/unit/ci/formal-verify-workflow-security.test.ts
+++ b/tests/unit/ci/formal-verify-workflow-security.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+
+type WorkflowDocument = {
+  on?: {
+    workflow_dispatch?: {
+      inputs?: Record<string, any>;
+    };
+  };
+  permissions?: Record<string, string>;
+  jobs?: Record<string, any>;
+};
+
+const workflowPath = path.resolve(process.cwd(), '.github/workflows/formal-verify.yml');
+const rawWorkflow = () => fs.readFileSync(workflowPath, 'utf8');
+const parseWorkflow = () => yaml.load(rawWorkflow()) as WorkflowDocument;
+
+describe('formal-verify workflow dispatch security', () => {
+  it('uses finite choices for dispatch target, engine, and solver', () => {
+    const workflow = parseWorkflow();
+    const inputs = workflow.on?.workflow_dispatch?.inputs ?? {};
+
+    expect(inputs.target?.type).toBe('choice');
+    expect(inputs.target?.options).toEqual([
+      'all',
+      'conformance',
+      'alloy',
+      'tla',
+      'smt',
+      'apalache',
+      'kani',
+      'spin',
+      'csp',
+      'lean',
+    ]);
+    expect(inputs.engine?.type).toBe('choice');
+    expect(inputs.engine?.options).toEqual(['tlc', 'apalache']);
+    expect(inputs.solver?.type).toBe('choice');
+    expect(inputs.solver?.options).toEqual(['z3', 'cvc5']);
+  });
+
+  it('removes jar path dispatch inputs and direct shell interpolation of tlaFile', () => {
+    const workflow = rawWorkflow();
+    const inputs = parseWorkflow().on?.workflow_dispatch?.inputs ?? {};
+
+    expect(inputs.alloyJar).toBeUndefined();
+    expect(inputs.tlaToolsJar).toBeUndefined();
+    expect(workflow).not.toContain('ALLOY_RUN_CMD');
+    expect(workflow).not.toMatch(/run:\s*\|[\s\S]*\$\{\{\s*inputs\.tlaFile/);
+    expect(workflow).toContain('TLA_FILE: ${{ github.event_name == \'workflow_dispatch\' && inputs.tlaFile || \'spec/tla/DomainSpec.tla\' }}');
+    expect(workflow).toContain('APALACHE_FILE: ${{ github.event_name == \'workflow_dispatch\' && inputs.tlaFile || \'spec/tla/DomainSpec.tla\' }}');
+  });
+
+  it('uses least-privilege permissions and disables persisted checkout credentials', () => {
+    const workflow = rawWorkflow();
+    const parsed = parseWorkflow();
+    const checkoutCount = (workflow.match(/uses: actions\/checkout@v4/g) ?? []).length;
+    const persistFalseCount = (workflow.match(/persist-credentials: false/g) ?? []).length;
+
+    expect(parsed.permissions).toEqual({ contents: 'read' });
+    expect(checkoutCount).toBeGreaterThan(0);
+    expect(persistFalseCount).toBe(checkoutCount);
+  });
+
+  it('authorizes workflow_dispatch actors before each formal job can execute repository scripts', () => {
+    const workflow = rawWorkflow();
+    const checkoutCount = (workflow.match(/uses: actions\/checkout@v4/g) ?? []).length;
+    const authCount = (workflow.match(/node scripts\/ci\/assert-workflow-dispatch-actor\.mjs/g) ?? []).length;
+
+    expect(authCount).toBe(checkoutCount);
+    expect(workflow).toContain("if: ${{ github.event_name == 'workflow_dispatch' }}");
+  });
+});

--- a/tests/unit/formal/input-policy.test.ts
+++ b/tests/unit/formal/input-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  resolveRepoRelativeFileInput,
+  validateChoice,
+} from '../../../scripts/formal/input-policy.mjs';
+
+describe('formal input policy', () => {
+  it('accepts approved repository-relative TLA files', () => {
+    const root = mkdtempSync(join(tmpdir(), 'formal-input-policy-'));
+    mkdirSync(join(root, 'spec', 'tla'), { recursive: true });
+    writeFileSync(join(root, 'spec', 'tla', 'DomainSpec.tla'), '---- MODULE DomainSpec ----\n', 'utf8');
+
+    const result = resolveRepoRelativeFileInput('spec/tla/DomainSpec.tla', {
+      repoRoot: root,
+      defaultPath: 'spec/tla/DomainSpec.tla',
+      allowedRoots: ['spec/tla'],
+      allowedExtensions: ['.tla'],
+      name: 'TLA file',
+    });
+
+    expect(result.relativePath).toBe('spec/tla/DomainSpec.tla');
+    expect(result.absolutePath).toBe(join(root, 'spec', 'tla', 'DomainSpec.tla'));
+  });
+
+  it.each([
+    '/etc/passwd',
+    'C:\\Windows\\win.ini',
+    '../spec/tla/DomainSpec.tla',
+    'spec/tla/../../package.json',
+    'spec\\tla\\DomainSpec.tla',
+    'scripts/formal/verify-tla.mjs',
+    'spec/tla/DomainSpec.js',
+    'spec/tla/DomainSpec.tla\u0000',
+  ])('rejects unsafe formal file input %s', (candidate) => {
+    expect(() => resolveRepoRelativeFileInput(candidate, {
+      repoRoot: process.cwd(),
+      defaultPath: 'spec/tla/DomainSpec.tla',
+      allowedRoots: ['spec/tla'],
+      allowedExtensions: ['.tla'],
+      name: 'TLA file',
+    })).toThrow();
+  });
+
+  it('validates finite dispatch choices', () => {
+    expect(validateChoice('apalache', {
+      allowed: ['tlc', 'apalache'],
+      name: 'engine',
+      defaultValue: 'tlc',
+    })).toBe('apalache');
+
+    expect(() => validateChoice('$(echo injected)', {
+      allowed: ['tlc', 'apalache'],
+      name: 'engine',
+      defaultValue: 'tlc',
+    })).toThrow('engine must be one of');
+  });
+});

--- a/tests/unit/formal/verify-alloy-security.test.ts
+++ b/tests/unit/formal/verify-alloy-security.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const scriptPath = resolve('scripts/formal/verify-alloy.mjs');
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'verify-alloy-security-'));
+  mkdirSync(join(dir, 'spec', 'alloy'), { recursive: true });
+  writeFileSync(join(dir, 'spec', 'alloy', 'Domain.als'), 'sig A {}\n', 'utf8');
+  return dir;
+}
+
+describe('verify-alloy security behavior', () => {
+  it('rejects unsafe Alloy file paths before tool execution', () => {
+    const dir = makeRepo();
+    const result = spawnSync(process.execPath, [scriptPath, '--file', '../outside.als'], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const summary = JSON.parse(readFileSync(join(dir, 'artifacts', 'hermetic-reports', 'formal', 'alloy-summary.json'), 'utf8'));
+    expect(summary.status).toBe('invalid_input');
+    expect(summary.output).toContain('parent traversal');
+  });
+
+  it('does not execute ALLOY_RUN_CMD through a shell', () => {
+    const dir = makeRepo();
+    const marker = join(dir, 'shell-marker');
+    const result = spawnSync(process.execPath, [scriptPath, '--file', 'spec/alloy/Domain.als'], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ALLOY_RUN_CMD: `node -e "require('fs').writeFileSync('${marker}', 'executed')"`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+    const summary = JSON.parse(readFileSync(join(dir, 'artifacts', 'hermetic-reports', 'formal', 'alloy-summary.json'), 'utf8'));
+    expect(summary.status).toBe('run_cmd_unsupported');
+  });
+});

--- a/tests/unit/formal/verify-tla-input-security.test.ts
+++ b/tests/unit/formal/verify-tla-input-security.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const tlaScriptPath = resolve('scripts/formal/verify-tla.mjs');
+const apalacheScriptPath = resolve('scripts/formal/verify-apalache.mjs');
+
+function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), 'verify-tla-input-security-'));
+  mkdirSync(join(dir, 'spec', 'tla'), { recursive: true });
+  writeFileSync(join(dir, 'spec', 'tla', 'DomainSpec.tla'), '---- MODULE DomainSpec ----\n====\n', 'utf8');
+  return dir;
+}
+
+describe('formal TLA input security', () => {
+  it('verify-tla rejects traversal paths before external tool execution', () => {
+    const dir = makeRepo();
+    const result = spawnSync(process.execPath, [tlaScriptPath, '--engine=tlc', '--file', '../package.json'], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const summary = JSON.parse(readFileSync(join(dir, 'artifacts', 'hermetic-reports', 'formal', 'tla-summary.json'), 'utf8'));
+    expect(summary.status).toBe('invalid_input');
+    expect(summary.output).toContain('parent traversal');
+  });
+
+  it('verify-apalache rejects paths outside spec/tla before external tool execution', () => {
+    const dir = makeRepo();
+    mkdirSync(join(dir, 'spec', 'alloy'), { recursive: true });
+    writeFileSync(join(dir, 'spec', 'alloy', 'Domain.als'), 'sig A {}\n', 'utf8');
+
+    const result = spawnSync(process.execPath, [apalacheScriptPath, '--file', 'spec/alloy/Domain.als'], {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    const summary = JSON.parse(readFileSync(join(dir, 'artifacts', 'hermetic-reports', 'formal', 'apalache-summary.json'), 'utf8'));
+    expect(summary.status).toBe('invalid_input');
+    expect(summary.output).toContain('Apalache TLA file must use one of these extensions');
+  });
+});


### PR DESCRIPTION
## Summary

- Harden `formal-verify.yml` workflow_dispatch inputs by converting finite values to `choice`, removing manual jar path dispatch inputs, and disabling persisted checkout credentials.
- Add a workflow_dispatch actor authorization script requiring write-like collaborator permissions before manual formal jobs run repository scripts.
- Add shared formal file input policy for approved repository-relative paths, and apply it to TLA, Apalache, and Alloy runners.
- Disable `ALLOY_RUN_CMD` shell-template execution in `scripts/formal/verify-alloy.mjs`; Alloy jar execution now uses argv-safe `java` arguments.
- Update formal run documentation and add regression tests for workflow dispatch boundaries and formal input validation.

Fixes #3378.

## Validation

- `pnpm -s exec vitest run tests/unit/ci/formal-verify-workflow-security.test.ts tests/unit/ci/assert-workflow-dispatch-actor.test.ts tests/unit/formal/input-policy.test.ts tests/unit/formal/verify-alloy-security.test.ts tests/unit/formal/verify-tla-input-security.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet scripts/formal/input-policy.mjs scripts/formal/verify-alloy.mjs scripts/formal/verify-tla.mjs scripts/formal/verify-apalache.mjs scripts/ci/assert-workflow-dispatch-actor.mjs tests/unit/ci/formal-verify-workflow-security.test.ts tests/unit/ci/assert-workflow-dispatch-actor.test.ts tests/unit/formal/input-policy.test.ts tests/unit/formal/verify-alloy-security.test.ts tests/unit/formal/verify-tla-input-security.test.ts`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run types:check`
- `pnpm -s run check:schemas`
- `git diff --check`

Local note: `pnpm -s run lint:actions` could not complete in this environment because the configured podman actionlint container failed with `cannot re-exec process to join the existing user namespace` (container exit 125). The workflow is covered by YAML parse/regression tests locally and will be validated by CI actionlint.

## Acceptance

- Manual formal dispatch finite inputs are typed choices.
- `tlaFile` is constrained to approved repository-relative `spec/tla/*.tla` paths before external formal tools run.
- Manual `alloyJar` / `tlaToolsJar` dispatch inputs are not exposed.
- Alloy shell command templates are not executed by `scripts/formal/verify-alloy.mjs`.
- Manual formal jobs require a write-like collaborator permission check before repository scripts run.

## Rollback

Revert this PR to restore the prior free-form formal dispatch and shell-template Alloy runner behavior.
