### PR TITLE
fix(ci): constrain runtime self-heal trace bundles

### DIFF
--- a/.github/workflows/runtime-conformance-self-heal.yml
+++ b/.github/workflows/runtime-conformance-self-heal.yml
@@ -31,8 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   actions: read
 
 jobs:
@@ -44,9 +43,23 @@ jobs:
         || vars.AE_RUNTIME_CONFORMANCE_SELF_HEAL_ENABLED == '1'
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      status: ${{ steps.pipeline.outputs.status || 'error' }}
+      reason: ${{ steps.pipeline.outputs.reason || '' }}
+      ingest_mode: ${{ steps.pipeline.outputs.ingest_mode || '' }}
+      apply_fixes: ${{ steps.config.outputs.apply_fixes || 'false' }}
+      dry_run: ${{ steps.config.outputs.dry_run || 'true' }}
+      patch_created: ${{ steps.patch.outputs.created || 'false' }}
+      patch_artifact: ${{ steps.patch.outputs.artifact_name || '' }}
+      violation_count: ${{ steps.pipeline.outputs.violation_count || '0' }}
+      failure_count: ${{ steps.pipeline.outputs.failure_count || '0' }}
     env:
       AE_RUNTIME_CONFORMANCE_TRACE_INPUT: ${{ vars.AE_RUNTIME_CONFORMANCE_TRACE_INPUT || '' }}
       AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE: ${{ vars.AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE || '' }}
+      AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE_DIR: ${{ vars.AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE_DIR || 'artifacts/observability/runtime-self-heal-inputs' }}
       AE_RUNTIME_CONFORMANCE_RULES: ${{ vars.AE_RUNTIME_CONFORMANCE_RULES || '' }}
       AE_RUNTIME_CONFORMANCE_APPLY_FIXES: ${{ vars.AE_RUNTIME_CONFORMANCE_APPLY_FIXES || '' }}
       AE_RUNTIME_CONFORMANCE_DRY_RUN: ${{ vars.AE_RUNTIME_CONFORMANCE_DRY_RUN || '' }}
@@ -57,6 +70,8 @@ jobs:
       DISPATCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || '' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -82,8 +97,18 @@ jobs:
             esac
           }
 
+          reject_output_control_chars() {
+            local name="$1"
+            local value="${2:-}"
+            if [[ "${value}" == *$'\n'* || "${value}" == *$'\r'* || "${value}" == *$'\t'* ]]; then
+              echo "::error::${name} must not contain control characters" >&2
+              exit 1
+            fi
+          }
+
           TRACE_INPUT="${DISPATCH_TRACE_INPUT:-${AE_RUNTIME_CONFORMANCE_TRACE_INPUT:-samples/conformance/sample-traces.json}}"
           TRACE_BUNDLE_INPUT="${DISPATCH_TRACE_BUNDLE:-${AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE:-}}"
+          TRACE_BUNDLE_INPUT_DIR="${AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE_DIR:-artifacts/observability/runtime-self-heal-inputs}"
           CONFORMANCE_RULES="${DISPATCH_CONFORMANCE_RULES:-${AE_RUNTIME_CONFORMANCE_RULES:-}}"
           APPLY_FIXES_RAW="${DISPATCH_APPLY_FIXES:-${AE_RUNTIME_CONFORMANCE_APPLY_FIXES:-false}}"
           DRY_RUN_RAW="${DISPATCH_DRY_RUN:-${AE_RUNTIME_CONFORMANCE_DRY_RUN:-true}}"
@@ -97,9 +122,15 @@ jobs:
           FAILURE_ARTIFACTS_PATH="artifacts/fix/runtime-self-heal-failures.json"
           FIX_OUTPUT_DIR=".ae/runtime-self-heal"
 
+          reject_output_control_chars "trace_input" "${TRACE_INPUT}"
+          reject_output_control_chars "trace_bundle_input" "${TRACE_BUNDLE_INPUT}"
+          reject_output_control_chars "trace_bundle_input_dir" "${TRACE_BUNDLE_INPUT_DIR}"
+          reject_output_control_chars "conformance_rules" "${CONFORMANCE_RULES}"
+
           {
             echo "trace_input=${TRACE_INPUT}"
             echo "trace_bundle_input=${TRACE_BUNDLE_INPUT}"
+            echo "trace_bundle_input_dir=${TRACE_BUNDLE_INPUT_DIR}"
             echo "conformance_rules=${CONFORMANCE_RULES}"
             echo "apply_fixes=${APPLY_FIXES}"
             echo "dry_run=${DRY_RUN}"
@@ -114,6 +145,7 @@ jobs:
             echo "## Runtime Conformance Self-Heal Config"
             echo "- trace_input: ${TRACE_INPUT}"
             echo "- trace_bundle_input: ${TRACE_BUNDLE_INPUT:-<none>}"
+            echo "- trace_bundle_input_dir: ${TRACE_BUNDLE_INPUT_DIR}"
             echo "- conformance_rules: ${CONFORMANCE_RULES:-<none>}"
             echo "- apply_fixes: ${APPLY_FIXES}"
             echo "- dry_run: ${DRY_RUN}"
@@ -124,6 +156,7 @@ jobs:
         env:
           TRACE_INPUT: ${{ steps.config.outputs.trace_input }}
           TRACE_BUNDLE_INPUT: ${{ steps.config.outputs.trace_bundle_input }}
+          TRACE_BUNDLE_INPUT_DIR: ${{ steps.config.outputs.trace_bundle_input_dir }}
           CONFORMANCE_RULES: ${{ steps.config.outputs.conformance_rules }}
           APPLY_FIXES: ${{ steps.config.outputs.apply_fixes }}
           DRY_RUN: ${{ steps.config.outputs.dry_run }}
@@ -141,13 +174,14 @@ jobs:
           INGEST_MODE=""
 
           if [ -n "${TRACE_BUNDLE_INPUT}" ]; then
-            if [ ! -f "${TRACE_BUNDLE_INPUT}" ]; then
-              STATUS="error"
-              REASON="trace_bundle not found: ${TRACE_BUNDLE_INPUT}"
-            else
-              mkdir -p "$(dirname "${TRACE_BUNDLE_PATH}")"
-              cp "${TRACE_BUNDLE_INPUT}" "${TRACE_BUNDLE_PATH}"
+            if node scripts/ci/validate-runtime-self-heal-trace-bundle.mjs \
+              --input "${TRACE_BUNDLE_INPUT}" \
+              --allowed-dir "${TRACE_BUNDLE_INPUT_DIR}" \
+              --output "${TRACE_BUNDLE_PATH}"; then
               INGEST_MODE="bundle-input"
+            else
+              STATUS="error"
+              REASON="trace_bundle validation failed"
             fi
           else
             if [ ! -f "${TRACE_INPUT}" ]; then
@@ -241,52 +275,50 @@ jobs:
             exit 1
           fi
 
-      - name: Create PR for auto-fix changes
-        id: pr
+      - name: Prepare auto-fix patch artifact
+        id: patch
         if: ${{ steps.pipeline.outputs.status == 'success' && steps.config.outputs.apply_fixes == 'true' && steps.config.outputs.dry_run == 'false' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
         shell: bash
         run: |
           set -euo pipefail
 
-          git add -A . ':(exclude)artifacts/**' ':(exclude).ae/**' ':(exclude)reports/**'
-          if git diff --cached --quiet; then
+          PATCH_PATH="artifacts/automation/runtime-conformance-self-heal.patch"
+          PATCH_ARTIFACT="runtime-conformance-self-heal-patch-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$(dirname "${PATCH_PATH}")"
+
+          git add -AN -- . ':(exclude)artifacts/**' ':(exclude).ae/**' ':(exclude)reports/**'
+
+          if git diff --quiet -- . ':(exclude)artifacts/**' ':(exclude).ae/**' ':(exclude)reports/**'; then
+            : > "${PATCH_PATH}"
             {
               echo "created=false"
-              echo "number="
-              echo "url="
+              echo "path=${PATCH_PATH}"
+              echo "artifact_name=${PATCH_ARTIFACT}"
             } >> "${GITHUB_OUTPUT}"
             {
-              echo "- auto-fix applied but no commit-ready changes were detected."
+              echo "- auto-fix applied but no patch-ready changes were detected."
             } >> "${GITHUB_STEP_SUMMARY}"
             exit 0
           fi
 
-          BRANCH="bot/runtime-conformance-self-heal-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "${BRANCH}"
-          git commit -m "chore(self-heal): runtime conformance auto-fix"
-          git push origin "${BRANCH}"
-
-          PR_JSON="$(gh pr create \
-            --base main \
-            --head "${BRANCH}" \
-            --title "chore(self-heal): runtime conformance auto-fix" \
-            --body "Automated runtime conformance self-heal pipeline output.\n\n- workflow: ${GITHUB_WORKFLOW}\n- run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\n- violations: ${{ steps.pipeline.outputs.violation_count }}\n- failure artifacts: ${{ steps.pipeline.outputs.failure_count }}\n\nRefs: #2287" \
-            --json number,url)"
-
-          PR_NUMBER="$(echo "${PR_JSON}" | jq -r '.number')"
-          PR_URL="$(echo "${PR_JSON}" | jq -r '.url')"
+          git diff --binary -- . ':(exclude)artifacts/**' ':(exclude).ae/**' ':(exclude)reports/**' > "${PATCH_PATH}"
 
           {
             echo "created=true"
-            echo "number=${PR_NUMBER}"
-            echo "url=${PR_URL}"
+            echo "path=${PATCH_PATH}"
+            echo "artifact_name=${PATCH_ARTIFACT}"
           } >> "${GITHUB_OUTPUT}"
 
-          echo "- auto-fix PR created: ${PR_URL}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "- auto-fix patch prepared for isolated PR creation." >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload auto-fix patch artifact
+        if: ${{ steps.patch.outputs.artifact_name != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.patch.outputs.artifact_name }}
+          path: ${{ steps.patch.outputs.path }}
+          if-no-files-found: error
+          retention-days: 1
 
       - name: Explain PR creation skip on non-default branch
         if: ${{ steps.pipeline.outputs.status == 'success' && steps.config.outputs.apply_fixes == 'true' && steps.config.outputs.dry_run == 'false' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
@@ -294,7 +326,16 @@ jobs:
           echo "- auto-fix PR creation skipped because workflow ref is not the default branch (${GITHUB_REF})." >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Emit automation report
-        if: always()
+        if: >-
+          ${{
+            always()
+            && (
+              steps.pipeline.outputs.status != 'success'
+              || steps.config.outputs.apply_fixes != 'true'
+              || steps.config.outputs.dry_run != 'false'
+              || github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+            )
+          }}
         env:
           AE_AUTOMATION_REPORT_FILE: artifacts/automation/runtime-conformance-self-heal-report.json
           PIPELINE_STATUS: ${{ steps.pipeline.outputs.status || 'error' }}
@@ -304,8 +345,8 @@ jobs:
           PIPELINE_FAILURE_COUNT: ${{ steps.pipeline.outputs.failure_count || '0' }}
           PIPELINE_APPLY_FIXES: ${{ steps.config.outputs.apply_fixes || 'false' }}
           PIPELINE_DRY_RUN: ${{ steps.config.outputs.dry_run || 'true' }}
-          PIPELINE_CREATED_PR: ${{ steps.pr.outputs.created || 'false' }}
-          PIPELINE_CREATED_PR_NUMBER: ${{ steps.pr.outputs.number || '' }}
+          PIPELINE_CREATED_PR: 'false'
+          PIPELINE_CREATED_PR_NUMBER: ''
         run: |
           node --input-type=module <<'NODE'
           import { emitAutomationReport } from './scripts/ci/lib/automation-report.mjs';
@@ -348,3 +389,141 @@ jobs:
             artifacts/automation/runtime-conformance-self-heal-report.json
             .ae/runtime-self-heal/**
           if-no-files-found: warn
+          retention-days: 7
+
+  create-pr:
+    needs: self-heal
+    if: ${{ needs.self-heal.outputs.status == 'success' && needs.self-heal.outputs.apply_fixes == 'true' && needs.self-heal.outputs.dry_run == 'false' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download auto-fix patch artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.self-heal.outputs.patch_artifact }}
+          path: artifacts/automation
+
+      - name: Create PR for auto-fix changes
+        id: pr
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          PATCH_CREATED: ${{ needs.self-heal.outputs.patch_created }}
+          PATCH_PATH: artifacts/automation/runtime-conformance-self-heal.patch
+          PIPELINE_VIOLATION_COUNT: ${{ needs.self-heal.outputs.violation_count }}
+          PIPELINE_FAILURE_COUNT: ${{ needs.self-heal.outputs.failure_count }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${PATCH_CREATED}" != "true" ] || [ ! -s "${PATCH_PATH}" ]; then
+            {
+              echo "created=false"
+              echo "number="
+              echo "url="
+            } >> "${GITHUB_OUTPUT}"
+            {
+              echo "- auto-fix applied but no commit-ready changes were detected."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          git apply --check --binary "${PATCH_PATH}"
+          git apply --binary "${PATCH_PATH}"
+
+          git add -A . ':(exclude)artifacts/**' ':(exclude).ae/**' ':(exclude)reports/**'
+          if git diff --cached --quiet; then
+            {
+              echo "created=false"
+              echo "number="
+              echo "url="
+            } >> "${GITHUB_OUTPUT}"
+            {
+              echo "- auto-fix patch applied but no commit-ready changes were detected."
+            } >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          BRANCH="bot/runtime-conformance-self-heal-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git commit -m "chore(self-heal): runtime conformance auto-fix"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin "${BRANCH}"
+
+          PR_JSON="$(gh pr create \
+            --base "${DEFAULT_BRANCH}" \
+            --head "${BRANCH}" \
+            --title "chore(self-heal): runtime conformance auto-fix" \
+            --body "Automated runtime conformance self-heal pipeline output.\n\n- workflow: ${GITHUB_WORKFLOW}\n- run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\n- violations: ${PIPELINE_VIOLATION_COUNT}\n- failure artifacts: ${PIPELINE_FAILURE_COUNT}\n\nRefs: #2287" \
+            --json number,url)"
+
+          PR_NUMBER="$(echo "${PR_JSON}" | jq -r '.number')"
+          PR_URL="$(echo "${PR_JSON}" | jq -r '.url')"
+
+          {
+            echo "created=true"
+            echo "number=${PR_NUMBER}"
+            echo "url=${PR_URL}"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "- auto-fix PR created: ${PR_URL}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Emit final automation report
+        if: always()
+        env:
+          AE_AUTOMATION_REPORT_FILE: artifacts/automation/runtime-conformance-self-heal-report.json
+          PIPELINE_STATUS: ${{ needs.self-heal.outputs.status || 'error' }}
+          PIPELINE_REASON: ${{ needs.self-heal.outputs.reason || '' }}
+          PIPELINE_INGEST_MODE: ${{ needs.self-heal.outputs.ingest_mode || '' }}
+          PIPELINE_VIOLATION_COUNT: ${{ needs.self-heal.outputs.violation_count || '0' }}
+          PIPELINE_FAILURE_COUNT: ${{ needs.self-heal.outputs.failure_count || '0' }}
+          PIPELINE_APPLY_FIXES: ${{ needs.self-heal.outputs.apply_fixes || 'false' }}
+          PIPELINE_DRY_RUN: ${{ needs.self-heal.outputs.dry_run || 'true' }}
+          PIPELINE_CREATED_PR: ${{ steps.pr.outputs.created || 'false' }}
+          PIPELINE_CREATED_PR_NUMBER: ${{ steps.pr.outputs.number || '' }}
+        run: |
+          node --input-type=module <<'NODE'
+          import { emitAutomationReport } from './scripts/ci/lib/automation-report.mjs';
+
+          const toInt = (value) => {
+            const parsed = Number.parseInt(String(value ?? ''), 10);
+            return Number.isFinite(parsed) ? parsed : 0;
+          };
+
+          const createdPrNumber = toInt(process.env.PIPELINE_CREATED_PR_NUMBER);
+          emitAutomationReport({
+            tool: 'runtime-conformance-self-heal',
+            mode: process.env.PIPELINE_DRY_RUN === 'true' ? 'dry-run' : 'apply',
+            status: process.env.PIPELINE_STATUS || 'error',
+            reason: process.env.PIPELINE_REASON || '',
+            prNumber: createdPrNumber > 0 ? createdPrNumber : undefined,
+            metrics: {
+              violations: toInt(process.env.PIPELINE_VIOLATION_COUNT),
+              failureArtifacts: toInt(process.env.PIPELINE_FAILURE_COUNT),
+              applyFixes: process.env.PIPELINE_APPLY_FIXES === 'true' ? 1 : 0,
+              dryRun: process.env.PIPELINE_DRY_RUN === 'true' ? 1 : 0,
+              createdPr: process.env.PIPELINE_CREATED_PR === 'true' ? 1 : 0,
+            },
+            data: {
+              ingestMode: process.env.PIPELINE_INGEST_MODE || '',
+            },
+          });
+          NODE
+
+      - name: Upload final automation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-conformance-self-heal-report-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/automation/runtime-conformance-self-heal-report.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/docs/operate/telemetry-as-context.md
+++ b/docs/operate/telemetry-as-context.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-03-23'
+lastVerified: '2026-06-02'
 owner: observability-ops
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -97,10 +97,12 @@ gh workflow run runtime-conformance-self-heal.yml   -f trace_input=samples/confo
 #### Main inputs
 
 - `trace_input`: NDJSON/JSON path used for ingest
-- `trace_bundle`: existing Trace Bundle path; skips ingest when supplied
+- `trace_bundle`: existing Trace Bundle path; skips ingest when supplied. The workflow accepts this path only under `AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE_DIR` (default: `artifacts/observability/runtime-self-heal-inputs`) and rejects absolute paths, parent traversal, `.git` metadata paths, symlinks, files outside the allowlist, and files that do not validate as `ae-trace-bundle/v1`.
 - `conformance_rules`: optional custom rules JSON
 - `apply_fixes`: run `ae fix apply` only when `true`
 - `dry_run`: run `ae fix apply --dry-run` when `true`
+
+The trace-processing job runs with read-only repository permissions. When `apply_fixes=true`, `dry_run=false`, and the workflow is running on the default branch, it writes a short-lived patch artifact and a separate `create-pr` job is the only job granted `contents: write` / `pull-requests: write` to apply that patch and open the auto-fix PR.
 
 #### Main outputs
 
@@ -113,6 +115,8 @@ gh workflow run runtime-conformance-self-heal.yml   -f trace_input=samples/confo
 ### 7. Security / PII handling
 
 - The CI self-heal workflow assumes that `trace_input` is already redacted upstream. When running `ae conformance ingest` manually, always pass `--redact` so sensitive fields such as email, tokens, or session identifiers are removed before ingest.
+- A supplied `trace_bundle` is validated and copied into the upload artifact set only after it passes the allowlisted-path and `ae-trace-bundle/v1` schema checks. Store dispatch-supplied bundles under `artifacts/observability/runtime-self-heal-inputs` unless `AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE_DIR` is deliberately changed.
+- Repository write credentials are isolated to the auto-fix PR creation job. The trace-processing job uses read-only `GITHUB_TOKEN` permissions, disables persisted checkout credentials, and rejects control characters in path-like values before writing step outputs.
 - When production data is involved, store the Trace Bundle in encrypted storage and do not paste raw events into the PR body.
 - During incident analysis, review `runtime-conformance-self-heal-report.json` and `runtime-self-heal-results.json` first, and only share the minimum necessary event excerpts.
 - `artifacts/ci/harness-health.json` aggregates the `runtimeConformance` gate. When the status is `fail` or `warn`, rerun with `run-trace` (legacy name: `run-conformance`) and only enable `autopilot:on` when continuous operation is justified.
@@ -202,10 +206,12 @@ gh workflow run runtime-conformance-self-heal.yml \
 ### 主な入力
 
 - `trace_input`: ingest 元の NDJSON/JSON パス
-- `trace_bundle`: 既存 trace bundle パス（指定時は ingest を省略）
+- `trace_bundle`: 既存 trace bundle パス（指定時は ingest を省略）。workflow では `AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE_DIR`（既定: `artifacts/observability/runtime-self-heal-inputs`）配下のみを許可し、絶対パス、親ディレクトリ遡り、`.git` metadata パス、symlink、allowlist 外ファイル、`ae-trace-bundle/v1` schema に合わないファイルを拒否する。
 - `conformance_rules`: 任意の custom rules JSON
 - `apply_fixes`: `true` の場合のみ `ae fix apply` を実行
 - `dry_run`: `true` の場合は `ae fix apply --dry-run`
+
+trace 処理 job は repository read-only 権限で実行する。`apply_fixes=true`、`dry_run=false`、かつ default branch 上で実行している場合のみ短期保持の patch artifact を作成し、その patch を適用して自動修正 PR を作成する `create-pr` job だけに `contents: write` / `pull-requests: write` を付与する。
 
 ### 出力
 
@@ -218,6 +224,8 @@ gh workflow run runtime-conformance-self-heal.yml \
 ## 7. セキュリティ / PII 運用
 
 - CI の self-heal workflow は `trace_input` が upstream 側で redaction 済みであることを前提とする。手動で `ae conformance ingest` を実行する場合は、`--redact` を必ず指定し、機微情報（例: email/token/sessionId）を除去する。
+- 指定された `trace_bundle` は allowlisted path と `ae-trace-bundle/v1` schema 検証に合格した場合のみ upload artifact set へコピーされる。dispatch で渡す bundle は、`AE_RUNTIME_CONFORMANCE_TRACE_BUNDLE_DIR` を意図的に変更しない限り `artifacts/observability/runtime-self-heal-inputs` 配下へ配置する。
+- repository write credential は自動修正 PR 作成 job に隔離する。trace 処理 job は read-only `GITHUB_TOKEN` 権限で実行し、checkout の persisted credential を無効化し、path 系の値を step output に書き出す前に制御文字を拒否する。
 - 本番データを扱う場合、trace bundle は暗号化ストレージへ保管し、PR本文へ生データを貼り付けない。
 - 失敗調査時は `runtime-conformance-self-heal-report.json` と `runtime-self-heal-results.json` を優先参照し、必要最小限の event 抜粋のみ共有する。
 - `artifacts/ci/harness-health.json` に `runtimeConformance` ゲートが集約されるため、fail/warn 時は `run-trace`（旧表記: `run-conformance`）で再実行し、継続運用時のみ `autopilot:on` を付与する。

--- a/scripts/ci/validate-runtime-self-heal-trace-bundle.mjs
+++ b/scripts/ci/validate-runtime-self-heal-trace-bundle.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const DEFAULT_ALLOWED_DIR = path.join('artifacts', 'observability', 'runtime-self-heal-inputs');
+const DEFAULT_OUTPUT = path.join('artifacts', 'observability', 'runtime-self-heal-trace-bundle.json');
+const TRACE_BUNDLE_SCHEMA = path.join('schema', 'trace-bundle.schema.json');
+
+const usage = () => {
+  process.stderr.write(`Usage: node scripts/ci/validate-runtime-self-heal-trace-bundle.mjs --input <path> [--allowed-dir <dir>] [--output <path>]\n`);
+};
+
+const parseArgs = (argv) => {
+  const options = {
+    allowedDir: DEFAULT_ALLOWED_DIR,
+    output: DEFAULT_OUTPUT,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === '--input' && next) {
+      options.input = next;
+      index += 1;
+    } else if (arg === '--allowed-dir' && next) {
+      options.allowedDir = next;
+      index += 1;
+    } else if (arg === '--output' && next) {
+      options.output = next;
+      index += 1;
+    } else if (arg === '--help') {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${arg}`);
+    }
+  }
+  if (!options.input) {
+    throw new Error('--input is required');
+  }
+  return options;
+};
+
+const pathSegments = (value) => value.split(/[\\/]+/u).filter(Boolean);
+
+const rejectUnsafeRelativePath = (name, value) => {
+  if (/[\u0000-\u001f\u007f]/u.test(value)) {
+    throw new Error(`${name} must not contain control characters`);
+  }
+  if (path.isAbsolute(value)) {
+    throw new Error(`${name} must be repository-relative`);
+  }
+  if (/^[a-zA-Z]:[\\/]/u.test(value) || value.startsWith('\\\\') || value.startsWith('//')) {
+    throw new Error(`${name} must be repository-relative`);
+  }
+  if (value.includes('\\')) {
+    throw new Error(`${name} must use POSIX-style separators`);
+  }
+  const segments = pathSegments(value);
+  if (segments.length === 0) {
+    throw new Error(`${name} must not be empty`);
+  }
+  for (const segment of segments) {
+    if (segment === '..') {
+      throw new Error(`${name} must not contain parent traversal`);
+    }
+    if (segment === '.git') {
+      throw new Error(`${name} must not reference repository metadata`);
+    }
+  }
+};
+
+const ensureUnder = (name, candidate, parent) => {
+  const relative = path.relative(parent, candidate);
+  if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+    return;
+  }
+  throw new Error(`${name} must be under ${path.relative(process.cwd(), parent) || parent}`);
+};
+
+const assertNoSymlinkInPath = (absolutePath, stopAt, name = 'trace_bundle') => {
+  const root = path.resolve(stopAt);
+  const target = path.resolve(absolutePath);
+  ensureUnder(name, target, root);
+  const rootStat = fs.lstatSync(root);
+  if (rootStat.isSymbolicLink()) {
+    throw new Error(`${name} must not traverse symlinks: ${path.relative(process.cwd(), root)}`);
+  }
+  const relative = path.relative(root, target);
+  let current = root;
+  for (const segment of pathSegments(relative)) {
+    current = path.join(current, segment);
+    const stat = fs.lstatSync(current);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`${name} must not traverse symlinks: ${path.relative(process.cwd(), current)}`);
+    }
+  }
+};
+
+const readJson = (file) => JSON.parse(fs.readFileSync(file, 'utf8'));
+
+const validateBundle = (repoRoot, inputPath) => {
+  const schema = readJson(path.join(repoRoot, TRACE_BUNDLE_SCHEMA));
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const validate = ajv.compile(schema);
+  const data = readJson(inputPath);
+  if (!validate(data)) {
+    const details = (validate.errors ?? [])
+      .slice(0, 5)
+      .map((error) => `${error.instancePath || '/'} ${error.message ?? ''}`.trim())
+      .join('; ');
+    throw new Error(`trace_bundle does not match ae-trace-bundle/v1 schema${details ? `: ${details}` : ''}`);
+  }
+};
+
+const main = () => {
+  const options = parseArgs(process.argv.slice(2));
+  const repoRoot = process.cwd();
+
+  rejectUnsafeRelativePath('allowed-dir', options.allowedDir);
+  rejectUnsafeRelativePath('input', options.input);
+  rejectUnsafeRelativePath('output', options.output);
+
+  const allowedDir = path.resolve(repoRoot, options.allowedDir);
+  const input = path.resolve(repoRoot, options.input);
+  const output = path.resolve(repoRoot, options.output);
+  const outputRoot = path.resolve(repoRoot, 'artifacts', 'observability');
+
+  ensureUnder('allowed-dir', allowedDir, repoRoot);
+  ensureUnder('input', input, allowedDir);
+  ensureUnder('output', output, outputRoot);
+
+  if (!fs.existsSync(input)) {
+    throw new Error(`trace_bundle not found: ${options.input}`);
+  }
+  assertNoSymlinkInPath(allowedDir, repoRoot, 'allowed-dir');
+  assertNoSymlinkInPath(input, allowedDir);
+  const stat = fs.statSync(input);
+  if (!stat.isFile()) {
+    throw new Error(`trace_bundle must be a regular file: ${options.input}`);
+  }
+
+  validateBundle(repoRoot, input);
+
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.copyFileSync(input, output);
+  process.stdout.write(`Validated runtime self-heal trace bundle: ${options.input} -> ${options.output}\n`);
+};
+
+try {
+  main();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`::error::${message}\n`);
+  process.exit(1);
+}

--- a/tests/unit/ci/runtime-conformance-self-heal-security.test.ts
+++ b/tests/unit/ci/runtime-conformance-self-heal-security.test.ts
@@ -1,0 +1,236 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import yaml from 'js-yaml';
+
+const repoRoot = process.cwd();
+const scriptPath = path.join(repoRoot, 'scripts/ci/validate-runtime-self-heal-trace-bundle.mjs');
+const workflowPath = path.join(repoRoot, '.github/workflows/runtime-conformance-self-heal.yml');
+
+const makeBundle = () => ({
+  schemaVersion: 'ae-trace-bundle/v1',
+  generatedAt: '2026-06-02T00:00:00.000Z',
+  source: {
+    environment: 'test',
+    service: 'runtime-self-heal',
+    input: {
+      path: 'samples/conformance/sample-traces.json',
+      format: 'json-events',
+    },
+    timeWindow: {
+      start: '2026-06-02T00:00:00.000Z',
+      end: '2026-06-02T00:00:01.000Z',
+    },
+  },
+  events: [
+    {
+      traceId: 'trace-1',
+      timestamp: '2026-06-02T00:00:00.000Z',
+      actor: 'tester',
+      event: 'request',
+    },
+  ],
+  grouping: {
+    by: 'traceId',
+    traceCount: 1,
+    traces: [
+      {
+        traceId: 'trace-1',
+        eventCount: 1,
+        firstTimestamp: '2026-06-02T00:00:00.000Z',
+        lastTimestamp: '2026-06-02T00:00:00.000Z',
+      },
+    ],
+  },
+  redaction: {
+    rules: [],
+    redactedFieldCount: 0,
+  },
+  summary: {
+    rawEventCount: 1,
+    validEventCount: 1,
+    invalidEventCount: 0,
+    sampledOutCount: 0,
+    emittedEventCount: 1,
+  },
+});
+
+const writeJson = (file: string, value: unknown) => {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+};
+
+const toRepoRelative = (absolutePath: string) => path.relative(repoRoot, absolutePath).split(path.sep).join('/');
+
+describe('runtime conformance self-heal trace bundle security', () => {
+  let sandbox: string;
+  let outputPath: string;
+
+  beforeEach(() => {
+    sandbox = path.join(repoRoot, '.codex-local', 'tmp', `runtime-self-heal-${process.pid}-${Date.now()}`);
+    outputPath = path.join(repoRoot, 'artifacts', 'observability', `runtime-self-heal-test-${process.pid}-${Date.now()}.json`);
+    fs.mkdirSync(sandbox, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+    fs.rmSync(outputPath, { force: true });
+  });
+
+  const runValidator = (input: string, allowedDir: string) => spawnSync(
+    process.execPath,
+    [
+      scriptPath,
+      '--input',
+      input,
+      '--allowed-dir',
+      allowedDir,
+      '--output',
+      toRepoRelative(outputPath),
+    ],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    },
+  );
+
+  it('copies only schema-valid trace bundles from the allowed input directory', () => {
+    const allowedDir = path.join(sandbox, 'allowed');
+    const bundlePath = path.join(allowedDir, 'bundle.json');
+    writeJson(bundlePath, makeBundle());
+
+    const result = runValidator(toRepoRelative(bundlePath), toRepoRelative(allowedDir));
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(outputPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(outputPath, 'utf8')).schemaVersion).toBe('ae-trace-bundle/v1');
+  });
+
+  it('rejects absolute paths, traversal, files outside the allowlist, symlinks, and invalid schemas', () => {
+    const allowedDir = path.join(sandbox, 'allowed');
+    const bundlePath = path.join(allowedDir, 'bundle.json');
+    writeJson(bundlePath, makeBundle());
+
+    const absolute = runValidator(bundlePath, toRepoRelative(allowedDir));
+    expect(absolute.status).not.toBe(0);
+    expect(absolute.stderr).toContain('repository-relative');
+
+    const traversal = runValidator(`${toRepoRelative(allowedDir)}/../allowed/bundle.json`, toRepoRelative(allowedDir));
+    expect(traversal.status).not.toBe(0);
+    expect(traversal.stderr).toContain('parent traversal');
+
+    const windowsDrive = runValidator('C:/runner/work/secret.json', toRepoRelative(allowedDir));
+    expect(windowsDrive.status).not.toBe(0);
+    expect(windowsDrive.stderr).toContain('repository-relative');
+
+    const backslash = runValidator(`${toRepoRelative(allowedDir)}\\bundle.json`, toRepoRelative(allowedDir));
+    expect(backslash.status).not.toBe(0);
+    expect(backslash.stderr).toContain('POSIX-style separators');
+
+    const controlChar = runValidator(`${toRepoRelative(allowedDir)}/bad\tname.json`, toRepoRelative(allowedDir));
+    expect(controlChar.status).not.toBe(0);
+    expect(controlChar.stderr).toContain('control characters');
+
+    const outsideDir = path.join(sandbox, 'outside');
+    const outsidePath = path.join(outsideDir, 'bundle.json');
+    writeJson(outsidePath, makeBundle());
+    const outside = runValidator(toRepoRelative(outsidePath), toRepoRelative(allowedDir));
+    expect(outside.status).not.toBe(0);
+    expect(outside.stderr).toContain('must be under');
+
+    const invalidPath = path.join(allowedDir, 'invalid.json');
+    writeJson(invalidPath, { schemaVersion: 'not-a-trace-bundle' });
+    const invalid = runValidator(toRepoRelative(invalidPath), toRepoRelative(allowedDir));
+    expect(invalid.status).not.toBe(0);
+    expect(invalid.stderr).toContain('ae-trace-bundle/v1 schema');
+
+    const symlinkPath = path.join(allowedDir, 'linked.json');
+    fs.symlinkSync(bundlePath, symlinkPath);
+    const symlink = runValidator(toRepoRelative(symlinkPath), toRepoRelative(allowedDir));
+    expect(symlink.status).not.toBe(0);
+    expect(symlink.stderr).toContain('must not traverse symlinks');
+
+    const symlinkRoot = path.join(sandbox, 'allowed-link');
+    fs.symlinkSync(allowedDir, symlinkRoot, 'dir');
+    const symlinkAllowlistRoot = runValidator(`${toRepoRelative(symlinkRoot)}/bundle.json`, toRepoRelative(symlinkRoot));
+    expect(symlinkAllowlistRoot.status).not.toBe(0);
+    expect(symlinkAllowlistRoot.stderr).toContain('allowed-dir must not traverse symlinks');
+  });
+
+  it('workflow validates trace_bundle before artifact upload and avoids persisted checkout credentials', () => {
+    const workflow = yaml.load(fs.readFileSync(workflowPath, 'utf8')) as any;
+    expect(workflow.permissions).toMatchObject({
+      contents: 'read',
+      actions: 'read',
+    });
+    expect(workflow.permissions).not.toHaveProperty('pull-requests');
+
+    const selfHeal = workflow.jobs?.['self-heal'];
+    expect(selfHeal?.permissions).toMatchObject({
+      contents: 'read',
+      actions: 'read',
+    });
+    expect(selfHeal?.permissions).not.toHaveProperty('pull-requests');
+
+    const steps = Array.isArray(selfHeal?.steps) ? selfHeal.steps : [];
+
+    const checkout = steps.find((step: any) => step?.uses === 'actions/checkout@v4');
+    expect(checkout?.with).toMatchObject({
+      'persist-credentials': false,
+    });
+
+    const configStep = steps.find((step: any) => step?.name === 'Resolve self-heal configuration');
+    expect(configStep?.run).toContain('TRACE_BUNDLE_INPUT_DIR=');
+    expect(configStep?.run).toContain('trace_bundle_input_dir=');
+    expect(configStep?.run).toContain('reject_output_control_chars');
+
+    const pipelineStep = steps.find((step: any) => step?.name === 'Run runtime conformance self-heal pipeline');
+    expect(pipelineStep?.run).toContain('scripts/ci/validate-runtime-self-heal-trace-bundle.mjs');
+    expect(pipelineStep?.run).toContain('--allowed-dir "${TRACE_BUNDLE_INPUT_DIR}"');
+    expect(pipelineStep?.run).not.toContain('cp "${TRACE_BUNDLE_INPUT}"');
+
+    const preparePatchStep = steps.find((step: any) => step?.name === 'Prepare auto-fix patch artifact');
+    expect(preparePatchStep?.run).toContain('git add -AN -- .');
+    expect(preparePatchStep?.run).toContain('git diff --binary');
+    expect(preparePatchStep?.run).toContain("':(exclude)artifacts/**'");
+
+    const uploadPatchStep = steps.find((step: any) => step?.name === 'Upload auto-fix patch artifact');
+    expect(uploadPatchStep?.uses).toBe('actions/upload-artifact@v4');
+    expect(uploadPatchStep?.with?.['retention-days']).toBe(1);
+
+    const createPrJob = workflow.jobs?.['create-pr'];
+    expect(createPrJob?.permissions).toMatchObject({
+      contents: 'write',
+      'pull-requests': 'write',
+      actions: 'read',
+    });
+
+    const createPrSteps = Array.isArray(createPrJob?.steps) ? createPrJob.steps : [];
+    const createPrCheckout = createPrSteps.find((step: any) => step?.uses === 'actions/checkout@v4');
+    expect(createPrCheckout?.with).toMatchObject({
+      'persist-credentials': false,
+    });
+
+    const downloadPatchStep = createPrSteps.find((step: any) => step?.name === 'Download auto-fix patch artifact');
+    expect(downloadPatchStep?.uses).toBe('actions/download-artifact@v4');
+
+    const createPrStep = createPrSteps.find((step: any) => step?.name === 'Create PR for auto-fix changes');
+    expect(createPrStep?.run).toContain('git apply --check --binary "${PATCH_PATH}"');
+    expect(createPrStep?.run).toContain('git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"');
+
+    const uploadStep = steps.find((step: any) => step?.name === 'Upload self-heal artifacts');
+    expect(uploadStep?.with?.['retention-days']).toBe(7);
+
+    const selfHealReportStep = steps.find((step: any) => step?.name === 'Emit automation report');
+    expect(selfHealReportStep?.if).toContain("steps.config.outputs.apply_fixes != 'true'");
+
+    const finalReportStep = createPrSteps.find((step: any) => step?.name === 'Emit final automation report');
+    expect(finalReportStep?.env?.PIPELINE_CREATED_PR).toContain('steps.pr.outputs.created');
+
+    const uploadFinalReportStep = createPrSteps.find((step: any) => step?.name === 'Upload final automation report');
+    expect(uploadFinalReportStep?.uses).toBe('actions/upload-artifact@v4');
+    expect(uploadFinalReportStep?.with?.path).toBe('artifacts/automation/runtime-conformance-self-heal-report.json');
+    expect(uploadFinalReportStep?.with?.['retention-days']).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

- Validate `runtime-conformance-self-heal.yml` `trace_bundle` inputs with a repository-relative allowlist before copying or uploading them.
- Reject absolute paths, parent traversal, repository metadata paths, symlink traversal, non-regular files, control-character paths, Windows-style paths, and invalid `ae-trace-bundle/v1` payloads.
- Run trace processing with read-only repository permissions and isolate write-scoped auto-fix PR creation into a separate `create-pr` job that applies a short-lived patch artifact.
- Disable persisted checkout credentials and document the new trace-bundle and token-boundary behavior.

## Acceptance

- Closes #3382.
- A caller-controlled `trace_bundle` cannot cause arbitrary readable workspace files to be copied into the uploaded self-heal artifact set.
- The trace-processing job no longer has repository write or pull-request write permissions.
- Auto-fix PR creation still works through an isolated write-scoped job when `apply_fixes=true`, `dry_run=false`, and the run is on the default branch.

## Verification

- `pnpm -s exec vitest run tests/unit/ci/runtime-conformance-self-heal-security.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet scripts/ci/validate-runtime-self-heal-trace-bundle.mjs tests/unit/ci/runtime-conformance-self-heal-security.test.ts`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:schemas`
- `pnpm -s run types:check`
- `git diff --check origin/main..HEAD`
- `pnpm -s run lint:actions` attempted locally but failed before lint execution because Podman rootless container startup returned `cannot re-exec process to join the existing user namespace` (exit 125); CI actionlint is expected to provide the authoritative workflow lint result.

## Rollback

- Revert this PR to restore the previous self-heal workflow behavior.
- If rollback is needed due to auto-fix PR creation regressions, keep `trace_bundle` dispatch use disabled until a replacement least-privilege path is deployed.
