### PR TITLE
fix(ci): harden Cedar summary enforcement

### DIFF
--- a/.github/workflows/cedar-quality-gates.yml
+++ b/.github/workflows/cedar-quality-gates.yml
@@ -17,61 +17,82 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'run-security') || contains(github.event.pull_request.labels.*.name, 'run-cedar')
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Validate Cedar policies (non-blocking)
+      - name: Validate Cedar policies
         id: cedar
+        env:
+          CEDAR_SUMMARY: artifacts/policies/cedar-summary.json
         run: |
-          set -e
-          node scripts/policies/validate-cedar.mjs || true
-          FILE="artifacts/policies/cedar-summary.json"
-          if [ -f "$FILE" ]; then
-            ok=$(jq -r '.okCount // 0' "$FILE" 2>/dev/null || printf "0\n")
-            ng=$(jq -r '.ngCount // 0' "$FILE" 2>/dev/null || printf "0\n")
-            files=$(jq -r '.filesScanned // 0' "$FILE" 2>/dev/null || printf "0\n")
-            {
-              printf "%s\n" "files=$files"
-              printf "%s\n" "ok=$ok"
-              printf "%s\n" "ng=$ng"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              printf "%s\n" "files=0"
-              printf "%s\n" "ok=0"
-              printf "%s\n" "ng=0"
-            } >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+          rm -f "$CEDAR_SUMMARY"
+          node scripts/policies/validate-cedar.mjs
+          node scripts/policies/cedar-summary-guard.mjs --summary "$CEDAR_SUMMARY" --write-output
       - name: Upload cedar summary
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cedar-summary
           path: artifacts/policies/cedar-summary.json
+          if-no-files-found: warn
+      - name: Enforce cedar (errors==0)
+        if: contains(github.event.pull_request.labels.*.name, 'enforce-security')
+        env:
+          CEDAR_SUMMARY: artifacts/policies/cedar-summary.json
+        run: node scripts/policies/cedar-summary-guard.mjs --summary "$CEDAR_SUMMARY" --enforce
+
+  cedar-comment:
+    needs: cedar-validate
+    if: always() && needs.cedar-validate.result != 'skipped' && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download cedar summary
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: cedar-summary
+          path: artifacts/policies
       - name: Comment PR with cedar summary
-        if: always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
             const header = '<!-- AE-CEDAR-SUMMARY -->\n';
+            const labels = (context.payload.pull_request.labels || []).map(label => label.name);
+            const enforced = labels.includes('enforce-security');
             const exists = fs.existsSync('artifacts/policies/cedar-summary.json');
-            let body = header + '### Cedar Policies (report-only)\n\n';
+            let body = header + `### Cedar Policies (${enforced ? 'enforced' : 'report-only'})\n\n`;
             if (exists) {
-              const j = JSON.parse(fs.readFileSync('artifacts/policies/cedar-summary.json','utf-8'));
-              body += `Files: ${j.filesScanned} (json=${j.jsonFiles}, cedar=${j.cedarFiles})\n`;
-              body += `Results: ok=${j.okCount}, ng=${j.ngCount}\n`;
-              body += `Tool: ${j.tool}\n`;
+              try {
+                const j = JSON.parse(fs.readFileSync('artifacts/policies/cedar-summary.json','utf-8'));
+                const int = (field) => {
+                  const value = j[field];
+                  if (!Number.isSafeInteger(value) || value < 0) {
+                    throw new Error(`${field} must be a non-negative safe integer`);
+                  }
+                  return value;
+                };
+                body += `Files: ${int('filesScanned')} (json=${int('jsonFiles')}, cedar=${int('cedarFiles')})\n`;
+                body += `Results: ok=${int('okCount')}, ng=${int('ngCount')}\n`;
+                body += `Tool: ${String(j.tool || 'cedar-validator')}\n`;
+              } catch (error) {
+                body += `Cedar summary artifact was invalid: ${error.message || String(error)}\n`;
+              }
             } else {
-              body += 'No cedar files found (policies/cedar).\n';
+              body += 'Cedar summary artifact was not available.\n';
             }
-            body += '\nPolicy: report-only';
+            body += enforced ? '\nPolicy: enforced (`enforce-security`)' : '\nPolicy: report-only';
             body += '\nDocs: docs/quality/cedar-quality-gates.md';
             const { owner, repo, number } = context.issue;
             const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
@@ -81,7 +102,3 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
             }
-      - name: Enforce cedar (errors==0)
-        if: (steps.cedar.outputs.ng != '' && steps.cedar.outputs.ng != '0') && contains(github.event.pull_request.labels.*.name, 'enforce-security')
-        run: |
-          printf "%s\n" "::error::Cedar validation found NG=${{ steps.cedar.outputs.ng }} (enforce-security)"; exit 1

--- a/docs/quality/cedar-quality-gates.md
+++ b/docs/quality/cedar-quality-gates.md
@@ -22,6 +22,7 @@ This workflow scans `policies/cedar/` for `.json` (Cedar JSON) and `.cedar` / `.
 - PR comment header: `<!-- AE-CEDAR-SUMMARY -->`
 - Trigger: add label `run-security` (or `run-cedar`)
 - Enforcement: add label `enforce-security` (fails when `ngCount > 0`)
+- Permission boundary: the validation job runs with read-only repository permissions; PR commenting is isolated in a separate job with `issues: write` / `pull-requests: write`.
 
 ### Environment variables
 
@@ -52,7 +53,7 @@ This workflow scans `policies/cedar/` for `.json` (Cedar JSON) and `.cedar` / `.
 
 - JSON validation is intentionally minimal. The checker looks for `policySet` or a `policies` array-like structure.
 - Text `.cedar` files are only checked for non-empty content.
-- The lane is report-only by default. Add `enforce-security` only when you want `ngCount > 0` to block the job.
+- The lane is report-only by default. Add `enforce-security` only when you want `ngCount > 0` to block the job. The enforcement step reads the validated summary through `scripts/policies/cedar-summary-guard.mjs`; it does not embed step outputs into shell.
 
 ## 日本語
 
@@ -65,6 +66,7 @@ This workflow scans `policies/cedar/` for `.json` (Cedar JSON) and `.cedar` / `.
 - PR comment header: `<!-- AE-CEDAR-SUMMARY -->`
 - 起動条件: `run-security` または `run-cedar` ラベルを付与
 - 強制条件: `enforce-security` ラベルを付与すると `ngCount > 0` で失敗させます
+- 権限境界: 検証 job は repository read-only 権限で実行し、PR コメントは `issues: write` / `pull-requests: write` を持つ別 job に分離します。
 
 ### 環境変数
 
@@ -95,4 +97,4 @@ This workflow scans `policies/cedar/` for `.json` (Cedar JSON) and `.cedar` / `.
 
 - JSON 検証は意図的に最小限です。チェッカーは `policySet` または `policies` の array-like structure の有無を確認します。
 - テキスト `.cedar` ファイルは non-empty かどうかだけを確認します。
-- このレーンは既定で報告専用（report-only）です。`ngCount > 0` を失敗条件にしたい PR のみ `enforce-security` を付けてください。
+- このレーンは既定で報告専用（report-only）です。`ngCount > 0` を失敗条件にしたい PR のみ `enforce-security` を付けてください。強制ステップは `scripts/policies/cedar-summary-guard.mjs` で検証済み summary を読み取り、step output を shell に直接埋め込みません。

--- a/scripts/policies/cedar-summary-guard.mjs
+++ b/scripts/policies/cedar-summary-guard.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_SUMMARY = path.join('artifacts', 'policies', 'cedar-summary.json');
+
+export function readCedarSummary(summaryPath = DEFAULT_SUMMARY) {
+  const resolved = path.resolve(summaryPath);
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+  } catch (error) {
+    throw new Error(`failed to read Cedar summary ${resolved}: ${error?.message ?? String(error)}`);
+  }
+  return parsed;
+}
+
+export function requireNonNegativeInteger(value, fieldName) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Cedar summary field ${fieldName} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+export function cedarSummaryCounts(summary) {
+  return {
+    files: requireNonNegativeInteger(summary?.filesScanned, 'filesScanned'),
+    ok: requireNonNegativeInteger(summary?.okCount, 'okCount'),
+    ng: requireNonNegativeInteger(summary?.ngCount, 'ngCount'),
+  };
+}
+
+export function writeGithubOutput(counts, outputPath = process.env.GITHUB_OUTPUT) {
+  if (!outputPath) {
+    throw new Error('GITHUB_OUTPUT is required to write Cedar summary outputs');
+  }
+  const lines = [
+    `files=${requireNonNegativeInteger(counts.files, 'files')}`,
+    `ok=${requireNonNegativeInteger(counts.ok, 'ok')}`,
+    `ng=${requireNonNegativeInteger(counts.ng, 'ng')}`,
+  ];
+  fs.appendFileSync(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+export function enforceCedarSummary(summary) {
+  const counts = cedarSummaryCounts(summary);
+  if (counts.ng > 0) {
+    throw new Error(`Cedar validation found NG=${counts.ng} (enforce-security)`);
+  }
+  return counts;
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = {
+    summary: DEFAULT_SUMMARY,
+    writeOutput: false,
+    enforce: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--summary' && argv[index + 1]) {
+      args.summary = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith('--summary=')) {
+      args.summary = arg.slice('--summary='.length);
+    } else if (arg === '--write-output') {
+      args.writeOutput = true;
+    } else if (arg === '--enforce') {
+      args.enforce = true;
+    } else if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+export function main(argv = process.argv.slice(2), env = process.env) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log('Usage: node scripts/policies/cedar-summary-guard.mjs [--summary <path>] [--write-output] [--enforce]');
+    return 0;
+  }
+  const summary = readCedarSummary(args.summary);
+  const counts = args.enforce ? enforceCedarSummary(summary) : cedarSummaryCounts(summary);
+  if (args.writeOutput) {
+    writeGithubOutput(counts, env.GITHUB_OUTPUT);
+  }
+  console.log(`Cedar summary validated: files=${counts.files} ok=${counts.ok} ng=${counts.ng}`);
+  return 0;
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  try {
+    process.exit(main());
+  } catch (error) {
+    console.error(error?.message ?? String(error));
+    process.exit(1);
+  }
+}

--- a/tests/unit/ci/cedar-quality-gates-workflow-security.test.ts
+++ b/tests/unit/ci/cedar-quality-gates-workflow-security.test.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+type WorkflowDocument = {
+  jobs?: Record<string, any>;
+};
+
+const workflowPath = path.resolve(process.cwd(), '.github/workflows/cedar-quality-gates.yml');
+const rawWorkflow = () => fs.readFileSync(workflowPath, 'utf8');
+const parseWorkflow = () => yaml.load(rawWorkflow()) as WorkflowDocument;
+
+describe('cedar quality gates workflow security', () => {
+  it('keeps validation read-only and isolates PR comment write permissions', () => {
+    const jobs = parseWorkflow().jobs ?? {};
+
+    expect(jobs['cedar-validate']?.permissions).toEqual({ contents: 'read' });
+    expect(jobs['cedar-comment']?.permissions).toEqual({
+      contents: 'read',
+      issues: 'write',
+      'pull-requests': 'write',
+    });
+  });
+
+  it('does not consume stale summaries or continue after validator process failures', () => {
+    const workflow = rawWorkflow();
+
+    expect(workflow).toContain('rm -f "$CEDAR_SUMMARY"');
+    expect(workflow).toContain('node scripts/policies/validate-cedar.mjs');
+    expect(workflow).toContain('node scripts/policies/cedar-summary-guard.mjs --summary "$CEDAR_SUMMARY" --write-output');
+    expect(workflow).not.toContain('node scripts/policies/validate-cedar.mjs || true');
+  });
+
+  it('uses checked-in guard logic for Cedar enforcement instead of shell interpolation of outputs', () => {
+    const jobs = parseWorkflow().jobs ?? {};
+    const enforceStep = jobs['cedar-validate']?.steps?.find((step: any) => step.name === 'Enforce cedar (errors==0)');
+    const workflow = rawWorkflow();
+
+    expect(enforceStep?.run).toBe('node scripts/policies/cedar-summary-guard.mjs --summary "$CEDAR_SUMMARY" --enforce');
+    expect(enforceStep?.run).not.toContain('${{');
+    expect(workflow).not.toMatch(/::error::Cedar validation found NG=\$\{\{/);
+  });
+
+  it('reports invalid comment summaries instead of coercing rejected counts to zero', () => {
+    const workflow = rawWorkflow();
+
+    expect(workflow).toContain('Cedar summary artifact was invalid:');
+    expect(workflow).toContain('must be a non-negative safe integer');
+    expect(workflow).not.toContain('Number.isSafeInteger(value) && value >= 0 ? value : 0');
+  });
+
+  it('keeps the Cedar PR comment heading consistent with enforcement mode', () => {
+    const workflow = rawWorkflow();
+
+    expect(workflow).toContain("const enforced = labels.includes('enforce-security');");
+    expect(workflow).toContain("`### Cedar Policies (${enforced ? 'enforced' : 'report-only'})\\n\\n`");
+    expect(workflow).not.toContain("let body = header + '### Cedar Policies (report-only)");
+  });
+});

--- a/tests/unit/policies/cedar-summary-guard.test.ts
+++ b/tests/unit/policies/cedar-summary-guard.test.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  cedarSummaryCounts,
+  enforceCedarSummary,
+  readCedarSummary,
+  writeGithubOutput,
+} from '../../../scripts/policies/cedar-summary-guard.mjs';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), 'artifacts', 'tmp-cedar-summary-guard-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeSummary(summary: unknown) {
+  const file = path.join(tmpDir, 'cedar-summary.json');
+  fs.writeFileSync(file, JSON.stringify(summary), 'utf8');
+  return file;
+}
+
+describe('cedar-summary-guard', () => {
+  it('reads and exports validated integer counts only', () => {
+    const summaryPath = writeSummary({
+      filesScanned: 2,
+      okCount: 1,
+      ngCount: 1,
+    });
+    const outputPath = path.join(tmpDir, 'github-output.txt');
+    const counts = cedarSummaryCounts(readCedarSummary(summaryPath));
+
+    writeGithubOutput(counts, outputPath);
+
+    expect(counts).toEqual({ files: 2, ok: 1, ng: 1 });
+    expect(fs.readFileSync(outputPath, 'utf8')).toBe('files=2\nok=1\nng=1\n');
+  });
+
+  it('rejects shell-like strings instead of forwarding them as outputs', () => {
+    const summaryPath = writeSummary({
+      filesScanned: 1,
+      okCount: 0,
+      ngCount: '0; echo injected',
+    });
+
+    expect(() => cedarSummaryCounts(readCedarSummary(summaryPath))).toThrow(/ngCount must be a non-negative safe integer/);
+  });
+
+  it('enforces ngCount with the checked-in script logic', () => {
+    expect(enforceCedarSummary({ filesScanned: 1, okCount: 1, ngCount: 0 })).toEqual({ files: 1, ok: 1, ng: 0 });
+    expect(() => enforceCedarSummary({ filesScanned: 1, okCount: 0, ngCount: 1 })).toThrow(
+      /Cedar validation found NG=1/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3379.

- Split Cedar validation from PR commenting so the validator runs with read-only repository permissions and the comment job holds the write-scoped token.
- Remove `|| true` summary consumption, delete stale Cedar summaries before validation, and validate count fields as non-negative safe integers before writing `$GITHUB_OUTPUT`.
- Replace shell interpolation of `steps.cedar.outputs.ng` with a checked-in Cedar summary guard script for enforcement.
- Document the Cedar quality-gate permission boundary and enforcement behavior.

## Acceptance

- Cedar validation job cannot comment on PRs and uses `contents: read` only.
- Invalid or non-numeric `ngCount` values are rejected before step output or enforcement use.
- `enforce-security` enforcement reads the validated summary through `scripts/policies/cedar-summary-guard.mjs` instead of interpolating a step output into shell.

## Local verification

- `pnpm -s exec vitest run tests/unit/ci/cedar-quality-gates-workflow-security.test.ts tests/unit/policies/cedar-summary-guard.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet scripts/policies/cedar-summary-guard.mjs tests/unit/ci/cedar-quality-gates-workflow-security.test.ts tests/unit/policies/cedar-summary-guard.test.ts`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run types:check`
- `pnpm -s run check:schemas`
- `git diff --check`

Note: local `pnpm -s run lint:actions` is blocked in this environment by rootless Podman user-namespace re-exec failure (`exit=125`); GitHub Actions actionlint is expected to provide the authoritative workflow lint.

## Rollback

Revert this PR to restore the previous single-job Cedar validation/commenting workflow and shell-based enforcement path.