### PR TITLE
fix(security): require approval for installer apply

### DIFF
--- a/src/cli/setup-cli.ts
+++ b/src/cli/setup-cli.ts
@@ -7,7 +7,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import path from 'node:path';
 import { createInterface } from 'node:readline/promises';
-import { InstallerManager } from '../utils/installer-manager.js';
+import { INSTALLER_APPROVAL_SCOPE, InstallerManager } from '../utils/installer-manager.js';
 import { safeExit } from '../utils/safe-exit.js';
 
 type PackageManager = 'npm' | 'yarn' | 'pnpm';
@@ -17,6 +17,13 @@ type SetupOptions = {
   name?: string;
   packageManager?: string;
 };
+
+const CLI_INSTALL_APPROVAL = {
+  approved: true,
+  scope: INSTALLER_APPROVAL_SCOPE,
+  approvedBy: 'ae setup CLI',
+  reason: 'operator invoked setup command',
+} as const;
 
 const PACKAGE_MANAGERS = new Set<PackageManager>(['npm', 'yarn', 'pnpm']);
 
@@ -281,7 +288,10 @@ export function createSetupCommand(): Command {
         return;
       }
 
-      const installContext: { projectName?: string; packageManager?: PackageManager } = {};
+      const installContext: { projectName?: string; packageManager?: PackageManager; dryRun: false; approval: typeof CLI_INSTALL_APPROVAL } = {
+        dryRun: false,
+        approval: CLI_INSTALL_APPROVAL,
+      };
       if (projectName) {
         installContext.projectName = projectName;
       }
@@ -323,7 +333,10 @@ export function createSetupCommand(): Command {
         return;
       }
 
-      const installContext: { projectName?: string; packageManager?: PackageManager } = {};
+      const installContext: { projectName?: string; packageManager?: PackageManager; dryRun: false; approval: typeof CLI_INSTALL_APPROVAL } = {
+        dryRun: false,
+        approval: CLI_INSTALL_APPROVAL,
+      };
       if (options.name) {
         installContext.projectName = options.name;
       }

--- a/src/commands/extended/installer-command.ts
+++ b/src/commands/extended/installer-command.ts
@@ -5,8 +5,13 @@
 
 import { BaseExtendedCommand } from './base-command.js';
 import type { ExtendedCommandResult, ExtendedCommandConfig } from './base-command.js';
-import { InstallerManager } from '../../utils/installer-manager.js';
-import type { InstallationTemplate, InstallationResult } from '../../utils/installer-manager.js';
+import { INSTALLER_APPROVAL_SCOPE, InstallerManager } from '../../utils/installer-manager.js';
+import type {
+  InstallationTemplate,
+  InstallationResult,
+  InstallerApproval,
+  PlannedInstallationChange,
+} from '../../utils/installer-manager.js';
 import { ContextManager } from '../../utils/context-manager.js';
 import { TokenOptimizer } from '../../utils/token-optimizer.js';
 import type * as fs from 'fs/promises';
@@ -19,6 +24,9 @@ export interface InstallerCommandResult extends ExtendedCommandResult {
   suggestions?: string[];
   recommendations?: string[];
   availableTemplates?: InstallationTemplate[];
+  dryRun?: boolean;
+  approvalRequired?: boolean;
+  plannedChanges?: PlannedInstallationChange[];
 }
 
 export class InstallerCommand extends BaseExtendedCommand {
@@ -86,7 +94,15 @@ export class InstallerCommand extends BaseExtendedCommand {
 
         default:
           // Treat as template installation
-          return await this.handleInstallTemplate(action, args.slice(1), installerManager, contextManager, tokenOptimizer, projectRoot);
+          return await this.handleInstallTemplate(
+            action,
+            args.slice(1),
+            installerManager,
+            contextManager,
+            tokenOptimizer,
+            projectRoot,
+            context
+          );
       }
 
     } catch (error: any) {
@@ -119,7 +135,8 @@ export class InstallerCommand extends BaseExtendedCommand {
         }
       }
 
-      message += 'Usage: /ae:installer <template-id> to install a template\n';
+      message += 'Usage: /ae:installer <template-id> to preview a template installation\n';
+      message += `Use /ae:installer <template-id> --apply only with ${INSTALLER_APPROVAL_SCOPE} approval\n`;
       message += 'Use /ae:installer suggest for project-specific recommendations';
 
       this.recordMetric('success');
@@ -162,7 +179,7 @@ export class InstallerCommand extends BaseExtendedCommand {
           message += `   Reason: ${reason}\n\n`;
         }
         
-        message += `Use /ae:installer <template-id> to install any of these templates`;
+        message += `Use /ae:installer <template-id> to preview any of these templates`;
       } else {
         message += 'No specific suggestions for this project.\n';
         message += 'Use /ae:installer list to see all available templates';
@@ -191,7 +208,8 @@ export class InstallerCommand extends BaseExtendedCommand {
     installerManager: InstallerManager, 
     contextManager: ContextManager, 
     tokenOptimizer: TokenOptimizer,
-    projectRoot: string
+    projectRoot: string,
+    commandContext: any
   ): Promise<InstallerCommandResult> {
     try {
       // Check if template exists
@@ -218,7 +236,7 @@ export class InstallerCommand extends BaseExtendedCommand {
       }
 
       // Parse additional options from args
-      const installationContext = this.parseInstallationOptions(additionalArgs, projectRoot);
+      const installationContext = this.parseInstallationOptions(additionalArgs, projectRoot, commandContext);
 
       // Install the template
       const result: InstallationResult = await installerManager.installTemplate(templateId, installationContext);
@@ -241,7 +259,58 @@ export class InstallerCommand extends BaseExtendedCommand {
           });
         }
 
+        if (result.approvalRequired) {
+          return {
+            success: false,
+            message: errorMessage,
+            approvalRequired: true,
+            plannedChanges: result.plannedChanges ?? [],
+            evidence: [
+              'Installer apply was rejected before dependency installation or project writes',
+              `Required approval scope: ${INSTALLER_APPROVAL_SCOPE}`,
+            ],
+            recommendations: [
+              `Rerun with --apply only after trusted-operator approval scope "${INSTALLER_APPROVAL_SCOPE}" is present`,
+            ],
+          };
+        }
+
         return this.createErrorResult(errorMessage);
+      }
+
+      if (result.dryRun === true) {
+        this.recordMetric('preview');
+        let message = `Previewed '${template.name}' template installation (dry run).\n`;
+        message += 'No dependencies were installed and no project files were changed.\n\n';
+
+        if (result.plannedChanges && result.plannedChanges.length > 0) {
+          message += 'Planned changes:\n';
+          result.plannedChanges.forEach(change => {
+            const commandPreview = change.command
+              ? ` [${[change.command, ...(change.args ?? [])].join(' ')}]`
+              : '';
+            message += `  • ${change.action}: ${change.target}${commandPreview}\n`;
+          });
+          message += '\n';
+        }
+
+        message += `To apply these changes, rerun with --apply from a context that carries `;
+        message += `approval.scope="${INSTALLER_APPROVAL_SCOPE}" and approval.approved=true.`;
+
+        return {
+          success: true,
+          message,
+          dryRun: true,
+          plannedChanges: result.plannedChanges ?? [],
+          evidence: [
+            `Previewed template: ${template.name}`,
+            `Planned ${result.plannedChanges?.length ?? 0} installer changes`,
+            'No installer writes or package-manager commands were executed'
+          ],
+          recommendations: [
+            `Obtain trusted-operator approval with scope "${INSTALLER_APPROVAL_SCOPE}" before using --apply`
+          ]
+        };
       }
 
       // Build success message
@@ -315,6 +384,8 @@ export class InstallerCommand extends BaseExtendedCommand {
         installedTemplate: templateId,
         installedDependencies: result.installedDependencies,
         createdFiles: result.createdFiles,
+        dryRun: false,
+        plannedChanges: result.plannedChanges ?? [],
         evidence,
         recommendations
       };
@@ -325,11 +396,17 @@ export class InstallerCommand extends BaseExtendedCommand {
     }
   }
 
-  private parseInstallationOptions(args: string[], projectRoot: string): any {
+  private parseInstallationOptions(args: string[], projectRoot: string, commandContext: any): any {
     const options: any = {
       projectRoot,
-      projectName: path.basename(projectRoot)
+      projectName: path.basename(projectRoot),
+      dryRun: true
     };
+
+    const approval = this.extractInstallerApproval(commandContext);
+    if (approval) {
+      options.approval = approval;
+    }
 
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
@@ -350,10 +427,29 @@ export class InstallerCommand extends BaseExtendedCommand {
           options.packageManager = manager;
         }
         i++; // Skip next arg
+      } else if (arg === '--apply') {
+        options.dryRun = false;
+      } else if (arg === '--dry-run' || arg === '--preview') {
+        options.dryRun = true;
+      } else if (arg === '--allow-lifecycle-scripts') {
+        options.allowLifecycleScripts = true;
       }
     }
 
     return options;
+  }
+
+  private extractInstallerApproval(commandContext: any): InstallerApproval | undefined {
+    const approval = commandContext?.approval;
+    if (approval?.approved === true && approval?.scope === INSTALLER_APPROVAL_SCOPE) {
+      return {
+        approved: true,
+        scope: INSTALLER_APPROVAL_SCOPE,
+        ...(typeof approval.approvedBy === 'string' ? { approvedBy: approval.approvedBy } : {}),
+        ...(typeof approval.reason === 'string' ? { reason: approval.reason } : {}),
+      };
+    }
+    return undefined;
   }
 
   private generatePostInstallationRecommendations(template: InstallationTemplate, result: InstallationResult): string[] {
@@ -407,19 +503,22 @@ Actions:
   • help                 Show this help message
 
 Template Installation:
-  /ae:installer typescript-node --name=myproject
-  /ae:installer react-vite --packageManager=pnpm
-  /ae:installer express-api --name=api-server
+  /ae:installer typescript-node --name=myproject          # Preview only
+  /ae:installer react-vite --packageManager=pnpm          # Preview only
+  /ae:installer express-api --name=api-server --apply     # Requires trusted approval
 
 Options:
   --name=<name>           Set project name
   --packageManager=<mgr>  Use specific package manager (npm/yarn/pnpm)
+  --dry-run/--preview     Preview planned changes without writes or dependency installs (default)
+  --apply                 Apply planned changes only when context.approval.scope="${INSTALLER_APPROVAL_SCOPE}"
+  --allow-lifecycle-scripts Allow dependency lifecycle scripts during approved package installs
 
 Examples:
   /ae:installer list                    # List all templates
   /ae:installer suggest                 # Get recommendations  
-  /ae:installer typescript-node         # Install TypeScript Node.js template
-  /ae:installer react-vite --name=app   # Install React template with custom name`;
+  /ae:installer typescript-node         # Preview TypeScript Node.js template
+  /ae:installer react-vite --name=app   # Preview React template with custom name`;
 
     this.recordMetric('help_requested');
     return {
@@ -459,6 +558,9 @@ Examples:
   }
 
   protected override generateValidationClaim(data: any): string {
+    if (data.dryRun) {
+      return `Template "${data.installedTemplate ?? 'installer'}" installation was previewed without local changes`;
+    }
     if (data.installedTemplate) {
       return `Template "${data.installedTemplate}" was successfully installed`;
     } else if (data.availableTemplates) {
@@ -468,6 +570,9 @@ Examples:
   }
 
   protected override generateSummary(data: any): string {
+    if (data.dryRun) {
+      return 'Installer dry-run preview completed without applying changes';
+    }
     if (data.installedTemplate) {
       return `Successfully installed template: ${data.installedTemplate}`;
     } else if (data.availableTemplates) {

--- a/src/utils/installer-manager.ts
+++ b/src/utils/installer-manager.ts
@@ -879,18 +879,20 @@ end
       });
     }
 
-    for (const dependency of template.dependencies) {
-      const spec = this.formatDependencySpec(dependency);
+    const dependencySpecs = template.dependencies.map(dependency =>
+      this.formatDependencySpec(dependency)
+    );
+    if (dependencySpecs.length > 0) {
       const { command, args } = this.buildPackageManagerInvocation(
         context.packageManager,
-        [spec],
+        dependencySpecs,
         false,
         context.allowLifecycleScripts === true
       );
       result.plannedChanges?.push({
         type: 'dependency',
         action: 'install',
-        target: spec,
+        target: dependencySpecs.join(', '),
         command,
         args,
         details: context.allowLifecycleScripts === true
@@ -899,18 +901,20 @@ end
       });
     }
 
-    for (const dependency of template.devDependencies ?? []) {
-      const spec = this.formatDependencySpec(dependency);
+    const devDependencySpecs = (template.devDependencies ?? []).map(dependency =>
+      this.formatDependencySpec(dependency)
+    );
+    if (devDependencySpecs.length > 0) {
       const { command, args } = this.buildPackageManagerInvocation(
         context.packageManager,
-        [spec],
+        devDependencySpecs,
         true,
         context.allowLifecycleScripts === true
       );
       result.plannedChanges?.push({
         type: 'devDependency',
         action: 'install',
-        target: spec,
+        target: devDependencySpecs.join(', '),
         command,
         args,
         details: context.allowLifecycleScripts === true

--- a/src/utils/installer-manager.ts
+++ b/src/utils/installer-manager.ts
@@ -7,6 +7,13 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { stringify as toYamlString } from 'yaml';
+import {
+  resolveContainedWorkspacePath,
+  resolveWorkspacePath,
+  WorkspacePathPolicyError,
+} from './workspace-path-policy.js';
+
+export const INSTALLER_APPROVAL_SCOPE = 'installer-apply' as const;
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -106,6 +113,32 @@ export interface InstallationContext {
   nodeVersion?: string;
   existingPackageJson?: any;
   userPreferences?: Record<string, any>;
+  dryRun?: boolean;
+  approval?: InstallerApproval;
+  allowLifecycleScripts?: boolean;
+}
+
+export interface InstallerApproval {
+  approved: boolean;
+  scope: typeof INSTALLER_APPROVAL_SCOPE;
+  approvedBy?: string;
+  reason?: string;
+}
+
+export interface PlannedInstallationChange {
+  type:
+    | 'dependency'
+    | 'devDependency'
+    | 'packageJson'
+    | 'script'
+    | 'file'
+    | 'configuration'
+    | 'postInstallStep';
+  action: 'install' | 'write' | 'merge' | 'skip' | 'execute';
+  target: string;
+  command?: string;
+  args?: string[];
+  details?: string;
 }
 
 export interface InstallationResult {
@@ -118,6 +151,9 @@ export interface InstallationResult {
   warnings: string[];
   errors: string[];
   duration: number;
+  dryRun?: boolean;
+  approvalRequired?: boolean;
+  plannedChanges?: PlannedInstallationChange[];
 }
 
 export class InstallerManager {
@@ -125,7 +161,7 @@ export class InstallerManager {
   private projectRoot: string;
 
   constructor(projectRoot: string) {
-    this.projectRoot = projectRoot;
+    this.projectRoot = path.resolve(projectRoot);
     this.loadDefaultTemplates();
   }
 
@@ -184,10 +220,30 @@ export class InstallerManager {
       executedSteps: [],
       warnings: [],
       errors: [],
-      duration: 0
+      duration: 0,
+      dryRun: installContext.dryRun === true,
+      approvalRequired: false,
+      plannedChanges: []
     };
 
     try {
+      await this.collectPlannedChanges(template, installContext, result);
+
+      if (installContext.dryRun === true) {
+        result.message = `Dry-run preview for ${template.name}; no installer changes were applied`;
+        result.duration = Date.now() - startTime;
+        return result;
+      }
+
+      if (!this.hasTrustedApproval(installContext)) {
+        result.success = false;
+        result.approvalRequired = true;
+        result.message = `Installation requires explicit ${INSTALLER_APPROVAL_SCOPE} approval`;
+        result.errors.push(result.message);
+        result.duration = Date.now() - startTime;
+        return result;
+      }
+
       // Install dependencies
       await this.installDependencies(template, installContext, result);
       
@@ -297,6 +353,10 @@ export class InstallerManager {
    * Update package manager detection
    */
   async detectPackageManager(): Promise<'npm' | 'yarn' | 'pnpm'> {
+    return this.detectPackageManagerInternal({ allowExecutableProbe: true });
+  }
+
+  private async detectPackageManagerInternal(options: { allowExecutableProbe: boolean }): Promise<'npm' | 'yarn' | 'pnpm'> {
     const lockFiles = [
       { file: 'pnpm-lock.yaml', manager: 'pnpm' as const },
       { file: 'yarn.lock', manager: 'yarn' as const },
@@ -310,14 +370,18 @@ export class InstallerManager {
       }
     }
 
+    if (!options.allowExecutableProbe) {
+      return 'npm';
+    }
+
     // Check if package managers are globally available
     try {
-      await this.runCommand('pnpm --version', { silent: true });
+      await this.runCommandArgs('pnpm', ['--version'], { silent: true });
       return 'pnpm';
     } catch {}
 
     try {
-      await this.runCommand('yarn --version', { silent: true });
+      await this.runCommandArgs('yarn', ['--version'], { silent: true });
       return 'yarn';
     } catch {}
 
@@ -739,14 +803,40 @@ end
     }
   }
 
+  private hasTrustedApproval(context: Pick<InstallationContext, 'approval'>): boolean {
+    return context.approval?.approved === true && context.approval.scope === INSTALLER_APPROVAL_SCOPE;
+  }
+
+  private resolveProjectPath(context: InstallationContext, relativePath: string, label: string): string {
+    return resolveWorkspacePath(relativePath, {
+      workspaceRoot: context.projectRoot,
+      label,
+    });
+  }
+
+  private resolveProjectContainedPath(context: InstallationContext, relativePath: string, label: string): string {
+    return resolveContainedWorkspacePath(context.projectRoot, relativePath, label);
+  }
+
   private async prepareContext(context: Partial<InstallationContext>): Promise<InstallationContext> {
-    const packageManager = context.packageManager || await this.detectPackageManager();
+    const requestedProjectRoot = context.projectRoot ? path.resolve(context.projectRoot) : this.projectRoot;
+    if (requestedProjectRoot !== this.projectRoot) {
+      throw new WorkspacePathPolicyError('installer project root must match the approved manager workspace');
+    }
+
+    const trustedApproval = this.hasTrustedApproval(context);
+    const dryRun = context.dryRun ?? !trustedApproval;
+    const packageManager = context.packageManager
+      || await this.detectPackageManagerInternal({ allowExecutableProbe: dryRun !== true && trustedApproval });
     const projectName = context.projectName || path.basename(this.projectRoot);
     
     let existingPackageJson;
     try {
       const packageJsonContent = await fs.readFile(
-        path.join(this.projectRoot, 'package.json'),
+        resolveWorkspacePath('package.json', {
+          workspaceRoot: this.projectRoot,
+          label: 'installer package manifest',
+        }),
         'utf-8'
       );
       existingPackageJson = JSON.parse(packageJsonContent);
@@ -754,13 +844,119 @@ end
       // No existing package.json
     }
 
-    return {
+    const preparedContext: InstallationContext = {
       projectRoot: this.projectRoot,
       projectName,
       packageManager,
-      existingPackageJson,
-      ...context
+      dryRun,
+      allowLifecycleScripts: context.allowLifecycleScripts === true
     };
+    if (existingPackageJson !== undefined) {
+      preparedContext.existingPackageJson = existingPackageJson;
+    }
+    if (context.userPreferences !== undefined) {
+      preparedContext.userPreferences = context.userPreferences;
+    }
+    if (context.approval) {
+      preparedContext.approval = context.approval;
+    }
+    return preparedContext;
+  }
+
+  private async collectPlannedChanges(
+    template: InstallationTemplate,
+    context: InstallationContext,
+    result: InstallationResult
+  ): Promise<void> {
+    const packageJsonPath = this.resolveProjectPath(context, 'package.json', 'installer package manifest');
+    const packageJsonExists = await this.fileExists(packageJsonPath);
+    if (!packageJsonExists) {
+      result.plannedChanges?.push({
+        type: 'packageJson',
+        action: 'write',
+        target: 'package.json',
+        details: 'Create minimal package.json before dependency installation',
+      });
+    }
+
+    for (const dependency of template.dependencies) {
+      const spec = this.formatDependencySpec(dependency);
+      const { command, args } = this.buildPackageManagerInvocation(
+        context.packageManager,
+        [spec],
+        false,
+        context.allowLifecycleScripts === true
+      );
+      result.plannedChanges?.push({
+        type: 'dependency',
+        action: 'install',
+        target: spec,
+        command,
+        args,
+        details: context.allowLifecycleScripts === true
+          ? 'Lifecycle scripts are allowed by explicit installer context'
+          : 'Lifecycle scripts are suppressed by default',
+      });
+    }
+
+    for (const dependency of template.devDependencies ?? []) {
+      const spec = this.formatDependencySpec(dependency);
+      const { command, args } = this.buildPackageManagerInvocation(
+        context.packageManager,
+        [spec],
+        true,
+        context.allowLifecycleScripts === true
+      );
+      result.plannedChanges?.push({
+        type: 'devDependency',
+        action: 'install',
+        target: spec,
+        command,
+        args,
+        details: context.allowLifecycleScripts === true
+          ? 'Lifecycle scripts are allowed by explicit installer context'
+          : 'Lifecycle scripts are suppressed by default',
+      });
+    }
+
+    for (const scriptName of Object.keys(template.scripts)) {
+      result.plannedChanges?.push({
+        type: 'script',
+        action: 'write',
+        target: `package.json#scripts.${scriptName}`,
+        details: `Set npm script "${scriptName}"`,
+      });
+    }
+
+    for (const file of template.files) {
+      const resolved = this.resolveProjectContainedPath(context, file.path, 'installer template file');
+      const exists = await this.fileExists(resolved);
+      result.plannedChanges?.push({
+        type: 'file',
+        action: exists && !file.overwrite ? 'skip' : 'write',
+        target: file.path,
+        details: exists && !file.overwrite ? 'Existing file is protected by overwrite policy' : 'Create or overwrite template file',
+      });
+    }
+
+    for (const config of template.configurations) {
+      this.resolveProjectContainedPath(context, config.file, 'installer configuration file');
+      result.plannedChanges?.push({
+        type: 'configuration',
+        action: config.merge ? 'merge' : 'write',
+        target: config.file,
+        details: config.merge ? 'Merge with existing configuration where supported' : 'Write configuration file',
+      });
+    }
+
+    for (const step of template.postInstallSteps ?? []) {
+      result.plannedChanges?.push({
+        type: 'postInstallStep',
+        action: 'execute',
+        target: step.description,
+        details: 'Run post-install step after files and dependencies are applied',
+      });
+    }
   }
 
   private async installDependencies(
@@ -773,20 +969,34 @@ end
 
     // Install regular dependencies
     if (template.dependencies.length > 0) {
-      const depNames = template.dependencies.map(d => d.version ? `${d.name}@${d.version}` : d.name);
-      await this.runPackageManagerCommand(context.packageManager, 'install', depNames);
+      const depNames = template.dependencies.map(dependency => this.formatDependencySpec(dependency));
+      await this.runPackageManagerCommand(
+        context.packageManager,
+        'install',
+        depNames,
+        false,
+        context.allowLifecycleScripts === true
+      );
       result.installedDependencies.push(...depNames);
     }
 
     // Install dev dependencies
     if (template.devDependencies && template.devDependencies.length > 0) {
-      const devDepNames = template.devDependencies.map(d => d.version ? `${d.name}@${d.version}` : d.name);
-      await this.runPackageManagerCommand(context.packageManager, 'install', devDepNames, true);
+      const devDepNames = template.devDependencies.map(dependency => this.formatDependencySpec(dependency));
+      await this.runPackageManagerCommand(
+        context.packageManager,
+        'install',
+        devDepNames,
+        true,
+        context.allowLifecycleScripts === true
+      );
       result.installedDependencies.push(...devDepNames.map(d => `${d} (dev)`));
     }
 
     // Update scripts
-    await this.updatePackageJsonScripts(template.scripts, context);
+    if (Object.keys(template.scripts).length > 0) {
+      await this.updatePackageJsonScripts(template.scripts, context);
+    }
   }
 
   private async createTemplateFiles(
@@ -795,7 +1005,7 @@ end
     result: InstallationResult
   ): Promise<void> {
     for (const file of template.files) {
-      const filePath = path.join(context.projectRoot, file.path);
+      const filePath = this.resolveProjectContainedPath(context, file.path, 'installer template file');
       const dir = path.dirname(filePath);
 
       // Ensure directory exists
@@ -822,7 +1032,7 @@ end
     result: InstallationResult
   ): Promise<void> {
     for (const config of template.configurations) {
-      const configPath = path.join(context.projectRoot, config.file);
+      const configPath = this.resolveProjectContainedPath(context, config.file, 'installer configuration file');
       
       let configContent: string;
       if (typeof config.content === 'string') {
@@ -856,6 +1066,20 @@ end
             configContent = JSON.stringify(config.content, null, 2);
             result.warnings.push(`Configuration format "${config.format}" is not implemented, falling back to JSON`);
         }
+      }
+
+      if (config.merge && config.format === 'json') {
+        try {
+          const existingContent = await fs.readFile(configPath, 'utf-8');
+          const existingConfig = JSON.parse(existingContent);
+          if (isPlainObject(existingConfig) && isPlainObject(config.content)) {
+            configContent = JSON.stringify(this.mergePlainObjects(existingConfig, config.content), null, 2);
+          }
+        } catch {
+          // Missing or invalid existing JSON falls back to writing the generated configuration.
+        }
+      } else if (config.merge) {
+        result.warnings.push(`Configuration ${config.file} requested merge but ${config.format} merge is not implemented; writing generated content`);
       }
 
       const dir = path.dirname(configPath);
@@ -893,7 +1117,7 @@ end
   }
 
   private async ensurePackageJson(context: InstallationContext): Promise<void> {
-    const packageJsonPath = path.join(context.projectRoot, 'package.json');
+    const packageJsonPath = this.resolveProjectPath(context, 'package.json', 'installer package manifest');
     const exists = await this.fileExists(packageJsonPath);
     
     if (!exists) {
@@ -913,7 +1137,7 @@ end
   }
 
   private async updatePackageJsonScripts(scripts: Record<string, string>, context: InstallationContext): Promise<void> {
-    const packageJsonPath = path.join(context.projectRoot, 'package.json');
+    const packageJsonPath = this.resolveProjectPath(context, 'package.json', 'installer package manifest');
     const packageJsonContent = await fs.readFile(packageJsonPath, 'utf-8');
     const packageJson = JSON.parse(packageJsonContent);
     
@@ -926,35 +1150,39 @@ end
     packageManager: string, 
     command: string, 
     packages: string[], 
-    dev: boolean = false
+    dev: boolean = false,
+    allowLifecycleScripts: boolean = false
   ): Promise<void> {
-    let cmd: string;
-    
-    switch (packageManager) {
-      case 'yarn':
-        cmd = dev ? `yarn add -D ${packages.join(' ')}` : `yarn add ${packages.join(' ')}`;
-        break;
-      case 'pnpm':
-        cmd = dev ? `pnpm add -D ${packages.join(' ')}` : `pnpm add ${packages.join(' ')}`;
-        break;
-      default: // npm
-        cmd = dev ? `npm install --save-dev ${packages.join(' ')}` : `npm install ${packages.join(' ')}`;
+    if (command !== 'install') {
+      throw new Error(`Unsupported package manager command: ${command}`);
     }
-    
-    await this.runCommand(cmd);
+
+    const invocation = this.buildPackageManagerInvocation(packageManager, packages, dev, allowLifecycleScripts);
+    await this.runCommandArgs(invocation.command, invocation.args);
   }
 
   private async runCommand(command: string, options: { silent?: boolean } = {}): Promise<string> {
+    const trimmed = command.trim();
+    if (!trimmed || trimmed.includes('\0') || /[\r\n]/.test(trimmed)) {
+      throw new Error(`Cannot execute unsafe command: "${command}"`);
+    }
+    const [cmd, ...args] = trimmed.split(/\s+/);
+    if (!cmd) {
+      throw new Error(`Cannot execute empty command: "${command}"`);
+    }
+    return this.runCommandArgs(cmd, args, options);
+  }
+
+  private async runCommandArgs(command: string, args: string[], options: { silent?: boolean } = {}): Promise<string> {
     return new Promise((resolve, reject) => {
-      const [cmd, ...args] = command.split(' ');
-      
-      if (!cmd) {
-        reject(new Error(`Cannot execute empty command: "${command}"`));
+      if (!command) {
+        reject(new Error('Cannot execute empty command'));
         return;
       }
       
-      const process = spawn(cmd, args, { 
+      const process = spawn(command, args, {
         cwd: this.projectRoot,
+        shell: false,
         stdio: options.silent ? 'pipe' : 'inherit'
       });
       
@@ -974,7 +1202,7 @@ end
         if (code === 0) {
           resolve(output);
         } else {
-          reject(new Error(`Command failed with exit code ${code}: ${command}`));
+          reject(new Error(`Command failed with exit code ${code}: ${command} ${args.join(' ')}`.trim()));
         }
       });
       
@@ -1018,7 +1246,10 @@ end
   }
 
   private async saveCustomTemplate(template: InstallationTemplate): Promise<void> {
-    const customTemplatesPath = path.join(this.projectRoot, '.ae-framework', 'custom-templates.json');
+    const customTemplatesPath = resolveWorkspacePath('.ae-framework/custom-templates.json', {
+      workspaceRoot: this.projectRoot,
+      label: 'installer custom template registry',
+    });
     
     let customTemplates: InstallationTemplate[] = [];
     
@@ -1042,5 +1273,79 @@ end
     const dir = path.dirname(customTemplatesPath);
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(customTemplatesPath, JSON.stringify(customTemplates, null, 2));
+  }
+
+  private formatDependencySpec(dependency: Dependency): string {
+    const spec = dependency.version ? `${dependency.name}@${dependency.version}` : dependency.name;
+    this.assertSafePackageSpec(spec);
+    return spec;
+  }
+
+  private assertSafePackageSpec(spec: string): void {
+    if (!spec || spec.includes('\0') || /\s/.test(spec) || spec.startsWith('-')) {
+      throw new Error(`Unsafe package spec: ${spec}`);
+    }
+  }
+
+  private buildPackageManagerInvocation(
+    packageManager: string,
+    packages: string[],
+    dev: boolean,
+    allowLifecycleScripts: boolean
+  ): { command: string; args: string[] } {
+    for (const packageSpec of packages) {
+      this.assertSafePackageSpec(packageSpec);
+    }
+
+    switch (packageManager) {
+      case 'yarn':
+        return {
+          command: 'yarn',
+          args: [
+            'add',
+            ...(allowLifecycleScripts ? [] : ['--ignore-scripts']),
+            ...(dev ? ['-D'] : []),
+            ...packages,
+          ],
+        };
+      case 'pnpm':
+        return {
+          command: 'pnpm',
+          args: [
+            'add',
+            ...(allowLifecycleScripts ? [] : ['--ignore-scripts']),
+            ...(dev ? ['-D'] : []),
+            ...packages,
+          ],
+        };
+      case 'npm':
+        return {
+          command: 'npm',
+          args: [
+            'install',
+            ...(allowLifecycleScripts ? [] : ['--ignore-scripts']),
+            ...(dev ? ['--save-dev'] : []),
+            ...packages,
+          ],
+        };
+      default:
+        throw new Error(`Unsupported package manager: ${packageManager}`);
+    }
+  }
+
+  private mergePlainObjects(
+    base: Record<string, unknown>,
+    override: Record<string, unknown>
+  ): Record<string, unknown> {
+    const merged: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(override)) {
+      const current = merged[key];
+      if (isPlainObject(current) && isPlainObject(value)) {
+        merged[key] = this.mergePlainObjects(current, value);
+      } else {
+        merged[key] = value;
+      }
+    }
+    return merged;
   }
 }

--- a/tests/cli/setup-cli.test.ts
+++ b/tests/cli/setup-cli.test.ts
@@ -25,6 +25,7 @@ vi.mock('node:readline/promises', () => ({
 }));
 
 vi.mock('../../src/utils/installer-manager.js', () => ({
+  INSTALLER_APPROVAL_SCOPE: 'installer-apply',
   InstallerManager: class {
     constructor(root: string) {
       lastRoot = root;
@@ -156,10 +157,15 @@ describe('setup CLI', () => {
       'pnpm',
     ]);
 
-    expect(installTemplateMock).toHaveBeenCalledWith('typescript-node', {
+    expect(installTemplateMock).toHaveBeenCalledWith('typescript-node', expect.objectContaining({
       projectName: 'my-app',
       packageManager: 'pnpm',
-    });
+      dryRun: false,
+      approval: expect.objectContaining({
+        approved: true,
+        scope: 'installer-apply',
+      }),
+    }));
     expect(safeExitMock).not.toHaveBeenCalled();
     consoleLogSpy.mockRestore();
   });
@@ -216,10 +222,15 @@ describe('setup CLI', () => {
     const command = createSetupCommand();
     await command.parseAsync(['node', 'cli', 'wizard']);
 
-    expect(installTemplateMock).toHaveBeenCalledWith('typescript-node', {
+    expect(installTemplateMock).toHaveBeenCalledWith('typescript-node', expect.objectContaining({
       projectName: 'my-app',
       packageManager: 'pnpm',
-    });
+      dryRun: false,
+      approval: expect.objectContaining({
+        approved: true,
+        scope: 'installer-apply',
+      }),
+    }));
     expect(readlineCloseMock).toHaveBeenCalledTimes(4);
 
     Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinTTY, configurable: true });

--- a/tests/commands/installer-command.test.ts
+++ b/tests/commands/installer-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { InstallerCommand } from '../../src/commands/extended/installer-command.js';
-import { InstallerManager } from '../../src/utils/installer-manager.js';
+import { INSTALLER_APPROVAL_SCOPE, InstallerManager } from '../../src/utils/installer-manager.js';
 import { ContextManager } from '../../src/utils/context-manager.js';
 import * as fs from 'fs/promises';
 
@@ -15,6 +15,14 @@ describe('InstallerCommand', () => {
   let mockInstallerManager: any;
   let mockContextManager: any;
   const testContext = { projectRoot: '/test/project' };
+  const approvedTestContext = {
+    projectRoot: '/test/project',
+    approval: {
+      approved: true,
+      scope: INSTALLER_APPROVAL_SCOPE,
+      approvedBy: 'operator',
+    },
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -134,7 +142,55 @@ describe('InstallerCommand', () => {
   });
 
   describe('Template Installation', () => {
-    test('should install template successfully', async () => {
+    test('should preview template installation by default without updating project memory', async () => {
+      const mockTemplate = {
+        id: 'typescript-node',
+        name: 'TypeScript Node.js',
+        description: 'TypeScript Node.js project',
+        category: 'api',
+        language: 'typescript',
+        dependencies: [],
+        scripts: { dev: 'tsx src/index.ts' },
+        files: [],
+        configurations: []
+      };
+
+      const mockPreviewResult = {
+        success: true,
+        message: 'Dry-run preview',
+        installedDependencies: [],
+        createdFiles: [],
+        configuredFiles: [],
+        executedSteps: [],
+        warnings: [],
+        errors: [],
+        duration: 100,
+        dryRun: true,
+        plannedChanges: [
+          { type: 'script', action: 'write', target: 'package.json#scripts.dev' },
+        ],
+      };
+
+      mockInstallerManager.getTemplate.mockReturnValue(mockTemplate);
+      mockInstallerManager.installTemplate.mockResolvedValue(mockPreviewResult);
+
+      const result = await installerCommand.handler(['typescript-node'], testContext);
+
+      expect(result.success).toBe(true);
+      expect(result.dryRun).toBe(true);
+      expect(result.message).toContain('Previewed');
+      expect(result.message).toContain('No dependencies were installed');
+      expect(mockInstallerManager.installTemplate).toHaveBeenCalledWith(
+        'typescript-node',
+        expect.objectContaining({
+          dryRun: true,
+          projectRoot: '/test/project',
+        })
+      );
+      expect(mockContextManager.addToMemory).not.toHaveBeenCalled();
+    });
+
+    test('should install template successfully with explicit approval and --apply', async () => {
       const mockTemplate = {
         id: 'typescript-node',
         name: 'TypeScript Node.js',
@@ -162,7 +218,7 @@ describe('InstallerCommand', () => {
       mockInstallerManager.getTemplate.mockReturnValue(mockTemplate);
       mockInstallerManager.installTemplate.mockResolvedValue(mockInstallResult);
 
-      const result = await installerCommand.handler(['typescript-node'], testContext);
+      const result = await installerCommand.handler(['typescript-node', '--apply'], approvedTestContext);
 
       expect(result.success).toBe(true);
       expect(result.message).toContain('Successfully installed');
@@ -178,6 +234,51 @@ describe('InstallerCommand', () => {
           projectFramework: undefined
         }
       );
+      expect(mockInstallerManager.installTemplate).toHaveBeenCalledWith(
+        'typescript-node',
+        expect.objectContaining({
+          dryRun: false,
+          approval: expect.objectContaining({
+            approved: true,
+            scope: INSTALLER_APPROVAL_SCOPE,
+          }),
+        })
+      );
+    });
+
+    test('should reject --apply when trusted installer approval is missing', async () => {
+      const mockTemplate = {
+        id: 'typescript-node',
+        name: 'TypeScript Node.js',
+        category: 'api',
+        language: 'typescript',
+        dependencies: [],
+        scripts: {},
+        files: [],
+        configurations: []
+      };
+
+      mockInstallerManager.getTemplate.mockReturnValue(mockTemplate);
+      mockInstallerManager.installTemplate.mockResolvedValue({
+        success: false,
+        message: `Installation requires explicit ${INSTALLER_APPROVAL_SCOPE} approval`,
+        installedDependencies: [],
+        createdFiles: [],
+        configuredFiles: [],
+        executedSteps: [],
+        warnings: [],
+        errors: [`Installation requires explicit ${INSTALLER_APPROVAL_SCOPE} approval`],
+        duration: 1,
+        approvalRequired: true,
+        plannedChanges: [{ type: 'script', action: 'write', target: 'package.json#scripts.dev' }],
+      });
+
+      const result = await installerCommand.handler(['typescript-node', '--apply'], testContext);
+
+      expect(result.success).toBe(false);
+      expect(result.approvalRequired).toBe(true);
+      expect(result.message).toContain(INSTALLER_APPROVAL_SCOPE);
+      expect(mockContextManager.addToMemory).not.toHaveBeenCalled();
     });
 
     test('should handle non-existent template', async () => {
@@ -225,7 +326,7 @@ describe('InstallerCommand', () => {
       mockInstallerManager.getTemplate.mockReturnValue(mockTemplate);
       mockInstallerManager.installTemplate.mockResolvedValue(mockInstallResult);
 
-      const result = await installerCommand.handler(['failing-template'], testContext);
+      const result = await installerCommand.handler(['failing-template', '--apply'], approvedTestContext);
 
       expect(result.success).toBe(false);
       expect(result.message).toContain('Failed to install template');
@@ -263,14 +364,20 @@ describe('InstallerCommand', () => {
       await installerCommand.handler([
         'typescript-node',
         '--name=my-project',
-        '--packageManager=pnpm'
-      ], testContext);
+        '--packageManager=pnpm',
+        '--apply'
+      ], approvedTestContext);
 
       expect(mockInstallerManager.installTemplate).toHaveBeenCalledWith(
         'typescript-node',
         expect.objectContaining({
           projectName: 'my-project',
-          packageManager: 'pnpm'
+          packageManager: 'pnpm',
+          dryRun: false,
+          approval: expect.objectContaining({
+            approved: true,
+            scope: INSTALLER_APPROVAL_SCOPE,
+          }),
         })
       );
     });
@@ -337,7 +444,7 @@ describe('InstallerCommand', () => {
       mockInstallerManager.getTemplate.mockReturnValue(mockTemplate);
       mockInstallerManager.installTemplate.mockResolvedValue(mockInstallResult);
 
-      const result = await installerCommand.handler(['typescript-node'], testContext);
+      const result = await installerCommand.handler(['typescript-node', '--apply'], approvedTestContext);
 
       expect(result.success).toBe(true);
       expect(result.recommendations).toContain('Run type checking with npm run type-check or similar');
@@ -372,7 +479,7 @@ describe('InstallerCommand', () => {
       mockInstallerManager.getTemplate.mockReturnValue(mockTemplate);
       mockInstallerManager.installTemplate.mockResolvedValue(mockInstallResult);
 
-      const result = await installerCommand.handler(['react-vite'], testContext);
+      const result = await installerCommand.handler(['react-vite', '--apply'], approvedTestContext);
 
       expect(result.success).toBe(true);
       expect(result.recommendations?.some(r => r.includes('Start development server'))).toBe(true);

--- a/tests/utils/installer-manager.test.ts
+++ b/tests/utils/installer-manager.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect, beforeEach, vi, afterEach } from 'vitest';
-import { InstallerManager, InstallationTemplate } from '../../src/utils/installer-manager.js';
+import {
+  INSTALLER_APPROVAL_SCOPE,
+  InstallerManager,
+  InstallationTemplate,
+} from '../../src/utils/installer-manager.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { spawn } from 'child_process';
@@ -12,6 +16,13 @@ vi.mock('child_process');
 describe('InstallerManager', () => {
   let installerManager: InstallerManager;
   const testProjectRoot = '/test/project';
+  const approvedContext = {
+    dryRun: false,
+    approval: {
+      approved: true,
+      scope: INSTALLER_APPROVAL_SCOPE,
+    },
+  } as const;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -132,7 +143,7 @@ describe('InstallerManager', () => {
       };
       vi.mocked(spawn).mockReturnValue(mockProcess as any);
 
-      const result = await installerManager.installTemplate('typescript-node');
+      const result = await installerManager.installTemplate('typescript-node', approvedContext);
       
       expect(result.success).toBe(true);
       expect(result.message).toContain('Successfully installed');
@@ -160,7 +171,7 @@ describe('InstallerManager', () => {
       };
       vi.mocked(spawn).mockReturnValue(mockProcess as any);
 
-      const result = await installerManager.installTemplate('typescript-node');
+      const result = await installerManager.installTemplate('typescript-node', approvedContext);
       
       expect(result.success).toBe(false);
       expect(result.message).toContain('Installation failed');
@@ -179,6 +190,7 @@ describe('InstallerManager', () => {
       vi.mocked(spawn).mockReturnValue(mockProcess as any);
 
       await installerManager.installTemplate('typescript-node', {
+        ...approvedContext,
         projectName: 'test-project'
       });
       
@@ -187,6 +199,100 @@ describe('InstallerManager', () => {
         path.join(testProjectRoot, 'package.json'),
         expect.stringContaining('"name": "test"')
       );
+    });
+
+    test('should default to dry-run without approval and avoid writes or package-manager spawn', async () => {
+      const result = await installerManager.installTemplate('react-vite', {
+        packageManager: 'pnpm',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.dryRun).toBe(true);
+      expect(result.message).toContain('Dry-run preview');
+      expect(result.plannedChanges?.some(change => change.type === 'dependency')).toBe(true);
+      expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.writeFile)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.mkdir)).not.toHaveBeenCalled();
+    });
+
+    test('should reject explicit apply without installer approval before writes or package-manager spawn', async () => {
+      vi.mocked(fs.access).mockRejectedValue(new Error('not found'));
+
+      const result = await installerManager.installTemplate('react-vite', {
+        dryRun: false,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.approvalRequired).toBe(true);
+      expect(result.message).toContain(INSTALLER_APPROVAL_SCOPE);
+      expect(result.plannedChanges?.length).toBeGreaterThan(0);
+      expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.writeFile)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.mkdir)).not.toHaveBeenCalled();
+    });
+
+    test('should install dependencies with argv-safe spawn and lifecycle scripts suppressed by default', async () => {
+      const mockProcess = {
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn().mockImplementation((event, callback) => {
+          if (event === 'close') callback(0);
+        })
+      };
+      vi.mocked(spawn).mockReturnValue(mockProcess as any);
+
+      const result = await installerManager.installTemplate('react-vite', {
+        ...approvedContext,
+        packageManager: 'npm',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.dryRun).toBe(false);
+      expect(vi.mocked(spawn)).toHaveBeenNthCalledWith(
+        1,
+        'npm',
+        ['install', '--ignore-scripts', 'react@^18.2.0', 'react-dom@^18.2.0'],
+        expect.objectContaining({ shell: false, cwd: path.resolve(testProjectRoot) })
+      );
+      expect(vi.mocked(spawn)).toHaveBeenNthCalledWith(
+        2,
+        'npm',
+        [
+          'install',
+          '--ignore-scripts',
+          '--save-dev',
+          'typescript@^5.0.0',
+          '@types/react@^18.2.0',
+          '@types/react-dom@^18.2.0',
+          '@vitejs/plugin-react@^4.0.0',
+          'vite@^5.0.0',
+          'eslint@^8.0.0',
+        ],
+        expect.objectContaining({ shell: false, cwd: path.resolve(testProjectRoot) })
+      );
+    });
+
+    test('should validate template file paths before applying package or file writes', async () => {
+      const unsafeTemplate: InstallationTemplate = {
+        id: 'unsafe-path-template',
+        name: 'Unsafe Path Template',
+        description: 'Template with unsafe relative output',
+        category: 'library',
+        language: 'typescript',
+        dependencies: [{ name: 'left-pad' }],
+        scripts: { test: 'vitest' },
+        files: [{ path: '../outside.ts', content: 'export {}' }],
+        configurations: [],
+      };
+      installerManager['templates'].set(unsafeTemplate.id, unsafeTemplate);
+
+      const result = await installerManager.installTemplate(unsafeTemplate.id, approvedContext);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Installation failed');
+      expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.writeFile)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.mkdir)).not.toHaveBeenCalled();
     });
   });
 
@@ -409,6 +515,73 @@ describe('InstallerManager', () => {
       expect(result.warnings).toEqual([]);
       expect(result.configuredFiles).toEqual(expect.arrayContaining(['.env', 'config/app.ini']));
     });
+
+    test('should merge JSON configurations when merge policy is enabled', async () => {
+      const template: InstallationTemplate = {
+        id: 'json-merge-config-template',
+        name: 'JSON Merge Config Template',
+        description: 'Template for JSON configuration merge test',
+        category: 'library',
+        language: 'typescript',
+        dependencies: [],
+        scripts: {},
+        files: [],
+        configurations: [
+          {
+            file: 'tsconfig.json',
+            format: 'json',
+            merge: true,
+            content: {
+              compilerOptions: {
+                target: 'ES2022',
+                strict: true,
+              },
+            },
+          },
+        ],
+      };
+
+      vi.mocked(fs.readFile).mockResolvedValueOnce(JSON.stringify({
+        compilerOptions: {
+          module: 'commonjs',
+          strict: false,
+        },
+        include: ['src/**/*'],
+      }));
+
+      const result = {
+        success: true,
+        message: '',
+        installedDependencies: [],
+        createdFiles: [],
+        configuredFiles: [],
+        executedSteps: [],
+        warnings: [],
+        errors: [],
+        duration: 0,
+      };
+
+      await installerManager['applyConfigurations'](template, {
+        projectRoot: testProjectRoot,
+        projectName: 'test-project',
+        packageManager: 'pnpm',
+      }, result);
+
+      const writeCall = vi.mocked(fs.writeFile).mock.calls.find(
+        ([filePath]) => filePath === path.join(testProjectRoot, 'tsconfig.json')
+      );
+      expect(writeCall).toBeDefined();
+      const writtenConfig = JSON.parse(String(writeCall?.[1]));
+      expect(writtenConfig).toEqual({
+        compilerOptions: {
+          module: 'commonjs',
+          strict: true,
+          target: 'ES2022',
+        },
+        include: ['src/**/*'],
+      });
+      expect(result.configuredFiles).toContain('tsconfig.json');
+    });
   });
 
   describe('File Operations', () => {
@@ -422,7 +595,7 @@ describe('InstallerManager', () => {
       };
       vi.mocked(spawn).mockReturnValue(mockProcess as any);
 
-      await installerManager.installTemplate('typescript-node');
+      await installerManager.installTemplate('typescript-node', approvedContext);
       
       // Verify package.json was created (this is the first file created)
       expect(vi.mocked(fs.writeFile)).toHaveBeenCalledWith(
@@ -448,7 +621,7 @@ describe('InstallerManager', () => {
       };
       vi.mocked(spawn).mockReturnValue(mockProcess as any);
 
-      const result = await installerManager.installTemplate('typescript-node');
+      const result = await installerManager.installTemplate('typescript-node', approvedContext);
       
       expect(result.warnings.some(w => w.includes('already exists, skipping'))).toBe(true);
     });

--- a/tests/utils/installer-manager.test.ts
+++ b/tests/utils/installer-manager.test.ts
@@ -209,7 +209,29 @@ describe('InstallerManager', () => {
       expect(result.success).toBe(true);
       expect(result.dryRun).toBe(true);
       expect(result.message).toContain('Dry-run preview');
-      expect(result.plannedChanges?.some(change => change.type === 'dependency')).toBe(true);
+      const dependencyPlans =
+        result.plannedChanges?.filter(change => change.type === 'dependency') ?? [];
+      const devDependencyPlans =
+        result.plannedChanges?.filter(change => change.type === 'devDependency') ?? [];
+      expect(dependencyPlans).toHaveLength(1);
+      expect(dependencyPlans[0]?.args).toEqual([
+        'add',
+        '--ignore-scripts',
+        'react@^18.2.0',
+        'react-dom@^18.2.0',
+      ]);
+      expect(devDependencyPlans).toHaveLength(1);
+      expect(devDependencyPlans[0]?.args).toEqual([
+        'add',
+        '--ignore-scripts',
+        '-D',
+        'typescript@^5.0.0',
+        '@types/react@^18.2.0',
+        '@types/react-dom@^18.2.0',
+        '@vitejs/plugin-react@^4.0.0',
+        'vite@^5.0.0',
+        'eslint@^8.0.0',
+      ]);
       expect(vi.mocked(spawn)).not.toHaveBeenCalled();
       expect(vi.mocked(fs.writeFile)).not.toHaveBeenCalled();
       expect(vi.mocked(fs.mkdir)).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Default `/ae:installer <template>` to a dry-run preview that reports planned dependency installs, script changes, template files, configuration writes, and post-install steps without executing package-manager commands or writing project files.
- Require trusted installer approval (`approval.approved=true`, `approval.scope="installer-apply"`) before approved apply mode can install dependencies, update package scripts, write files/configuration, or run post-install steps.
- Harden `InstallerManager` with workspace-contained project paths, preflight plan validation, argv-safe package-manager spawning with lifecycle scripts suppressed by default, and JSON configuration merge support.
- Preserve `ae setup` as an operator-invoked path by passing explicit installer approval from the CLI wrapper.

## Acceptance

- Unapproved `/ae:installer` invocations and direct `InstallerManager.installTemplate()` calls return a preview/dry-run result and do not call package-manager spawn or filesystem write APIs.
- `--apply` without `installer-apply` approval is rejected before dependency installs, package script writes, file writes, or directory creation.
- Approved apply mode uses exact argv arrays with `shell:false` and includes `--ignore-scripts` unless lifecycle scripts are explicitly allowed.
- Template file/configuration paths are normalized under the approved project root before any write, rejecting parent traversal before package or file writes occur.
- Configuration merge policy is honored for JSON configuration files.

## Verification

- `pnpm -s exec vitest run tests/utils/installer-manager.test.ts tests/commands/installer-command.test.ts tests/cli/setup-cli.test.ts tests/unit/utils/workspace-path-policy.test.ts --reporter dot` — 4 files, 58 tests passed.
- `pnpm -s run types:check` — passed.
- `pnpm -s exec eslint --quiet src/utils/installer-manager.ts src/commands/extended/installer-command.ts src/cli/setup-cli.ts tests/utils/installer-manager.test.ts tests/commands/installer-command.test.ts tests/cli/setup-cli.test.ts` — passed.
- `pnpm -s run build` — passed.
- `node scripts/ci/validate-json.mjs` — passed.
- `pnpm -s run check:schemas` — passed.
- `pnpm -s run check:doc-consistency` — passed.
- `git diff --check` — passed.

## Rollback

Revert this PR to restore the previous installer behavior. This would also restore the prior behavior where `/ae:installer` could apply templates without a dry-run/approval boundary, so rollback should only be used if the approval boundary blocks a critical operator workflow and a replacement guard is ready.

Closes #3406
