### PR TITLE
fix(security): avoid validation adapter process probes

### DIFF
--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -2,7 +2,7 @@
 docRole: derived
 canonicalSource:
   - .github/workflows/agent-commands.yml
-lastVerified: '2026-06-02'
+lastVerified: '2026-06-03'
 ---
 
 # Agent Commands Catalog

--- a/src/agents/validation-task-adapter.ts
+++ b/src/agents/validation-task-adapter.ts
@@ -6,7 +6,6 @@
  * user stories, specifications, and code quality.
  */
 
-import { VerifyAgent } from './verify-agent.js';
 import type { TaskRequest, TaskResponse } from './task-types.js';
 import { extractValidationInput, formatSourceSummary, toValidationInput } from './validation-task-input.js';
 import { extractTraceabilityMatrixRows } from './validation-task-traceability.js';
@@ -32,13 +31,6 @@ export { VALIDATION_TASK_TYPES };
 export type { CoverageReport, ValidationIssue, ValidationResult, ValidationTaskType } from './validation-task-adapter.types.js';
 
 export class ValidationTaskAdapter {
-  private agent: VerifyAgent;
-
-  constructor() {
-    // VerifyAgent doesn't use config pattern like FormalAgent
-    this.agent = new VerifyAgent();
-  }
-
   /**
    * Main handler for Validation tasks from Claude Code
    */

--- a/tests/unit/agents/validation-adapter-construction.test.ts
+++ b/tests/unit/agents/validation-adapter-construction.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const childProcessMock = vi.hoisted(() => ({
+  execFileSync: vi.fn(() => ''),
+}));
+
+vi.mock('child_process', () => ({
+  execFileSync: childProcessMock.execFileSync,
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: childProcessMock.execFileSync,
+}));
+
+describe('validation task adapter construction', () => {
+  it('constructs without probing verifier tools or starting processes', async () => {
+    childProcessMock.execFileSync.mockClear();
+    const { ValidationTaskAdapter } = await import('../../../src/agents/validation-task-adapter.js');
+
+    new ValidationTaskAdapter();
+
+    expect(childProcessMock.execFileSync).not.toHaveBeenCalled();
+  });
+
+  it('constructs the CodeX task handler without verifier process execution', async () => {
+    childProcessMock.execFileSync.mockClear();
+    const { createCodexTaskAdapter } = await import('../../../src/agents/codex-task-adapter.js');
+
+    createCodexTaskAdapter();
+
+    expect(childProcessMock.execFileSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #3402 by removing the unused `VerifyAgent` construction from `ValidationTaskAdapter` so validation task-handler construction no longer creates verifier/container agents or runs Rust verifier discovery probes.
- Adds regression coverage that mocks `child_process.execFileSync` and proves both `new ValidationTaskAdapter()` and `createCodexTaskAdapter()` construction perform no verifier process execution.
- Refreshes the derived agent commands catalog date after `check:doc-consistency` reported the UTC-date-sensitive `docs/agents/commands.md` was out of sync.

## Acceptance

- Validation task adapter construction is side-effect free with respect to verifier process probes.
- CodeX task-handler construction is side-effect free with respect to verifier process probes.
- The previous validation behavior remains handled by the existing local validation heuristics; no `VerifyAgent` usage is removed because the field was unused.

## Verification

- `pnpm -s exec vitest run tests/unit/agents/validation-adapter-construction.test.ts tests/unit/agents/codex-task-adapter.test.ts --reporter dot` — 2 files, 9 tests passed.
- `pnpm -s run types:check` — passed.
- `pnpm -s exec eslint --quiet src/agents/validation-task-adapter.ts tests/unit/agents/validation-adapter-construction.test.ts tests/unit/agents/codex-task-adapter.test.ts` — passed.
- `pnpm -s run build` — passed.
- `pnpm -s run check:doc-consistency` — passed after regenerating `docs/agents/commands.md`.
- `git diff --check` — passed.

## Rollback

- Revert this PR to restore eager `VerifyAgent` construction in `ValidationTaskAdapter`; that would re-open the construction-time verifier process probe risk tracked by #3402.
