### PR TITLE
fix(security): constrain agent surface writes

### DIFF
--- a/artifacts/types/src/agents/task-types.d.ts
+++ b/artifacts/types/src/agents/task-types.d.ts
@@ -5,7 +5,21 @@ export interface TaskRequest {
     description: string;
     prompt: string;
     subagent_type: string;
-    context?: any;
+    context?: {
+        validationTaskType?: string;
+        strict?: boolean;
+        sources?: string | string[];
+        phaseState?: unknown;
+        outputDir?: string;
+        approval?: {
+            approved?: boolean;
+            scope?: string;
+            actor?: string;
+            reason?: string;
+        };
+        dryRun?: boolean;
+        [key: string]: unknown;
+    };
 }
 export interface TaskResponse {
     summary: string;
@@ -14,6 +28,8 @@ export interface TaskResponse {
     nextActions: string[];
     warnings: string[];
     shouldBlockProgress: boolean;
+    blockingReason?: string;
+    requiredHumanInput?: string;
 }
 export interface TaskHandler {
     handleTask: (request: TaskRequest) => Promise<TaskResponse>;

--- a/schema/codex-task-request.schema.json
+++ b/schema/codex-task-request.schema.json
@@ -22,12 +22,106 @@
     "context": {
       "type": [
         "object",
-        "array",
-        "string",
-        "number",
-        "boolean",
         "null"
-      ]
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "validationTaskType": {
+          "type": "string"
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "sources": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "phaseState": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "entities": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "required": [
+                  "attributes"
+                ],
+                "additionalProperties": true,
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "attributes": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "required": {
+                          "type": "boolean"
+                        },
+                        "description": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "acceptance_criteria": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "outputDir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "dryRun": {
+          "type": "boolean"
+        },
+        "approval": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "approved": {
+              "type": "boolean"
+            },
+            "scope": {
+              "type": "string",
+              "enum": [
+                "ui-scaffold"
+              ]
+            },
+            "actor": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "anyOf": [

--- a/src/agents/codex-task-adapter.ts
+++ b/src/agents/codex-task-adapter.ts
@@ -221,18 +221,105 @@ function recommendNextActions(phase: Phase): string[] {
   }
 }
 
+function hasTrustedUIApproval(context: Record<string, unknown>): boolean {
+  const approval = context['approval'];
+  if (!approval || typeof approval !== 'object') {
+    return false;
+  }
+  const approvalRecord = approval as Record<string, unknown>;
+  return approvalRecord['approved'] === true && approvalRecord['scope'] === 'ui-scaffold';
+}
+
+function hasUnsafePathSegment(value: string): boolean {
+  return value.split(/[\\/]+/u).some((segment) => segment === '..' || segment === '.git');
+}
+
+function findExistingAncestor(absolutePath: string): string {
+  let current = absolutePath;
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return current;
+    }
+    current = parent;
+  }
+  return current;
+}
+
+function resolveUIOutputDir(outputDir: unknown): { ok: true; absolutePath: string; relativePath: string } | { ok: false; errors: string[] } {
+  const rawOutputDir = typeof outputDir === 'string' && outputDir.trim().length > 0
+    ? outputDir.trim()
+    : 'apps';
+  const errors: string[] = [];
+  if (/[\u0000-\u001f\u007f]/u.test(rawOutputDir)) {
+    errors.push('context.outputDir must not contain control characters');
+  }
+  if (path.isAbsolute(rawOutputDir) || path.win32.isAbsolute(rawOutputDir)) {
+    errors.push('context.outputDir must be repository-relative');
+  }
+  if (hasUnsafePathSegment(rawOutputDir)) {
+    errors.push('context.outputDir must not contain parent-directory or .git segments');
+  }
+
+  const repoRoot = process.cwd();
+  const realRepoRoot = fs.existsSync(repoRoot) ? fs.realpathSync(repoRoot) : repoRoot;
+  const absolutePath = path.resolve(repoRoot, rawOutputDir);
+  const relativePath = path.relative(repoRoot, absolutePath);
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    errors.push('context.outputDir must stay inside the repository workspace');
+  }
+  const existingAncestor = findExistingAncestor(absolutePath);
+  const realExistingAncestor = fs.existsSync(existingAncestor) ? fs.realpathSync(existingAncestor) : existingAncestor;
+  const realAncestorRelative = path.relative(realRepoRoot, realExistingAncestor);
+  if (realAncestorRelative && (realAncestorRelative.startsWith('..') || path.isAbsolute(realAncestorRelative))) {
+    errors.push('context.outputDir must not resolve through a symlink outside the repository workspace');
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+  return { ok: true, absolutePath, relativePath };
+}
+
 async function handleUI(request: TaskRequest, parentSpan?: any): Promise<TaskResponse> {
-  const ctx = (request as any).context || {};
+  const ctx = ((request as any).context && typeof (request as any).context === 'object') ? (request as any).context : {};
   const phaseState = ctx.phaseState;
-  const outputDir = ctx.outputDir || 'apps';
+  const outputDirPolicy = resolveUIOutputDir(ctx.outputDir);
+  const policyWarnings: string[] = [];
+  if (outputDirPolicy.ok === false) {
+    const outputDirErrors = outputDirPolicy.errors;
+    return {
+      summary: 'Blocked: invalid UI scaffold output policy',
+      analysis: outputDirErrors.join('\n'),
+      recommendations: [
+        'Use a repository-relative outputDir such as artifacts/ui-scaffold or apps',
+        'Remove absolute paths, parent-directory escapes, and .git path segments from context.outputDir',
+      ],
+      nextActions: ['Provide a safe context.outputDir and rerun codex task (ui)'],
+      warnings: outputDirErrors,
+      shouldBlockProgress: true,
+      blockingReason: 'unsafe-ui-output-dir',
+      requiredHumanInput: 'safe repository-relative context.outputDir',
+    };
+  }
+  const outputDir = outputDirPolicy.absolutePath;
+  const trustedApproval = hasTrustedUIApproval(ctx);
 
   let effectiveState = phaseState;
-  // Resolve dryRun precedence: context.dryRun > CODEX_UI_DRY_RUN env > fallback
+  // Resolve dryRun precedence: context.dryRun > CODEX_UI_DRY_RUN env > fallback.
+  // Untrusted requests are always forced to dry-run so prompt-injected context cannot
+  // turn UI scaffolding into filesystem writes.
   let dryRun: boolean | undefined = typeof ctx.dryRun === 'boolean' ? ctx.dryRun : undefined;
   if (dryRun === undefined) {
     const env = process.env['CODEX_UI_DRY_RUN'];
     if (env === '0') dryRun = false;
     else if (env === '1') dryRun = true;
+  }
+  if (!trustedApproval) {
+    if (dryRun === false) {
+      policyWarnings.push('untrusted-ui-request-forced-dry-run: context.approval.scope=ui-scaffold with approved=true is required before file writes');
+    }
+    dryRun = true;
   }
   if (dryRun === undefined && (!phaseState?.entities || Object.keys(phaseState.entities).length === 0)) {
     dryRun = true;
@@ -310,10 +397,11 @@ async function handleUI(request: TaskRequest, parentSpan?: any): Promise<TaskRes
     analysis: files.length ? files.map(f => `• ${f}`).join('\n') : 'No files generated',
     recommendations: [
       dryRun ? 'Provide context.phaseState.entities to generate real files' : `Files generated: ${files.length}`,
+      dryRun && !trustedApproval ? 'Provide context.approval={ approved: true, scope: "ui-scaffold" } only for trusted write-capable runs' : '',
       'Review a11y/performance metrics'
-    ],
+    ].filter(Boolean),
     nextActions: ['pnpm run test:a11y', 'pnpm run test:coverage'],
-    warnings: [],
+    warnings: policyWarnings,
     shouldBlockProgress: false,
   };
   span.end();

--- a/src/agents/codex-task-adapter.ts
+++ b/src/agents/codex-task-adapter.ts
@@ -231,7 +231,7 @@ function hasTrustedUIApproval(context: Record<string, unknown>): boolean {
 }
 
 function hasUnsafePathSegment(value: string): boolean {
-  return value.split(/[\\/]+/u).some((segment) => segment === '..' || segment === '.git');
+  return value.split(/[\\/]+/u).some((segment) => segment === '..' || segment.toLowerCase() === '.git');
 }
 
 function findExistingAncestor(absolutePath: string): string {

--- a/src/agents/rust-verification-agent.ts
+++ b/src/agents/rust-verification-agent.ts
@@ -847,12 +847,23 @@ export class RustVerificationAgent {
     const allowList = [
       'PATH',
       'HOME',
+      'USERPROFILE',
+      'HOMEDRIVE',
+      'HOMEPATH',
+      'APPDATA',
+      'LOCALAPPDATA',
       'CARGO_HOME',
       'RUSTUP_HOME',
       'RUSTFLAGS',
       'RUST_BACKTRACE',
       'TERM',
       'CI',
+      'TMPDIR',
+      'TEMP',
+      'TMP',
+      'SystemRoot',
+      'ComSpec',
+      'PATHEXT',
     ];
     const env: NodeJS.ProcessEnv = {};
     for (const key of allowList) {

--- a/src/agents/rust-verification-agent.ts
+++ b/src/agents/rust-verification-agent.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFileSync } from 'child_process';
-import { readFileSync, existsSync, writeFileSync, readdirSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
 import * as path from 'path';
 
 export interface RustVerificationRequest {
@@ -34,6 +34,11 @@ export interface VerificationOptions {
   unwindLimit?: number; // for CBMC
   strictMode?: boolean;
   generateReport?: boolean;
+  /**
+   * Source mutations are disabled by default. Set to true only after the caller
+   * has passed an authenticated, approved write-capable policy boundary.
+   */
+  allowSourceMutation?: boolean;
   checkOverflow?: boolean;
   checkConcurrency?: boolean;
 }
@@ -178,6 +183,7 @@ export class RustVerificationAgent {
       // Run Prusti verification
       const output = execFileSync('cargo', ['prusti'], {
         cwd: request.projectPath,
+        env: this.buildVerifierEnv(),
         timeout: (request.options.timeout || 300) * 1000,
         encoding: 'utf8',
         maxBuffer: 10 * 1024 * 1024 // 10MB buffer
@@ -251,6 +257,7 @@ export class RustVerificationAgent {
 
       const output = execFileSync('cargo', kaniArgs, {
         cwd: request.projectPath,
+        env: this.buildVerifierEnv(),
         timeout: (request.options.timeout || 600) * 1000,
         encoding: 'utf8',
         maxBuffer: 20 * 1024 * 1024 // 20MB buffer
@@ -315,7 +322,10 @@ export class RustVerificationAgent {
       const rustSources = this.resolveRustSources(request.projectPath);
       execFileSync('goto-cc', ['-o', 'program.goto', ...rustSources], {
         cwd: request.projectPath,
-        encoding: 'utf8'
+        env: this.buildVerifierEnv(),
+        timeout: (request.options.timeout || 1200) * 1000,
+        encoding: 'utf8',
+        maxBuffer: 20 * 1024 * 1024
       });
 
       // Run CBMC
@@ -331,6 +341,7 @@ export class RustVerificationAgent {
 
       const output = execFileSync('cbmc', cbmcArgs, {
         cwd: request.projectPath,
+        env: this.buildVerifierEnv(),
         timeout: (request.options.timeout || 1200) * 1000,
         encoding: 'utf8',
         maxBuffer: 50 * 1024 * 1024 // 50MB buffer
@@ -393,8 +404,10 @@ export class RustVerificationAgent {
     try {
       const output = execFileSync('cargo', ['miri', 'test'], {
         cwd: request.projectPath,
+        env: this.buildVerifierEnv(),
         timeout: (request.options.timeout || 600) * 1000,
-        encoding: 'utf8'
+        encoding: 'utf8',
+        maxBuffer: 20 * 1024 * 1024
       });
 
       // Parse Miri output
@@ -450,19 +463,19 @@ export class RustVerificationAgent {
       try {
         switch (tool) {
           case 'prusti':
-            execFileSync('cargo', ['prusti', '--version'], { stdio: 'pipe' });
+            execFileSync('cargo', ['prusti', '--version'], { stdio: 'pipe', env: this.buildVerifierEnv() });
             this.installedTools.add(tool);
             break;
           case 'kani':
-            execFileSync('cargo', ['kani', '--version'], { stdio: 'pipe' });
+            execFileSync('cargo', ['kani', '--version'], { stdio: 'pipe', env: this.buildVerifierEnv() });
             this.installedTools.add(tool);
             break;
           case 'cbmc':
-            execFileSync('cbmc', ['--version'], { stdio: 'pipe' });
+            execFileSync('cbmc', ['--version'], { stdio: 'pipe', env: this.buildVerifierEnv() });
             this.installedTools.add(tool);
             break;
           case 'miri':
-            execFileSync('cargo', ['miri', '--version'], { stdio: 'pipe' });
+            execFileSync('cargo', ['miri', '--version'], { stdio: 'pipe', env: this.buildVerifierEnv() });
             this.installedTools.add(tool);
             break;
           case 'loom':
@@ -502,8 +515,10 @@ export class RustVerificationAgent {
     try {
       const output = execFileSync('cargo', ['test', '--features', 'loom'], {
         cwd: request.projectPath,
+        env: this.buildVerifierEnv(),
         timeout: (request.options.timeout || 300) * 1000,
-        encoding: 'utf8'
+        encoding: 'utf8',
+        maxBuffer: 20 * 1024 * 1024
       });
 
       const checks: VerificationCheck[] = [{
@@ -593,6 +608,10 @@ export class RustVerificationAgent {
   }
 
   private async prepareProjectForVerification(request: RustVerificationRequest): Promise<void> {
+    if (request.options.allowSourceMutation !== true) {
+      return;
+    }
+
     // Add verification dependencies to Cargo.toml if needed
     const cargoTomlPath = path.join(request.projectPath, 'Cargo.toml');
     let cargoContent = readFileSync(cargoTomlPath, 'utf8');
@@ -818,8 +837,31 @@ export class RustVerificationAgent {
       summary: this.generateSummary(results)
     };
 
-    const reportPath = path.join(projectPath, 'verification-report.json');
+    const reportDir = path.join(projectPath, 'target', 'ae-verification');
+    mkdirSync(reportDir, { recursive: true });
+    const reportPath = path.join(reportDir, 'verification-report.json');
     writeFileSync(reportPath, JSON.stringify(report, null, 2));
+  }
+
+  private buildVerifierEnv(): NodeJS.ProcessEnv {
+    const allowList = [
+      'PATH',
+      'HOME',
+      'CARGO_HOME',
+      'RUSTUP_HOME',
+      'RUSTFLAGS',
+      'RUST_BACKTRACE',
+      'TERM',
+      'CI',
+    ];
+    const env: NodeJS.ProcessEnv = {};
+    for (const key of allowList) {
+      const value = process.env[key];
+      if (value !== undefined) {
+        env[key] = value;
+      }
+    }
+    return env;
   }
 
   private generateSummary(results: RustVerificationResult[]): string {

--- a/src/agents/task-types.ts
+++ b/src/agents/task-types.ts
@@ -6,6 +6,28 @@ export interface TaskRequestContext {
   validationTaskType?: string;
   strict?: boolean;
   sources?: string | string[];
+  /**
+   * Phase-specific state. UI generation currently accepts `entities`.
+   */
+  phaseState?: unknown;
+  /**
+   * UI scaffold output root. The CodeX adapter accepts only repository-relative,
+   * non-traversing paths before any filesystem writes are allowed.
+   */
+  outputDir?: string;
+  /**
+   * Explicit operator approval for trusted write-capable phases.
+   */
+  approval?: {
+    approved?: boolean;
+    scope?: string;
+    actor?: string;
+    reason?: string;
+  };
+  /**
+   * When true, phases that support it must avoid writing generated files.
+   */
+  dryRun?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/generators/ui-scaffold-generator.ts
+++ b/src/generators/ui-scaffold-generator.ts
@@ -55,7 +55,10 @@ export class UIScaffoldGenerator {
 
   constructor(phaseState: PhaseState, options: GeneratorOptions) {
     this.phaseState = phaseState;
-    this.options = options;
+    this.options = {
+      ...options,
+      outputDir: path.resolve(options.outputDir),
+    };
     // Find ae-framework root directory
     const currentDir = process.cwd();
     const frameworkRoot = this.findFrameworkRoot(currentDir);
@@ -92,6 +95,59 @@ export class UIScaffoldGenerator {
     
     // Fallback to current working directory
     return process.cwd();
+  }
+
+  private sanitizePathSegment(value: string, fallback = 'entity'): string {
+    const normalized = value
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/gu, '')
+      .replace(/[^a-zA-Z0-9_-]+/gu, '-')
+      .replace(/^-+|-+$/gu, '')
+      .toLowerCase();
+    return normalized || fallback;
+  }
+
+  private sanitizeComponentName(value: string): string {
+    const words = value
+      .normalize('NFKD')
+      .replace(/[\u0300-\u036f]/gu, '')
+      .split(/[^a-zA-Z0-9]+/u)
+      .filter((part) => part.length > 0);
+    const candidate = words
+      .map((word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+      .join('');
+    return /^[A-Za-z]/u.test(candidate) ? candidate : `Entity${candidate || 'Scaffold'}`;
+  }
+
+  private findExistingAncestor(absolutePath: string): string {
+    let current = absolutePath;
+    while (!fs.existsSync(current)) {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return current;
+      }
+      current = parent;
+    }
+    return current;
+  }
+
+  private resolveOutputPath(relativeOutputPath: string): string {
+    const outputRoot = path.resolve(this.options.outputDir);
+    const absolutePath = path.resolve(outputRoot, relativeOutputPath);
+    const relativeToRoot = path.relative(outputRoot, absolutePath);
+    if (!relativeToRoot || relativeToRoot.startsWith('..') || path.isAbsolute(relativeToRoot)) {
+      throw new Error(`Generated UI output escaped approved output directory: ${relativeOutputPath}`);
+    }
+    if (fs.existsSync(outputRoot)) {
+      const realOutputRoot = fs.realpathSync(outputRoot);
+      const existingAncestor = this.findExistingAncestor(absolutePath);
+      const realExistingAncestor = fs.realpathSync(existingAncestor);
+      const realRelativeToRoot = path.relative(realOutputRoot, realExistingAncestor);
+      if (realRelativeToRoot && (realRelativeToRoot.startsWith('..') || path.isAbsolute(realRelativeToRoot))) {
+        throw new Error(`Generated UI output resolved outside approved output directory: ${relativeOutputPath}`);
+      }
+    }
+    return absolutePath;
   }
 
   async generateAll(): Promise<Record<string, GenerationResult>> {
@@ -155,7 +211,7 @@ export class UIScaffoldGenerator {
     ];
 
     for (const { template, output } of templates) {
-      const outputPath = path.join(this.options.outputDir, output);
+      const outputPath = this.resolveOutputPath(output);
       
       if (!this.options.dryRun) {
         if (fs.existsSync(outputPath) && !this.options.overwrite) {
@@ -175,7 +231,8 @@ export class UIScaffoldGenerator {
 
   private buildTemplateContext(entityName: string, entityDef: EntityDefinition): any {
     const attributes = entityDef.attributes;
-    const entityNameLower = entityName.toLowerCase();
+    const entityNameLower = this.sanitizePathSegment(entityName);
+    const entityComponentName = this.sanitizeComponentName(entityName);
     
     // Find key fields
     const displayNameField = this.findDisplayNameField(attributes);
@@ -191,8 +248,9 @@ export class UIScaffoldGenerator {
     const optionalFormFields = this.getOptionalFormFields(editableAttributes);
 
     return {
-      EntityName: entityName,
+      EntityName: entityComponentName,
       entityName: entityNameLower,
+      originalEntityName: entityName,
       description: entityDef.description,
       attributes,
       editableAttributes,

--- a/src/services/mcp-server.ts
+++ b/src/services/mcp-server.ts
@@ -572,6 +572,13 @@ export class MCPServer extends EventEmitter {
         break;
 
       case 'enum':
+        if (Array.isArray(value)) {
+          const invalidValue = value.find((item) => !rule.value.includes(item));
+          if (invalidValue !== undefined) {
+            return rule.message || `Parameter '${paramName}' must contain only: ${rule.value.join(', ')}`;
+          }
+          break;
+        }
         if (!rule.value.includes(value)) {
           return rule.message || `Parameter '${paramName}' must be one of: ${rule.value.join(', ')}`;
         }
@@ -614,6 +621,10 @@ export async function createRustVerificationServer(projectRoot: string): Promise
           unwindLimit: 10,
           strictMode: true,
           generateReport: true
+        },
+        security: {
+          requireOperatorApproval: true,
+          workspaceRoot: projectRoot
         }
       })
     ]

--- a/src/services/plugins/rust-verification-plugin.ts
+++ b/src/services/plugins/rust-verification-plugin.ts
@@ -5,6 +5,8 @@
 
 import { RustVerificationAgent, type RustVerificationRequest, type RustVerificationResult, type VerificationTool } from '../../agents/rust-verification-agent.js';
 import { VerifyAgent } from '../../agents/verify-agent.js';
+import { existsSync, realpathSync } from 'fs';
+import * as path from 'path';
 import type { 
   MCPPlugin, 
   MCPServer, 
@@ -12,6 +14,13 @@ import type {
   MCPRequest, 
   MCPResponse 
 } from '../mcp-server.js';
+
+class RustVerificationSecurityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RustVerificationSecurityError';
+  }
+}
 
 export interface RustVerificationPluginConfig {
   enabledTools: string[];
@@ -26,6 +35,10 @@ export interface RustVerificationPluginConfig {
     autoDetect: boolean;
     searchDepth: number;
   };
+  security: {
+    requireOperatorApproval: boolean;
+    workspaceRoot?: string;
+  };
 }
 
 export class RustVerificationPlugin implements MCPPlugin {
@@ -38,7 +51,7 @@ export class RustVerificationPlugin implements MCPPlugin {
   private config: RustVerificationPluginConfig;
 
   constructor(config: Partial<RustVerificationPluginConfig> = {}) {
-    this.config = {
+    const defaults: RustVerificationPluginConfig = {
       enabledTools: ['prusti', 'kani', 'miri'],
       defaultOptions: {
         timeout: 300,
@@ -51,7 +64,25 @@ export class RustVerificationPlugin implements MCPPlugin {
         autoDetect: true,
         searchDepth: 5
       },
-      ...config
+      security: {
+        requireOperatorApproval: true,
+      },
+    };
+    this.config = {
+      ...defaults,
+      ...config,
+      defaultOptions: {
+        ...defaults.defaultOptions,
+        ...config.defaultOptions,
+      },
+      projectDiscovery: {
+        ...defaults.projectDiscovery,
+        ...config.projectDiscovery,
+      },
+      security: {
+        ...defaults.security,
+        ...config.security,
+      },
     };
 
     this.rustAgent = new RustVerificationAgent();
@@ -87,6 +118,7 @@ export class RustVerificationPlugin implements MCPPlugin {
         method: 'POST',
         handler: this.verifyRustProject.bind(this),
         description: 'Run comprehensive Rust formal verification on a project',
+        authentication: true,
         parameters: [
           {
             name: 'projectPath',
@@ -208,28 +240,40 @@ export class RustVerificationPlugin implements MCPPlugin {
   // Endpoint handlers
   private async verifyRustProject(request: MCPRequest): Promise<MCPResponse> {
     try {
-      const { projectPath, verificationTools, options, sourceFiles } = request.body;
+      const body = request.body && typeof request.body === 'object'
+        ? request.body as Record<string, unknown>
+        : {};
+      const { projectPath, verificationTools, options, sourceFiles } = body;
+      const authorizationError = this.validateVerificationAuthorization(request);
+      if (authorizationError) {
+        return authorizationError;
+      }
+      const workspaceRoot = this.getWorkspaceRoot(request);
+      const normalizedProjectPath = this.resolveWorkspaceRelativePath(projectPath, workspaceRoot, 'projectPath', {
+        mustExist: true,
+      });
 
       // Use default tools if not specified
-      const toolsToUse = verificationTools || this.config.enabledTools;
+      const toolsToUse = Array.isArray(verificationTools) ? verificationTools : this.config.enabledTools;
       
       // Merge with default options
       const verificationOptions = {
         ...this.config.defaultOptions,
-        ...options
+        ...(options && typeof options === 'object' ? options : {})
       };
 
       // Discover source files if not provided
       let rustSourceFiles = sourceFiles;
       if (!rustSourceFiles) {
-        rustSourceFiles = await this.discoverSourceFiles(projectPath);
+        rustSourceFiles = await this.discoverSourceFiles(normalizedProjectPath.absolutePath);
       }
+      const normalizedSourceFiles = this.normalizeSourceFiles(rustSourceFiles, normalizedProjectPath.absolutePath);
 
       // Prepare verification request
       const verificationRequest: RustVerificationRequest = {
-        projectPath,
-        sourceFiles: rustSourceFiles.map((file: any) => ({
-          path: file.path || file,
+        projectPath: normalizedProjectPath.absolutePath,
+        sourceFiles: normalizedSourceFiles.map((file: any) => ({
+          path: file.absolutePath,
           content: file.content || '',
           annotations: file.annotations || []
         })),
@@ -257,12 +301,18 @@ export class RustVerificationPlugin implements MCPPlugin {
             requestId: request.context.requestId,
             timestamp: Date.now(),
             toolsUsed: toolsToUse,
-            projectPath
+            projectPath: normalizedProjectPath.relativePath
           }
         }
       };
 
     } catch (error) {
+      if (error instanceof RustVerificationSecurityError) {
+        return {
+          status: 400,
+          error: error.message
+        };
+      }
       return {
         status: 500,
         error: `Rust verification failed: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -302,10 +352,14 @@ export class RustVerificationPlugin implements MCPPlugin {
 
   private async discoverRustProjects(request: MCPRequest): Promise<MCPResponse> {
     try {
-      const searchPath = (request.params as any)['searchPath'] || request.context.projectRoot;
+      const workspaceRoot = this.getWorkspaceRoot(request);
+      const searchPathParam = (request.params as any)['searchPath'] || '.';
+      const searchPath = this.resolveWorkspaceRelativePath(searchPathParam, workspaceRoot, 'searchPath', {
+        mustExist: true,
+      });
       const maxDepth = (request.params as any)['maxDepth'] || this.config.projectDiscovery.searchDepth;
 
-      const projects = await this.findRustProjects(searchPath, maxDepth);
+      const projects = await this.findRustProjects(searchPath.absolutePath, maxDepth);
 
       return {
         status: 200,
@@ -318,7 +372,7 @@ export class RustVerificationPlugin implements MCPPlugin {
             metadata: project.metadata
           })),
           metadata: {
-            searchPath,
+            searchPath: searchPath.relativePath,
             maxDepth,
             projectsFound: projects.length,
             timestamp: Date.now()
@@ -327,6 +381,12 @@ export class RustVerificationPlugin implements MCPPlugin {
       };
 
     } catch (error) {
+      if (error instanceof RustVerificationSecurityError) {
+        return {
+          status: 400,
+          error: error.message
+        };
+      }
       return {
         status: 500,
         error: `Failed to discover Rust projects: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -336,9 +396,17 @@ export class RustVerificationPlugin implements MCPPlugin {
 
   private async analyzeRustCode(request: MCPRequest): Promise<MCPResponse> {
     try {
-      const { projectPath, analysisType = 'verification-readiness' } = request.body;
+      const body = request.body && typeof request.body === 'object'
+        ? request.body as Record<string, unknown>
+        : {};
+      const { projectPath } = body;
+      const analysisType = typeof body['analysisType'] === 'string' ? body['analysisType'] : 'verification-readiness';
+      const workspaceRoot = this.getWorkspaceRoot(request);
+      const normalizedProjectPath = this.resolveWorkspaceRelativePath(projectPath, workspaceRoot, 'projectPath', {
+        mustExist: true,
+      });
 
-      const analysis = await this.performCodeAnalysis(projectPath, analysisType);
+      const analysis = await this.performCodeAnalysis(normalizedProjectPath.absolutePath, analysisType);
       const recommendations = this.generateAnalysisRecommendations(analysis);
 
       return {
@@ -347,7 +415,7 @@ export class RustVerificationPlugin implements MCPPlugin {
           analysis,
           recommendations,
           metadata: {
-            projectPath,
+            projectPath: normalizedProjectPath.relativePath,
             analysisType,
             timestamp: Date.now()
           }
@@ -355,6 +423,12 @@ export class RustVerificationPlugin implements MCPPlugin {
       };
 
     } catch (error) {
+      if (error instanceof RustVerificationSecurityError) {
+        return {
+          status: 400,
+          error: error.message
+        };
+      }
       return {
         status: 500,
         error: `Code analysis failed: ${error instanceof Error ? error.message : 'Unknown error'}`
@@ -363,6 +437,124 @@ export class RustVerificationPlugin implements MCPPlugin {
   }
 
   // Helper methods
+  private validateVerificationAuthorization(request: MCPRequest): MCPResponse | null {
+    const user = request.user;
+    const permissions = new Set(user?.permissions || []);
+    const roles = new Set(user?.roles || []);
+    const authorized = permissions.has('rust:verify')
+      || permissions.has('rust-verification:write')
+      || roles.has('admin')
+      || roles.has('operator');
+    if (!authorized) {
+      return {
+        status: 403,
+        error: 'Rust verification requires rust:verify permission or admin/operator role'
+      };
+    }
+
+    if (!this.config.security.requireOperatorApproval) {
+      return null;
+    }
+
+    const body = request.body && typeof request.body === 'object'
+      ? request.body as Record<string, unknown>
+      : {};
+    const options = body['options'] && typeof body['options'] === 'object'
+      ? body['options'] as Record<string, unknown>
+      : {};
+    const approvalCandidate = body['approval'] && typeof body['approval'] === 'object'
+      ? body['approval']
+      : options['approval'];
+    const approval = approvalCandidate && typeof approvalCandidate === 'object'
+      ? approvalCandidate as Record<string, unknown>
+      : {};
+    const approved = approval['approved'] === true && approval['scope'] === 'rust-verification';
+    if (!approved) {
+      return {
+        status: 403,
+        error: 'Rust verification requires explicit operator approval with approval.scope=rust-verification'
+      };
+    }
+    return null;
+  }
+
+  private getWorkspaceRoot(request: MCPRequest): string {
+    const configuredRoot = this.config.security.workspaceRoot || request.context.projectRoot;
+    const absoluteRoot = path.resolve(configuredRoot);
+    return existsSync(absoluteRoot) ? realpathSync(absoluteRoot) : absoluteRoot;
+  }
+
+  private hasUnsafeRelativePath(value: string): boolean {
+    return value.split(/[\\/]+/u).some((segment) => segment === '..' || segment === '.git');
+  }
+
+  private resolveWorkspaceRelativePath(
+    value: unknown,
+    root: string,
+    label: string,
+    { mustExist = false }: { mustExist?: boolean } = {},
+  ): { absolutePath: string; relativePath: string } {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      throw new RustVerificationSecurityError(`${label} must be a non-empty repository-relative path`);
+    }
+    const rawPath = value.trim();
+    if (/[\u0000-\u001f\u007f]/u.test(rawPath)) {
+      throw new RustVerificationSecurityError(`${label} must not contain control characters`);
+    }
+    if (path.isAbsolute(rawPath) || path.win32.isAbsolute(rawPath)) {
+      throw new RustVerificationSecurityError(`${label} must be repository-relative`);
+    }
+    if (this.hasUnsafeRelativePath(rawPath)) {
+      throw new RustVerificationSecurityError(`${label} must not contain parent-directory or .git segments`);
+    }
+
+    const absolutePath = path.resolve(root, rawPath);
+    const relativePath = path.relative(root, absolutePath);
+    if (relativePath && (relativePath.startsWith('..') || path.isAbsolute(relativePath))) {
+      throw new RustVerificationSecurityError(`${label} must stay inside the configured workspace root`);
+    }
+    if (mustExist && !existsSync(absolutePath)) {
+      throw new RustVerificationSecurityError(`${label} does not exist inside the configured workspace root`);
+    }
+
+    const realPath = existsSync(absolutePath) ? realpathSync(absolutePath) : absolutePath;
+    const realRelativePath = path.relative(root, realPath);
+    if (realRelativePath && (realRelativePath.startsWith('..') || path.isAbsolute(realRelativePath))) {
+      throw new RustVerificationSecurityError(`${label} resolves outside the configured workspace root`);
+    }
+
+    return {
+      absolutePath: realPath,
+      relativePath: relativePath ? relativePath.split(path.sep).join('/') : '.',
+    };
+  }
+
+  private resolveProjectRelativePath(
+    value: unknown,
+    projectRoot: string,
+    label: string,
+  ): { absolutePath: string; relativePath: string } {
+    return this.resolveWorkspaceRelativePath(value, projectRoot, label);
+  }
+
+  private normalizeSourceFiles(sourceFiles: unknown, projectRoot: string): Array<{ absolutePath: string; content: string; annotations: any[] }> {
+    if (!Array.isArray(sourceFiles)) {
+      throw new RustVerificationSecurityError('sourceFiles must be an array when provided');
+    }
+    return sourceFiles.map((file, index) => {
+      const fileRecord = typeof file === 'object' && file !== null
+        ? file as Record<string, unknown>
+        : {};
+      const sourcePath = typeof file === 'string' ? file : fileRecord['path'];
+      const normalizedPath = this.resolveProjectRelativePath(sourcePath, projectRoot, `sourceFiles[${index}].path`);
+      return {
+        absolutePath: normalizedPath.absolutePath,
+        content: typeof fileRecord['content'] === 'string' ? fileRecord['content'] : '',
+        annotations: Array.isArray(fileRecord['annotations']) ? fileRecord['annotations'] : [],
+      };
+    });
+  }
+
   private async discoverSourceFiles(projectPath: string): Promise<Array<{path: string, content: string}>> {
     const fs = await import('fs/promises');
     const path = await import('path');
@@ -377,7 +569,7 @@ export class RustVerificationPlugin implements MCPPlugin {
           const fullPath = path.join(srcDir, file);
           try {
             const content = await fs.readFile(fullPath, 'utf-8');
-            files.push({ path: fullPath, content });
+              files.push({ path: path.relative(projectPath, fullPath), content });
           } catch (error) {
             console.warn(`Could not read file ${fullPath}:`, error);
           }

--- a/src/services/plugins/rust-verification-plugin.ts
+++ b/src/services/plugins/rust-verification-plugin.ts
@@ -7,6 +7,11 @@ import { RustVerificationAgent, type RustVerificationRequest, type RustVerificat
 import { VerifyAgent } from '../../agents/verify-agent.js';
 import { existsSync, realpathSync } from 'fs';
 import * as path from 'path';
+import {
+  resolveWorkspacePath,
+  toWorkspaceRelativePath,
+  WorkspacePathPolicyError,
+} from '../../utils/workspace-path-policy.js';
 import type { 
   MCPPlugin, 
   MCPServer, 
@@ -442,7 +447,6 @@ export class RustVerificationPlugin implements MCPPlugin {
     const permissions = new Set(user?.permissions || []);
     const roles = new Set(user?.roles || []);
     const authorized = permissions.has('rust:verify')
-      || permissions.has('rust-verification:write')
       || roles.has('admin')
       || roles.has('operator');
     if (!authorized) {
@@ -481,11 +485,19 @@ export class RustVerificationPlugin implements MCPPlugin {
   private getWorkspaceRoot(request: MCPRequest): string {
     const configuredRoot = this.config.security.workspaceRoot || request.context.projectRoot;
     const absoluteRoot = path.resolve(configuredRoot);
-    return existsSync(absoluteRoot) ? realpathSync(absoluteRoot) : absoluteRoot;
+    return existsSync(absoluteRoot) ? this.safeRealpath(absoluteRoot, 'workspaceRoot') : absoluteRoot;
   }
 
   private hasUnsafeRelativePath(value: string): boolean {
-    return value.split(/[\\/]+/u).some((segment) => segment === '..' || segment === '.git');
+    return value.split(/[\\/]+/u).some((segment) => segment === '..' || segment.toLowerCase() === '.git');
+  }
+
+  private safeRealpath(value: string, label: string): string {
+    try {
+      return realpathSync(value);
+    } catch {
+      throw new RustVerificationSecurityError(`${label} could not be resolved safely`);
+    }
   }
 
   private resolveWorkspaceRelativePath(
@@ -508,25 +520,33 @@ export class RustVerificationPlugin implements MCPPlugin {
       throw new RustVerificationSecurityError(`${label} must not contain parent-directory or .git segments`);
     }
 
-    const absolutePath = path.resolve(root, rawPath);
-    const relativePath = path.relative(root, absolutePath);
-    if (relativePath && (relativePath.startsWith('..') || path.isAbsolute(relativePath))) {
-      throw new RustVerificationSecurityError(`${label} must stay inside the configured workspace root`);
+    let absolutePath: string;
+    try {
+      absolutePath = rawPath === '.'
+        ? root
+        : resolveWorkspacePath(rawPath, { workspaceRoot: root, label });
+    } catch (error) {
+      if (error instanceof WorkspacePathPolicyError) {
+        throw new RustVerificationSecurityError(error.message);
+      }
+      throw error;
     }
     if (mustExist && !existsSync(absolutePath)) {
       throw new RustVerificationSecurityError(`${label} does not exist inside the configured workspace root`);
     }
 
-    const realPath = existsSync(absolutePath) ? realpathSync(absolutePath) : absolutePath;
-    const realRelativePath = path.relative(root, realPath);
-    if (realRelativePath && (realRelativePath.startsWith('..') || path.isAbsolute(realRelativePath))) {
-      throw new RustVerificationSecurityError(`${label} resolves outside the configured workspace root`);
+    const realPath = existsSync(absolutePath) ? this.safeRealpath(absolutePath, label) : absolutePath;
+    try {
+      return {
+        absolutePath: realPath,
+        relativePath: toWorkspaceRelativePath(realPath, { workspaceRoot: root, label }),
+      };
+    } catch (error) {
+      if (error instanceof WorkspacePathPolicyError) {
+        throw new RustVerificationSecurityError(error.message);
+      }
+      throw error;
     }
-
-    return {
-      absolutePath: realPath,
-      relativePath: relativePath ? relativePath.split(path.sep).join('/') : '.',
-    };
   }
 
   private resolveProjectRelativePath(

--- a/src/utils/workspace-path-policy.ts
+++ b/src/utils/workspace-path-policy.ts
@@ -40,13 +40,21 @@ const nearestExistingAncestor = (resolvedPath: string): string | null => {
   return current;
 };
 
+const safeRealpathSync = (value: string, label: string): string => {
+  try {
+    return realpathSync(value);
+  } catch {
+    throw new WorkspacePathPolicyError(`${label} could not be resolved safely`);
+  }
+};
+
 const assertExistingAncestorWithin = (workspaceRoot: string, resolvedPath: string, label: string): void => {
   if (!existsSync(workspaceRoot)) return;
   const ancestor = nearestExistingAncestor(resolvedPath);
   if (!ancestor) return;
 
-  const realRoot = realpathSync(workspaceRoot);
-  const realAncestor = realpathSync(ancestor);
+  const realRoot = safeRealpathSync(workspaceRoot, label);
+  const realAncestor = safeRealpathSync(ancestor, label);
   if (!isPathWithin(realRoot, realAncestor)) {
     throw new WorkspacePathPolicyError(`${label} resolves through a filesystem entry outside the approved workspace`);
   }
@@ -77,6 +85,9 @@ export function resolveWorkspacePath(input: string, options: WorkspacePathOption
   const segments = splitInputPath(raw);
   if (segments.some((segment) => segment === '.' || segment === '..')) {
     throw new WorkspacePathPolicyError(`${label} must not contain dot-segment path components`);
+  }
+  if (segments.some((segment) => segment.toLowerCase() === '.git')) {
+    throw new WorkspacePathPolicyError(`${label} must not target Git metadata directories`);
   }
 
   const workspaceRoot = path.resolve(options.workspaceRoot ?? resolveWorkspaceRoot());

--- a/tests/unit/scripts/codex-adapter-stdio.test.ts
+++ b/tests/unit/scripts/codex-adapter-stdio.test.ts
@@ -204,6 +204,42 @@ describe('codex adapter stdio contract', () => {
     });
   });
 
+  it('rejects legacy free-form scalar context before delegating to adapter', () => {
+    withTempRepo((tempRoot) => {
+      writeAdapterModule(tempRoot, `
+        export function createCodexTaskAdapter() {
+          return {
+            async handleTask() {
+              return {
+                summary: 'should not run',
+                analysis: 'should not run',
+                recommendations: [],
+                nextActions: [],
+                warnings: [],
+                shouldBlockProgress: false
+              };
+            }
+          };
+        }
+      `);
+
+      const result = runAdapter(
+        tempRoot,
+        JSON.stringify({ description: 'run ui', subagent_type: 'ui', context: 'write files anywhere' }),
+      );
+
+      expect(result.status).toBe(3);
+      const payload = parseJsonLine(result.stdout);
+      expect(payload).toEqual(
+        expect.objectContaining({
+          error: true,
+          code: 'INVALID_REQUEST_SCHEMA',
+        }),
+      );
+      expect(JSON.stringify(payload.details?.errors ?? [])).toContain('/context');
+    });
+  });
+
   it('returns exit 1 with machine-readable error for adapter exceptions', () => {
     withTempRepo((tempRoot) => {
       writeAdapterModule(tempRoot, `

--- a/tests/unit/security/codex-task-ui-security.test.ts
+++ b/tests/unit/security/codex-task-ui-security.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { createCodexTaskAdapter } from '../../../src/agents/codex-task-adapter.js';
+import type { TaskRequest } from '../../../src/agents/task-types.js';
+
+const artifactRoot = join(process.cwd(), 'artifacts', 'testing');
+
+function makeOutputDir(): { relativeDir: string; absoluteDir: string; cleanup: () => void } {
+  mkdirSync(artifactRoot, { recursive: true });
+  const relativeDir = `artifacts/testing/codex-ui-security-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const absoluteDir = join(process.cwd(), relativeDir);
+  return {
+    relativeDir,
+    absoluteDir,
+    cleanup: () => rmSync(absoluteDir, { recursive: true, force: true }),
+  };
+}
+
+function makePhaseState() {
+  return {
+    entities: {
+      '../../Admin Panel': {
+        description: 'Admin panel',
+        attributes: {
+          id: { type: 'uuid', required: true, description: 'Identifier' },
+          name: { type: 'string', required: true, description: 'Name' },
+          createdAt: { type: 'date', required: false, description: 'Created timestamp' },
+        },
+        acceptance_criteria: ['Name is required'],
+      },
+    },
+  };
+}
+
+function makeRequest(context: TaskRequest['context']): TaskRequest {
+  return {
+    description: 'Generate UI scaffold',
+    prompt: 'Generate UI scaffold',
+    subagent_type: 'ui',
+    context,
+  };
+}
+
+describe('CodeX Task UI scaffold security boundary', () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it('forces untrusted UI scaffold requests to dry-run before filesystem writes', async () => {
+    const output = makeOutputDir();
+    cleanup = output.cleanup;
+    const adapter = createCodexTaskAdapter();
+
+    const response = await adapter.handleTask(makeRequest({
+      phaseState: makePhaseState(),
+      outputDir: output.relativeDir,
+      dryRun: false,
+    }));
+
+    expect(response.shouldBlockProgress).toBe(false);
+    expect(response.summary).toContain('(dry-run)');
+    expect(response.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('untrusted-ui-request-forced-dry-run'),
+    ]));
+    expect(existsSync(join(output.absoluteDir, 'apps', 'web', 'app', 'admin-panel', 'page.tsx'))).toBe(false);
+  });
+
+  it('blocks absolute and parent-directory UI output roots before scaffolding', async () => {
+    const adapter = createCodexTaskAdapter();
+
+    const response = await adapter.handleTask(makeRequest({
+      phaseState: makePhaseState(),
+      outputDir: '../outside-ui-root',
+      dryRun: false,
+      approval: { approved: true, scope: 'ui-scaffold' },
+    }));
+
+    expect(response.shouldBlockProgress).toBe(true);
+    expect(response.blockingReason).toBe('unsafe-ui-output-dir');
+    expect(response.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('context.outputDir must not contain parent-directory'),
+    ]));
+  });
+
+  it('blocks UI output roots whose existing ancestor resolves outside the repository', async () => {
+    mkdirSync(artifactRoot, { recursive: true });
+    const outside = join(process.cwd(), '..', `codex-ui-outside-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    const symlinkPath = join(artifactRoot, `codex-ui-link-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(outside, { recursive: true });
+    try {
+      symlinkSync(outside, symlinkPath, 'dir');
+    } catch {
+      rmSync(outside, { recursive: true, force: true });
+      return;
+    }
+    cleanup = () => {
+      rmSync(symlinkPath, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    };
+    const adapter = createCodexTaskAdapter();
+
+    const response = await adapter.handleTask(makeRequest({
+      phaseState: makePhaseState(),
+      outputDir: relative(process.cwd(), symlinkPath),
+      dryRun: false,
+      approval: { approved: true, scope: 'ui-scaffold' },
+    }));
+
+    expect(response.shouldBlockProgress).toBe(true);
+    expect(response.blockingReason).toBe('unsafe-ui-output-dir');
+    expect(response.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('symlink outside the repository workspace'),
+    ]));
+  });
+
+  it('writes only under the approved output root and sanitizes entity path segments for trusted requests', async () => {
+    const output = makeOutputDir();
+    cleanup = output.cleanup;
+    const adapter = createCodexTaskAdapter();
+
+    const response = await adapter.handleTask(makeRequest({
+      phaseState: makePhaseState(),
+      outputDir: output.relativeDir,
+      dryRun: false,
+      approval: { approved: true, scope: 'ui-scaffold', actor: 'operator' },
+    }));
+
+    expect(response.shouldBlockProgress).toBe(false);
+    expect(response.summary).not.toContain('(dry-run)');
+    expect(response.analysis).toContain('apps/web/app/admin-panel/page.tsx');
+    expect(existsSync(join(output.absoluteDir, 'apps', 'web', 'app', 'admin-panel', 'page.tsx'))).toBe(true);
+    expect(existsSync(join(output.absoluteDir, '..', 'Admin Panel', 'page.tsx'))).toBe(false);
+  });
+});

--- a/tests/unit/security/codex-task-ui-security.test.ts
+++ b/tests/unit/security/codex-task-ui-security.test.ts
@@ -86,6 +86,23 @@ describe('CodeX Task UI scaffold security boundary', () => {
     ]));
   });
 
+  it('blocks case-insensitive Git metadata segments in UI output roots', async () => {
+    const adapter = createCodexTaskAdapter();
+
+    const response = await adapter.handleTask(makeRequest({
+      phaseState: makePhaseState(),
+      outputDir: 'artifacts/testing/.GIT/generated-ui',
+      dryRun: false,
+      approval: { approved: true, scope: 'ui-scaffold' },
+    }));
+
+    expect(response.shouldBlockProgress).toBe(true);
+    expect(response.blockingReason).toBe('unsafe-ui-output-dir');
+    expect(response.warnings).toEqual(expect.arrayContaining([
+      expect.stringContaining('context.outputDir must not contain parent-directory or .git segments'),
+    ]));
+  });
+
   it('blocks UI output roots whose existing ancestor resolves outside the repository', async () => {
     mkdirSync(artifactRoot, { recursive: true });
     const outside = join(process.cwd(), '..', `codex-ui-outside-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);

--- a/tests/unit/security/rust-verification-agent-mutation.test.ts
+++ b/tests/unit/security/rust-verification-agent-mutation.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { RustVerificationAgent } from '../../../src/agents/rust-verification-agent.js';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(() => ''),
+}));
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(() => ''),
+}));
+
+const artifactRoot = join(process.cwd(), 'artifacts', 'testing');
+
+function makeWorkspace(): { projectPath: string; sourcePath: string; cleanup: () => void } {
+  mkdirSync(artifactRoot, { recursive: true });
+  const projectPath = join(artifactRoot, `rust-agent-mutation-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const sourcePath = join(projectPath, 'src', 'main.rs');
+  mkdirSync(join(projectPath, 'src'), { recursive: true });
+  writeFileSync(join(projectPath, 'Cargo.toml'), '[package]\nname = "fixture"\nversion = "0.1.0"\nedition = "2021"\n', 'utf8');
+  writeFileSync(sourcePath, 'fn main() {\n    println!("ok");\n}\n', 'utf8');
+  return {
+    projectPath,
+    sourcePath,
+    cleanup: () => rmSync(projectPath, { recursive: true, force: true }),
+  };
+}
+
+describe('RustVerificationAgent mutation policy', () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it('does not mutate Rust sources for annotation preparation unless explicitly enabled', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const original = readFileSync(fixture.sourcePath, 'utf8');
+    const agent = new RustVerificationAgent();
+
+    await agent.verifyRustProject({
+      projectPath: fixture.projectPath,
+      sourceFiles: [{
+        path: fixture.sourcePath,
+        content: original,
+        annotations: [{ type: 'assert', line: 1, content: 'true' }],
+      }],
+      verificationTools: [],
+      options: { generateReport: false },
+    });
+
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(original);
+  });
+
+  it('writes combined reports into target/ae-verification instead of the project root', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const original = readFileSync(fixture.sourcePath, 'utf8');
+    const agent = new RustVerificationAgent();
+
+    await agent.verifyRustProject({
+      projectPath: fixture.projectPath,
+      sourceFiles: [{ path: fixture.sourcePath, content: original }],
+      verificationTools: [],
+      options: { generateReport: true },
+    });
+
+    expect(existsSync(join(fixture.projectPath, 'verification-report.json'))).toBe(false);
+    expect(existsSync(join(fixture.projectPath, 'target', 'ae-verification', 'verification-report.json'))).toBe(true);
+  });
+});

--- a/tests/unit/security/rust-verification-agent-mutation.test.ts
+++ b/tests/unit/security/rust-verification-agent-mutation.test.ts
@@ -70,4 +70,28 @@ describe('RustVerificationAgent mutation policy', () => {
     expect(existsSync(join(fixture.projectPath, 'verification-report.json'))).toBe(false);
     expect(existsSync(join(fixture.projectPath, 'target', 'ae-verification', 'verification-report.json'))).toBe(true);
   });
+
+  it('keeps verifier environment secret-minimized while preserving OS runtime variables', () => {
+    const previousUserProfile = process.env['USERPROFILE'];
+    const previousTemp = process.env['TEMP'];
+    const previousSecret = process.env['AWS_SECRET_ACCESS_KEY'];
+    process.env['USERPROFILE'] = 'C:\\Users\\runner';
+    process.env['TEMP'] = 'C:\\Temp';
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'do-not-copy';
+    try {
+      const agent = new RustVerificationAgent();
+      const env = (agent as unknown as { buildVerifierEnv: () => NodeJS.ProcessEnv }).buildVerifierEnv();
+
+      expect(env['USERPROFILE']).toBe('C:\\Users\\runner');
+      expect(env['TEMP']).toBe('C:\\Temp');
+      expect(env['AWS_SECRET_ACCESS_KEY']).toBeUndefined();
+    } finally {
+      if (previousUserProfile === undefined) delete process.env['USERPROFILE'];
+      else process.env['USERPROFILE'] = previousUserProfile;
+      if (previousTemp === undefined) delete process.env['TEMP'];
+      else process.env['TEMP'] = previousTemp;
+      if (previousSecret === undefined) delete process.env['AWS_SECRET_ACCESS_KEY'];
+      else process.env['AWS_SECRET_ACCESS_KEY'] = previousSecret;
+    }
+  });
 });

--- a/tests/unit/security/rust-verification-plugin-security.test.ts
+++ b/tests/unit/security/rust-verification-plugin-security.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { MCPServer, type MCPRequest } from '../../../src/services/mcp-server.js';
+import { RustVerificationPlugin } from '../../../src/services/plugins/rust-verification-plugin.js';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(() => ''),
+}));
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn(() => ''),
+}));
+
+type RustAgentStub = {
+  getAvailableTools: () => string[];
+  verifyRustProject: ReturnType<typeof vi.fn>;
+};
+
+const artifactRoot = join(process.cwd(), 'artifacts', 'testing');
+
+function makeWorkspace(): { workspace: string; cratePath: string; cleanup: () => void } {
+  mkdirSync(artifactRoot, { recursive: true });
+  const workspace = join(artifactRoot, `rust-plugin-security-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  const cratePath = join(workspace, 'crate');
+  mkdirSync(join(cratePath, 'src'), { recursive: true });
+  writeFileSync(join(cratePath, 'Cargo.toml'), '[package]\nname = "fixture"\nversion = "0.1.0"\nedition = "2021"\n', 'utf8');
+  writeFileSync(join(cratePath, 'src', 'main.rs'), 'fn main() {}\n', 'utf8');
+  return {
+    workspace,
+    cratePath,
+    cleanup: () => rmSync(workspace, { recursive: true, force: true }),
+  };
+}
+
+async function makeServer(workspace: string, rustAgent: RustAgentStub): Promise<MCPServer> {
+  const plugin = new RustVerificationPlugin({
+    enabledTools: [],
+    security: {
+      requireOperatorApproval: true,
+      workspaceRoot: workspace,
+    },
+  });
+  (plugin as unknown as { rustAgent: RustAgentStub }).rustAgent = rustAgent;
+  const server = new MCPServer({
+    name: 'rust-security-test',
+    version: '1.0.0',
+    endpoints: [],
+    capabilities: [],
+    plugins: [plugin],
+  }, workspace);
+  await server.start();
+  return server;
+}
+
+function makeRequest(workspace: string, overrides: Partial<MCPRequest> = {}): MCPRequest {
+  const base: MCPRequest = {
+    path: '/rust/verify',
+    method: 'POST',
+    params: {},
+    headers: {},
+    user: {
+      id: 'operator-1',
+      name: 'Operator',
+      roles: [],
+      permissions: ['rust:verify'],
+    },
+    context: {
+      requestId: `req-${Date.now()}`,
+      timestamp: Date.now(),
+      serverName: 'rust-security-test',
+      version: '1.0.0',
+      environment: 'testing',
+      projectRoot: workspace,
+    },
+    body: {
+      projectPath: 'crate',
+      sourceFiles: [{ path: 'src/main.rs', content: 'fn main() {}\n' }],
+      options: { generateReport: false },
+      approval: { approved: true, scope: 'rust-verification' },
+    },
+  };
+  return {
+    ...base,
+    ...overrides,
+    body: overrides.body ?? base.body,
+    context: overrides.context ?? base.context,
+    params: overrides.params ?? base.params,
+    headers: overrides.headers ?? base.headers,
+  };
+}
+
+describe('RustVerificationPlugin security boundary', () => {
+  let cleanup: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it('requires authentication before Rust verification can reach writes or process execution', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, { user: undefined }));
+
+    expect(response.status).toBe(401);
+    expect(response.error).toContain('Authentication required');
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
+  it('requires rust verification permission or operator role before executing tools', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, {
+      user: { id: 'viewer', name: 'Viewer', roles: [], permissions: [] },
+    }));
+
+    expect(response.status).toBe(403);
+    expect(response.error).toContain('requires rust:verify permission');
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
+  it('requires explicit operator approval for verification writes/process execution', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, {
+      body: {
+        projectPath: 'crate',
+        sourceFiles: [{ path: 'src/main.rs', content: 'fn main() {}\n' }],
+        options: { generateReport: false },
+      },
+    }));
+
+    expect(response.status).toBe(403);
+    expect(response.error).toContain('approval.scope=rust-verification');
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
+  it('rejects absolute project paths before executing tools', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, {
+      body: {
+        projectPath: fixture.cratePath,
+        sourceFiles: [{ path: 'src/main.rs', content: 'fn main() {}\n' }],
+        options: { generateReport: false },
+        approval: { approved: true, scope: 'rust-verification' },
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.error).toContain('projectPath must be repository-relative');
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
+  it('rejects source file traversal before executing tools', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, {
+      body: {
+        projectPath: 'crate',
+        sourceFiles: [{ path: '../outside.rs', content: 'fn main() {}\n' }],
+        options: { generateReport: false },
+        approval: { approved: true, scope: 'rust-verification' },
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.error).toContain('sourceFiles[0].path must not contain parent-directory');
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
+  it('rejects workspace symlink escapes before executing tools', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const outside = join(artifactRoot, `rust-plugin-outside-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    mkdirSync(join(outside, 'src'), { recursive: true });
+    writeFileSync(join(outside, 'Cargo.toml'), '[package]\nname = "outside"\nversion = "0.1.0"\nedition = "2021"\n', 'utf8');
+    writeFileSync(join(outside, 'src', 'main.rs'), 'fn main() {}\n', 'utf8');
+    try {
+      symlinkSync(outside, join(fixture.workspace, 'linked-crate'), 'dir');
+    } catch {
+      rmSync(outside, { recursive: true, force: true });
+      return;
+    }
+    const previousCleanup = cleanup;
+    cleanup = () => {
+      previousCleanup?.();
+      rmSync(outside, { recursive: true, force: true });
+    };
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, {
+      body: {
+        projectPath: 'linked-crate',
+        sourceFiles: [{ path: 'src/main.rs', content: 'fn main() {}\n' }],
+        options: { generateReport: false },
+        approval: { approved: true, scope: 'rust-verification' },
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.error).toContain('projectPath resolves outside');
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
+  it('normalizes approved project and source paths under the workspace before delegating', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn(async () => []) };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace));
+
+    expect(response.status).toBe(200);
+    expect(rustAgent.verifyRustProject).toHaveBeenCalledTimes(1);
+    const verificationRequest = rustAgent.verifyRustProject.mock.calls[0]?.[0];
+    expect(verificationRequest.projectPath).toBe(fixture.cratePath);
+    expect(verificationRequest.sourceFiles[0].path).toBe(join(fixture.cratePath, 'src', 'main.rs'));
+    expect(relative(fixture.workspace, verificationRequest.projectPath)).not.toMatch(/^\.\./u);
+    expect(existsSync(verificationRequest.sourceFiles[0].path)).toBe(true);
+  });
+
+  it('accepts approved verification tool arrays after endpoint validation', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn(async () => []) };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, {
+      body: {
+        projectPath: 'crate',
+        sourceFiles: [{ path: 'src/main.rs', content: 'fn main() {}\\n' }],
+        verificationTools: ['miri'],
+        options: { generateReport: false },
+        approval: { approved: true, scope: 'rust-verification' },
+      },
+    }));
+
+    expect(response.status).toBe(200);
+    expect(rustAgent.verifyRustProject.mock.calls[0]?.[0].verificationTools).toEqual(['miri']);
+  });
+});

--- a/tests/unit/security/rust-verification-plugin-security.test.ts
+++ b/tests/unit/security/rust-verification-plugin-security.test.ts
@@ -188,6 +188,65 @@ describe('RustVerificationPlugin security boundary', () => {
     expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
   });
 
+  it('rejects case-insensitive Git metadata path segments before executing tools', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, {
+      body: {
+        projectPath: 'crate',
+        sourceFiles: [{ path: '.GIT/config', content: '' }],
+        options: { generateReport: false },
+        approval: { approved: true, scope: 'rust-verification' },
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.error).toContain('sourceFiles[0].path must not contain parent-directory or .git segments');
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
+  it('returns a controlled policy error for unusable workspace roots', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(join(fixture.workspace, 'missing-root'), rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace));
+
+    expect(response.status).toBe(400);
+    expect(response.error).toContain('projectPath does not exist inside the configured workspace root');
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
+  it('returns a controlled policy error when path realpath resolution fails', async () => {
+    const fixture = makeWorkspace();
+    cleanup = fixture.cleanup;
+    const loopPath = join(fixture.workspace, 'loop');
+    try {
+      symlinkSync(loopPath, loopPath, 'dir');
+    } catch {
+      return;
+    }
+    const rustAgent = { getAvailableTools: () => [], verifyRustProject: vi.fn() };
+    const server = await makeServer(fixture.workspace, rustAgent);
+
+    const response = await server.processRequest(makeRequest(fixture.workspace, {
+      body: {
+        projectPath: 'loop',
+        sourceFiles: [{ path: 'src/main.rs', content: '' }],
+        options: { generateReport: false },
+        approval: { approved: true, scope: 'rust-verification' },
+      },
+    }));
+
+    expect(response.status).toBe(400);
+    expect(response.error).toMatch(/projectPath (could not be resolved safely|does not exist inside the configured workspace root)/u);
+    expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
+  });
+
   it('rejects workspace symlink escapes before executing tools', async () => {
     const fixture = makeWorkspace();
     cleanup = fixture.cleanup;
@@ -219,7 +278,7 @@ describe('RustVerificationPlugin security boundary', () => {
     }));
 
     expect(response.status).toBe(400);
-    expect(response.error).toContain('projectPath resolves outside');
+    expect(response.error).toContain('outside');
     expect(rustAgent.verifyRustProject).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/utils/workspace-path-policy.test.ts
+++ b/tests/unit/utils/workspace-path-policy.test.ts
@@ -28,6 +28,7 @@ describe('workspace path policy', () => {
       '../generated',
       'generated/../outside',
       'generated/./typescript',
+      '.GIT/config',
       'C:\\temp\\generated',
       'generated\\typescript',
       '//server/share/generated',


### PR DESCRIPTION
## Summary

- Closes #3399 by requiring authenticated/operator-approved Rust verification before tool execution, constraining Rust project/source paths to the configured workspace, rejecting symlink escapes, and limiting verifier process environment/timeout behavior.
- Closes #3400 by making CodeX Task UI scaffolding dry-run by default unless trusted approval is present, replacing free-form scalar context with a structured schema, constraining/symlink-checking output roots, and sanitizing generated UI path/component names.
- Adds regression tests covering denied Rust verification requests, path traversal/symlink rejection, read-only Rust mutation behavior, UI dry-run enforcement, unsafe UI output roots, and request-schema rejection for legacy scalar context.

## Acceptance

- Rust `/rust/verify` requires authentication, `rust:verify`/operator authorization, and explicit `approval.scope=rust-verification` before delegation to verifier tools.
- Rust `projectPath`, discovered/provided `sourceFiles[].path`, analyze paths, and project discovery paths are repository-relative and cannot escape the configured workspace via absolute paths, `..`, `.git`, or symlinks.
- Rust source mutation is opt-in via `allowSourceMutation`; reports are written under `target/ae-verification/`.
- CodeX UI scaffold writes require `context.approval={ approved: true, scope: "ui-scaffold" }`; untrusted requests are forced to dry-run.
- CodeX UI output roots and every generated path remain under the approved root, with entity names normalized to path-safe/component-safe identifiers.

## Verification

- `pnpm -s exec vitest run tests/unit/security/rust-verification-agent-mutation.test.ts tests/unit/security/rust-verification-plugin-security.test.ts tests/unit/security/codex-task-ui-security.test.ts tests/unit/scripts/codex-adapter-stdio.test.ts tests/services/mcp-server.test.ts tests/unit/agents/codex-task-adapter.test.ts --reporter dot` — 6 files, 56 tests passed.
- `pnpm -s run types:check` — passed.
- `pnpm -s run build` — passed.
- `pnpm -s exec eslint --quiet src/services/plugins/rust-verification-plugin.ts src/services/mcp-server.ts src/agents/rust-verification-agent.ts src/agents/codex-task-adapter.ts src/generators/ui-scaffold-generator.ts tests/unit/security/rust-verification-plugin-security.test.ts tests/unit/security/rust-verification-agent-mutation.test.ts tests/unit/security/codex-task-ui-security.test.ts tests/unit/scripts/codex-adapter-stdio.test.ts` — passed.
- `pnpm -s run check:schemas` — passed.
- `node scripts/ci/validate-json.mjs` — passed.
- `pnpm -s run check:doc-consistency` — passed.
- `git diff --check` — passed.

## Rollback

- Revert this PR to restore the previous Rust verification and CodeX UI scaffold request handling. This would re-open the unauthenticated/unapproved write/process and output-path risks tracked by #3399 and #3400.
