### PR TITLE
fix(ci): require verify-lite assurance provenance

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
@@ -108,6 +110,7 @@ jobs:
           AE_POLICY_ASSURANCE_MODE_CONFIG: ${{ vars.AE_POLICY_ASSURANCE_MODE || '' }}
         with:
           script: |
+            const crypto = require('crypto');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = Number(process.env.PR_NUMBER || 0);
@@ -156,7 +159,51 @@ jobs:
               return;
             }
 
+            async function exportTrustedDigest(envName, path) {
+              try {
+                const response = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path,
+                  ref: pr.base.sha,
+                });
+                const content = response.data;
+                if (Array.isArray(content) || content.type !== 'file' || typeof content.content !== 'string') {
+                  core.warning(`Trusted provenance digest skipped for ${path}: content is not a file`);
+                  return;
+                }
+                const encoding = content.encoding === 'base64' ? 'base64' : 'utf8';
+                const digest = crypto
+                  .createHash('sha256')
+                  .update(Buffer.from(content.content, encoding))
+                  .digest('hex');
+                core.exportVariable(envName, digest);
+              } catch (error) {
+                core.warning(`Trusted provenance digest skipped for ${path}: ${error instanceof Error ? error.message : String(error)}`);
+              }
+            }
+
             core.setOutput('verify_lite_run_id', String(run.id));
+            core.exportVariable('AE_VERIFY_LITE_RUN_ID', String(run.id));
+            core.exportVariable('AE_VERIFY_LITE_RUN_ATTEMPT', String(run.run_attempt || ''));
+            core.exportVariable('AE_VERIFY_LITE_HEAD_SHA', pr.head.sha);
+            core.exportVariable('AE_VERIFY_LITE_WORKFLOW_NAME', run.name || 'Verify Lite');
+            core.exportVariable('AE_VERIFY_LITE_EVENT_NAME', run.event || 'pull_request');
+            core.exportVariable('AE_VERIFY_LITE_CONCLUSION', run.conclusion || '');
+            core.exportVariable('AE_VERIFY_LITE_REPOSITORY', `${owner}/${repo}`);
+            core.exportVariable('AE_VERIFY_LITE_TRUSTED_REF', pr.base.sha);
+            await exportTrustedDigest(
+              'AE_VERIFY_LITE_TRUSTED_GENERATOR_SHA256',
+              'scripts/assurance/build-claim-evidence-manifest.mjs',
+            );
+            await exportTrustedDigest(
+              'AE_VERIFY_LITE_TRUSTED_SCHEMA_SHA256',
+              'schema/claim-evidence-manifest.schema.json',
+            );
+            await exportTrustedDigest(
+              'AE_VERIFY_LITE_TRUSTED_CONTRACT_SHA256',
+              'scripts/ci/lib/claim-evidence-manifest-contract.mjs',
+            );
             if (labelStrict && !explicitMode) {
               core.exportVariable('AE_POLICY_ASSURANCE_MODE', 'strict');
             }
@@ -166,7 +213,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: verify-lite-report
-          path: .
+          path: artifacts
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
           run-id: ${{ steps.assurance-policy.outputs.verify_lite_run_id }}

--- a/.github/workflows/verify-lite.yml
+++ b/.github/workflows/verify-lite.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       # Intentional: run before docs-only detection to fail fast on root pollution
       # regardless of PR change scope.
       - name: Enforce root layout policy
@@ -316,6 +317,12 @@ jobs:
             fi
           done
           pnpm -s run claim-evidence:generate "${args[@]}"
+      - name: Write claim evidence provenance (report-only)
+        if: ${{ steps.docs-only.outputs.docs_only != 'true' && always() }}
+        continue-on-error: true
+        env:
+          VERIFY_LITE_PR_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/ci/write-verify-lite-assurance-provenance.mjs
       - name: Enforce assurance summary (strict; label-gated)
         if: ${{ steps.docs-only.outputs.docs_only != 'true' && github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-assurance') }}
         run: |
@@ -404,6 +411,7 @@ jobs:
             artifacts/assurance/assurance-summary.md
             artifacts/assurance/claim-evidence-manifest.json
             artifacts/assurance/claim-evidence-manifest.md
+            artifacts/assurance/claim-evidence-provenance.json
             artifacts/quality/quality-scorecard.json
             artifacts/quality/quality-scorecard.md
             artifacts/discovery-pack/discovery-pack-validate-report.json

--- a/fixtures/assurance-e2e/inventory-waiver/expected/change-package-v2.json
+++ b/fixtures/assurance-e2e/inventory-waiver/expected/change-package-v2.json
@@ -214,7 +214,10 @@
     "mode": "report-only",
     "enforced": false,
     "reason": "Policy decision assurance result is waived.",
-    "warnings": [],
+    "warnings": [
+      "provenance: claim evidence provenance not found: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json",
+      "provenance: claim evidence provenance missing: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json"
+    ],
     "errors": []
   },
   "releaseControls": {

--- a/fixtures/assurance-e2e/inventory-waiver/expected/policy-decision-js-v1.json
+++ b/fixtures/assurance-e2e/inventory-waiver/expected/policy-decision-js-v1.json
@@ -13,7 +13,10 @@
   "evaluation": {
     "ok": true,
     "errors": [],
-    "warnings": [],
+    "warnings": [
+      "assurance: provenance: claim evidence provenance not found: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json",
+      "assurance: provenance: claim evidence provenance missing: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json"
+    ],
     "inferredRisk": {
       "level": "risk:low",
       "labels": {
@@ -66,7 +69,14 @@
         "path": "artifacts/assurance-e2e/inventory-waiver/claim-evidence-manifest.json",
         "present": true,
         "schemaVersion": "claim-evidence-manifest/v1",
-        "generatedAt": "2026-05-06T00:00:00.000Z"
+        "generatedAt": "2026-05-06T00:00:00.000Z",
+        "provenance": {
+          "path": "artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json",
+          "present": false,
+          "trusted": false,
+          "schemaVersion": null,
+          "generatedAt": null
+        }
       },
       "summary": {
         "totalClaims": 3,
@@ -138,7 +148,10 @@
           "claimId": "manual-fraud-review"
         }
       ],
-      "warnings": [],
+      "warnings": [
+        "provenance: claim evidence provenance not found: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json",
+        "provenance: claim evidence provenance missing: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json"
+      ],
       "errors": []
     }
   }

--- a/fixtures/assurance-e2e/inventory-waiver/expected/policy-gate-summary.json
+++ b/fixtures/assurance-e2e/inventory-waiver/expected/policy-gate-summary.json
@@ -11,7 +11,10 @@
   "evaluation": {
     "ok": true,
     "errors": [],
-    "warnings": [],
+    "warnings": [
+      "assurance: provenance: claim evidence provenance not found: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json",
+      "assurance: provenance: claim evidence provenance missing: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json"
+    ],
     "inferredRisk": {
       "level": "risk:low",
       "labels": {
@@ -64,7 +67,14 @@
         "path": "artifacts/assurance-e2e/inventory-waiver/claim-evidence-manifest.json",
         "present": true,
         "schemaVersion": "claim-evidence-manifest/v1",
-        "generatedAt": "2026-05-06T00:00:00.000Z"
+        "generatedAt": "2026-05-06T00:00:00.000Z",
+        "provenance": {
+          "path": "artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json",
+          "present": false,
+          "trusted": false,
+          "schemaVersion": null,
+          "generatedAt": null
+        }
       },
       "summary": {
         "totalClaims": 3,
@@ -136,7 +146,10 @@
           "claimId": "manual-fraud-review"
         }
       ],
-      "warnings": [],
+      "warnings": [
+        "provenance: claim evidence provenance not found: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json",
+        "provenance: claim evidence provenance missing: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json"
+      ],
       "errors": []
     }
   }

--- a/fixtures/assurance-e2e/inventory-waiver/expected/policy-gate-summary.md
+++ b/fixtures/assurance-e2e/inventory-waiver/expected/policy-gate-summary.md
@@ -14,4 +14,7 @@
     - id=change-package-v2:waiver:0:manual-fraud-review, claim=manual-fraud-review, status=active, owner=@team-risk, expires=2099-12-31, reason=Manual fraud review is active while automated model validation evidence is being collected.
 - required checks:
   - verify-lite: success
+- warnings:
+  - assurance: provenance: claim evidence provenance not found: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json
+  - assurance: provenance: claim evidence provenance missing: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json
 

--- a/fixtures/assurance-e2e/inventory-waiver/expected/policy-input-v1.json
+++ b/fixtures/assurance-e2e/inventory-waiver/expected/policy-input-v1.json
@@ -308,6 +308,23 @@
         "waivers": []
       }
     ],
+    "provenance": {
+      "path": "artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json",
+      "present": false,
+      "trusted": false,
+      "schemaVersion": null,
+      "generatedAt": null,
+      "workflow": null,
+      "source": null,
+      "artifact": null,
+      "generator": null,
+      "warnings": [
+        "claim evidence provenance not found: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json"
+      ],
+      "errors": [
+        "claim evidence provenance missing: artifacts/assurance-e2e/inventory-waiver/claim-evidence-provenance.json"
+      ]
+    },
     "warnings": [],
     "errors": []
   }

--- a/schema/policy-decision-v1.schema.json
+++ b/schema/policy-decision-v1.schema.json
@@ -462,6 +462,45 @@
                 "null"
               ],
               "format": "date-time"
+            },
+            "provenance": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true,
+              "required": [
+                "path",
+                "present",
+                "trusted",
+                "schemaVersion",
+                "generatedAt"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "present": {
+                  "type": "boolean"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "schemaVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "generatedAt": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                }
+              }
             }
           }
         },

--- a/schema/policy-gate-summary-v1.schema.json
+++ b/schema/policy-gate-summary-v1.schema.json
@@ -369,6 +369,45 @@
                 "null"
               ],
               "format": "date-time"
+            },
+            "provenance": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true,
+              "required": [
+                "path",
+                "present",
+                "trusted",
+                "schemaVersion",
+                "generatedAt"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "present": {
+                  "type": "boolean"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "schemaVersion": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "generatedAt": {
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "format": "date-time"
+                }
+              }
             }
           }
         },

--- a/schema/policy-input-v1.schema.json
+++ b/schema/policy-input-v1.schema.json
@@ -464,6 +464,45 @@
           ],
           "format": "date-time"
         },
+        "provenance": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "required": [
+            "path",
+            "present",
+            "trusted",
+            "schemaVersion",
+            "generatedAt"
+          ],
+          "properties": {
+            "path": {
+              "type": "string",
+              "minLength": 1
+            },
+            "present": {
+              "type": "boolean"
+            },
+            "trusted": {
+              "type": "boolean"
+            },
+            "schemaVersion": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "generatedAt": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time"
+            }
+          }
+        },
         "summary": {
           "type": "object",
           "additionalProperties": false,

--- a/scripts/assurance/run-e2e-scenario.mjs
+++ b/scripts/assurance/run-e2e-scenario.mjs
@@ -286,6 +286,16 @@ function buildPolicyArtifacts({ scenarioName, generatedAt, manifestPath, outputD
   const policy = loadRiskPolicy('policy/risk-policy.yml');
   const assurance = inspectClaimEvidenceManifest(manifestPath, generatedAt);
   assurance.path = canonical.claimEvidenceManifest;
+  if (assurance.provenance) {
+    const originalProvenancePath = assurance.provenance.path;
+    const canonicalProvenancePath = `${path.posix.dirname(canonical.claimEvidenceManifest)}/claim-evidence-provenance.json`;
+    const normalizeProvenancePath = (message) => String(message).split(originalProvenancePath).join(canonicalProvenancePath);
+    assurance.provenance.path = canonicalProvenancePath;
+    assurance.provenance.warnings = (Array.isArray(assurance.provenance.warnings) ? assurance.provenance.warnings : [])
+      .map(normalizeProvenancePath);
+    assurance.provenance.errors = (Array.isArray(assurance.provenance.errors) ? assurance.provenance.errors : [])
+      .map(normalizeProvenancePath);
+  }
   const pullRequest = {
     labels: [{ name: 'risk:low' }],
     body: '## Acceptance\nFixture scenario reproduces verify-lite, assurance summary, claim evidence manifest, and policy decision artifacts.\n\n## Rollback\nRevert the fixture scenario, runner, and expected golden artifacts.',

--- a/scripts/ci/policy-gate.mjs
+++ b/scripts/ci/policy-gate.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
@@ -33,7 +34,9 @@ const SUMMARY_CONTRACT_ID = 'policy-gate-summary.v1';
 const POLICY_INPUT_PATH = 'artifacts/ci/policy-input-v1.json';
 const POLICY_DECISION_PATH = 'artifacts/ci/policy-decision-js-v1.json';
 const CLAIM_EVIDENCE_MANIFEST_PATH = 'artifacts/assurance/claim-evidence-manifest.json';
+const CLAIM_EVIDENCE_PROVENANCE_PATH = 'artifacts/assurance/claim-evidence-provenance.json';
 const CLAIM_LEVEL_SUMMARY_PATH = 'artifacts/assurance/claim-level-summary.json';
+const CLAIM_EVIDENCE_PROVENANCE_SCHEMA_VERSION = 'verify-lite-assurance-provenance/v1';
 const PLAN_ARTIFACT_PATH = 'artifacts/plan/plan-artifact.json';
 const PLAN_ARTIFACT_SCHEMA_PATH = 'schema/plan-artifact.schema.json';
 const PLAN_ARTIFACT_VALIDATION_JSON_PATH = 'artifacts/plan/plan-artifact-validation.json';
@@ -718,7 +721,168 @@ function normalizeClaimLevelSummaryClaim(claim, nowDate) {
   };
 }
 
-function inspectClaimEvidenceManifest(manifestPath = CLAIM_EVIDENCE_MANIFEST_PATH, now = new Date().toISOString()) {
+function optionalString(value) {
+  const normalized = String(value ?? '').trim();
+  return normalized || null;
+}
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function displayPath(filePath) {
+  const relativePath = path.relative(process.cwd(), filePath);
+  if (relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)) {
+    return relativePath.split(path.sep).join('/');
+  }
+  return filePath;
+}
+
+function trustedProvenanceContextFromEnv(env = process.env) {
+  return {
+    runId: optionalString(env.AE_VERIFY_LITE_RUN_ID),
+    runAttempt: optionalString(env.AE_VERIFY_LITE_RUN_ATTEMPT),
+    headSha: optionalString(env.AE_VERIFY_LITE_HEAD_SHA),
+    workflowName: optionalString(env.AE_VERIFY_LITE_WORKFLOW_NAME),
+    eventName: optionalString(env.AE_VERIFY_LITE_EVENT_NAME),
+    conclusion: optionalString(env.AE_VERIFY_LITE_CONCLUSION),
+    repository: optionalString(env.AE_VERIFY_LITE_REPOSITORY),
+    generatorSha256: optionalString(env.AE_VERIFY_LITE_TRUSTED_GENERATOR_SHA256),
+    schemaSha256: optionalString(env.AE_VERIFY_LITE_TRUSTED_SCHEMA_SHA256),
+    contractSha256: optionalString(env.AE_VERIFY_LITE_TRUSTED_CONTRACT_SHA256),
+  };
+}
+
+const REQUIRED_TRUSTED_PROVENANCE_FIELDS = [
+  ['run id', 'runId'],
+  ['run attempt', 'runAttempt'],
+  ['head sha', 'headSha'],
+  ['workflow name', 'workflowName'],
+  ['event name', 'eventName'],
+  ['conclusion', 'conclusion'],
+  ['repository', 'repository'],
+  ['generator sha256', 'generatorSha256'],
+  ['schema sha256', 'schemaSha256'],
+  ['contract sha256', 'contractSha256'],
+];
+
+function compareTrustedValue(errors, label, expected, actual, { required = false } = {}) {
+  if (!expected) {
+    if (required) {
+      errors.push(`trusted provenance ${label} context missing`);
+    }
+    return false;
+  }
+  if (!actual) {
+    errors.push(`trusted provenance ${label} missing`);
+    return true;
+  }
+  if (String(actual) !== String(expected)) {
+    errors.push(`trusted provenance ${label} mismatch: expected ${expected}, got ${actual}`);
+  }
+  return true;
+}
+
+function inspectClaimEvidenceProvenance({
+  manifestPath,
+  provenancePath = CLAIM_EVIDENCE_PROVENANCE_PATH,
+  trustedContext = trustedProvenanceContextFromEnv(),
+} = {}) {
+  const absoluteProvenancePath = path.resolve(provenancePath);
+  const displayProvenancePath = displayPath(absoluteProvenancePath);
+  const baseState = {
+    path: displayProvenancePath,
+    present: false,
+    trusted: false,
+    schemaVersion: null,
+    generatedAt: null,
+    workflow: null,
+    source: null,
+    artifact: null,
+    generator: null,
+    warnings: [],
+    errors: [],
+  };
+
+  if (!fs.existsSync(absoluteProvenancePath)) {
+    return {
+      ...baseState,
+      warnings: [`claim evidence provenance not found: ${displayProvenancePath}`],
+      errors: [`claim evidence provenance missing: ${displayProvenancePath}`],
+    };
+  }
+
+  try {
+    const payload = JSON.parse(fs.readFileSync(absoluteProvenancePath, 'utf8'));
+    const errors = [];
+    const warnings = [];
+    const schemaVersion = optionalString(payload?.schemaVersion);
+    const generatedAt = optionalString(payload?.generatedAt);
+    const workflow = payload?.workflow && typeof payload.workflow === 'object' ? payload.workflow : {};
+    const source = payload?.source && typeof payload.source === 'object' ? payload.source : {};
+    const artifact = payload?.artifact && typeof payload.artifact === 'object' ? payload.artifact : {};
+    const generator = payload?.generator && typeof payload.generator === 'object' ? payload.generator : {};
+
+    if (schemaVersion !== CLAIM_EVIDENCE_PROVENANCE_SCHEMA_VERSION) {
+      errors.push(`claim evidence provenance schemaVersion must be ${CLAIM_EVIDENCE_PROVENANCE_SCHEMA_VERSION}`);
+    }
+
+    const absoluteManifestPath = path.resolve(manifestPath || CLAIM_EVIDENCE_MANIFEST_PATH);
+    if (!fs.existsSync(absoluteManifestPath)) {
+      errors.push(`claim evidence manifest missing for provenance digest check: ${displayPath(absoluteManifestPath)}`);
+    } else {
+      const actualDigest = sha256File(absoluteManifestPath);
+      compareTrustedValue(errors, 'manifest sha256', actualDigest, artifact.manifestSha256);
+    }
+
+    const trustedComparisons = [
+      ['run id', 'runId', workflow.runId],
+      ['run attempt', 'runAttempt', workflow.runAttempt],
+      ['head sha', 'headSha', source.sha],
+      ['workflow name', 'workflowName', workflow.name],
+      ['event name', 'eventName', workflow.eventName],
+      ['conclusion', 'conclusion', 'success'],
+      ['repository', 'repository', payload.repository],
+      ['generator sha256', 'generatorSha256', generator.sha256],
+      ['schema sha256', 'schemaSha256', generator.schemaSha256],
+      ['contract sha256', 'contractSha256', generator.contractSha256],
+    ];
+    for (const [label, key, actual] of trustedComparisons) {
+      compareTrustedValue(errors, label, trustedContext[key], actual, { required: true });
+    }
+
+    const missingTrustedContext = REQUIRED_TRUSTED_PROVENANCE_FIELDS
+      .filter(([, key]) => !trustedContext[key])
+      .map(([label]) => label);
+    if (missingTrustedContext.length > 0) {
+      warnings.push(`trusted Verify Lite run metadata incomplete; missing ${missingTrustedContext.join(', ')}`);
+    }
+
+    return {
+      ...baseState,
+      present: true,
+      trusted: errors.length === 0,
+      schemaVersion,
+      generatedAt,
+      workflow,
+      source,
+      artifact,
+      generator,
+      warnings,
+      errors,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ...baseState,
+      present: true,
+      warnings: [`failed to parse claim evidence provenance: ${message}`],
+      errors: [`failed to parse claim evidence provenance: ${message}`],
+    };
+  }
+}
+
+function inspectClaimEvidenceManifest(manifestPath = CLAIM_EVIDENCE_MANIFEST_PATH, now = new Date().toISOString(), options = {}) {
   const absolutePath = path.resolve(manifestPath);
   const nowDate = toDateOnly(now);
   const baseState = {
@@ -734,9 +898,15 @@ function inspectClaimEvidenceManifest(manifestPath = CLAIM_EVIDENCE_MANIFEST_PAT
       unresolved: 0,
     },
     claims: [],
+    provenance: null,
     warnings: [],
     errors: [],
   };
+  const provenanceState = inspectClaimEvidenceProvenance({
+    manifestPath: absolutePath,
+    provenancePath: options.provenancePath || path.join(path.dirname(absolutePath), 'claim-evidence-provenance.json'),
+    trustedContext: options.trustedContext,
+  });
 
   if (!fs.existsSync(absolutePath)) {
     return baseState;
@@ -762,6 +932,7 @@ function inspectClaimEvidenceManifest(manifestPath = CLAIM_EVIDENCE_MANIFEST_PAT
         ...(securitySummary ? { security: securitySummary } : {}),
       },
       claims,
+      provenance: provenanceState,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -855,6 +1026,25 @@ function buildAssuranceEvaluation(manifestState, options = {}) {
     }
   }
 
+  const provenance = manifestState?.provenance;
+  if (manifestState?.present && manifestState?.schemaVersion === 'claim-evidence-manifest/v1') {
+    if (provenance?.warnings?.length > 0) {
+      warnings.push(...provenance.warnings.map((warning) => `provenance: ${warning}`));
+    }
+    if (modeState.value === 'strict') {
+      if (!provenance?.present) {
+        errors.push('assurance provenance missing; next action: generate and upload claim-evidence-provenance.json with verify-lite-report');
+      } else if (provenance.trusted !== true) {
+        const provenanceErrors = Array.isArray(provenance.errors) && provenance.errors.length > 0
+          ? provenance.errors
+          : ['claim evidence provenance is not trusted'];
+        errors.push(...provenanceErrors.map((error) => `assurance provenance not trusted: ${error}`));
+      }
+    } else if (provenance?.errors?.length > 0) {
+      warnings.push(...provenance.errors.map((error) => `provenance: ${error}`));
+    }
+  }
+
   const claims = Array.isArray(manifestState?.claims) ? manifestState.claims : [];
   const waivers = flattenAssuranceWaivers(claims);
   for (const claim of claims) {
@@ -909,6 +1099,13 @@ function buildAssuranceEvaluation(manifestState, options = {}) {
       present: Boolean(manifestState?.present),
       schemaVersion: manifestState?.schemaVersion ?? null,
       generatedAt: manifestState?.generatedAt ?? null,
+      provenance: provenance ? {
+        path: provenance.path,
+        present: Boolean(provenance.present),
+        trusted: Boolean(provenance.trusted),
+        schemaVersion: provenance.schemaVersion ?? null,
+        generatedAt: provenance.generatedAt ?? null,
+      } : null,
     },
     summary,
     claims: claims.map((claim) => {
@@ -1508,6 +1705,7 @@ export {
   buildPolicyGateReport,
   inspectAssuranceEvidence,
   inspectClaimEvidenceManifest,
+  inspectClaimEvidenceProvenance,
   inspectClaimLevelSummary,
   run,
   toCheckEntries,

--- a/scripts/ci/write-verify-lite-assurance-provenance.mjs
+++ b/scripts/ci/write-verify-lite-assurance-provenance.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_OUTPUT = 'artifacts/assurance/claim-evidence-provenance.json';
+const MANIFEST_PATH = 'artifacts/assurance/claim-evidence-manifest.json';
+const GENERATOR_PATH = 'scripts/assurance/build-claim-evidence-manifest.mjs';
+const CONTRACT_PATH = 'scripts/ci/lib/claim-evidence-manifest-contract.mjs';
+const SCHEMA_PATH = 'schema/claim-evidence-manifest.schema.json';
+const SCHEMA_VERSION = 'verify-lite-assurance-provenance/v1';
+
+function sha256File(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function ensureParent(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function env(name) {
+  const value = String(process.env[name] || '').trim();
+  return value || null;
+}
+
+function buildProvenance(outputPath = DEFAULT_OUTPUT) {
+  const generatedAt = isoNow();
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    generatedAt,
+    repository: env('GITHUB_REPOSITORY'),
+    workflow: {
+      name: env('GITHUB_WORKFLOW') || 'Verify Lite',
+      ref: env('GITHUB_WORKFLOW_REF'),
+      sha: env('GITHUB_WORKFLOW_SHA'),
+      runId: env('GITHUB_RUN_ID'),
+      runAttempt: env('GITHUB_RUN_ATTEMPT'),
+      eventName: env('GITHUB_EVENT_NAME'),
+      actor: env('GITHUB_ACTOR'),
+    },
+    source: {
+      ref: env('GITHUB_REF'),
+      sha: env('VERIFY_LITE_PR_HEAD_SHA') || env('GITHUB_SHA'),
+      baseRef: env('GITHUB_BASE_REF'),
+      headRef: env('GITHUB_HEAD_REF'),
+    },
+    artifact: {
+      name: 'verify-lite-report',
+      manifestPath: MANIFEST_PATH,
+      manifestSha256: sha256File(MANIFEST_PATH),
+      provenancePath: outputPath,
+    },
+    generator: {
+      command: 'pnpm -s run claim-evidence:generate',
+      path: GENERATOR_PATH,
+      sha256: sha256File(GENERATOR_PATH),
+      schemaPath: SCHEMA_PATH,
+      schemaSha256: sha256File(SCHEMA_PATH),
+      contractPath: CONTRACT_PATH,
+      contractSha256: sha256File(CONTRACT_PATH),
+    },
+  };
+}
+
+function parseArgs(argv) {
+  let outputPath = DEFAULT_OUTPUT;
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if ((arg === '--out' || arg === '--output') && argv[index + 1]) {
+      outputPath = argv[++index];
+    } else if (arg.startsWith('--out=')) {
+      outputPath = arg.slice('--out='.length);
+    } else if (arg.startsWith('--output=')) {
+      outputPath = arg.slice('--output='.length);
+    } else if (arg === '--help') {
+      process.stdout.write('Usage: node scripts/ci/write-verify-lite-assurance-provenance.mjs [--out <path>]\n');
+      process.exit(0);
+    }
+  }
+  return { outputPath };
+}
+
+function main() {
+  const { outputPath } = parseArgs(process.argv);
+  const provenance = buildProvenance(outputPath);
+  ensureParent(outputPath);
+  fs.writeFileSync(outputPath, `${JSON.stringify(provenance, null, 2)}\n`);
+  process.stdout.write(`[verify-lite-provenance] wrote ${outputPath}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  main();
+}
+
+export { buildProvenance };

--- a/tests/unit/ci/policy-gate.test.ts
+++ b/tests/unit/ci/policy-gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import crypto from 'node:crypto';
 import { join } from 'node:path';
 import {
   buildMarkdownSummary,
@@ -99,10 +100,104 @@ function assuranceState(overrides: Record<string, unknown> = {}) {
         ],
       },
     ],
+    provenance: {
+      path: '/workspace/artifacts/assurance/claim-evidence-provenance.json',
+      present: true,
+      trusted: true,
+      schemaVersion: 'verify-lite-assurance-provenance/v1',
+      generatedAt: '2026-04-28T18:20:00.000Z',
+      warnings: [],
+      errors: [],
+    },
     warnings: [],
     errors: [],
     ...overrides,
   };
+}
+
+function sha256File(filePath: string) {
+  return crypto.createHash('sha256').update(readFileSync(filePath)).digest('hex');
+}
+
+function trustedProvenanceContext(overrides: Record<string, unknown> = {}) {
+  return {
+    runId: '123456789',
+    runAttempt: '1',
+    headSha: 'abc123trustedhead',
+    workflowName: 'Verify Lite',
+    eventName: 'pull_request',
+    conclusion: 'success',
+    repository: 'itdojp/ae-framework',
+    generatorSha256: 'generator-sha',
+    schemaSha256: 'schema-sha',
+    contractSha256: 'contract-sha',
+    ...overrides,
+  };
+}
+
+function writeClaimEvidenceManifest(manifestPath: string) {
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      schemaVersion: 'claim-evidence-manifest/v1',
+      generatedAt: '2026-05-08T00:00:00.000Z',
+      summary: {
+        totalClaims: 1,
+        fullySupported: 1,
+        partiallySupported: 0,
+        waived: 0,
+        unresolved: 0,
+      },
+      claims: [
+        {
+          id: 'trusted-claim',
+          status: 'satisfied',
+          evidenceRefs: [],
+          missingEvidenceRefs: [],
+          waiverRefs: [],
+        },
+      ],
+    }),
+  );
+}
+
+function writeClaimEvidenceProvenance(
+  provenancePath: string,
+  manifestPath: string,
+  trustedContext: Record<string, unknown>,
+  overrides: Record<string, unknown> = {},
+) {
+  writeFileSync(
+    provenancePath,
+    JSON.stringify({
+      schemaVersion: 'verify-lite-assurance-provenance/v1',
+      generatedAt: '2026-05-08T00:01:00.000Z',
+      repository: trustedContext.repository,
+      workflow: {
+        name: trustedContext.workflowName,
+        runId: trustedContext.runId,
+        runAttempt: trustedContext.runAttempt,
+        eventName: trustedContext.eventName,
+      },
+      source: {
+        sha: trustedContext.headSha,
+      },
+      artifact: {
+        name: 'verify-lite-report',
+        manifestPath: 'artifacts/assurance/claim-evidence-manifest.json',
+        manifestSha256: sha256File(manifestPath),
+      },
+      generator: {
+        path: 'scripts/assurance/build-claim-evidence-manifest.mjs',
+        sha256: trustedContext.generatorSha256,
+        schemaPath: 'schema/claim-evidence-manifest.schema.json',
+        schemaSha256: trustedContext.schemaSha256,
+        contractPath: 'scripts/ci/lib/claim-evidence-manifest-contract.mjs',
+        contractSha256: trustedContext.contractSha256,
+      },
+      ...overrides,
+    }),
+  );
 }
 
 describe('policy-gate', () => {
@@ -811,6 +906,216 @@ describe('policy-gate', () => {
       expect(result.ok).toBe(false);
       expect(result.errors).toEqual(expect.arrayContaining([
         expect.stringContaining('assurance claim partial-proof is missing required evidence'),
+        'assurance decision is block',
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('trusts strict claim evidence only when Verify Lite provenance matches run metadata and trusted digests', () => {
+    mkdirSync(join(process.cwd(), 'artifacts'), { recursive: true });
+    const tempDir = mkdtempSync(join(process.cwd(), 'artifacts', 'policy-gate-provenance-valid-'));
+    const manifestPath = join(tempDir, 'claim-evidence-manifest.json');
+    const provenancePath = join(tempDir, 'claim-evidence-provenance.json');
+    const trustedContext = trustedProvenanceContext();
+
+    try {
+      writeClaimEvidenceManifest(manifestPath);
+      writeClaimEvidenceProvenance(provenancePath, manifestPath, trustedContext);
+
+      const assurance = inspectClaimEvidenceManifest(manifestPath, '2026-05-08T00:00:00.000Z', {
+        provenancePath,
+        trustedContext,
+      });
+      const result = evaluatePolicyGate({
+        policy,
+        pullRequest: {
+          labels: [{ name: 'risk:low' }],
+          body: '## Rollback\nnone\n\n## Acceptance\nok',
+        },
+        changedFiles: ['src/feature/example.ts'],
+        reviews: [],
+        statusRollup: [checkRun('verify-lite')],
+        assurance,
+        assuranceMode: 'strict',
+      });
+
+      expect(assurance.provenance.trusted).toBe(true);
+      expect(result.ok).toBe(true);
+      expect(result.assurance.manifest.provenance).toMatchObject({
+        present: true,
+        trusted: true,
+        schemaVersion: 'verify-lite-assurance-provenance/v1',
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails strict claim evidence when Verify Lite provenance is missing', () => {
+    mkdirSync(join(process.cwd(), 'artifacts'), { recursive: true });
+    const tempDir = mkdtempSync(join(process.cwd(), 'artifacts', 'policy-gate-provenance-missing-'));
+    const manifestPath = join(tempDir, 'claim-evidence-manifest.json');
+    const provenancePath = join(tempDir, 'claim-evidence-provenance.json');
+
+    try {
+      writeClaimEvidenceManifest(manifestPath);
+
+      const assurance = inspectClaimEvidenceManifest(manifestPath, '2026-05-08T00:00:00.000Z', {
+        provenancePath,
+        trustedContext: trustedProvenanceContext(),
+      });
+      const result = evaluatePolicyGate({
+        policy,
+        pullRequest: {
+          labels: [{ name: 'risk:low' }],
+          body: '## Rollback\nnone\n\n## Acceptance\nok',
+        },
+        changedFiles: ['src/feature/example.ts'],
+        reviews: [],
+        statusRollup: [checkRun('verify-lite')],
+        assurance,
+        assuranceMode: 'strict',
+      });
+
+      expect(assurance.provenance).toMatchObject({
+        present: false,
+        trusted: false,
+      });
+      expect(result.ok).toBe(false);
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.stringContaining('assurance provenance missing'),
+        'assurance decision is block',
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces missing claim evidence provenance as report-only warning', () => {
+    mkdirSync(join(process.cwd(), 'artifacts'), { recursive: true });
+    const tempDir = mkdtempSync(join(process.cwd(), 'artifacts', 'policy-gate-provenance-report-only-'));
+    const manifestPath = join(tempDir, 'claim-evidence-manifest.json');
+    const provenancePath = join(tempDir, 'claim-evidence-provenance.json');
+
+    try {
+      writeClaimEvidenceManifest(manifestPath);
+
+      const assurance = inspectClaimEvidenceManifest(manifestPath, '2026-05-08T00:00:00.000Z', {
+        provenancePath,
+        trustedContext: trustedProvenanceContext(),
+      });
+      const result = evaluatePolicyGate({
+        policy,
+        pullRequest: {
+          labels: [{ name: 'risk:low' }],
+          body: '## Rollback\nnone\n\n## Acceptance\nok',
+        },
+        changedFiles: ['src/feature/example.ts'],
+        reviews: [],
+        statusRollup: [checkRun('verify-lite')],
+        assurance,
+        assuranceMode: 'report-only',
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.assurance.manifest.provenance).toMatchObject({
+        present: false,
+        trusted: false,
+      });
+      expect(result.warnings).toEqual(expect.arrayContaining([
+        expect.stringContaining('provenance: claim evidence provenance not found'),
+        expect.stringContaining('provenance: claim evidence provenance missing'),
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails strict claim evidence when trusted provenance context digests are incomplete', () => {
+    mkdirSync(join(process.cwd(), 'artifacts'), { recursive: true });
+    const tempDir = mkdtempSync(join(process.cwd(), 'artifacts', 'policy-gate-provenance-context-'));
+    const manifestPath = join(tempDir, 'claim-evidence-manifest.json');
+    const provenancePath = join(tempDir, 'claim-evidence-provenance.json');
+    const trustedContext = trustedProvenanceContext();
+
+    try {
+      writeClaimEvidenceManifest(manifestPath);
+      writeClaimEvidenceProvenance(provenancePath, manifestPath, trustedContext);
+
+      const assurance = inspectClaimEvidenceManifest(manifestPath, '2026-05-08T00:00:00.000Z', {
+        provenancePath,
+        trustedContext: trustedProvenanceContext({
+          generatorSha256: '',
+          schemaSha256: '',
+          contractSha256: '',
+        }),
+      });
+      const result = evaluatePolicyGate({
+        policy,
+        pullRequest: {
+          labels: [{ name: 'risk:low' }],
+          body: '## Rollback\nnone\n\n## Acceptance\nok',
+        },
+        changedFiles: ['src/feature/example.ts'],
+        reviews: [],
+        statusRollup: [checkRun('verify-lite')],
+        assurance,
+        assuranceMode: 'strict',
+      });
+
+      expect(assurance.provenance.trusted).toBe(false);
+      expect(result.ok).toBe(false);
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.stringContaining('assurance provenance not trusted: trusted provenance generator sha256 context missing'),
+        expect.stringContaining('assurance provenance not trusted: trusted provenance schema sha256 context missing'),
+        expect.stringContaining('assurance provenance not trusted: trusted provenance contract sha256 context missing'),
+        'assurance decision is block',
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails strict claim evidence when provenance manifest digest does not match the downloaded artifact', () => {
+    mkdirSync(join(process.cwd(), 'artifacts'), { recursive: true });
+    const tempDir = mkdtempSync(join(process.cwd(), 'artifacts', 'policy-gate-provenance-digest-'));
+    const manifestPath = join(tempDir, 'claim-evidence-manifest.json');
+    const provenancePath = join(tempDir, 'claim-evidence-provenance.json');
+    const trustedContext = trustedProvenanceContext();
+
+    try {
+      writeClaimEvidenceManifest(manifestPath);
+      writeClaimEvidenceProvenance(provenancePath, manifestPath, trustedContext, {
+        artifact: {
+          name: 'verify-lite-report',
+          manifestPath: 'artifacts/assurance/claim-evidence-manifest.json',
+          manifestSha256: '0'.repeat(64),
+        },
+      });
+
+      const assurance = inspectClaimEvidenceManifest(manifestPath, '2026-05-08T00:00:00.000Z', {
+        provenancePath,
+        trustedContext,
+      });
+      const result = evaluatePolicyGate({
+        policy,
+        pullRequest: {
+          labels: [{ name: 'risk:low' }],
+          body: '## Rollback\nnone\n\n## Acceptance\nok',
+        },
+        changedFiles: ['src/feature/example.ts'],
+        reviews: [],
+        statusRollup: [checkRun('verify-lite')],
+        assurance,
+        assuranceMode: 'strict',
+      });
+
+      expect(assurance.provenance.trusted).toBe(false);
+      expect(result.ok).toBe(false);
+      expect(result.errors).toEqual(expect.arrayContaining([
+        expect.stringContaining('assurance provenance not trusted: trusted provenance manifest sha256 mismatch'),
         'assurance decision is block',
       ]));
     } finally {

--- a/tests/unit/ci/verify-lite-assurance-provenance.test.ts
+++ b/tests/unit/ci/verify-lite-assurance-provenance.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildProvenance } from '../../../scripts/ci/write-verify-lite-assurance-provenance.mjs';
+
+const ENV_KEYS = [
+  'GITHUB_REPOSITORY',
+  'GITHUB_WORKFLOW',
+  'GITHUB_RUN_ID',
+  'GITHUB_RUN_ATTEMPT',
+  'GITHUB_EVENT_NAME',
+  'GITHUB_SHA',
+  'VERIFY_LITE_PR_HEAD_SHA',
+];
+
+const originalEnv = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const original = originalEnv.get(key);
+    if (original === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = original;
+    }
+  }
+});
+
+describe('verify-lite assurance provenance writer', () => {
+  it('records the pull request head SHA instead of the pull_request merge commit SHA', () => {
+    process.env.GITHUB_REPOSITORY = 'itdojp/ae-framework';
+    process.env.GITHUB_WORKFLOW = 'Verify Lite';
+    process.env.GITHUB_RUN_ID = '123456789';
+    process.env.GITHUB_RUN_ATTEMPT = '1';
+    process.env.GITHUB_EVENT_NAME = 'pull_request';
+    process.env.GITHUB_SHA = 'merge-commit-sha';
+    process.env.VERIFY_LITE_PR_HEAD_SHA = 'pr-head-sha';
+
+    const provenance = buildProvenance('artifacts/assurance/claim-evidence-provenance.json');
+
+    expect(provenance.source.sha).toBe('pr-head-sha');
+    expect(provenance.workflow.runId).toBe('123456789');
+    expect(provenance.artifact.manifestPath).toBe('artifacts/assurance/claim-evidence-manifest.json');
+  });
+});

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -320,12 +320,25 @@ describe('workflow permission boundaries', () => {
   it('policy-gate downloads verify-lite assurance artifacts before label-derived strict mode', () => {
     const workflow = readWorkflow('policy-gate.yml');
     expect(workflow).toContain('actions: read');
+    expect(workflow).toContain('persist-credentials: false');
     expect(workflow).toContain('Resolve assurance policy inputs');
     expect(workflow).toContain("labels.has('enforce-assurance')");
     expect(workflow).toContain("core.exportVariable('AE_POLICY_ASSURANCE_MODE', 'strict')");
+    expect(workflow).toContain("core.exportVariable('AE_VERIFY_LITE_RUN_ID', String(run.id));");
+    expect(workflow).toContain('AE_VERIFY_LITE_TRUSTED_GENERATOR_SHA256');
     expect(workflow).toContain('Download verify-lite assurance artifacts');
     expect(workflow).toContain('name: verify-lite-report');
+    expect(workflow).toContain('path: artifacts');
     expect(workflow).toContain('run-id: ${{ steps.assurance-policy.outputs.verify_lite_run_id }}');
+  });
+
+  it('verify-lite records claim evidence provenance before uploading assurance artifacts', () => {
+    const workflow = readWorkflow('verify-lite.yml');
+    expect(workflow).toContain('persist-credentials: false');
+    expect(workflow).toContain('Write claim evidence provenance (report-only)');
+    expect(workflow).toContain('VERIFY_LITE_PR_HEAD_SHA');
+    expect(workflow).toContain('node scripts/ci/write-verify-lite-assurance-provenance.mjs');
+    expect(workflow).toContain('artifacts/assurance/claim-evidence-provenance.json');
   });
 
   it('release workflows attest official SBOM and quality release assets before upload', () => {


### PR DESCRIPTION
## Summary

- Add `claim-evidence-provenance.json` generation to Verify Lite and include it in `verify-lite-report`.
- Bind Policy Gate assurance consumption to Verify Lite run metadata and trusted base-ref digests for the claim-evidence generator, schema, and semantic contract.
- Fail strict assurance mode closed when claim evidence provenance is missing or mismatched, while keeping report-only mode non-blocking.
- Disable persisted checkout credentials in Verify Lite / Policy Gate and update policy input/decision/summary schemas and golden fixtures.

Closes #3390.

## Acceptance

- Strict assurance mode no longer trusts a PR-generated `claim-evidence-manifest.json` unless accompanying provenance matches the selected Verify Lite run and trusted base-ref generator/schema/contract digests.
- Missing or mismatched provenance is surfaced by Policy Gate; strict mode blocks, report-only mode remains non-blocking.
- Verify Lite uploads the provenance artifact alongside claim evidence.

## Verification

- `pnpm -s exec vitest run tests/scripts/assurance-e2e-scenario.test.ts tests/unit/ci/policy-shadow-compare.test.ts tests/unit/ci/policy-gate.test.ts tests/unit/ci/workflow-permission-boundary.test.ts tests/unit/ci/validate-policy-gate-summary.test.ts tests/unit/formal/run-model-checks-security.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet scripts/ci/policy-gate.mjs scripts/ci/write-verify-lite-assurance-provenance.mjs scripts/verify/run-model-checks.mjs tests/unit/ci/policy-gate.test.ts tests/unit/ci/workflow-permission-boundary.test.ts tests/unit/formal/run-model-checks-security.test.ts`
- `pnpm -s run check:schemas`
- `pnpm -s run types:check`
- `git diff --check`

## Local limitation

- `pnpm -s run lint:actions` was attempted, but the local Podman rootless actionlint runner failed before lint execution with `cannot re-exec process to join the existing user namespace` (container exit 125). CI actionlint should be treated as authoritative.

## Rollback

- Revert this PR. Policy Gate will return to consuming Verify Lite claim evidence without provenance enforcement.
