### PR TITLE
fix(security): constrain integration CLI paths

### DIFF
--- a/src/cli/integration-cli.ts
+++ b/src/cli/integration-cli.ts
@@ -8,12 +8,21 @@ import { toMessage } from '../utils/error-utils.js';
 import { safeExit } from '../utils/safe-exit.js';
 import chalk from 'chalk';
 import { promises as fs, existsSync, statSync } from 'node:fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { loadConfig } from '../core/config.js';
 import { IntegrationTestOrchestrator } from '../integration/test-orchestrator.js';
 import { E2ETestRunner } from '../integration/runners/e2e-runner.js';
 import { APITestRunner } from '../integration/runners/api-runner.js';
 import { HTMLTestReporter } from '../integration/reporters/html-reporter.js';
+import {
+  INTEGRATION_WRITE_APPROVAL_SCOPE,
+  createIntegrationPathContext,
+  getDefaultIntegrationOutputDir,
+  isIntegrationAgentContext,
+  resolveIntegrationInputPath,
+  resolveIntegrationOutputPath,
+  type IntegrationPathContext,
+} from '../integration/path-policy.js';
 import type { 
   TestCase,
   TestSuite,
@@ -24,8 +33,6 @@ import type {
   TestDiscovery
 } from '../integration/types.js';
 
-const DEFAULT_INTEGRATION_OUTPUT_DIR = join('artifacts', 'integration', 'test-results');
-
 const parseOptionalBoolean = (value?: string | boolean): boolean => {
   if (value === undefined) return true;
   if (typeof value === 'boolean') return value;
@@ -33,14 +40,23 @@ const parseOptionalBoolean = (value?: string | boolean): boolean => {
   return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'y';
 };
 
+interface IntegrationWritePolicy {
+  dryRun: boolean;
+  agentContext: boolean;
+  approvalRequired: boolean;
+}
+
 // Simple test discovery implementation
 class FileSystemTestDiscovery implements TestDiscovery {
+  constructor(private readonly pathContext: IntegrationPathContext) {}
+
   async discoverTests(patterns: string[]): Promise<TestCase[]> {
     const tests: TestCase[] = [];
     
     for (const pattern of patterns) {
-      if (existsSync(pattern)) {
-        const content = await fs.readFile(pattern, 'utf-8');
+      const resolved = resolveIntegrationInputPath(pattern, this.pathContext, 'integration test discovery path');
+      if (existsSync(resolved.resolvedPath)) {
+        const content = await fs.readFile(resolved.resolvedPath, 'utf-8');
         try {
           const data = JSON.parse(content);
           if (Array.isArray(data)) {
@@ -49,7 +65,7 @@ class FileSystemTestDiscovery implements TestDiscovery {
             tests.push(data);
           }
         } catch (error) {
-          console.warn(`Failed to parse test file ${pattern}:`, error);
+          console.warn(`Failed to parse test file ${resolved.workspaceRelativePath}:`, error);
         }
       }
     }
@@ -61,8 +77,9 @@ class FileSystemTestDiscovery implements TestDiscovery {
     const suites: TestSuite[] = [];
     
     for (const pattern of patterns) {
-      if (existsSync(pattern)) {
-        const content = await fs.readFile(pattern, 'utf-8');
+      const resolved = resolveIntegrationInputPath(pattern, this.pathContext, 'integration suite discovery path');
+      if (existsSync(resolved.resolvedPath)) {
+        const content = await fs.readFile(resolved.resolvedPath, 'utf-8');
         try {
           const data = JSON.parse(content);
           if (Array.isArray(data)) {
@@ -71,7 +88,7 @@ class FileSystemTestDiscovery implements TestDiscovery {
             suites.push(data);
           }
         } catch (error) {
-          console.warn(`Failed to parse suite file ${pattern}:`, error);
+          console.warn(`Failed to parse suite file ${resolved.workspaceRelativePath}:`, error);
         }
       }
     }
@@ -83,8 +100,9 @@ class FileSystemTestDiscovery implements TestDiscovery {
     const fixtures: TestFixture[] = [];
     
     for (const pattern of patterns) {
-      if (existsSync(pattern)) {
-        const content = await fs.readFile(pattern, 'utf-8');
+      const resolved = resolveIntegrationInputPath(pattern, this.pathContext, 'integration fixture discovery path');
+      if (existsSync(resolved.resolvedPath)) {
+        const content = await fs.readFile(resolved.resolvedPath, 'utf-8');
         try {
           const data = JSON.parse(content);
           if (Array.isArray(data)) {
@@ -93,7 +111,7 @@ class FileSystemTestDiscovery implements TestDiscovery {
             fixtures.push(data);
           }
         } catch (error) {
-          console.warn(`Failed to parse fixtures file ${pattern}:`, error);
+          console.warn(`Failed to parse fixtures file ${resolved.workspaceRelativePath}:`, error);
         }
       }
     }
@@ -105,8 +123,10 @@ class FileSystemTestDiscovery implements TestDiscovery {
 export class IntegrationTestingCli {
   private orchestrator: IntegrationTestOrchestrator;
   private discovery: TestDiscovery;
+  private pathContext: IntegrationPathContext;
 
   constructor() {
+    this.pathContext = createIntegrationPathContext();
     // Default configuration
     const config: IntegrationTestConfig = {
       environments: [this.createDefaultEnvironment()],
@@ -122,7 +142,7 @@ export class IntegrationTestingCli {
           video: false,
           trace: false,
           slowMo: 0,
-          outputDir: DEFAULT_INTEGRATION_OUTPUT_DIR
+          outputDir: this.getDefaultOutputDir()
         }),
         new APITestRunner({
           timeout: 10000,
@@ -156,7 +176,7 @@ export class IntegrationTestingCli {
     };
 
     this.orchestrator = new IntegrationTestOrchestrator(config);
-    this.discovery = new FileSystemTestDiscovery();
+    this.discovery = new FileSystemTestDiscovery(this.pathContext);
   }
 
   /**
@@ -180,7 +200,7 @@ export class IntegrationTestingCli {
       .option('--retries <num>', 'Number of retries for failed tests', '1')
       .option('--fail-fast', 'Stop execution on first failure')
       .option('--skip-on-failure', 'Skip remaining tests on failure')
-      .option('--output-dir <dir>', 'Output directory for results', DEFAULT_INTEGRATION_OUTPUT_DIR)
+      .option('--output-dir <dir>', 'Output directory for results', this.getDefaultOutputDir())
       .option('--report-format <formats>', 'Report formats (comma-separated)', 'html,json')
       .option('--categories <categories>', 'Test categories to run (comma-separated)')
       .option('--tags <tags>', 'Test tags to run (comma-separated)')
@@ -188,6 +208,9 @@ export class IntegrationTestingCli {
       .option('--screenshots', 'Capture screenshots on failures')
       .option('--video', 'Record video of test execution')
       .option('--coverage', 'Measure code coverage')
+      .option('--dry-run', 'Preview write-capable integration execution without writing artifacts')
+      .option('--apply', 'Apply write-capable integration execution in an agent context')
+      .option('--approval-scope <scope>', `Trusted write approval scope (${INTEGRATION_WRITE_APPROVAL_SCOPE})`)
       .action(async (options) => {
         await this.handleRunCommand(options);
       });
@@ -200,6 +223,9 @@ export class IntegrationTestingCli {
       .option('-t, --type <type>', 'Discovery type (tests, suites, fixtures, all)', 'all')
       .option('-o, --output <file>', 'Output file for discovered items')
       .option('--format <format>', 'Output format (json, table)', 'table')
+      .option('--dry-run', 'Preview discovery output writes without writing files')
+      .option('--apply', 'Apply discovery output writes in an agent context')
+      .option('--approval-scope <scope>', `Trusted write approval scope (${INTEGRATION_WRITE_APPROVAL_SCOPE})`)
       .action(async (options) => {
         await this.handleDiscoverCommand(options);
       });
@@ -221,6 +247,9 @@ export class IntegrationTestingCli {
       .option('-o, --output <file>', 'Output file')
       .option('--test-type <testType>', 'Test type for generation (e2e, api, unit)', 'e2e')
       .option('--name <name>', 'Name for generated item', 'Sample Test')
+      .option('--dry-run', 'Preview generated output without writing files')
+      .option('--apply', 'Apply generated output writes in an agent context')
+      .option('--approval-scope <scope>', `Trusted write approval scope (${INTEGRATION_WRITE_APPROVAL_SCOPE})`)
       .action(async (options) => {
         await this.handleGenerateCommand(options);
       });
@@ -243,6 +272,9 @@ export class IntegrationTestingCli {
       .option('-v, --view <reportId>', 'View specific report')
       .option('-c, --clean', 'Clean old reports')
       .option('--days <days>', 'Report retention days', '30')
+      .option('--dry-run', 'Preview report cleanup without deleting files')
+      .option('--apply', 'Apply report cleanup in an agent context')
+      .option('--approval-scope <scope>', `Trusted write approval scope (${INTEGRATION_WRITE_APPROVAL_SCOPE})`)
       .action(async (options) => {
         await this.handleReportsCommand(options);
       });
@@ -257,24 +289,46 @@ export class IntegrationTestingCli {
     try {
       const cfg = await loadConfig();
       const mode = cfg.mode ?? 'copilot';
+      const writePolicy = this.getWritePolicy(options);
       console.log('🚀 Starting integration test execution...');
 
-      // Initialize orchestrator
-      await this.orchestrator.initialize();
-
       // Parse patterns
-      const suitePatterns = options.suites ? options.suites.split(',').map((s: string) => s.trim()) : [];
-      const testPatterns = options.tests ? options.tests.split(',').map((s: string) => s.trim()) : [];
+      const suitePatterns = this.parsePathList(options.suites);
+      const testPatterns = this.parsePathList(options.tests);
       const allPatterns = [...suitePatterns, ...testPatterns];
 
       if (allPatterns.length === 0) {
         // Default patterns
-        allPatterns.push('./tests/**/*.json', './tests/**/*.test.json');
+        allPatterns.push('tests/**/*.json', 'tests/**/*.test.json');
       }
+      const safePatterns = allPatterns.map((pattern) =>
+        resolveIntegrationInputPath(pattern, this.pathContext, 'integration test pattern').workspaceRelativePath
+      );
+      const outputDir = resolveIntegrationOutputPath(
+        options.outputDir,
+        this.pathContext,
+        'integration output directory',
+      ).workspaceRelativePath;
+
+      if (writePolicy.approvalRequired) {
+        console.error(chalk.red(`❌ Integration writes require --approval-scope ${INTEGRATION_WRITE_APPROVAL_SCOPE} when --apply is used in an agent context`));
+        safeExit(1);
+        return;
+      }
+
+      if (writePolicy.dryRun) {
+        console.log('🔎 Dry-run preview: no tests will be executed and no integration artifacts will be written.');
+        console.log(`   Read patterns: ${safePatterns.join(', ')}`);
+        console.log(`   Planned output directory: ${outputDir}`);
+        return;
+      }
+
+      // Initialize orchestrator only after path policy and write approval checks pass.
+      await this.orchestrator.initialize();
 
       // Discover tests
       console.log('🔍 Discovering tests...');
-      const discovered = await this.orchestrator.discoverTests(this.discovery, allPatterns);
+      const discovered = await this.orchestrator.discoverTests(this.discovery, safePatterns);
       
       console.log(`📋 Found ${discovered.tests.length} tests, ${discovered.suites.length} suites, ${discovered.fixtures.length} fixtures`);
 
@@ -306,7 +360,7 @@ export class IntegrationTestingCli {
         recordVideo: options.video || false,
         collectLogs: true,
         measureCoverage: options.coverage || false,
-        outputDir: options.outputDir,
+        outputDir,
         reportFormat: options.reportFormat.split(',').map((f: string) => f.trim()),
         filters: {
           categories: options.categories ? options.categories.split(',').map((c: string) => c.trim()) : undefined,
@@ -397,9 +451,15 @@ export class IntegrationTestingCli {
    */
   private async handleDiscoverCommand(options: any): Promise<void> {
     try {
+      const writePolicy = this.getWritePolicy(options);
       console.log('🔍 Discovering test resources...');
 
-      const patterns = options.patterns.split(',').map((p: string) => p.trim());
+      const patterns = this.parsePathList(options.patterns).map((pattern) =>
+        resolveIntegrationInputPath(pattern, this.pathContext, 'integration discovery pattern').workspaceRelativePath
+      );
+      const outputPath = options.output
+        ? resolveIntegrationOutputPath(options.output, this.pathContext, 'integration discovery output').workspaceRelativePath
+        : undefined;
       
       let items: any = [];
       let itemType = '';
@@ -436,9 +496,24 @@ export class IntegrationTestingCli {
         console.log(JSON.stringify(items, null, 2));
       }
 
-      if (options.output) {
-        await fs.writeFile(options.output, JSON.stringify(items, null, 2));
-        console.log(`💾 Results saved to ${options.output}`);
+      if (outputPath) {
+        if (writePolicy.approvalRequired) {
+          console.error(chalk.red(`❌ Integration discovery output writes require --approval-scope ${INTEGRATION_WRITE_APPROVAL_SCOPE} when --apply is used in an agent context`));
+          safeExit(1);
+          return;
+        }
+        if (writePolicy.dryRun) {
+          console.log(`🔎 Dry-run preview: discovery results would be saved to ${outputPath}`);
+          return;
+        }
+        const resolvedOutput = resolveIntegrationOutputPath(
+          outputPath,
+          this.pathContext,
+          'integration discovery output',
+        ).resolvedPath;
+        await fs.mkdir(dirname(resolvedOutput), { recursive: true });
+        await fs.writeFile(resolvedOutput, JSON.stringify(items, null, 2));
+        console.log(`💾 Results saved to ${outputPath}`);
       }
 
     } catch (error) {
@@ -492,6 +567,7 @@ export class IntegrationTestingCli {
    */
   private async handleGenerateCommand(options: any): Promise<void> {
     try {
+      const writePolicy = this.getWritePolicy(options);
       console.log(`🛠️ Generating sample ${options.type}...`);
 
       let generatedItem: any;
@@ -514,8 +590,23 @@ export class IntegrationTestingCli {
       }
 
       if (options.output) {
-        await fs.writeFile(options.output, JSON.stringify(generatedItem, null, 2));
-        console.log(`✅ Generated ${options.type} saved to ${options.output}`);
+        const outputPath = resolveIntegrationOutputPath(
+          options.output,
+          this.pathContext,
+          'integration generated output',
+        );
+        if (writePolicy.approvalRequired) {
+          console.error(chalk.red(`❌ Integration generated output writes require --approval-scope ${INTEGRATION_WRITE_APPROVAL_SCOPE} when --apply is used in an agent context`));
+          safeExit(1);
+          return;
+        }
+        if (writePolicy.dryRun) {
+          console.log(`🔎 Dry-run preview: generated ${options.type} would be saved to ${outputPath.workspaceRelativePath}`);
+          return;
+        }
+        await fs.mkdir(dirname(outputPath.resolvedPath), { recursive: true });
+        await fs.writeFile(outputPath.resolvedPath, JSON.stringify(generatedItem, null, 2));
+        console.log(`✅ Generated ${options.type} saved to ${outputPath.workspaceRelativePath}`);
       } else {
         console.log(JSON.stringify(generatedItem, null, 2));
       }
@@ -562,14 +653,19 @@ export class IntegrationTestingCli {
    * Handle the reports command
    */
   private async handleReportsCommand(options: any): Promise<void> {
-    const reportsDir = DEFAULT_INTEGRATION_OUTPUT_DIR;
+    const writePolicy = this.getWritePolicy(options);
+    const reportsDir = resolveIntegrationOutputPath(
+      this.getDefaultOutputDir(),
+      this.pathContext,
+      'integration reports directory',
+    );
 
     if (options.list) {
       console.log('📄 Available Test Reports:\n');
       
       try {
-        if (existsSync(reportsDir)) {
-          const files = await fs.readdir(reportsDir);
+        if (existsSync(reportsDir.resolvedPath)) {
+          const files = await fs.readdir(reportsDir.resolvedPath);
           const reportFiles = files.filter(f => f.endsWith('.html') || f.endsWith('.json'));
           
           if (reportFiles.length === 0) {
@@ -577,7 +673,7 @@ export class IntegrationTestingCli {
           } else {
             reportFiles.forEach((file, index) => {
               console.log(`${index + 1}. ${file}`);
-              const filePath = join(reportsDir, file);
+              const filePath = join(reportsDir.resolvedPath, file);
               if (existsSync(filePath)) {
                 const stats = statSync(filePath);
                 console.log(`   Created: ${stats.ctime.toLocaleString()}`);
@@ -596,31 +692,67 @@ export class IntegrationTestingCli {
 
     if (options.clean) {
       console.log('🧹 Cleaning old reports...');
+      if (writePolicy.approvalRequired) {
+        console.error(chalk.red(`❌ Integration report cleanup requires --approval-scope ${INTEGRATION_WRITE_APPROVAL_SCOPE} when --apply is used in an agent context`));
+        safeExit(1);
+        return;
+      }
       
       const retentionDays = parseInt(options.days);
       const cutoffDate = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
       
       try {
-        if (existsSync(reportsDir)) {
-          const files = await fs.readdir(reportsDir);
+        if (existsSync(reportsDir.resolvedPath)) {
+          const files = await fs.readdir(reportsDir.resolvedPath);
           let cleaned = 0;
           
           for (const file of files) {
-            const filePath = join(reportsDir, file);
+            const filePath = join(reportsDir.resolvedPath, file);
             const stats = statSync(filePath);
             
             if (stats.ctime < cutoffDate) {
-              await fs.unlink(filePath);
+              if (!writePolicy.dryRun) {
+                await fs.unlink(filePath);
+              }
               cleaned++;
             }
           }
           
-          console.log(`✅ Cleaned ${cleaned} old reports (older than ${retentionDays} days)`);
+          if (writePolicy.dryRun) {
+            console.log(`🔎 Dry-run preview: would clean ${cleaned} old reports (older than ${retentionDays} days)`);
+          } else {
+            console.log(`✅ Cleaned ${cleaned} old reports (older than ${retentionDays} days)`);
+          }
         }
       } catch (error) {
                 console.error(chalk.red(`❌ Failed to clean reports: ${toMessage(error)}`));
       }
     }
+  }
+
+  private parsePathList(value?: string): string[] {
+    if (!value) return [];
+    return value
+      .split(',')
+      .map((item: string) => item.trim())
+      .filter((item: string) => item.length > 0);
+  }
+
+  private getWritePolicy(options: any): IntegrationWritePolicy {
+    const agentContext = isIntegrationAgentContext();
+    const applyRequested = options.apply === true;
+    const approved = options.approvalScope === INTEGRATION_WRITE_APPROVAL_SCOPE;
+    const approvalRequired = agentContext && applyRequested && !approved;
+    const dryRun = options.dryRun === true || (agentContext && !applyRequested);
+    return {
+      dryRun,
+      agentContext,
+      approvalRequired,
+    };
+  }
+
+  private getDefaultOutputDir(): string {
+    return getDefaultIntegrationOutputDir(this.pathContext);
   }
 
   /**

--- a/src/integration/path-policy.ts
+++ b/src/integration/path-policy.ts
@@ -1,0 +1,141 @@
+import path from 'node:path';
+import {
+  resolveContainedWorkspacePath,
+  resolveWorkspacePath,
+  resolveWorkspaceRoot,
+  toWorkspaceRelativePath,
+  WorkspacePathPolicyError,
+} from '../utils/workspace-path-policy.js';
+
+export const INTEGRATION_WRITE_APPROVAL_SCOPE = 'integration-cli-write' as const;
+export const DEFAULT_INTEGRATION_ARTIFACT_ROOT = 'artifacts/integration' as const;
+export const DEFAULT_INTEGRATION_OUTPUT_DIR = 'artifacts/integration/test-results' as const;
+
+export interface IntegrationPathContext {
+  workspaceRoot: string;
+  artifactRoot: string;
+}
+
+export interface ResolvedIntegrationPath {
+  resolvedPath: string;
+  workspaceRelativePath: string;
+}
+
+export interface IntegrationPathContextOptions {
+  workspaceRoot?: string;
+  artifactRoot?: string;
+}
+
+const hasWindowsAbsolutePrefix = (value: string): boolean =>
+  path.win32.isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value);
+
+const isPathWithin = (baseDir: string, candidatePath: string): boolean => {
+  const relative = path.relative(baseDir, candidatePath);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
+const normalizeWorkspaceRelativePath = (input: string, label: string): string => {
+  const raw = String(input).trim();
+  if (!raw) {
+    throw new WorkspacePathPolicyError(`${label} must be a non-empty workspace-relative path`);
+  }
+  if (raw.includes('\0')) {
+    throw new WorkspacePathPolicyError(`${label} must not contain NUL bytes`);
+  }
+  if (raw.includes('\\')) {
+    throw new WorkspacePathPolicyError(`${label} must use POSIX-style '/' separators`);
+  }
+  if (raw.startsWith('//') || path.posix.isAbsolute(raw) || path.isAbsolute(raw) || hasWindowsAbsolutePrefix(raw)) {
+    throw new WorkspacePathPolicyError(`${label} must be relative to the approved workspace`);
+  }
+
+  const segments = raw.split('/').filter(segment => segment !== '' && segment !== '.');
+  if (segments.length === 0) {
+    throw new WorkspacePathPolicyError(`${label} must be a non-empty workspace-relative path`);
+  }
+  if (segments.some(segment => segment === '..')) {
+    throw new WorkspacePathPolicyError(`${label} must not contain parent-directory path components`);
+  }
+
+  return segments.join('/');
+};
+
+export function createIntegrationPathContext(
+  options: IntegrationPathContextOptions = {},
+): IntegrationPathContext {
+  const workspaceRoot = resolveWorkspaceRoot({ defaultRoot: options.workspaceRoot ?? process.cwd() });
+  const artifactRootInput = options.artifactRoot ?? process.env['AE_INTEGRATION_ARTIFACT_ROOT'] ?? DEFAULT_INTEGRATION_ARTIFACT_ROOT;
+  const artifactRoot = resolveWorkspacePath(
+    normalizeWorkspaceRelativePath(artifactRootInput, 'integration artifact root'),
+    { workspaceRoot, label: 'integration artifact root' },
+  );
+  return { workspaceRoot, artifactRoot };
+}
+
+export function getDefaultIntegrationOutputDir(context: IntegrationPathContext): string {
+  const artifactRoot = toWorkspaceRelativePath(context.artifactRoot, {
+    workspaceRoot: context.workspaceRoot,
+    label: 'integration artifact root',
+  });
+  return path.posix.join(artifactRoot, 'test-results');
+}
+
+export function resolveIntegrationInputPath(
+  input: string,
+  context: IntegrationPathContext,
+  label = 'integration input path',
+): ResolvedIntegrationPath {
+  const workspaceRelative = normalizeWorkspaceRelativePath(input, label);
+  const resolvedPath = resolveWorkspacePath(workspaceRelative, {
+    workspaceRoot: context.workspaceRoot,
+    label,
+  });
+  return {
+    resolvedPath,
+    workspaceRelativePath: toWorkspaceRelativePath(resolvedPath, {
+      workspaceRoot: context.workspaceRoot,
+      label,
+    }),
+  };
+}
+
+export function resolveIntegrationOutputPath(
+  input: string,
+  context: IntegrationPathContext,
+  label = 'integration output path',
+): ResolvedIntegrationPath {
+  let resolvedPath: string;
+
+  if (path.isAbsolute(input) || hasWindowsAbsolutePrefix(input)) {
+    throw new WorkspacePathPolicyError(`${label} must be relative to the approved integration artifact root`);
+  } else {
+    const workspaceRelative = normalizeWorkspaceRelativePath(input, label);
+    resolvedPath = resolveWorkspacePath(workspaceRelative, {
+      workspaceRoot: context.workspaceRoot,
+      label,
+    });
+  }
+
+  if (!isPathWithin(context.artifactRoot, resolvedPath)) {
+    throw new WorkspacePathPolicyError(`${label} must stay under the approved integration artifact root`);
+  }
+
+  const artifactRelative = path.relative(context.artifactRoot, resolvedPath).replace(/\\/g, '/');
+  if (artifactRelative !== '') {
+    resolvedPath = resolveContainedWorkspacePath(context.artifactRoot, artifactRelative, label);
+  }
+
+  return {
+    resolvedPath,
+    workspaceRelativePath: toWorkspaceRelativePath(resolvedPath, {
+      workspaceRoot: context.workspaceRoot,
+      label,
+    }),
+  };
+}
+
+export function isIntegrationAgentContext(): boolean {
+  const raw = process.env['AE_INTEGRATION_AGENT_CONTEXT'] ?? process.env['AE_AGENT_CONTEXT'];
+  if (!raw) return false;
+  return ['1', 'true', 'yes', 'y'].includes(raw.trim().toLowerCase());
+}

--- a/src/integration/runners/e2e-runner.ts
+++ b/src/integration/runners/e2e-runner.ts
@@ -6,8 +6,12 @@
 import { v4 as uuidv4 } from 'uuid';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-
-const DEFAULT_E2E_OUTPUT_DIR = join('artifacts', 'integration', 'test-results');
+import {
+  createIntegrationPathContext,
+  getDefaultIntegrationOutputDir,
+  resolveIntegrationOutputPath,
+  type IntegrationPathContext,
+} from '../path-policy.js';
 
 /**
  * Test step result interface - for internal step tracking
@@ -100,13 +104,19 @@ export class E2ETestRunner implements TestRunner {
 
   private config: E2EConfig;
   private outputDir: string;
+  private pathContext: IntegrationPathContext;
   private browser: Browser | null = null;
   private context: BrowserContext | null = null;
   private currentPage: BrowserPage | null = null;
 
   constructor(config: E2EConfig) {
     this.config = config;
-    this.outputDir = config.outputDir ?? DEFAULT_E2E_OUTPUT_DIR;
+    this.pathContext = createIntegrationPathContext();
+    this.outputDir = this.resolveOutputDir(config.outputDir ?? getDefaultIntegrationOutputDir(this.pathContext));
+  }
+
+  setOutputDir(outputDir: string): void {
+    this.outputDir = this.resolveOutputDir(outputDir);
   }
 
   /**
@@ -630,5 +640,13 @@ export class E2ETestRunner implements TestRunner {
     if (result.screenshots.length > 0) {
       console.log(`E2E: Captured ${result.screenshots.length} screenshots`);
     }
+  }
+
+  private resolveOutputDir(outputDir: string): string {
+    return resolveIntegrationOutputPath(
+      outputDir,
+      this.pathContext,
+      'e2e runner output directory',
+    ).resolvedPath;
   }
 }

--- a/src/integration/test-orchestrator.ts
+++ b/src/integration/test-orchestrator.ts
@@ -7,6 +7,11 @@ import { EventEmitter } from 'events';
 import { v4 as uuidv4 } from 'uuid';
 import { promises as fs } from 'fs';
 import { join } from 'path';
+import {
+  createIntegrationPathContext,
+  resolveIntegrationOutputPath,
+  type IntegrationPathContext,
+} from './path-policy.js';
 import type {
   TestCase,
   TestSuite,
@@ -32,10 +37,12 @@ export class IntegrationTestOrchestrator extends EventEmitter {
   private testFixtures: Map<string, TestFixture> = new Map();
   private activeExecutions: Map<string, Promise<TestExecutionSummary>> = new Map();
   private runnerLocks: Map<string, Promise<void>> = new Map();
+  private pathContext: IntegrationPathContext;
 
   constructor(config: IntegrationTestConfig) {
     super();
     this.config = config;
+    this.pathContext = createIntegrationPathContext();
     this.setupEnvironments();
     this.setupRunners();
     this.setupReporters();
@@ -102,6 +109,7 @@ export class IntegrationTestOrchestrator extends EventEmitter {
     environmentName: string,
     config: TestExecutionConfig
   ): Promise<TestResult> {
+    this.resolveOutputDir(config.outputDir, 'integration test output directory');
     const test = this.testCases.get(testId);
     if (!test) {
       throw new Error(`Test not found: ${testId}`);
@@ -122,6 +130,7 @@ export class IntegrationTestOrchestrator extends EventEmitter {
     return await this.withRunnerLock(runner.id, async () => {
       let setupCompleted = false;
       let testResult: TestResult | null = null;
+      this.configureRunnerOutputDir(runner, config.outputDir);
 
       const buildErrorResult = (error: unknown): TestResult => ({
         id: uuidv4(),
@@ -249,6 +258,7 @@ export class IntegrationTestOrchestrator extends EventEmitter {
     if (!environment) {
       throw new Error(`Environment not found: ${environmentName}`);
     }
+    this.resolveOutputDir(config.outputDir, 'integration suite output directory');
 
     this.emit('suite_started', { suiteId, environment: environmentName, executionId });
 
@@ -626,7 +636,11 @@ export class IntegrationTestOrchestrator extends EventEmitter {
     size: number;
   }>> {
     const artifacts: Array<{ name: string; path: string; size: number }> = [];
-    const artifactDir = join(outputDir, executionId);
+    const safeOutputDir = this.resolveOutputDir(
+      outputDir,
+      'integration artifact collection directory',
+    );
+    const artifactDir = join(safeOutputDir.resolvedPath, executionId);
 
     try {
       const files = await fs.readdir(artifactDir);
@@ -664,8 +678,11 @@ export class IntegrationTestOrchestrator extends EventEmitter {
     summary: TestExecutionSummary, 
     config: TestExecutionConfig
   ): Promise<void> {
-    const outputDir = config.outputDir;
-    await fs.mkdir(outputDir, { recursive: true });
+    const outputDir = this.resolveOutputDir(
+      config.outputDir,
+      'integration report output directory',
+    );
+    await fs.mkdir(outputDir.resolvedPath, { recursive: true });
 
     for (const format of config.reportFormat) {
       const reporter = Array.from(this.reporters.values())
@@ -675,7 +692,7 @@ export class IntegrationTestOrchestrator extends EventEmitter {
         try {
           const content = await reporter.generateReport(summary);
           const fileName = `test-report-${summary.id}.${format}`;
-          const filePath = join(outputDir, fileName);
+          const filePath = join(outputDir.resolvedPath, fileName);
           await reporter.saveReport(content, filePath);
 
           this.emit('report_generated', { format, filePath });
@@ -712,6 +729,21 @@ export class IntegrationTestOrchestrator extends EventEmitter {
         this.runnerLocks.delete(runnerId);
       }
     }
+  }
+
+  private configureRunnerOutputDir(runner: TestRunner, outputDir: string): void {
+    const runnerWithOutputDir = runner as TestRunner & {
+      setOutputDir?: (nextOutputDir: string) => void;
+    };
+    runnerWithOutputDir.setOutputDir?.(outputDir);
+  }
+
+  private resolveOutputDir(outputDir: string, label: string) {
+    return resolveIntegrationOutputPath(
+      outputDir,
+      this.pathContext,
+      label,
+    );
   }
 
   private formatError(error: unknown): string {

--- a/tests/integration/integration-cli.test.ts
+++ b/tests/integration/integration-cli.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { IntegrationTestingCli } from '../../src/cli/integration-cli.js';
-import { writeFileSync, existsSync, mkdirSync } from 'fs';
+import { promises as fsp, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { createIntegrationTempDir, applyIntegrationRetry } from '../_helpers/integration-test-utils.js';
 import './setup';
@@ -20,6 +20,7 @@ describe('IntegrationTestingCli', () => {
   let tempDir: string;
   let cwdSpy: ReturnType<typeof vi.spyOn>;
   const inTemp = (name: string): string => join(tempDir, name);
+  const artifactPath = (name: string): string => ['artifacts', 'integration', name].join('/');
 
   beforeEach(async () => {
     tempDir = await createIntegrationTempDir('integration-cli-');
@@ -76,8 +77,8 @@ describe('IntegrationTestingCli', () => {
         }
       }];
 
-      const testFile = inTemp('test-discovery.json');
-      writeFileSync(testFile, JSON.stringify(testData, null, 2));
+      const testFile = 'test-discovery.json';
+      writeFileSync(inTemp(testFile), JSON.stringify(testData, null, 2));
 
       const command = cli.createCommand();
       const args = ['node', 'cli', 'discover', '--patterns', testFile, '--type', 'tests'];
@@ -95,13 +96,13 @@ describe('IntegrationTestingCli', () => {
       const suiteData = createSampleSuiteData();
       const fixtureData = createSampleFixtureData();
 
-      const testFile = inTemp('discover-tests.json');
-      const suiteFile = inTemp('discover-suites.json');
-      const fixtureFile = inTemp('discover-fixtures.json');
+      const testFile = 'discover-tests.json';
+      const suiteFile = 'discover-suites.json';
+      const fixtureFile = 'discover-fixtures.json';
 
-      writeFileSync(testFile, JSON.stringify([testData], null, 2));
-      writeFileSync(suiteFile, JSON.stringify([suiteData], null, 2));
-      writeFileSync(fixtureFile, JSON.stringify([fixtureData], null, 2));
+      writeFileSync(inTemp(testFile), JSON.stringify([testData], null, 2));
+      writeFileSync(inTemp(suiteFile), JSON.stringify([suiteData], null, 2));
+      writeFileSync(inTemp(fixtureFile), JSON.stringify([fixtureData], null, 2));
 
       const command = cli.createCommand();
       const args = [
@@ -119,10 +120,10 @@ describe('IntegrationTestingCli', () => {
 
     it('should save discovery results to file', async () => {
       const testData = createSampleTestData();
-      const testFile = inTemp('discover-input.json');
-      const outputFile = inTemp('discovery-output.json');
+      const testFile = 'discover-input.json';
+      const outputFile = artifactPath('discovery-output.json');
 
-      writeFileSync(testFile, JSON.stringify([testData], null, 2));
+      writeFileSync(inTemp(testFile), JSON.stringify([testData], null, 2));
 
       const command = cli.createCommand();
       const args = [
@@ -137,7 +138,7 @@ describe('IntegrationTestingCli', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining(`Results saved to ${outputFile}`)
       );
-      expect(existsSync(outputFile)).toBe(true);
+      expect(existsSync(inTemp(outputFile))).toBe(true);
     });
 
     it('should handle invalid patterns gracefully', async () => {
@@ -153,6 +154,23 @@ describe('IntegrationTestingCli', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Discovering test resources')
       );
+    });
+
+    it('should reject absolute discovery paths before filesystem reads', async () => {
+      const readSpy = vi.spyOn(fsp, 'readFile');
+      const command = cli.createCommand();
+      const args = [
+        'node', 'cli', 'discover',
+        '--patterns', join(tempDir, 'outside.json'),
+        '--type', 'tests'
+      ];
+
+      await command.parseAsync(args);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Discovery failed')
+      );
+      expect(readSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -204,7 +222,7 @@ describe('IntegrationTestingCli', () => {
 
   describe('generate command', () => {
     it('should generate sample test', async () => {
-      const outputFile = inTemp('generated-test.json');
+      const outputFile = artifactPath('generated-test.json');
 
       const command = cli.createCommand();
       const args = [
@@ -223,11 +241,11 @@ describe('IntegrationTestingCli', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining(`Generated test saved to ${outputFile}`)
       );
-      expect(existsSync(outputFile)).toBe(true);
+      expect(existsSync(inTemp(outputFile))).toBe(true);
     });
 
     it('should generate sample suite', async () => {
-      const outputFile = inTemp('generated-suite.json');
+      const outputFile = artifactPath('generated-suite.json');
 
       const command = cli.createCommand();
       const args = [
@@ -242,11 +260,11 @@ describe('IntegrationTestingCli', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Generated suite saved to')
       );
-      expect(existsSync(outputFile)).toBe(true);
+      expect(existsSync(inTemp(outputFile))).toBe(true);
     });
 
     it('should generate sample fixture', async () => {
-      const outputFile = inTemp('generated-fixture.json');
+      const outputFile = artifactPath('generated-fixture.json');
 
       const command = cli.createCommand();
       const args = [
@@ -261,11 +279,11 @@ describe('IntegrationTestingCli', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Generated fixture saved to')
       );
-      expect(existsSync(outputFile)).toBe(true);
+      expect(existsSync(inTemp(outputFile))).toBe(true);
     });
 
     it('should generate sample environment', async () => {
-      const outputFile = inTemp('generated-environment.json');
+      const outputFile = artifactPath('generated-environment.json');
 
       const command = cli.createCommand();
       const args = [
@@ -280,7 +298,7 @@ describe('IntegrationTestingCli', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Generated environment saved to')
       );
-      expect(existsSync(outputFile)).toBe(true);
+      expect(existsSync(inTemp(outputFile))).toBe(true);
     });
 
     it('should output to console without file', async () => {
@@ -310,6 +328,108 @@ describe('IntegrationTestingCli', () => {
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('Generation failed')
       );
+    });
+
+    it('should reject generated output outside the integration artifact root before writing', async () => {
+      const writeSpy = vi.spyOn(fsp, 'writeFile');
+      const command = cli.createCommand();
+      const args = [
+        'node', 'cli', 'generate',
+        '--type', 'test',
+        '--output', 'generated-outside-artifacts.json'
+      ];
+
+      await command.parseAsync(args);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Generation failed')
+      );
+      expect(writeSpy).not.toHaveBeenCalled();
+      expect(existsSync(inTemp('generated-outside-artifacts.json'))).toBe(false);
+    });
+
+    it('should default agent-context generated output writes to dry-run', async () => {
+      const previous = process.env['AE_INTEGRATION_AGENT_CONTEXT'];
+      process.env['AE_INTEGRATION_AGENT_CONTEXT'] = '1';
+      try {
+        const outputFile = artifactPath('agent-generated-test.json');
+        const command = cli.createCommand();
+        const args = [
+          'node', 'cli', 'generate',
+          '--type', 'test',
+          '--output', outputFile
+        ];
+
+        await command.parseAsync(args);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Dry-run preview')
+        );
+        expect(existsSync(inTemp(outputFile))).toBe(false);
+      } finally {
+        if (previous === undefined) {
+          delete process.env['AE_INTEGRATION_AGENT_CONTEXT'];
+        } else {
+          process.env['AE_INTEGRATION_AGENT_CONTEXT'] = previous;
+        }
+      }
+    });
+
+    it('should require trusted approval for agent-context apply writes', async () => {
+      const previous = process.env['AE_INTEGRATION_AGENT_CONTEXT'];
+      process.env['AE_INTEGRATION_AGENT_CONTEXT'] = '1';
+      try {
+        const outputFile = artifactPath('agent-apply-without-approval.json');
+        const command = cli.createCommand();
+        const args = [
+          'node', 'cli', 'generate',
+          '--type', 'test',
+          '--output', outputFile,
+          '--apply'
+        ];
+
+        await command.parseAsync(args);
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          expect.stringContaining('approval-scope integration-cli-write')
+        );
+        expect(existsSync(inTemp(outputFile))).toBe(false);
+      } finally {
+        if (previous === undefined) {
+          delete process.env['AE_INTEGRATION_AGENT_CONTEXT'];
+        } else {
+          process.env['AE_INTEGRATION_AGENT_CONTEXT'] = previous;
+        }
+      }
+    });
+
+    it('should allow agent-context apply writes with trusted approval scope', async () => {
+      const previous = process.env['AE_INTEGRATION_AGENT_CONTEXT'];
+      process.env['AE_INTEGRATION_AGENT_CONTEXT'] = '1';
+      try {
+        const outputFile = artifactPath('agent-apply-approved.json');
+        const command = cli.createCommand();
+        const args = [
+          'node', 'cli', 'generate',
+          '--type', 'test',
+          '--output', outputFile,
+          '--apply',
+          '--approval-scope', 'integration-cli-write'
+        ];
+
+        await command.parseAsync(args);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining(`Generated test saved to ${outputFile}`)
+        );
+        expect(existsSync(inTemp(outputFile))).toBe(true);
+      } finally {
+        if (previous === undefined) {
+          delete process.env['AE_INTEGRATION_AGENT_CONTEXT'];
+        } else {
+          process.env['AE_INTEGRATION_AGENT_CONTEXT'] = previous;
+        }
+      }
     });
   });
 
@@ -424,13 +544,13 @@ describe('IntegrationTestingCli', () => {
         tests: [testData.id]
       };
 
-      const testFile = inTemp('run-test.json');
-      const suiteFile = inTemp('run-suite.json');
+      const testFile = 'run-test.json';
+      const suiteFile = 'run-suite.json';
 
-      writeFileSync(testFile, JSON.stringify([testData], null, 2));
-      writeFileSync(suiteFile, JSON.stringify([suiteData], null, 2));
+      writeFileSync(inTemp(testFile), JSON.stringify([testData], null, 2));
+      writeFileSync(inTemp(suiteFile), JSON.stringify([suiteData], null, 2));
 
-      const outputDir = inTemp('test-results-run');
+      const outputDir = artifactPath('test-results-run');
 
       const command = cli.createCommand();
       const args = [
@@ -451,8 +571,8 @@ describe('IntegrationTestingCli', () => {
 
     it('should handle execution filters', async () => {
       const testData = createSampleTestData();
-      const testFile = inTemp('filtered-test.json');
-      writeFileSync(testFile, JSON.stringify([testData], null, 2));
+      const testFile = 'filtered-test.json';
+      writeFileSync(inTemp(testFile), JSON.stringify([testData], null, 2));
 
       const command = cli.createCommand();
       const args = [
@@ -473,8 +593,8 @@ describe('IntegrationTestingCli', () => {
 
     it('should handle parallel execution options', async () => {
       const testData = createSampleTestData();
-      const testFile = inTemp('parallel-test.json');
-      writeFileSync(testFile, JSON.stringify([testData], null, 2));
+      const testFile = 'parallel-test.json';
+      writeFileSync(inTemp(testFile), JSON.stringify([testData], null, 2));
 
       const command = cli.createCommand();
       const args = [
@@ -491,6 +611,32 @@ describe('IntegrationTestingCli', () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining('Starting integration test execution')
       );
+    });
+
+    it('should keep default run output under an overridden artifact root', async () => {
+      const previous = process.env['AE_INTEGRATION_ARTIFACT_ROOT'];
+      process.env['AE_INTEGRATION_ARTIFACT_ROOT'] = 'artifacts/custom-integration';
+      try {
+        const customCli = new IntegrationTestingCli();
+        const command = customCli.createCommand();
+        const args = [
+          'node', 'cli', 'run',
+          '--tests', 'nonexistent.json',
+          '--dry-run'
+        ];
+
+        await command.parseAsync(args);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Planned output directory: artifacts/custom-integration/test-results')
+        );
+      } finally {
+        if (previous === undefined) {
+          delete process.env['AE_INTEGRATION_ARTIFACT_ROOT'];
+        } else {
+          process.env['AE_INTEGRATION_ARTIFACT_ROOT'] = previous;
+        }
+      }
     });
   });
 
@@ -528,7 +674,7 @@ describe('IntegrationTestingCli', () => {
   describe('integration workflow', () => {
     it('should support complete testing workflow', async () => {
       // 1. Generate sample test
-      const testFile = inTemp('workflow-test.json');
+      const testFile = artifactPath('workflow-test.json');
 
       let command = cli.createCommand();
       await command.parseAsync([
@@ -564,7 +710,8 @@ describe('IntegrationTestingCli', () => {
       await command.parseAsync([
         'node', 'cli', 'run',
         '--tests', testFile,
-        '--environment', 'default'
+        '--environment', 'default',
+        '--output-dir', artifactPath('workflow-results')
       ]);
 
       expect(consoleLogSpy).toHaveBeenCalledWith(

--- a/tests/integration/test-orchestrator.test.ts
+++ b/tests/integration/test-orchestrator.test.ts
@@ -3,7 +3,8 @@
  * Phase 2.3: Test suite for integration test orchestrator
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fsp } from 'fs';
 import { join } from 'path';
 import { IntegrationTestOrchestrator } from '../../src/integration/test-orchestrator.js';
 import { E2ETestRunner } from '../../src/integration/runners/e2e-runner.js';
@@ -151,11 +152,13 @@ describe('IntegrationTestOrchestrator', () => {
   let mockDiscovery: TestDiscovery;
   let config: IntegrationTestConfig;
   let integrationTempDir: string;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
   const getOutputDir = (suffix = 'test-results') =>
-    join(integrationTempDir, suffix);
+    ['artifacts', 'integration', suffix].join('/');
 
   beforeEach(async () => {
     integrationTempDir = await createIntegrationTempDir('integration-orchestrator-');
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(integrationTempDir);
 
     config = {
       environments: [createMockEnvironment()],
@@ -199,6 +202,10 @@ describe('IntegrationTestOrchestrator', () => {
     registerIntegrationCleanup(() => {
       orchestrator.removeAllListeners();
     });
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
   });
 
   describe('initialization', () => {
@@ -382,6 +389,43 @@ describe('IntegrationTestOrchestrator', () => {
 
       // Wait for first execution to complete
       await firstExecution;
+    });
+
+    it('should reject suite output directories outside the artifact root before report writes', async () => {
+      const mkdirSpy = vi.spyOn(fsp, 'mkdir');
+      const config: TestExecutionConfig = {
+        environment: 'test',
+        parallel: false,
+        maxConcurrency: 1,
+        timeout: 60000,
+        retries: 1,
+        generateReport: true,
+        outputDir: 'outside-integration-results',
+        reportFormat: ['html']
+      };
+
+      await expect(orchestrator.executeSuite('suite-1', 'test', config))
+        .rejects.toThrow('approved integration artifact root');
+      expect(mkdirSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reject absolute output directories even when they point inside the artifact root', async () => {
+      const mkdirSpy = vi.spyOn(fsp, 'mkdir');
+      const absoluteOutputDir = join(integrationTempDir, 'artifacts', 'integration', 'absolute-results');
+      const config: TestExecutionConfig = {
+        environment: 'test',
+        parallel: false,
+        maxConcurrency: 1,
+        timeout: 60000,
+        retries: 1,
+        generateReport: true,
+        outputDir: absoluteOutputDir,
+        reportFormat: ['html']
+      };
+
+      await expect(orchestrator.executeSuite('suite-1', 'test', config))
+        .rejects.toThrow('must be relative');
+      expect(mkdirSpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- Add an integration path policy that resolves caller-supplied integration CLI inputs under the approved workspace and outputs under the approved integration artifact root.
- Constrain `integration run`, `discover`, `generate`, report cleanup, orchestrator report/artifact collection, and E2E runner screenshots/video/trace output before local filesystem reads or writes.
- Add agent-context dry-run behavior for write-capable integration CLI modes and require `--approval-scope integration-cli-write` for agent-context `--apply` writes.

## Acceptance

- Rejects absolute paths, parent-directory escapes, `.git` metadata targeting, and symlink escapes through the shared workspace path policy before integration CLI read/write sinks.
- Keeps default artifacts under `artifacts/integration/test-results` and allows the artifact root to be explicitly set with `AE_INTEGRATION_ARTIFACT_ROOT`.
- Prevents unapproved agent-context writes by defaulting to dry-run previews when `AE_INTEGRATION_AGENT_CONTEXT` or `AE_AGENT_CONTEXT` is set.
- Adds regression tests proving rejected paths do not reach read/write sinks and approved agent-context apply writes remain possible.

## Verification

- `pnpm -s exec vitest run tests/integration/integration-cli.test.ts tests/integration/test-orchestrator.test.ts tests/unit/utils/workspace-path-policy.test.ts --reporter dot`
- `pnpm -s run types:check`
- `pnpm -s exec eslint --quiet src/cli/integration-cli.ts src/integration/path-policy.ts src/integration/test-orchestrator.ts src/integration/runners/e2e-runner.ts tests/integration/integration-cli.test.ts tests/integration/test-orchestrator.test.ts`
- `pnpm -s run build`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

Revert this PR to restore the previous integration CLI path handling and artifact write behavior.

Closes #3408
