### PR TITLE
fix(ci): enforce read-only PR validation boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,46 @@ jobs:
       pr_labels: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
       pr_number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
       pr_head_sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+  verify-summary-publisher:
+    name: "Verify Traceability Summary (publisher: pr)"
+    if: >-
+      ${{
+        always()
+        && github.event_name == 'pull_request'
+        && github.event.pull_request.base.ref == 'main'
+        && github.event.pull_request.head.repo.full_name == github.repository
+      }}
+    needs: [verify-entry]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download Verify summary
+        uses: actions/download-artifact@v4
+        with:
+          name: verify-pr-summary
+          path: artifacts_dl/verify-pr-summary
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('artifacts_dl/verify-pr-summary/pr-summary.md', 'utf8');
+            const issueNumber = context.payload.pull_request?.number || Number(process.env.PR_NUMBER || 0);
+            if (!issueNumber) {
+              return;
+            }
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body
+            });
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
   qa-entry:
     name: "QA Bench (entry: pr/push)"
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,8 +251,6 @@ jobs:
     if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
     uses: ./.github/workflows/verify.yml
     secrets: inherit
     with:

--- a/.github/workflows/fail-fast-spec-validation.yml
+++ b/.github/workflows/fail-fast-spec-validation.yml
@@ -10,6 +10,10 @@ concurrency:
   group: fail-fast-spec-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   NODE_VERSION: '20'
   PNPM_VERSION: '10'
@@ -24,6 +28,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           # Only fetch files needed for spec validation
           sparse-checkout: |
             spec

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -7,11 +7,20 @@ concurrency:
   group: spec-check-${{ github.event.pull_request.number || github.ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   tla:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:

--- a/.github/workflows/spec-generate-model.yml
+++ b/.github/workflows/spec-generate-model.yml
@@ -22,18 +22,20 @@ concurrency:
 permissions:
   contents: read
   actions: read
-  checks: write
-  pull-requests: write
-  issues: write
 
 jobs:
   generate-artifacts:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     env:
       AE_HOST_STORE: ${{ github.workspace }}/.pnpm-store
       PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -88,67 +90,19 @@ jobs:
             echo '## Generate Artifacts Summary' >> "$GITHUB_STEP_SUMMARY"
             echo 'No diff summary produced.' >> "$GITHUB_STEP_SUMMARY"
           fi
-      - name: Comment diff on PR
-        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = 'artifacts/hermetic-reports/spec/generate-artifacts-diff.json';
-            const summary = fs.existsSync(path) ? JSON.parse(fs.readFileSync(path, 'utf8')) : null;
-            const lines = [];
-            lines.push('### Generate Artifacts Preview');
-            if (!summary) {
-              lines.push('No diff summary generated.');
-            } else {
-              lines.push(`Generated at: ${summary.generatedAt}`);
-              for (const target of summary.targets || []) {
-                const status = target.hasChanges ? 'CHANGED' : 'clean';
-                lines.push(`- ${target.path}: ${status}`);
-                if (target.hasChanges && target.files) {
-                  const sample = target.files.slice(0, 10);
-                  for (const file of sample) {
-                    lines.push(`  - ${file.status} ${file.file}`);
-                  }
-                  if (target.files.length > sample.length) {
-                    lines.push(`  - … (${target.files.length - sample.length} more)`);
-                  }
-                }
-              }
-            }
-            const body = lines.join("\n");
-            const { data: existing } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-            const marker = '<!-- generate-artifacts-preview -->';
-            const decoratedBody = [body, marker].join("\n\n");
-            const previous = existing.find((c) => c.user.login === 'github-actions[bot]' && c.body.includes(marker));
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body: decoratedBody
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: decoratedBody
-              });
-            }
-
   model-based-tests:
     runs-on: ubuntu-latest
     needs: generate-artifacts
+    permissions:
+      contents: read
+      actions: read
     env:
       AE_HOST_STORE: ${{ github.workspace }}/.pnpm-store
       PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -200,6 +154,9 @@ jobs:
   trace-conformance:
     runs-on: ubuntu-latest
     needs: model-based-tests
+    permissions:
+      contents: read
+      actions: read
     env:
       AE_HOST_STORE: ${{ github.workspace }}/.pnpm-store
       PNPM_STORE_PATH: ${{ github.workspace }}/.pnpm-store
@@ -208,6 +165,8 @@ jobs:
       KVONCE_OTLP_PAYLOAD_URL: ${{ github.event.inputs.kvonce_otlp_payload_url || '' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -431,8 +390,94 @@ jobs:
             artifacts/hermetic-reports/trace/ndjson/kvonce-validation.json
             artifacts/automation/kvonce-trace-validation-report.json
           if-no-files-found: warn
+  publish-generate-artifacts-preview:
+    if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    needs: generate-artifacts
+    permissions:
+      actions: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download diff summary
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: generate-artifacts-diff
+          path: artifacts/hermetic-reports/spec
+      - name: Comment diff on PR
+        if: ${{ steps.download.outcome == 'success' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'artifacts/hermetic-reports/spec/generate-artifacts-diff.json';
+            const summary = fs.existsSync(path) ? JSON.parse(fs.readFileSync(path, 'utf8')) : null;
+            const lines = [];
+            lines.push('### Generate Artifacts Preview');
+            if (!summary) {
+              lines.push('No diff summary generated.');
+            } else {
+              lines.push(`Generated at: ${summary.generatedAt}`);
+              for (const target of summary.targets || []) {
+                const status = target.hasChanges ? 'CHANGED' : 'clean';
+                lines.push(`- ${target.path}: ${status}`);
+                if (target.hasChanges && target.files) {
+                  const sample = target.files.slice(0, 10);
+                  for (const file of sample) {
+                    lines.push(`  - ${file.status} ${file.file}`);
+                  }
+                  if (target.files.length > sample.length) {
+                    lines.push(`  - … (${target.files.length - sample.length} more)`);
+                  }
+                }
+              }
+            }
+            const body = lines.join("\n");
+            const { data: existing } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const marker = '<!-- generate-artifacts-preview -->';
+            const decoratedBody = [body, marker].join("\n\n");
+            const previous = existing.find((c) => c.user.login === 'github-actions[bot]' && c.body.includes(marker));
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body: decoratedBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: decoratedBody
+              });
+            }
+
+  publish-trace-summary:
+    if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    needs: trace-conformance
+    permissions:
+      actions: read
+      checks: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download trace artifacts
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: kvonce-trace-results
+          path: artifacts
       - name: Update PR with trace summary
-        if: github.event_name == 'pull_request'
+        if: ${{ steps.download.outcome == 'success' }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -440,19 +485,18 @@ jobs:
             const path = require('path');
             const marker = '<!-- kvonce-trace-summary -->';
             const cases = [
-              { key: 'OTLP', dir: 'artifacts/hermetic-reports/trace/otlp' },
-              { key: 'NDJSON', dir: 'artifacts/hermetic-reports/trace/ndjson' },
+              { key: 'OTLP', file: 'artifacts/hermetic-reports/trace/otlp/kvonce-validation.json' },
+              { key: 'NDJSON', file: 'artifacts/hermetic-reports/trace/ndjson/kvonce-validation.json' },
             ];
 
             let body = `${marker}\n### KvOnce Trace Validation`;
 
             for (const item of cases) {
-              const reportPath = path.join(process.cwd(), item.dir, 'kvonce-validation.json');
-              if (!fs.existsSync(reportPath)) {
+              if (!fs.existsSync(item.file)) {
                 body += `\n- ${item.key}: ⚠️ validation file missing`;
                 continue;
               }
-              const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+              const report = JSON.parse(fs.readFileSync(item.file, 'utf8'));
               const issues = Array.isArray(report.issues) ? report.issues : [];
               const renderedIssues = issues.slice(0, 10).map((issue) => {
                 const key = issue.key ?? 'unknown';
@@ -479,16 +523,13 @@ jobs:
             }
 
       - name: Publish trace validation check
-        if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ always() }}
         uses: actions/github-script@v7
         env:
-          TRACE_JOB_STATUS: ${{ job.status }}
-          VALID_OTLP: ${{ steps.trace_summary.outputs.valid_otlp }}
-          VALID_NDJSON: ${{ steps.trace_summary.outputs.valid_ndjson }}
-          ISSUES_OTLP: ${{ steps.trace_summary.outputs.issues_otlp }}
-          ISSUES_NDJSON: ${{ steps.trace_summary.outputs.issues_ndjson }}
+          TRACE_JOB_RESULT: ${{ needs.trace-conformance.result }}
         with:
           script: |
+            const fs = require('fs');
             const { owner, repo } = context.repo;
             const headSha = context.payload.pull_request?.head?.sha;
             if (!headSha) {
@@ -496,25 +537,31 @@ jobs:
               return;
             }
 
-            const validOtlp = process.env.VALID_OTLP || 'missing';
-            const validNdjson = process.env.VALID_NDJSON || 'missing';
-            const issuesOtlp = process.env.ISSUES_OTLP || 'N/A';
-            const issuesNdjson = process.env.ISSUES_NDJSON || 'N/A';
+            const readReport = (file) => {
+              if (!fs.existsSync(file)) {
+                return { valid: 'missing', issues: 'N/A' };
+              }
+              const report = JSON.parse(fs.readFileSync(file, 'utf8'));
+              const issues = Array.isArray(report.issues) ? report.issues.length : 0;
+              return { valid: String(report.valid), issues: String(issues) };
+            };
 
-            const traceJobStatus = (process.env.TRACE_JOB_STATUS || '').toLowerCase();
+            const otlp = readReport('artifacts/hermetic-reports/trace/otlp/kvonce-validation.json');
+            const ndjson = readReport('artifacts/hermetic-reports/trace/ndjson/kvonce-validation.json');
+            const traceJobResult = (process.env.TRACE_JOB_RESULT || '').toLowerCase();
 
             let conclusion = 'success';
-            if (traceJobStatus && traceJobStatus !== 'success') {
+            if (traceJobResult && traceJobResult !== 'success') {
               conclusion = 'failure';
-            } else if (validOtlp === 'false' || validNdjson === 'false') {
+            } else if (otlp.valid === 'false' || ndjson.valid === 'false') {
               conclusion = 'failure';
-            } else if (validOtlp === 'missing' && validNdjson === 'missing') {
+            } else if (otlp.valid === 'missing' && ndjson.valid === 'missing') {
               conclusion = 'neutral';
             }
 
             const summaryLines = [
-              `OTLP: ${validOtlp} (issues: ${issuesOtlp})`,
-              `NDJSON: ${validNdjson} (issues: ${issuesNdjson})`,
+              `OTLP: ${otlp.valid} (issues: ${otlp.issues})`,
+              `NDJSON: ${ndjson.valid} (issues: ${ndjson.issues})`,
             ];
 
             const checkName = 'KvOnce Trace Validation';

--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -45,18 +45,24 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
+  actions: read
 
 jobs:
   fail-fast-spec:
     name: Fail-Fast Spec Validation
     if: github.event_name != 'push' || github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/fail-fast-spec-validation.yml
 
   spec-check:
     name: Spec Check
     needs: fail-fast-spec
     if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && needs.fail-fast-spec.result != 'failure'
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/spec-check.yml
 
   spec-validation:
@@ -64,9 +70,14 @@ jobs:
     if: always() && needs.fail-fast-spec.result != 'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -231,23 +242,6 @@ jobs:
             artifacts/domain/replay-fixtures.sample.json
           retention-days: 30
       
-      - name: Post PR comment (upsert)
-        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.check-spec.outputs.spec_exists == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const header = '<!-- AE-SPEC-VALIDATION -->\n';
-            const body = header + (fs.existsSync('spec-validation-report.md') ? fs.readFileSync('spec-validation-report.md','utf-8') : 'No report');
-            const { owner, repo, number } = context.issue;
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
-            const mine = comments.data.find(c => c.body && c.body.startsWith(header));
-            if (mine) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
-            }
-      
       - name: Skip validation (no spec file)
         if: steps.check-spec.outputs.spec_exists == 'false'
         run: |
@@ -258,6 +252,47 @@ jobs:
   validate-artifacts:
     needs: fail-fast-spec
     if: always() && needs.fail-fast-spec.result != 'failure' && github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/validate-artifacts-ajv.yml
     with:
       strict: ${{ contains(github.event.pull_request.labels.*.name, 'enforce-artifacts') }}
+
+  post-spec-validation-comment:
+    needs: spec-validation
+    if: ${{ always() && github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && needs.spec-validation.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download validation artifacts
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: spec-validation-artifacts-${{ github.run_id }}
+          path: artifacts/spec-validation
+      - name: Post PR comment (upsert)
+        if: ${{ steps.download.outcome == 'success' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = 'artifacts/spec-validation/spec-validation-report.md';
+            if (!fs.existsSync(reportPath)) {
+              core.info('spec-validation-report.md not found; skipping comment publication.');
+              return;
+            }
+            const header = '<!-- AE-SPEC-VALIDATION -->\n';
+            const body = header + fs.readFileSync(reportPath, 'utf-8');
+            const { owner, repo, number } = context.issue;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
+            const mine = comments.data.find(c => c.body && c.body.startsWith(header));
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: number, body });
+            }

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -142,15 +142,13 @@ jobs:
           path: |
             artifacts/codex/model-check.json
             artifacts/codex/*.tlc.log.txt
-  post-summary:
-    if: ${{ github.event_name == 'pull_request' }}
+  build-summary:
+    if: ${{ github.event_name == 'pull_request' || inputs.trigger == 'pull_request' }}
     runs-on: ubuntu-latest
     needs: [traceability, model-check, contracts-check, contracts-exec]
     permissions:
       contents: read
       actions: read
-      issues: write
-      pull-requests: write
     continue-on-error: >-
       ${{
         (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking'))
@@ -291,12 +289,37 @@ jobs:
             fi
           } > pr-summary.md
           cat pr-summary.md
+      - name: Upload PR summary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-pr-summary
+          path: pr-summary.md
+  post-summary:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs: [build-summary]
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+      pull-requests: write
+    continue-on-error: >-
+      ${{
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking'))
+        || (inputs.trigger == 'pull_request' && contains(inputs.pr_labels, 'ci-non-blocking'))
+      }}
+    steps:
+      - name: Download PR summary
+        uses: actions/download-artifact@v4
+        with:
+          name: verify-pr-summary
+          path: artifacts_dl/verify-pr-summary
       - name: Post PR comment
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('pr-summary.md', 'utf8');
+            const body = fs.readFileSync('artifacts_dl/verify-pr-summary/pr-summary.md', 'utf8');
             const issueNumber = context.payload.pull_request?.number || Number(process.env.PR_NUMBER || 0);
             if (!issueNumber) {
               return;

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -50,9 +50,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   traceability:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     continue-on-error: >-
       ${{
         (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking'))
@@ -60,6 +67,8 @@ jobs:
       }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Generate traceability matrix
         run: |
           chmod +x ./scripts/verify/traceability.sh
@@ -83,6 +92,9 @@ jobs:
           fi
   model-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     continue-on-error: >-
       ${{
         (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking'))
@@ -90,6 +102,8 @@ jobs:
       }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -115,7 +129,7 @@ jobs:
       - name: Run model checks (TLA+)
         env:
           ALLOY_JAR: ${{ github.workspace }}/.cache/tools/alloy.jar
-          ALLOY_RUN_CMD: java -jar $ALLOY_JAR exec -q -o - -f {file}
+          ALLOY_CMD_JSON: '["exec","-q","-o","-","-f","{file}"]'
           JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
         run: |
           node --version
@@ -129,16 +143,20 @@ jobs:
             artifacts/codex/model-check.json
             artifacts/codex/*.tlc.log.txt
   post-summary:
-    if: ${{ github.event_name == 'pull_request' || inputs.trigger == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     needs: [traceability, model-check, contracts-check, contracts-exec]
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+      pull-requests: write
     continue-on-error: >-
       ${{
         (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-non-blocking'))
         || (inputs.trigger == 'pull_request' && contains(inputs.pr_labels, 'ci-non-blocking'))
       }}
     steps:
-      - uses: actions/checkout@v4
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -293,8 +311,13 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
   contracts-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run contracts presence check (report-only)
         run: |
           node scripts/verify/run-contracts-check.mjs
@@ -311,8 +334,13 @@ jobs:
   contracts-exec:
     if: ${{ github.event_name == 'pull_request' || inputs.trigger == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Determine enforcement from labels
         if: >-
           ${{
@@ -350,6 +378,9 @@ jobs:
   formal-enforce:
     if: ${{ github.event_name == 'pull_request' || inputs.trigger == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     needs: [model-check]
     steps:
       - name: Determine enforcement from labels
@@ -379,9 +410,14 @@ jobs:
   formal-conformance-optin:
     if: ${{ github.event_name == 'pull_request' || inputs.trigger == 'pull_request' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Determine if run-formal label is present
         if: >-
           ${{

--- a/scripts/verify/run-model-checks.mjs
+++ b/scripts/verify/run-model-checks.mjs
@@ -8,7 +8,6 @@ const outDir = path.join(repoRoot, 'artifacts', 'codex');
 const toolsDir = path.join(repoRoot, '.cache', 'tools');
 const tlaJar = path.join(toolsDir, 'tla2tools.jar');
 const alloyJar = process.env.ALLOY_JAR || path.join(toolsDir, 'alloy.jar');
-const alloyRunCmd = process.env.ALLOY_RUN_CMD || null; // e.g. 'java -jar $ALLOY_JAR -f {file}'
 
 async function ensureDir(dir) {
   await fs.mkdir(dir, { recursive: true });
@@ -63,6 +62,38 @@ async function download(url, dest) {
     const curl = spawn('curl', ['-L', '-sS', url, '-o', dest], { stdio: 'inherit' });
     curl.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`curl exit ${code}`))));
   });
+}
+
+function parseAlloyArgTemplate() {
+  const jsonTemplate = (process.env.ALLOY_CMD_JSON || '').trim();
+  const rawTemplate = (process.env.ALLOY_CMD_ARGS || '').trim();
+  if (jsonTemplate) {
+    try {
+      const parsed = JSON.parse(jsonTemplate);
+      if (!Array.isArray(parsed)) {
+        console.warn(`[run-model-checks] Warning: ALLOY_CMD_JSON is valid JSON but not an array. Value: ${jsonTemplate}`);
+      } else {
+        return parsed.map(String);
+      }
+    } catch (err) {
+      console.warn(`[run-model-checks] Warning: Invalid JSON in ALLOY_CMD_JSON: ${jsonTemplate}`);
+      console.warn(`[run-model-checks] Error: ${err?.message ?? String(err)}`);
+    }
+    console.warn('[run-model-checks] Falling back to ALLOY_CMD_ARGS or default argv template.');
+  }
+  if (rawTemplate) {
+    return rawTemplate.split(/\s+/u).filter(Boolean);
+  }
+  return ['exec', '-q', '-o', '-', '-f', '{file}'];
+}
+
+function buildAlloyJavaArgs(file) {
+  const template = parseAlloyArgTemplate();
+  const rendered = template.map((arg) => (arg === '{file}' ? file : arg));
+  if (!template.includes('{file}')) {
+    rendered.push(file);
+  }
+  return ['-jar', alloyJar, ...rendered];
 }
 
 async function resolveTlaConfig(modulePath) {
@@ -160,88 +191,21 @@ async function main() {
   if (alsFiles.length === 0) {
     summary.alloy.skipped.push('No .als found');
   } else {
-    // Optional execution via ALLOY_RUN_CMD (with {file} placeholder)
+    if (process.env.ALLOY_RUN_CMD) {
+      console.warn('[run-model-checks] Warning: ALLOY_RUN_CMD shell templates are ignored. Use ALLOY_CMD_JSON/ALLOY_CMD_ARGS for argv-safe Alloy arguments.');
+    }
     let haveJar = false;
     try { await fs.stat(alloyJar); haveJar = true; } catch {}
-    if (!alloyRunCmd) {
-      // Safe default: if ALLOY_JAR is available, run `java -jar $ALLOY_JAR {file}`
-      if (haveJar) {
-        const timeoutMs = parseInt(process.env.ALLOY_TIMEOUT_MS || '', 10) || (3 * 60 * 1000);
-        for (const f of alsFiles) {
-          const name = path.basename(f, '.als');
-          const logPath = path.join(outDir, `${name}.alloy.log.txt`);
-          try {
-            await ensureDir(outDir);
-            const res = await new Promise((resolve) => {
-              const args = ['-jar', alloyJar, f];
-              const addArgsJson = (process.env.ALLOY_CMD_JSON || '').trim();
-              const addArgs = (process.env.ALLOY_CMD_ARGS || '').trim();
-              if (addArgsJson) {
-                try {
-                  const arr = JSON.parse(addArgsJson);
-                  if (Array.isArray(arr)) {
-                    args.push(...arr.map(String));
-                  } else {
-                    console.warn(`[run-model-checks] Warning: ALLOY_CMD_JSON is valid JSON but not an array. Value: ${addArgsJson}`);
-                    console.warn('[run-model-checks] Falling back to ALLOY_CMD_ARGS or no extra arguments.');
-                    if (addArgs) args.push(...addArgs.split(/\s+/));
-                  }
-                } catch (err) {
-                  console.warn(`[run-model-checks] Warning: Invalid JSON in ALLOY_CMD_JSON: ${addArgsJson}`);
-                  console.warn(`[run-model-checks] Error: ${err?.message ?? String(err)}`);
-                  console.warn('[run-model-checks] Falling back to ALLOY_CMD_ARGS or no extra arguments.');
-                  if (addArgs) args.push(...addArgs.split(/\s+/));
-                }
-              } else if (addArgs) {
-                // Fallback: simple whitespace split (avoid quotes/escaping); prefer ALLOY_CMD_JSON
-                args.push(...addArgs.split(/\s+/));
-              }
-              const sh = spawn('java', args, { cwd: repoRoot });
-              let out = ''; let err = '';
-              let terminated = false;
-              const timer = setTimeout(() => {
-                if (!terminated && sh.exitCode === null) {
-                  sh.kill('SIGTERM');
-                  setTimeout(() => { if (!terminated && sh.exitCode === null) sh.kill('SIGKILL'); }, 10 * 1000);
-                }
-              }, timeoutMs);
-              sh.stdout.on('data', d => out += d.toString());
-              sh.stderr.on('data', d => err += d.toString());
-              sh.on('exit', async (code, signal) => {
-                terminated = true;
-                clearTimeout(timer);
-                await fs.writeFile(logPath, out + (err ? `\n[stderr]\n${err}` : ''), 'utf8');
-                const timeout = code === null && signal === 'SIGKILL';
-                let failRegex;
-                try {
-                  failRegex = new RegExp(process.env.ALLOY_FAIL_REGEX || 'Exception|ERROR|FAILED|Counterexample|assertion', 'i');
-                } catch (reErr) {
-                  console.warn(`[run-model-checks] Warning: Invalid ALLOY_FAIL_REGEX '${process.env.ALLOY_FAIL_REGEX}'. Using default.`);
-                  failRegex = /Exception|ERROR|FAILED|Counterexample|assertion/i;
-                }
-                const okHeuristic = code === 0 && !timeout && !failRegex.test(out + err);
-                resolve({ ok: okHeuristic, code, signal, timeout, log: path.relative(repoRoot, logPath) });
-              });
-            });
-            summary.alloy.results.push({ file: path.relative(repoRoot, f), ok: res.ok, code: res.code, signal: res.signal, timeout: res.timeout, log: res.log });
-          } catch (e) {
-            summary.alloy.errors.push({ file: path.relative(repoRoot, f), error: String(e) });
-          }
-        }
-      } else {
-        summary.alloy.skipped.push('No ALLOY_RUN_CMD; detection only.');
-        for (const f of alsFiles) summary.alloy.results.push({ file: path.relative(repoRoot, f), ok: null });
-      }
-    } else {
+    if (haveJar) {
+      const timeoutMs = parseInt(process.env.ALLOY_TIMEOUT_MS || '', 10) || (3 * 60 * 1000);
       for (const f of alsFiles) {
         const name = path.basename(f, '.als');
         const logPath = path.join(outDir, `${name}.alloy.log.txt`);
-        const cmd = alloyRunCmd.replace('{file}', f).replace('$ALLOY_JAR', alloyJar);
         try {
           await ensureDir(outDir);
           const res = await new Promise((resolve) => {
-            const timeoutMs = parseInt(process.env.ALLOY_TIMEOUT_MS || '', 10) || (3 * 60 * 1000);
-            const sh = spawn(cmd, { shell: true, cwd: repoRoot });
+            const args = buildAlloyJavaArgs(f);
+            const sh = spawn('java', args, { cwd: repoRoot });
             let out = ''; let err = '';
             let terminated = false;
             const timer = setTimeout(() => {
@@ -257,7 +221,15 @@ async function main() {
               clearTimeout(timer);
               await fs.writeFile(logPath, out + (err ? `\n[stderr]\n${err}` : ''), 'utf8');
               const timeout = code === null && signal === 'SIGKILL';
-              resolve({ ok: code === 0 && !timeout, code, signal, timeout, log: path.relative(repoRoot, logPath) });
+              let failRegex;
+              try {
+                failRegex = new RegExp(process.env.ALLOY_FAIL_REGEX || 'Exception|ERROR|FAILED|Counterexample|assertion', 'i');
+              } catch {
+                console.warn(`[run-model-checks] Warning: Invalid ALLOY_FAIL_REGEX '${process.env.ALLOY_FAIL_REGEX}'. Using default.`);
+                failRegex = /Exception|ERROR|FAILED|Counterexample|assertion/i;
+              }
+              const okHeuristic = code === 0 && !timeout && !failRegex.test(out + err);
+              resolve({ ok: okHeuristic, code, signal, timeout, log: path.relative(repoRoot, logPath) });
             });
           });
           summary.alloy.results.push({ file: path.relative(repoRoot, f), ok: res.ok, code: res.code, signal: res.signal, timeout: res.timeout, log: res.log });
@@ -265,6 +237,9 @@ async function main() {
           summary.alloy.errors.push({ file: path.relative(repoRoot, f), error: String(e) });
         }
       }
+    } else {
+      summary.alloy.skipped.push('No Alloy jar available; detection only.');
+      for (const f of alsFiles) summary.alloy.results.push({ file: path.relative(repoRoot, f), ok: null });
     }
   }
   await ensureDir(outDir);

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -570,3 +570,115 @@ describe('workflow permission boundaries', () => {
     expect(run).not.toContain('$DT_BASE_URL/api/v1/bom');
   });
 });
+
+const jobSteps = (workflow: WorkflowDocument, jobName: string) => {
+  const steps = workflow.jobs?.[jobName]?.steps;
+  if (!Array.isArray(steps)) {
+    throw new Error(`steps not found for ${jobName}`);
+  }
+  return steps;
+};
+
+const expectCheckoutCredentialsDisabled = (steps: any[]) => {
+  const checkouts = steps.filter((step) => step?.uses === 'actions/checkout@v4');
+  expect(checkouts.length).toBeGreaterThan(0);
+  for (const checkout of checkouts) {
+    expect(checkout.with).toMatchObject({ 'persist-credentials': false });
+  }
+};
+
+const expectReadOnlyJobPermissions = (workflow: WorkflowDocument, jobName: string) => {
+  expect(workflow.jobs?.[jobName]?.permissions).toMatchObject({
+    contents: 'read',
+    actions: 'read',
+  });
+  expect(workflow.jobs?.[jobName]?.permissions).not.toHaveProperty('issues');
+  expect(workflow.jobs?.[jobName]?.permissions).not.toHaveProperty('pull-requests');
+  expect(workflow.jobs?.[jobName]?.permissions).not.toHaveProperty('checks');
+};
+
+describe('CI workflow read-only PR validation boundaries', () => {
+  it('Verify Traceability uses argv-safe Alloy arguments and read-only validation jobs', () => {
+    const ci = parseWorkflow('ci.yml');
+    expect(ci.jobs?.['verify-entry']?.permissions).toEqual({ contents: 'read' });
+
+    const workflow = parseWorkflow('verify.yml');
+    const raw = readWorkflow('verify.yml');
+    expect(workflow.permissions).toMatchObject({ contents: 'read', actions: 'read' });
+    expect(raw).not.toContain('ALLOY_RUN_CMD');
+    expect(raw).toContain('ALLOY_CMD_JSON');
+
+    for (const jobName of ['traceability', 'model-check', 'contracts-check', 'contracts-exec', 'formal-conformance-optin']) {
+      expectReadOnlyJobPermissions(workflow, jobName);
+      expectCheckoutCredentialsDisabled(jobSteps(workflow, jobName));
+    }
+
+    const postSummary = workflow.jobs?.['post-summary'];
+    expect(postSummary?.permissions).toMatchObject({
+      actions: 'read',
+      issues: 'write',
+      'pull-requests': 'write',
+    });
+    expect(jobSteps(workflow, 'post-summary').some((step) => step?.uses === 'actions/checkout@v4')).toBe(false);
+  });
+
+  it('Spec Validation keeps PR validation read-only and publishes comments from a separate job', () => {
+    const workflow = parseWorkflow('spec-validation.yml');
+    expect(workflow.permissions).toMatchObject({ contents: 'read', actions: 'read' });
+    expect(workflow.permissions).not.toHaveProperty('pull-requests');
+
+    expect(workflow.jobs?.['fail-fast-spec']?.permissions).toMatchObject({ contents: 'read', actions: 'read' });
+    expect(workflow.jobs?.['spec-check']?.permissions).toMatchObject({ contents: 'read', actions: 'read' });
+    expectReadOnlyJobPermissions(workflow, 'spec-validation');
+    expectCheckoutCredentialsDisabled(jobSteps(workflow, 'spec-validation'));
+    expect(jobSteps(workflow, 'spec-validation').some((step) => step?.uses === 'actions/github-script@v7')).toBe(false);
+
+    const postJob = workflow.jobs?.['post-spec-validation-comment'];
+    expect(postJob?.permissions).toMatchObject({
+      actions: 'read',
+      issues: 'write',
+      'pull-requests': 'write',
+    });
+    expect(jobSteps(workflow, 'post-spec-validation-comment').some((step) => step?.uses === 'actions/checkout@v4')).toBe(false);
+
+    const failFast = parseWorkflow('fail-fast-spec-validation.yml');
+    expect(failFast.permissions).toMatchObject({ contents: 'read', actions: 'read' });
+    expectCheckoutCredentialsDisabled(jobSteps(failFast, 'fail-fast-validation'));
+
+    const specCheck = parseWorkflow('spec-check.yml');
+    expect(specCheck.permissions).toMatchObject({ contents: 'read', actions: 'read' });
+    expectReadOnlyJobPermissions(specCheck, 'tla');
+    expectCheckoutCredentialsDisabled(jobSteps(specCheck, 'tla'));
+  });
+
+  it('Spec Generate and Model PR validation jobs are read-only and publication jobs do not checkout PR content', () => {
+    const workflow = parseWorkflow('spec-generate-model.yml');
+    expect(workflow.permissions).toMatchObject({ contents: 'read', actions: 'read' });
+    expect(workflow.permissions).not.toHaveProperty('checks');
+    expect(workflow.permissions).not.toHaveProperty('issues');
+    expect(workflow.permissions).not.toHaveProperty('pull-requests');
+
+    for (const jobName of ['generate-artifacts', 'model-based-tests', 'trace-conformance']) {
+      expectReadOnlyJobPermissions(workflow, jobName);
+      expectCheckoutCredentialsDisabled(jobSteps(workflow, jobName));
+      expect(jobSteps(workflow, jobName).some((step) => step?.uses === 'actions/github-script@v7')).toBe(false);
+    }
+
+    const preview = workflow.jobs?.['publish-generate-artifacts-preview'];
+    expect(preview?.permissions).toMatchObject({
+      actions: 'read',
+      issues: 'write',
+      'pull-requests': 'write',
+    });
+    expect(jobSteps(workflow, 'publish-generate-artifacts-preview').some((step) => step?.uses === 'actions/checkout@v4')).toBe(false);
+
+    const trace = workflow.jobs?.['publish-trace-summary'];
+    expect(trace?.permissions).toMatchObject({
+      actions: 'read',
+      checks: 'write',
+      issues: 'write',
+      'pull-requests': 'write',
+    });
+    expect(jobSteps(workflow, 'publish-trace-summary').some((step) => step?.uses === 'actions/checkout@v4')).toBe(false);
+  });
+});

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -602,6 +602,15 @@ describe('CI workflow read-only PR validation boundaries', () => {
     const ci = parseWorkflow('ci.yml');
     expect(ci.jobs?.['verify-entry']?.permissions).toEqual({ contents: 'read' });
 
+    const verifyPublisher = ci.jobs?.['verify-summary-publisher'];
+    expect(verifyPublisher?.needs).toEqual(['verify-entry']);
+    expect(verifyPublisher?.permissions).toMatchObject({
+      actions: 'read',
+      issues: 'write',
+      'pull-requests': 'write',
+    });
+    expect(jobSteps(ci, 'verify-summary-publisher').some((step) => step?.uses === 'actions/checkout@v4')).toBe(false);
+
     const workflow = parseWorkflow('verify.yml');
     const raw = readWorkflow('verify.yml');
     expect(workflow.permissions).toMatchObject({ contents: 'read', actions: 'read' });
@@ -613,7 +622,12 @@ describe('CI workflow read-only PR validation boundaries', () => {
       expectCheckoutCredentialsDisabled(jobSteps(workflow, jobName));
     }
 
+    expectReadOnlyJobPermissions(workflow, 'build-summary');
+    expect(jobSteps(workflow, 'build-summary').some((step) => step?.uses === 'actions/checkout@v4')).toBe(false);
+    expect(jobSteps(workflow, 'build-summary').some((step) => step?.uses === 'actions/github-script@v7')).toBe(false);
+
     const postSummary = workflow.jobs?.['post-summary'];
+    expect(postSummary?.needs).toEqual(['build-summary']);
     expect(postSummary?.permissions).toMatchObject({
       actions: 'read',
       issues: 'write',

--- a/tests/unit/formal/run-model-checks-security.test.ts
+++ b/tests/unit/formal/run-model-checks-security.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const scriptPath = resolve('scripts/verify/run-model-checks.mjs');
+const tmpRoot = resolve('.codex-local/tmp');
+
+const makeRepo = () => {
+  mkdirSync(tmpRoot, { recursive: true });
+  const dir = mkdtempSync(join(tmpRoot, 'run-model-checks-security-'));
+  mkdirSync(join(dir, 'spec', 'formal'), { recursive: true });
+  writeFileSync(join(dir, 'spec', 'formal', 'safe;name.als'), 'sig A {}\n', 'utf8');
+  return dir;
+};
+
+const makeFakeJava = (dir: string) => {
+  const bin = join(dir, 'bin');
+  mkdirSync(bin, { recursive: true });
+  const log = join(dir, 'java-argv.json');
+  const java = join(bin, 'java');
+  writeFileSync(java, `#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.writeFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(2)));\nconsole.log('fake alloy ok');\n`, { mode: 0o755 });
+  return { bin, log };
+};
+
+describe('run-model-checks Alloy execution security', () => {
+  it('ignores ALLOY_RUN_CMD shell templates and passes Alloy file paths as argv', () => {
+    const dir = makeRepo();
+    const marker = join(dir, 'shell-marker');
+    const alloyJar = join(dir, '.cache', 'tools', 'alloy.jar');
+    mkdirSync(dirname(alloyJar), { recursive: true });
+    writeFileSync(alloyJar, 'fake jar', 'utf8');
+    const fakeJava = makeFakeJava(dir);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ALLOY_JAR: alloyJar,
+        ALLOY_RUN_CMD: `node -e "require('fs').writeFileSync('${marker}', 'executed')"`,
+        ALLOY_CMD_JSON: '["exec","-q","-o","-","-f","{file}"]',
+        PATH: `${fakeJava.bin}:${process.env.PATH ?? ''}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(marker)).toBe(false);
+    expect(result.stderr + result.stdout).toContain('ALLOY_RUN_CMD shell templates are ignored');
+    const argv = JSON.parse(readFileSync(fakeJava.log, 'utf8')) as string[];
+    expect(argv.slice(0, 6)).toEqual(['-jar', alloyJar, 'exec', '-q', '-o', '-']);
+    expect(argv[6]).toBe('-f');
+    expect(argv[7]).toBe(join(dir, 'spec', 'formal', 'safe;name.als'));
+
+    const summary = JSON.parse(readFileSync(join(dir, 'artifacts', 'codex', 'model-check.json'), 'utf8'));
+    expect(summary.alloy.results[0].ok).toBe(true);
+  });
+});

--- a/tests/unit/formal/run-model-checks-security.test.ts
+++ b/tests/unit/formal/run-model-checks-security.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, resolve, dirname } from 'node:path';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { delimiter, dirname, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const scriptPath = resolve('scripts/verify/run-model-checks.mjs');
@@ -19,40 +19,53 @@ const makeFakeJava = (dir: string) => {
   mkdirSync(bin, { recursive: true });
   const log = join(dir, 'java-argv.json');
   const java = join(bin, 'java');
-  writeFileSync(java, `#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.writeFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(2)));\nconsole.log('fake alloy ok');\n`, { mode: 0o755 });
+  const javaHelper = join(bin, 'java-helper.cjs');
+  writeFileSync(
+    javaHelper,
+    `const fs = require('node:fs');\nfs.writeFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(2)));\nconsole.log('fake alloy ok');\n`,
+    { mode: 0o755 },
+  );
+  writeFileSync(java, `#!/bin/sh\nexec "${process.execPath}" "${javaHelper}" "$@"\n`, { mode: 0o755 });
+  writeFileSync(join(bin, 'java.cmd'), `@echo off\r\n"${process.execPath}" "${javaHelper}" %*\r\n`, {
+    mode: 0o755,
+  });
   return { bin, log };
 };
 
 describe('run-model-checks Alloy execution security', () => {
   it('ignores ALLOY_RUN_CMD shell templates and passes Alloy file paths as argv', () => {
     const dir = makeRepo();
-    const marker = join(dir, 'shell-marker');
-    const alloyJar = join(dir, '.cache', 'tools', 'alloy.jar');
-    mkdirSync(dirname(alloyJar), { recursive: true });
-    writeFileSync(alloyJar, 'fake jar', 'utf8');
-    const fakeJava = makeFakeJava(dir);
+    try {
+      const marker = join(dir, 'shell-marker');
+      const alloyJar = join(dir, '.cache', 'tools', 'alloy.jar');
+      mkdirSync(dirname(alloyJar), { recursive: true });
+      writeFileSync(alloyJar, 'fake jar', 'utf8');
+      const fakeJava = makeFakeJava(dir);
 
-    const result = spawnSync(process.execPath, [scriptPath], {
-      cwd: dir,
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        ALLOY_JAR: alloyJar,
-        ALLOY_RUN_CMD: `node -e "require('fs').writeFileSync('${marker}', 'executed')"`,
-        ALLOY_CMD_JSON: '["exec","-q","-o","-","-f","{file}"]',
-        PATH: `${fakeJava.bin}:${process.env.PATH ?? ''}`,
-      },
-    });
+      const result = spawnSync(process.execPath, [scriptPath], {
+        cwd: dir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ALLOY_JAR: alloyJar,
+          ALLOY_RUN_CMD: `node -e "require('fs').writeFileSync('${marker}', 'executed')"`,
+          ALLOY_CMD_JSON: '["exec","-q","-o","-","-f","{file}"]',
+          PATH: [fakeJava.bin, process.env.PATH ?? ''].filter(Boolean).join(delimiter),
+        },
+      });
 
-    expect(result.status).toBe(0);
-    expect(existsSync(marker)).toBe(false);
-    expect(result.stderr + result.stdout).toContain('ALLOY_RUN_CMD shell templates are ignored');
-    const argv = JSON.parse(readFileSync(fakeJava.log, 'utf8')) as string[];
-    expect(argv.slice(0, 6)).toEqual(['-jar', alloyJar, 'exec', '-q', '-o', '-']);
-    expect(argv[6]).toBe('-f');
-    expect(argv[7]).toBe(join(dir, 'spec', 'formal', 'safe;name.als'));
+      expect(result.status).toBe(0);
+      expect(existsSync(marker)).toBe(false);
+      expect(result.stderr + result.stdout).toContain('ALLOY_RUN_CMD shell templates are ignored');
+      const argv = JSON.parse(readFileSync(fakeJava.log, 'utf8')) as string[];
+      expect(argv.slice(0, 6)).toEqual(['-jar', alloyJar, 'exec', '-q', '-o', '-']);
+      expect(argv[6]).toBe('-f');
+      expect(argv[7]).toBe(join(dir, 'spec', 'formal', 'safe;name.als'));
 
-    const summary = JSON.parse(readFileSync(join(dir, 'artifacts', 'codex', 'model-check.json'), 'utf8'));
-    expect(summary.alloy.results[0].ok).toBe(true);
+      const summary = JSON.parse(readFileSync(join(dir, 'artifacts', 'codex', 'model-check.json'), 'utf8'));
+      expect(summary.alloy.results[0].ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replace Verify Traceability Alloy shell-template execution with argv-safe Alloy jar arguments.
- Keep Verify Traceability validation jobs read-only with checkout credentials disabled; PR comment publication no longer checks out PR content.
- Keep Spec Validation / Spec Check PR validation read-only with checkout credentials disabled; move spec-validation PR comment publication to a separate artifact-consuming job.
- Keep Spec Generate & Model PR validation jobs read-only with checkout credentials disabled; move Generate Artifacts and KvOnce trace PR comment/check publication to separate artifact-consuming jobs.

## Acceptance

- Closes #3387.
- Closes #3388.
- Closes #3389.
- PR-controlled Alloy file paths are passed as argv, not interpolated into a shell command.
- PR validation jobs that run checked-out local actions/package scripts do not have `issues`, `pull-requests`, or `checks` write permissions and use `persist-credentials: false`.
- GitHub write operations are isolated into jobs that do not checkout PR content and only consume uploaded artifacts.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm -s exec vitest run tests/unit/formal/run-model-checks-security.test.ts tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet scripts/verify/run-model-checks.mjs tests/unit/formal/run-model-checks-security.test.ts tests/unit/ci/workflow-permission-boundary.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run check:schemas`
- `git diff --check`
- `pnpm -s run lint:actions` attempted locally but failed before lint execution because Podman rootless container startup returned `cannot re-exec process to join the existing user namespace` (exit 125); CI workflow lint is the authoritative actionlint result.

## Rollback

- Revert this PR to restore the previous workflow publication placement and Alloy runner behavior.
- If rollback is needed because a publication job regresses, keep the read-only validation changes and reintroduce publication through a trusted, checkout-free follow-up job.
