### PR TITLE
fix(security): constrain extended command paths

### DIFF
--- a/src/commands/extended/analyze-command-unified.ts
+++ b/src/commands/extended/analyze-command-unified.ts
@@ -9,6 +9,7 @@ import * as ts from 'typescript';
 import { BaseExtendedCommand } from './base-command.js';
 import type { ExtendedCommandResult } from './base-command.js';
 import type { CommandContext } from '../slash-command-manager.js';
+import { resolveExtendedCommandPath } from './workspace-paths.js';
 import type { 
   CodeAnalysis, 
   AnalysisTarget, 
@@ -61,7 +62,7 @@ export class UnifiedAnalyzeCommand extends BaseExtendedCommand {
     if (!target) {
       throw new Error('Target path is required for analysis');
     }
-    const fullPath = path.resolve(context.projectRoot, target);
+    const fullPath = resolveExtendedCommandPath(context, target, 'analysis target path');
     
     try {
       const stats = await fs.stat(fullPath);

--- a/src/commands/extended/document-command-unified.ts
+++ b/src/commands/extended/document-command-unified.ts
@@ -9,6 +9,10 @@ import * as ts from 'typescript';
 import { BaseExtendedCommand } from './base-command.js';
 import type { ExtendedCommandResult } from './base-command.js';
 import type { CommandContext } from '../slash-command-manager.js';
+import {
+  resolveExtendedCommandContainedPath,
+  resolveExtendedCommandPath,
+} from './workspace-paths.js';
 import type { 
   DocumentationResult, 
   AnalysisTarget, 
@@ -63,7 +67,7 @@ export class UnifiedDocumentCommand extends BaseExtendedCommand {
     if (!target) {
       throw new Error('Target path is required for documentation generation');
     }
-    const fullPath = path.resolve(context.projectRoot, target);
+    const fullPath = resolveExtendedCommandPath(context, target, 'documentation target path');
     
     try {
       const stats = await fs.stat(fullPath);
@@ -72,7 +76,7 @@ export class UnifiedDocumentCommand extends BaseExtendedCommand {
         type: stats.isDirectory() ? 'directory' : 'file'
       };
 
-      const result = await this.generateDocumentation(analysisTarget, options);
+      const result = await this.generateDocumentation(analysisTarget, options, context);
       const summary = this.generateSummary(result);
 
       return {
@@ -97,7 +101,11 @@ export class UnifiedDocumentCommand extends BaseExtendedCommand {
     }
   }
 
-  private async generateDocumentation(target: AnalysisTarget, options: DocumentationOptions): Promise<DocumentationResult> {
+  private async generateDocumentation(
+    target: AnalysisTarget,
+    options: DocumentationOptions,
+    context: CommandContext
+  ): Promise<DocumentationResult> {
     const startTime = Date.now();
     
     let files: string[] = [];
@@ -112,6 +120,9 @@ export class UnifiedDocumentCommand extends BaseExtendedCommand {
     const dependencies = new Set<string>();
     let totalLines = 0;
     let outputPath: string | undefined;
+    const outputDir = options.output
+      ? resolveExtendedCommandPath(context, options.output, 'documentation output directory')
+      : undefined;
 
     // Process each file
     for (const file of files) {
@@ -123,8 +134,8 @@ export class UnifiedDocumentCommand extends BaseExtendedCommand {
       totalLines += fileDoc.fileMetrics.linesOfCode;
 
       // Write individual file documentation if requested
-      if (options.output) {
-        const fileOutputPath = this.getOutputPath(file, options.output, options.format || 'markdown');
+      if (outputDir) {
+        const fileOutputPath = this.getOutputPath(file, outputDir, options.format || 'markdown');
         const formatted = this.formatDocumentation(fileDoc, options.format || 'markdown');
         await fs.writeFile(fileOutputPath, formatted);
         outputPath = options.output;
@@ -606,7 +617,7 @@ export class UnifiedDocumentCommand extends BaseExtendedCommand {
   private getOutputPath(inputFile: string, outputDir: string, format: string): string {
     const basename = path.basename(inputFile, path.extname(inputFile));
     const extension = format === 'api-json' ? 'json' : 'md';
-    return path.join(outputDir, `${basename}.${extension}`);
+    return resolveExtendedCommandContainedPath(outputDir, `${basename}.${extension}`, 'documentation output file');
   }
 
   private calculateDocumentationCompleteness(result: DocumentationResult): number {

--- a/src/commands/extended/document-command-unified.ts
+++ b/src/commands/extended/document-command-unified.ts
@@ -107,6 +107,9 @@ export class UnifiedDocumentCommand extends BaseExtendedCommand {
     context: CommandContext
   ): Promise<DocumentationResult> {
     const startTime = Date.now();
+    const outputDir = options.output
+      ? resolveExtendedCommandPath(context, options.output, 'documentation output directory')
+      : undefined;
     
     let files: string[] = [];
     if (target.type === 'directory') {
@@ -120,9 +123,6 @@ export class UnifiedDocumentCommand extends BaseExtendedCommand {
     const dependencies = new Set<string>();
     let totalLines = 0;
     let outputPath: string | undefined;
-    const outputDir = options.output
-      ? resolveExtendedCommandPath(context, options.output, 'documentation output directory')
-      : undefined;
 
     // Process each file
     for (const file of files) {

--- a/src/commands/extended/improve-command-unified.ts
+++ b/src/commands/extended/improve-command-unified.ts
@@ -9,6 +9,7 @@ import * as ts from 'typescript';
 import { BaseExtendedCommand } from './base-command.js';
 import type { ExtendedCommandResult } from './base-command.js';
 import type { CommandContext } from '../slash-command-manager.js';
+import { resolveExtendedCommandPath } from './workspace-paths.js';
 import type { 
   ImprovementResult, 
   AnalysisTarget, 
@@ -62,7 +63,7 @@ export class UnifiedImproveCommand extends BaseExtendedCommand {
     if (!target) {
       throw new Error('Target path is required');
     }
-    const fullPath = path.resolve(context.projectRoot, target);
+    const fullPath = resolveExtendedCommandPath(context, target, 'improvement target path');
     
     try {
       const stats = await fs.stat(fullPath);

--- a/src/commands/extended/troubleshoot-command-unified.ts
+++ b/src/commands/extended/troubleshoot-command-unified.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { BaseExtendedCommand } from './base-command.js';
 import type { ExtendedCommandResult } from './base-command.js';
 import type { CommandContext } from '../slash-command-manager.js';
+import { resolveExtendedCommandPath, toExtendedCommandRelativePath } from './workspace-paths.js';
 import type { 
   TroubleshootResult, 
   AnalysisTarget, 
@@ -109,6 +110,10 @@ export class UnifiedTroubleshootCommand extends BaseExtendedCommand {
     const solutions: Solution[] = [];
     const issues: Issue[] = [];
     const suggestions: any[] = [];
+    const logPath = options.logs
+      ? resolveExtendedCommandPath(context, options.logs, 'troubleshoot log path')
+      : undefined;
+    const displayLogPath = logPath ? toExtendedCommandRelativePath(context, logPath) : undefined;
 
     // Auto-detect common issues if --auto flag is used
     if (options.auto || !description || description === 'General troubleshooting') {
@@ -127,8 +132,8 @@ export class UnifiedTroubleshootCommand extends BaseExtendedCommand {
     }
 
     // Analyze logs if provided
-    if (options.logs) {
-      const logAnalysis = await this.analyzeLogs(options.logs);
+    if (logPath && displayLogPath) {
+      const logAnalysis = await this.analyzeLogs(logPath, displayLogPath);
       detectedIssues.push(...logAnalysis.issues);
       diagnosis.push(...logAnalysis.diagnosis);
       solutions.push(...logAnalysis.solutions);
@@ -663,7 +668,7 @@ export class UnifiedTroubleshootCommand extends BaseExtendedCommand {
     return { issues, diagnosis, solutions };
   }
 
-  private async analyzeLogs(logsPath: string): Promise<{
+  private async analyzeLogs(logsPath: string, displayPath = logsPath): Promise<{
     issues: DetectedIssue[];
     diagnosis: Diagnosis[];
     solutions: Solution[];
@@ -692,7 +697,7 @@ export class UnifiedTroubleshootCommand extends BaseExtendedCommand {
             type: 'log-error',
             severity: 'medium',
             message: errorLine.trim(),
-            location: { file: logsPath },
+            location: { file: displayPath },
             frequency: errorLines.filter(line => line.includes(errorLine.split(' ')[0] || '')).length
           });
         }
@@ -722,8 +727,8 @@ export class UnifiedTroubleshootCommand extends BaseExtendedCommand {
       issues.push({
         type: 'log-access-error',
         severity: 'low',
-        message: `Cannot access log file: ${logsPath}`,
-        location: { file: logsPath }
+        message: `Cannot access log file: ${displayPath}`,
+        location: { file: displayPath }
       });
     }
 

--- a/src/commands/extended/workspace-paths.ts
+++ b/src/commands/extended/workspace-paths.ts
@@ -1,0 +1,35 @@
+import path from 'node:path';
+import type { CommandContext } from '../slash-command-manager.js';
+import {
+  resolveContainedWorkspacePath,
+  resolveWorkspacePath,
+  toWorkspaceRelativePath,
+} from '../../utils/workspace-path-policy.js';
+
+const commandWorkspaceRoot = (context: CommandContext): string => path.resolve(context.projectRoot);
+
+export function resolveExtendedCommandPath(
+  context: CommandContext,
+  inputPath: string,
+  label: string,
+): string {
+  return resolveWorkspacePath(inputPath, {
+    workspaceRoot: commandWorkspaceRoot(context),
+    label,
+  });
+}
+
+export function resolveExtendedCommandContainedPath(
+  baseDir: string,
+  relativePath: string,
+  label: string,
+): string {
+  return resolveContainedWorkspacePath(baseDir, relativePath, label);
+}
+
+export function toExtendedCommandRelativePath(context: CommandContext, resolvedPath: string): string {
+  return toWorkspaceRelativePath(resolvedPath, {
+    workspaceRoot: commandWorkspaceRoot(context),
+    label: 'extended command path',
+  });
+}

--- a/tests/commands/extended-commands.test.ts
+++ b/tests/commands/extended-commands.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { SlashCommandManager } from '../../src/commands/slash-command-manager.js';
 import * as fs from 'fs/promises';
@@ -22,6 +23,21 @@ describe('Extended Commands', () => {
       expect(analyzeCommand).toBeDefined();
       expect(analyzeCommand?.description).toContain('Deep code analysis');
       expect(analyzeCommand?.aliases).toContain('/analyze');
+    });
+
+
+    test.each([
+      ['/ae:analyze /etc/passwd', 'analysis target path'],
+      ['/ae:analyze ../outside.ts', 'analysis target path'],
+      ['/ae:analyze src/../outside.ts', 'analysis target path'],
+    ])('rejects unsafe analysis target %s before filesystem access', async (command, label) => {
+      const result = await manager.execute(command);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain(label);
+      expect(fs.stat).not.toHaveBeenCalled();
+      expect(fs.readFile).not.toHaveBeenCalled();
+      expect(fs.readdir).not.toHaveBeenCalled();
     });
 
     test('should analyze a file', async () => {
@@ -55,6 +71,29 @@ describe('Extended Commands', () => {
       expect(troubleshootCommand?.aliases).toContain('/a:troubleshoot');
     });
 
+
+    test.each([
+      ['/ae:troubleshoot --logs=/etc/passwd', 'troubleshoot log path'],
+      ['/ae:troubleshoot --logs=../outside.log', 'troubleshoot log path'],
+      ['/ae:troubleshoot --logs=logs/../outside.log', 'troubleshoot log path'],
+    ])('rejects unsafe troubleshoot log path %s before filesystem access', async (command, label) => {
+      const result = await manager.execute(command);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain(label);
+      expect(fs.readFile).not.toHaveBeenCalled();
+    });
+
+    test('reads troubleshoot logs only under the approved project root', async () => {
+      vi.mocked(fs.readFile).mockResolvedValue('ERROR failed to connect\ninfo recovered');
+
+      const result = await manager.execute('/ae:troubleshoot log analysis --logs=logs/app.log');
+
+      expect(result.success).toBe(true);
+      expect(fs.readFile).toHaveBeenCalledWith(path.join(testProjectRoot, 'logs', 'app.log'), 'utf-8');
+      expect(result.data?.detectedIssues?.[0]?.location?.file).toBe('logs/app.log');
+    });
+
     test('should analyze described issue', async () => {
       const result = await manager.execute('/ae:troubleshoot Cannot find module express');
       
@@ -81,6 +120,22 @@ describe('Extended Commands', () => {
       expect(improveCommand).toBeDefined();
       expect(improveCommand?.aliases).toContain('/improve');
       expect(improveCommand?.aliases).toContain('/a:improve');
+    });
+
+
+    test.each([
+      ['/ae:improve /etc/passwd', 'improvement target path'],
+      ['/ae:improve ../outside.ts', 'improvement target path'],
+      ['/ae:improve src/../outside.ts', 'improvement target path'],
+    ])('rejects unsafe improvement target %s before filesystem access', async (command, label) => {
+      const result = await manager.execute(command);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain(label);
+      expect(fs.stat).not.toHaveBeenCalled();
+      expect(fs.readFile).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+      expect(fs.readdir).not.toHaveBeenCalled();
     });
 
     test('should suggest improvements for code', async () => {
@@ -119,6 +174,47 @@ describe('Extended Commands', () => {
       expect(documentCommand).toBeDefined();
       expect(documentCommand?.aliases).toContain('/document');
       expect(documentCommand?.aliases).toContain('/a:document');
+    });
+
+
+    test.each([
+      ['/ae:document /etc/passwd', 'documentation target path'],
+      ['/ae:document ../outside.ts', 'documentation target path'],
+      ['/ae:document src/../outside.ts', 'documentation target path'],
+    ])('rejects unsafe documentation target %s before filesystem access', async (command, label) => {
+      const result = await manager.execute(command);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain(label);
+      expect(fs.stat).not.toHaveBeenCalled();
+      expect(fs.readFile).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+      expect(fs.readdir).not.toHaveBeenCalled();
+    });
+
+    test('rejects unsafe documentation output directory before write', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => false } as any);
+      vi.mocked(fs.readFile).mockResolvedValue('export function test() {}');
+
+      const result = await manager.execute('/ae:document src/test.ts --output=../outside-docs');
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('documentation output directory');
+      expect(fs.readFile).not.toHaveBeenCalled();
+      expect(fs.readdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    test('writes documentation only under the approved project root', async () => {
+      vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => false } as any);
+      vi.mocked(fs.readFile).mockResolvedValue('export function test() {}');
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined as any);
+
+      const result = await manager.execute('/ae:document src/test.ts --output=docs/generated');
+
+      expect(result.success).toBe(true);
+      expect(fs.writeFile).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(fs.writeFile).mock.calls[0]?.[0]).toBe(path.join(testProjectRoot, 'docs', 'generated', 'test.md'));
     });
 
     test.skip('should generate documentation for TypeScript file', async () => {

--- a/tests/commands/extended-commands.test.ts
+++ b/tests/commands/extended-commands.test.ts
@@ -192,11 +192,14 @@ describe('Extended Commands', () => {
       expect(fs.readdir).not.toHaveBeenCalled();
     });
 
-    test('rejects unsafe documentation output directory before write', async () => {
-      vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => false } as any);
+    test.each([
+      ['/ae:document src/test.ts --output=../outside-docs', false],
+      ['/ae:document src --output=../outside-docs', true],
+    ])('rejects unsafe documentation output directory before source IO for %s', async (command, isDirectory) => {
+      vi.mocked(fs.stat).mockResolvedValue({ isDirectory: () => isDirectory } as any);
       vi.mocked(fs.readFile).mockResolvedValue('export function test() {}');
 
-      const result = await manager.execute('/ae:document src/test.ts --output=../outside-docs');
+      const result = await manager.execute(command);
 
       expect(result.success).toBe(false);
       expect(result.message).toContain('documentation output directory');


### PR DESCRIPTION
## Summary

- Closes #3404 by routing extended command filesystem arguments through the shared workspace path policy.
- Rejects absolute paths, parent-directory traversal, dot-segment traversal, Git metadata paths, and symlink-ancestor escapes for analyze, document, improve, and troubleshoot log inputs before command filesystem access.
- Constrains documentation output files to a validated workspace-relative output directory and reports troubleshoot log locations as workspace-relative paths.
- Adds regression tests proving unsafe target, log, and output paths are rejected before mocked read/traversal/write sinks execute.

## Acceptance

- `/ae:analyze`, `/ae:document`, and `/ae:improve` target paths must be workspace-relative and contained under `context.projectRoot` before `stat`, `readdir`, `readFile`, or `writeFile` can run.
- `/ae:document --output` must be workspace-relative and contained under `context.projectRoot` before source traversal/read/write work starts.
- `/ae:troubleshoot --logs` must be workspace-relative and contained under `context.projectRoot` before auto-detection or log reads run.
- Existing valid workspace-relative command paths remain supported.

## Verification

- `pnpm -s exec vitest run tests/commands/extended-commands.test.ts tests/unit/utils/workspace-path-policy.test.ts --reporter dot` — 2 files, 28 tests passed, 3 skipped.
- `pnpm -s run types:check` — passed.
- `pnpm -s exec eslint --quiet src/commands/extended/workspace-paths.ts src/commands/extended/analyze-command-unified.ts src/commands/extended/document-command-unified.ts src/commands/extended/improve-command-unified.ts src/commands/extended/troubleshoot-command-unified.ts tests/commands/extended-commands.test.ts` — passed.
- `pnpm -s run build` — passed.
- `node scripts/ci/validate-json.mjs` — passed.
- `pnpm -s run check:schemas` — passed.
- `pnpm -s run check:doc-consistency` — passed.
- `git diff --check` — passed.

## Rollback

- Revert this PR to restore the previous direct `path.resolve(context.projectRoot, ...)` and unconstrained log/output behavior; doing so would re-open the workspace path traversal risk tracked by #3404.
