### PR TITLE
fix(ci): isolate Phase 6 Lighthouse token

### DIFF
--- a/.github/workflows/phase6-validation.yml
+++ b/.github/workflows/phase6-validation.yml
@@ -8,11 +8,16 @@ concurrency:
   cancel-in-progress: true
 
 # Lockfile drift should fail Phase 6 validation instead of mutating deps in CI.
+permissions:
+  contents: read
+
 jobs:
   accessibility-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with: { node-version: '20' }
@@ -28,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with: { node-version: '20' }
@@ -42,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with: { node-version: '20' }
@@ -52,13 +61,13 @@ jobs:
         run: |
           npm install -g @lhci/cli
           lhci autorun --config=./configs/lighthouserc.cjs
-        env:
-          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
 
   opa-policy-validation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup OPA
         uses: open-policy-agent/setup-opa@v2
         with: { version: latest }
@@ -79,6 +88,8 @@ jobs:
       AE_QUALITY_PROFILE: development
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with: { node-version: '20' }

--- a/docs/phases/phase-6-uiux.md
+++ b/docs/phases/phase-6-uiux.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: 2026-03-11
+lastVerified: 2026-06-02
 owner: phase-docs
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -15,6 +15,7 @@ verificationCommand: pnpm -s run check:doc-consistency
 Phase 6 turns user stories and domain models into production‑ready UI/UX via automated scaffolding, design system integration, a11y/perf quality gates, and telemetry. Inputs: Phase 3/5 outputs. Outputs: components, tokens, state architecture, and reports.
 
 > Status note (2026-02-18): adapter thresholds in `.github/workflows/adapter-thresholds.yml` run only when the PR includes `run-adapters`. Within those runs, a11y/perf/lighthouse are report-only by default and become blocking only with `enforce-*` labels. Treat threshold values in this document as targets unless explicitly tied to a specific workflow policy.
+> Security note (2026-06-02): `.github/workflows/phase6-validation.yml` runs pull-request Lighthouse collection without `LHCI_GITHUB_APP_TOKEN`; token-backed upload/status posting must stay in a trusted-ref follow-up lane, not in PR-controlled validation code.
 
 ## English (Detailed)
 
@@ -81,6 +82,7 @@ lhci autorun --upload.target=temporary-public-storage
 Phase 6は、Phase 3（ユーザーストーリー）とPhase 5（ドメインモデル）の成果を受けて、**実用的なUI/UXを自動生成・検証・承認**するフェーズです。
 
 > 現行ステータス（2026-02-18）: `.github/workflows/adapter-thresholds.yml` のアダプタしきい値は PR に `run-adapters` ラベルがある場合のみ実行されます。実行時は a11y/perf/lighthouse が既定 report-only で、`enforce-*` ラベル付与時のみブロッキングです。本書のしきい値は、個別workflowで明示しない限り目標値として扱ってください。
+> セキュリティ注記（2026-06-02）: `.github/workflows/phase6-validation.yml` の pull-request Lighthouse collection は `LHCI_GITHUB_APP_TOKEN` を使用しません。token-backed upload/status posting は PR-controlled validation code ではなく trusted-ref follow-up lane に限定してください。
 
 Design Systems統合、アクセシビリティ確保、パフォーマンス最適化、品質ゲートを通じて、**Production Ready**なフロントエンド成果物を提供します。
 

--- a/tests/unit/ci/phase6-validation-workflow-security.test.ts
+++ b/tests/unit/ci/phase6-validation-workflow-security.test.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+type WorkflowDocument = {
+  permissions?: Record<string, string>;
+};
+
+const workflowPath = path.resolve(process.cwd(), '.github/workflows/phase6-validation.yml');
+const rawWorkflow = () => fs.readFileSync(workflowPath, 'utf8');
+const parseWorkflow = () => yaml.load(rawWorkflow()) as WorkflowDocument;
+
+describe('phase6 validation workflow security', () => {
+  it('runs pull_request validation with read-only permissions', () => {
+    expect(parseWorkflow().permissions).toEqual({ contents: 'read' });
+  });
+
+  it('does not expose the Lighthouse CI app token to checked-out PR code', () => {
+    const workflow = rawWorkflow();
+
+    expect(workflow).not.toContain('LHCI_GITHUB_APP_TOKEN');
+    expect(workflow).not.toContain('secrets.LHCI_GITHUB_APP_TOKEN');
+    expect(workflow).toContain('lhci autorun --config=./configs/lighthouserc.cjs');
+  });
+
+  it('disables persisted checkout credentials in all Phase 6 jobs', () => {
+    const workflow = rawWorkflow();
+    const checkoutCount = (workflow.match(/uses: actions\/checkout@v4/g) ?? []).length;
+    const persistFalseCount = (workflow.match(/persist-credentials: false/g) ?? []).length;
+
+    expect(checkoutCount).toBeGreaterThan(0);
+    expect(persistFalseCount).toBe(checkoutCount);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3381.

- Remove `LHCI_GITHUB_APP_TOKEN` from the `pull_request` Phase 6 Lighthouse CI step.
- Add explicit read-only workflow permissions and disable persisted checkout credentials across Phase 6 validation jobs.
- Add workflow regression coverage for the no-secret Lighthouse PR boundary.
- Document that token-backed Lighthouse upload/status posting belongs in a trusted-ref follow-up lane, not PR-controlled validation.

## Acceptance

- Phase 6 pull-request validation has `permissions: contents: read`.
- All `actions/checkout@v4` steps set `persist-credentials: false`.
- `LHCI_GITHUB_APP_TOKEN` / `secrets.LHCI_GITHUB_APP_TOKEN` do not appear in `.github/workflows/phase6-validation.yml`.

## Local verification

- `pnpm -s exec vitest run tests/unit/ci/phase6-validation-workflow-security.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet tests/unit/ci/phase6-validation-workflow-security.test.ts`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run types:check`
- `pnpm -s run check:schemas`
- `git diff --check`

Note: local `pnpm -s run lint:actions` is blocked in this environment by rootless Podman user-namespace re-exec failure (`exit=125`); GitHub Actions actionlint is expected to provide workflow lint evidence.

## Rollback

Revert this PR to restore the previous Phase 6 Lighthouse token exposure behavior.