### PR TITLE
fix(security): constrain quality gate command execution

### DIFF
--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: quality-gates-report
-          path: reports/quality-gates
+          path: artifacts/quality/reports
           if-no-files-found: warn
   type-coverage:
     uses: ./.github/workflows/ci-core.yml
@@ -143,11 +143,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: quality-gates-report
-          path: reports/quality-gates
+          path: artifacts/quality/reports
       - name: Locate quality report
         id: report
         run: |
-          REPORT=$(find reports/quality-gates -name 'quality-report-*-latest.json' | head -n1 || true)
+          REPORT=$(find artifacts/quality/reports -name 'quality-report-*-latest.json' | head -n1 || true)
           printf "report=%s\n" "$REPORT" >> "$GITHUB_OUTPUT"
       - name: Load previous quality summary
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ clean-sample-*.json
 artifacts/cassettes/
 artifacts/codex/
 artifacts/hermetic-reports/
+artifacts/quality/
 artifacts/testing/
 artifacts/schema-validation/
 artifacts/api/.tmp/

--- a/config/quality-policy.json
+++ b/config/quality-policy.json
@@ -435,7 +435,7 @@
 
   "reporting": {
     "formats": ["json", "html", "junit"],
-    "outputDirectory": "reports/quality-gates",
+    "outputDirectory": "artifacts/quality/reports",
     "retention": {
       "days": 30,
       "maxReports": 100

--- a/docs/product/USER-MANUAL.md
+++ b/docs/product/USER-MANUAL.md
@@ -248,7 +248,7 @@ pnpm run ae-framework -- validate --traceability --strict --sources docs/specs/I
 pnpm run evaluate:usefulness -- --strict-inputs --min-score 70 \
   --traceability docs/specs/ISSUE-TRACEABILITY-MATRIX.json \
   --verify-profile artifacts/verify-profile-summary.json \
-  --quality-report reports/quality-gates/quality-report-ci-latest.json \
+  --quality-report artifacts/quality/reports/quality-report-ci-latest.json \
   --run-manifest-check artifacts/run-manifest-check.json
 
 # dependency audit
@@ -534,7 +534,7 @@ pnpm run ae-framework -- validate --traceability --strict --sources docs/specs/I
 pnpm run evaluate:usefulness -- --strict-inputs --min-score 70 \
   --traceability docs/specs/ISSUE-TRACEABILITY-MATRIX.json \
   --verify-profile artifacts/verify-profile-summary.json \
-  --quality-report reports/quality-gates/quality-report-ci-latest.json \
+  --quality-report artifacts/quality/reports/quality-report-ci-latest.json \
   --run-manifest-check artifacts/run-manifest-check.json
 
 # 依存監査

--- a/docs/quality/progress-summary.md
+++ b/docs/quality/progress-summary.md
@@ -22,7 +22,7 @@ pnpm run progress:summary
 
 ### Default inputs
 - `metrics/project-metrics.json`
-- `reports/quality-gates/quality-report-*-latest.json` (preferred; if none exist, the generator falls back to the most recent `quality-report-*.json` under `reports/quality-gates/`)
+- `artifacts/quality/reports/quality-report-*-latest.json` (preferred; if none exist, the generator falls back to the most recent `quality-report-*.json` under `artifacts/quality/reports/`)
 - `traceability.json`
 - `.ae/phase-state.json`
 
@@ -72,7 +72,7 @@ pnpm run progress:summary
 
 ### 既定の入力
 - `metrics/project-metrics.json`
-- `reports/quality-gates/quality-report-*-latest.json`（優先。存在しない場合は、generator が `reports/quality-gates/` 配下の最新 `quality-report-*.json` へフォールバックします）
+- `artifacts/quality/reports/quality-report-*-latest.json`（優先。存在しない場合は、generator が `artifacts/quality/reports/` 配下の最新 `quality-report-*.json` へフォールバックします）
 - `traceability.json`
 - `.ae/phase-state.json`
 

--- a/docs/quality/usefulness-evaluation.md
+++ b/docs/quality/usefulness-evaluation.md
@@ -27,7 +27,7 @@ pnpm run evaluate:usefulness -- --strict-inputs --min-score 70
 - Run index: `artifacts/runs/index.json`
 - Traceability: `traceability.json`
 - Verify profile summary: `artifacts/verify-profile-summary.json`
-- Quality report: `reports/quality-gates/quality-report-ci-latest.json`
+- Quality report: `artifacts/quality/reports/quality-report-ci-latest.json`
 - Run manifest check: `artifacts/run-manifest-check.json`
 
 Override these with `--run-index`, `--traceability`, `--verify-profile`, `--quality-report`, and `--run-manifest-check` when the defaults do not match the current workspace or CI artifact layout.
@@ -82,7 +82,7 @@ pnpm run evaluate:usefulness -- --strict-inputs --min-score 70
 - 実行インデックス（Run index）: `artifacts/runs/index.json`
 - トレーサビリティ（Traceability）: `traceability.json`
 - Verify profile summary: `artifacts/verify-profile-summary.json`
-- Quality report: `reports/quality-gates/quality-report-ci-latest.json`
+- Quality report: `artifacts/quality/reports/quality-report-ci-latest.json`
 - Run manifest check: `artifacts/run-manifest-check.json`
 
 必要に応じて `--run-index` / `--traceability` / `--verify-profile` / `--quality-report` / `--run-manifest-check` で上書き可能です。

--- a/docs/quality/verification-gates.md
+++ b/docs/quality/verification-gates.md
@@ -61,7 +61,7 @@ Related documents:
 | DbC condition | Representative verification method | Representative evidence |
 | --- | --- | --- |
 | Preconditions | request validation / negative tests / type guards | `artifacts/verify-lite/verify-lite-run-summary.json` (see `docs/quality/ARTIFACTS-CONTRACT.md`) |
-| Postconditions | state assertions / event assertions / integration tests | `reports/quality-gates/quality-report-*.json`, `artifacts/hermetic-reports/conformance/summary.json` |
+| Postconditions | state assertions / event assertions / integration tests | `artifacts/quality/reports/quality-report-*.json`, `artifacts/hermetic-reports/conformance/summary.json` |
 | Invariants | property tests / runtime conformance monitors / DB constraints | `artifacts/properties/summary.json`, `artifacts/hermetic-reports/conformance/summary.json` |
 
 ### PR レポート
@@ -72,7 +72,7 @@ Related documents:
 
 ### Report metadata
 
-Quality gate reports (`reports/quality-gates/quality-report-*.json`) include a `meta` object for run-level metadata. That object may contain `runId`, `commitSha`, `branch`, `createdAt`, `agent`, `model`, and `traceId`. Values are taken from CI/local environment variables when available; only `runId` and `createdAt` are always populated.
+Quality gate reports (`artifacts/quality/reports/quality-report-*.json`) include a `meta` object for run-level metadata. That object may contain `runId`, `commitSha`, `branch`, `createdAt`, `agent`, `model`, and `traceId`. Values are taken from CI/local environment variables when available; only `runId` and `createdAt` are always populated.
 
 ### Operational caution
 
@@ -132,7 +132,7 @@ Quality gate reports (`reports/quality-gates/quality-report-*.json`) include a `
 | DbC 条件 | 代表的な検証手段 | 代表的な証跡 |
 | --- | --- | --- |
 | Preconditions | request validation / negative tests / type guards | `artifacts/verify-lite/verify-lite-run-summary.json`（詳細は `docs/quality/ARTIFACTS-CONTRACT.md`） |
-| Postconditions | state assertions / event assertions / integration tests | `reports/quality-gates/quality-report-*.json`, `artifacts/hermetic-reports/conformance/summary.json` |
+| Postconditions | state assertions / event assertions / integration tests | `artifacts/quality/reports/quality-report-*.json`, `artifacts/hermetic-reports/conformance/summary.json` |
 | Invariants | property tests / runtime conformance monitors / DB constraints | `artifacts/properties/summary.json`, `artifacts/hermetic-reports/conformance/summary.json` |
 
 ### PR レポート
@@ -143,7 +143,7 @@ Quality gate reports (`reports/quality-gates/quality-report-*.json`) include a `
 
 ### レポートメタデータ
 
-quality gate report（`reports/quality-gates/quality-report-*.json`）には、run-level metadata を表す `meta` object が含まれます。代表項目は `runId`、`commitSha`、`branch`、`createdAt`、`agent`、`model`、`traceId` です。値は CI / local environment variable から取得できるものだけを使用し、`runId` と `createdAt` は常に設定されます。
+quality gate report（`artifacts/quality/reports/quality-report-*.json`）には、run-level metadata を表す `meta` object が含まれます。代表項目は `runId`、`commitSha`、`branch`、`createdAt`、`agent`、`model`、`traceId` です。値は CI / local environment variable から取得できるものだけを使用し、`runId` と `createdAt` は常に設定されます。
 
 ### 運用上の注意
 

--- a/docs/reference/CLI-COMMANDS-REFERENCE.md
+++ b/docs/reference/CLI-COMMANDS-REFERENCE.md
@@ -396,7 +396,7 @@ ae domain-model --language --sources "glossary.md"
   --run-index artifacts/runs/index.json \
   --traceability traceability.json \
   --verify-profile artifacts/verify-profile-summary.json \
-  --quality-report reports/quality-gates/quality-report-ci-latest.json \
+  --quality-report artifacts/quality/reports/quality-report-ci-latest.json \
   --run-manifest-check artifacts/run-manifest-check.json \
   --out-json artifacts/evaluation/ae-framework-usefulness-latest.json \
   --out-markdown artifacts/evaluation/ae-framework-usefulness-latest.md

--- a/src/cli/quality-cli.ts
+++ b/src/cli/quality-cli.ts
@@ -8,7 +8,13 @@ import chalk from 'chalk';
 import { qualityPolicy } from '../quality/policy-loader.js';
 import { toMessage } from '../utils/error-utils.js';
 import { safeExit } from '../utils/safe-exit.js';
-import { QualityGateRunner } from '../quality/quality-gate-runner.js';
+import { QualityGateRunner, type QualityGateExecutionOptions } from '../quality/quality-gate-runner.js';
+import {
+  createQualityPathContext,
+  getDefaultQualityReportDir,
+  isQualityAgentContext,
+  QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+} from '../quality/quality-command-policy.js';
 import { AutoFixEngine } from '../cegis/auto-fix-engine.js';
 import type { FailureArtifact as EngineFailureArtifact, FailureCategory as EngineFailureCategory } from '../cegis/types.js';
 import { FailureArtifactSchema as EngineFailureArtifactSchema } from '../cegis/types.js';
@@ -186,12 +192,48 @@ const loadFailureArtifacts = (inputPath?: string): EngineFailureArtifact[] => {
 
 type QualityOutputFormat = 'text' | 'json';
 
+interface QualityExecutionPolicy {
+  dryRun: boolean;
+  apply: boolean;
+  approvalScope?: string;
+  approvalRequired: boolean;
+}
+
 const normalizeQualityOutputFormat = (rawFormat: string | undefined): QualityOutputFormat => {
   const normalized = (rawFormat ?? 'text').toLowerCase();
   if (normalized === 'text' || normalized === 'json') {
     return normalized;
   }
   throw new Error(`Unsupported --format: ${rawFormat}. Expected one of: text, json`);
+};
+
+const getDefaultQualityOutputDir = (): string => getDefaultQualityReportDir(createQualityPathContext());
+
+const getQualityExecutionPolicy = (options: { dryRun?: boolean; apply?: boolean; approvalScope?: string }): QualityExecutionPolicy => {
+  const agentContext = isQualityAgentContext();
+  const apply = options.apply === true;
+  const approvalScope = options.approvalScope;
+  const dryRun = options.dryRun === true || (agentContext && !apply);
+  const approvalRequired = agentContext && apply && approvalScope !== QUALITY_GATE_EXECUTION_APPROVAL_SCOPE;
+  const policy: QualityExecutionPolicy = {
+    dryRun,
+    apply,
+    approvalRequired,
+  };
+  if (approvalScope !== undefined) {
+    policy.approvalScope = approvalScope;
+  }
+  return policy;
+};
+
+const applyApprovalScope = (
+  options: QualityGateExecutionOptions,
+  executionPolicy: QualityExecutionPolicy
+): QualityGateExecutionOptions => {
+  if (executionPolicy.approvalScope !== undefined) {
+    options.approvalScope = executionPolicy.approvalScope;
+  }
+  return options;
 };
 
 export function createQualityCommand(): Command {
@@ -206,9 +248,11 @@ export function createQualityCommand(): Command {
     .option('-g, --gates <gates>', 'Comma-separated list of specific gates to run')
     .option('--sequential', 'Run gates sequentially instead of in parallel')
     .option('--dry-run', 'Show what would be executed without running')
+    .option('--apply', 'Execute quality gates in an agent context after trusted approval')
+    .option('--approval-scope <scope>', `Trusted execution approval scope (${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE})`)
     .option('-v, --verbose', 'Verbose output with detailed results')
     .option('-t, --timeout <ms>', 'Timeout for each gate in milliseconds', '300000')
-    .option('-o, --output <dir>', 'Output directory for reports', 'reports/quality-gates')
+    .option('-o, --output <dir>', 'Output directory for reports', getDefaultQualityOutputDir())
     .option('--format <format>', 'Output format (text|json)', 'text')
     .option('--no-history', 'Skip timestamped history report and write latest report only')
     .action(async (options) => {
@@ -224,23 +268,34 @@ export function createQualityCommand(): Command {
 
       const printJson = outputFormat === 'json';
       try {
+        const executionPolicy = getQualityExecutionPolicy(options);
+        if (executionPolicy.approvalRequired) {
+          console.error(chalk.red(`❌ Quality gate execution requires --approval-scope ${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE} when --apply is used in an agent context`));
+          safeExit(1);
+          return;
+        }
+
         if (!printJson) {
           console.log(chalk.blue(`🔍 Running quality gates for ${options.env} environment`));
+          if (executionPolicy.dryRun) {
+            console.log(chalk.yellow('🔎 Dry-run preview: quality gate processes and report writes will not run.'));
+          }
         }
         
         const runner = new QualityGateRunner();
-        const report = await runner.executeGates({
+        const report = await runner.executeGates(applyApprovalScope({
           environment: options.env,
           gates: options.gates ? options.gates.split(',').map((g: string) => g.trim()) : undefined,
           parallel: !options.sequential,
-          dryRun: options.dryRun,
+          dryRun: executionPolicy.dryRun,
+          apply: executionPolicy.apply,
           verbose: options.verbose,
           timeout: parseInt(options.timeout),
           outputDir: options.output,
           noHistory: options.history === false,
           printSummary: !printJson,
           silent: printJson,
-        });
+        }, executionPolicy));
 
         if (printJson) {
           console.log(JSON.stringify(report, null, 2));
@@ -274,9 +329,11 @@ export function createQualityCommand(): Command {
     .option('-g, --gates <gates>', 'Comma-separated list of specific gates to run')
     .option('--sequential', 'Run gates sequentially instead of in parallel')
     .option('--dry-run', 'Show what would be executed without running')
+    .option('--apply', 'Execute quality gates and auto-fix in an agent context after trusted approval')
+    .option('--approval-scope <scope>', `Trusted execution approval scope (${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE})`)
     .option('-v, --verbose', 'Verbose output with detailed results')
     .option('-t, --timeout <ms>', 'Timeout for each gate in milliseconds', '300000')
-    .option('-o, --output <dir>', 'Output directory for reports', 'reports/quality-gates')
+    .option('-o, --output <dir>', 'Output directory for reports', getDefaultQualityOutputDir())
     .option('--format <format>', 'Output format (text|json)', 'text')
     .option('--no-history', 'Skip timestamped history report and write latest report only')
     .option('--max-rounds <number>', 'Maximum reconciliation rounds', '3')
@@ -297,6 +354,13 @@ export function createQualityCommand(): Command {
 
       const printJson = outputFormat === 'json';
       try {
+        const executionPolicy = getQualityExecutionPolicy(options);
+        if (executionPolicy.approvalRequired) {
+          console.error(chalk.red(`❌ Quality gate execution requires --approval-scope ${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE} when --apply is used in an agent context`));
+          safeExit(1);
+          return;
+        }
+
         const maxRounds = Math.max(1, parseInt(options.maxRounds, 10) || 1);
         const runner = new QualityGateRunner();
         let lastReport: Awaited<ReturnType<QualityGateRunner['executeGates']>> | null = null;
@@ -306,20 +370,24 @@ export function createQualityCommand(): Command {
           if (!printJson) {
             console.log(chalk.blue(`🔁 Reconciliation round ${round}/${maxRounds}`));
             console.log(chalk.blue(`🔍 Running quality gates for ${options.env} environment`));
+            if (executionPolicy.dryRun) {
+              console.log(chalk.yellow('🔎 Dry-run preview: quality gate processes, report writes, and auto-fix writes will not run.'));
+            }
           }
 
-          const report = await runner.executeGates({
+          const report = await runner.executeGates(applyApprovalScope({
             environment: options.env,
             gates: options.gates ? options.gates.split(',').map((g: string) => g.trim()) : undefined,
             parallel: !options.sequential,
-            dryRun: options.dryRun,
+            dryRun: executionPolicy.dryRun,
+            apply: executionPolicy.apply,
             verbose: options.verbose,
             timeout: parseInt(options.timeout, 10) || 300000,
             outputDir: options.output,
             noHistory: options.history === false,
             printSummary: !printJson,
             silent: printJson,
-          });
+          }, executionPolicy));
 
           lastReport = report;
 
@@ -339,7 +407,7 @@ export function createQualityCommand(): Command {
             break;
           }
 
-          if (options.dryRun) {
+          if (executionPolicy.dryRun) {
             if (!printJson) {
               console.log(chalk.yellow('ℹ️  Dry-run mode enabled; skipping auto-fix.'));
             }

--- a/src/quality/quality-command-policy.ts
+++ b/src/quality/quality-command-policy.ts
@@ -1,0 +1,222 @@
+import path from 'node:path';
+import {
+  resolveContainedWorkspacePath,
+  resolveWorkspacePath,
+  resolveWorkspaceRoot,
+  toWorkspaceRelativePath,
+  WorkspacePathPolicyError,
+} from '../utils/workspace-path-policy.js';
+import type { QualityGate } from './policy-loader.js';
+
+export const QUALITY_GATE_EXECUTION_APPROVAL_SCOPE = 'quality-gate-execution' as const;
+export const DEFAULT_QUALITY_ARTIFACT_ROOT = 'artifacts/quality' as const;
+export const DEFAULT_QUALITY_REPORT_DIR = 'artifacts/quality/reports' as const;
+
+export class QualityCommandPolicyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'QualityCommandPolicyError';
+  }
+}
+
+export interface QualityPathContext {
+  workspaceRoot: string;
+  artifactRoot: string;
+}
+
+export interface QualityPathContextOptions {
+  workspaceRoot?: string;
+  artifactRoot?: string;
+}
+
+export interface ResolvedQualityPath {
+  resolvedPath: string;
+  workspaceRelativePath: string;
+}
+
+export interface ApprovedQualityGateCommand {
+  gateKey: string;
+  executable: string;
+  args: readonly string[];
+  displayCommand: string;
+  policyCommand: string;
+  allowNonZeroExit?: boolean;
+}
+
+type ApprovedQualityGateCommandDefinition = Omit<ApprovedQualityGateCommand, 'gateKey'>;
+
+const hasWindowsAbsolutePrefix = (value: string): boolean =>
+  path.win32.isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value);
+
+const isPathWithin = (baseDir: string, candidatePath: string): boolean => {
+  const relative = path.relative(baseDir, candidatePath);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
+const normalizeWorkspaceRelativePath = (input: string, label: string): string => {
+  const raw = String(input).trim();
+  if (!raw) {
+    throw new WorkspacePathPolicyError(`${label} must be a non-empty workspace-relative path`);
+  }
+  if (raw.includes('\0')) {
+    throw new WorkspacePathPolicyError(`${label} must not contain NUL bytes`);
+  }
+  if (raw.includes('\\')) {
+    throw new WorkspacePathPolicyError(`${label} must use POSIX-style '/' separators`);
+  }
+  if (raw.startsWith('//') || path.posix.isAbsolute(raw) || path.isAbsolute(raw) || hasWindowsAbsolutePrefix(raw)) {
+    throw new WorkspacePathPolicyError(`${label} must be relative to the approved workspace`);
+  }
+
+  const segments = raw.split('/').filter(segment => segment !== '' && segment !== '.');
+  if (segments.length === 0) {
+    throw new WorkspacePathPolicyError(`${label} must be a non-empty workspace-relative path`);
+  }
+  if (segments.some(segment => segment === '..')) {
+    throw new WorkspacePathPolicyError(`${label} must not contain parent-directory path components`);
+  }
+
+  return segments.join('/');
+};
+
+const normalizePolicyCommand = (command: string): string => command.trim().replace(/\s+/g, ' ');
+
+const commandDefinitions = {
+  accessibility: {
+    executable: 'npm',
+    args: ['run', 'test:a11y'],
+    displayCommand: 'npm run test:a11y',
+    policyCommand: 'npm run test:a11y',
+  },
+  coverage: {
+    executable: 'npm',
+    args: ['run', 'coverage'],
+    displayCommand: 'npm run coverage',
+    policyCommand: 'npm run coverage',
+  },
+  lighthouse: {
+    executable: 'lhci',
+    args: ['autorun'],
+    displayCommand: 'lhci autorun (non-zero exit tolerated)',
+    policyCommand: 'lhci autorun || true',
+    allowNonZeroExit: true,
+  },
+  linting: {
+    executable: 'node',
+    args: ['scripts/quality/check-lint-summary.mjs'],
+    displayCommand: 'node scripts/quality/check-lint-summary.mjs',
+    policyCommand: 'node scripts/quality/check-lint-summary.mjs',
+  },
+  security: {
+    executable: 'pnpm',
+    args: ['audit', '--prod', '--json'],
+    displayCommand: 'pnpm audit --prod --json',
+    policyCommand: 'pnpm audit --prod --json',
+  },
+  tdd: {
+    executable: 'node',
+    args: ['scripts/quality/tdd-smoke-check.mjs'],
+    displayCommand: 'node scripts/quality/tdd-smoke-check.mjs',
+    policyCommand: 'node scripts/quality/tdd-smoke-check.mjs',
+  },
+  performance: {
+    executable: 'npm',
+    args: ['run', 'test:benchmarks'],
+    displayCommand: 'npm run test:benchmarks',
+    policyCommand: 'npm run test:benchmarks',
+  },
+  'api-validation': {
+    executable: 'npm',
+    args: ['run', 'validate:api'],
+    displayCommand: 'npm run validate:api',
+    policyCommand: 'npm run validate:api',
+  },
+} as const satisfies Record<string, ApprovedQualityGateCommandDefinition>;
+
+export const APPROVED_QUALITY_GATE_COMMANDS: Readonly<Record<string, ApprovedQualityGateCommandDefinition>> = commandDefinitions;
+
+export function getApprovedQualityGateCommand(gateKey: string, gate: QualityGate): ApprovedQualityGateCommand {
+  const definition = APPROVED_QUALITY_GATE_COMMANDS[gateKey];
+  if (!definition) {
+    throw new QualityCommandPolicyError(
+      `Quality gate '${gateKey}' does not have a code-owned command allowlist entry`
+    );
+  }
+
+  const policyCommand = normalizePolicyCommand(gate.commands.test);
+  const expectedPolicyCommand = normalizePolicyCommand(definition.policyCommand);
+  if (policyCommand !== expectedPolicyCommand) {
+    throw new QualityCommandPolicyError(
+      `Quality gate '${gateKey}' policy command is not trusted; expected '${definition.policyCommand}'`
+    );
+  }
+
+  const command: ApprovedQualityGateCommand = {
+    gateKey,
+    executable: definition.executable,
+    args: [...definition.args],
+    displayCommand: definition.displayCommand,
+    policyCommand: definition.policyCommand,
+  };
+  if (definition.allowNonZeroExit === true) {
+    command.allowNonZeroExit = true;
+  }
+  return command;
+}
+
+export function createQualityPathContext(options: QualityPathContextOptions = {}): QualityPathContext {
+  const workspaceRoot = resolveWorkspaceRoot({ defaultRoot: options.workspaceRoot ?? process.cwd() });
+  const artifactRootInput = options.artifactRoot ?? process.env['AE_QUALITY_ARTIFACT_ROOT'] ?? DEFAULT_QUALITY_ARTIFACT_ROOT;
+  const artifactRoot = resolveWorkspacePath(
+    normalizeWorkspaceRelativePath(artifactRootInput, 'quality artifact root'),
+    { workspaceRoot, label: 'quality artifact root' }
+  );
+  return { workspaceRoot, artifactRoot };
+}
+
+export function getDefaultQualityReportDir(context: QualityPathContext): string {
+  const artifactRoot = toWorkspaceRelativePath(context.artifactRoot, {
+    workspaceRoot: context.workspaceRoot,
+    label: 'quality artifact root',
+  });
+  return path.posix.join(artifactRoot, 'reports');
+}
+
+export function resolveQualityReportOutputDir(
+  input: string,
+  context: QualityPathContext,
+  label = 'quality report output directory'
+): ResolvedQualityPath {
+  if (path.isAbsolute(input) || hasWindowsAbsolutePrefix(input)) {
+    throw new WorkspacePathPolicyError(`${label} must be relative to the approved quality artifact root`);
+  }
+
+  const workspaceRelative = normalizeWorkspaceRelativePath(input, label);
+  let resolvedPath = resolveWorkspacePath(workspaceRelative, {
+    workspaceRoot: context.workspaceRoot,
+    label,
+  });
+
+  if (!isPathWithin(context.artifactRoot, resolvedPath)) {
+    throw new WorkspacePathPolicyError(`${label} must stay under the approved quality artifact root`);
+  }
+
+  const artifactRelative = path.relative(context.artifactRoot, resolvedPath).replace(/\\/g, '/');
+  if (artifactRelative !== '') {
+    resolvedPath = resolveContainedWorkspacePath(context.artifactRoot, artifactRelative, label);
+  }
+
+  return {
+    resolvedPath,
+    workspaceRelativePath: toWorkspaceRelativePath(resolvedPath, {
+      workspaceRoot: context.workspaceRoot,
+      label,
+    }),
+  };
+}
+
+export function isQualityAgentContext(): boolean {
+  const raw = process.env['AE_QUALITY_AGENT_CONTEXT'] ?? process.env['AE_AGENT_CONTEXT'];
+  if (!raw) return false;
+  return ['1', 'true', 'yes', 'y'].includes(raw.trim().toLowerCase());
+}

--- a/src/quality/quality-gate-runner.ts
+++ b/src/quality/quality-gate-runner.ts
@@ -3,17 +3,31 @@
  * Executes quality gates based on centralized policy configuration
  */
 
-import { spawn } from 'child_process';
+import { spawn } from 'node:child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import { QualityPolicyLoader, type QualityGateResult, type QualityReport, type QualityGate } from './policy-loader.js';
 import { buildReportMeta } from '../utils/report-meta.js';
+import {
+  type ApprovedQualityGateCommand,
+  createQualityPathContext,
+  getApprovedQualityGateCommand,
+  getDefaultQualityReportDir,
+  isQualityAgentContext,
+  QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+  resolveQualityReportOutputDir,
+} from './quality-command-policy.js';
 
 type CoverageThreshold = { lines?: number; functions?: number; branches?: number; statements?: number };
 type LintThreshold = { maxErrors?: number; maxWarnings?: number };
 type SecurityThreshold = { maxCritical?: number; maxHigh?: number; maxMedium?: number };
 type PerfThreshold = Record<string, number | undefined>;
 type A11yThreshold = Record<string, number | undefined>;
+type QualityGateExecutionRecord = {
+  gate: QualityGate;
+  key: string;
+  command: ApprovedQualityGateCommand;
+};
 
 // Mock telemetry for main branch compatibility
 type Attributes = Record<string, unknown>;
@@ -36,6 +50,8 @@ export interface QualityGateExecutionOptions {
   parallel?: boolean;
   timeout?: number;
   dryRun?: boolean;
+  apply?: boolean;
+  approvalScope?: string;
   verbose?: boolean;
   outputDir?: string;
   noHistory?: boolean;
@@ -43,13 +59,19 @@ export interface QualityGateExecutionOptions {
   silent?: boolean;
 }
 
+export interface QualityGateRunnerOptions {
+  spawnProcess?: typeof spawn;
+}
+
 export class QualityGateRunner {
   private policyLoader: QualityPolicyLoader;
+  private spawnProcess: typeof spawn;
   private results: QualityGateResult[] = [];
   private silent = false;
 
-  constructor(policyLoader?: QualityPolicyLoader) {
+  constructor(policyLoader?: QualityPolicyLoader, options: QualityGateRunnerOptions = {}) {
     this.policyLoader = policyLoader || new QualityPolicyLoader();
+    this.spawnProcess = options.spawnProcess ?? spawn;
   }
 
   /**
@@ -62,13 +84,24 @@ export class QualityGateRunner {
       parallel = true,
       timeout = 300000, // 5 minutes default
       dryRun = false,
+      apply = false,
+      approvalScope,
       verbose = false,
-      outputDir = 'reports/quality-gates',
       noHistory = false,
       printSummary = true,
       silent = false,
     } = options;
     this.silent = silent;
+    const pathContext = createQualityPathContext();
+    const outputDir = options.outputDir ?? getDefaultQualityReportDir(pathContext);
+    const resolvedOutputDir = resolveQualityReportOutputDir(outputDir, pathContext);
+    const agentContext = isQualityAgentContext();
+    if (agentContext && apply && approvalScope !== QUALITY_GATE_EXECUTION_APPROVAL_SCOPE) {
+      throw new Error(
+        `Quality gate execution requires approval scope '${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE}' when --apply is used in an agent context`
+      );
+    }
+    const effectiveDryRun = dryRun || (agentContext && !apply);
 
     const timer = mockTelemetry.createTimer('quality_gates.execution.total', {
       [TELEMETRY_ATTRIBUTES.SERVICE_COMPONENT]: 'quality-gates',
@@ -138,11 +171,17 @@ export class QualityGateRunner {
         this.log('⚠️  No quality gates found for execution');
         return this.generateEmptyReport(environment);
       }
+      const executionRecords: QualityGateExecutionRecord[] = gateRecords.map(({ gate, key }) => ({
+        gate,
+        key,
+        command: getApprovedQualityGateCommand(key, gate),
+      }));
 
-      this.log(`📋 Found ${gateRecords.length} quality gates to execute`);
+      this.log(`📋 Found ${executionRecords.length} quality gates to execute`);
       if (verbose) {
-        gateRecords.forEach(({ gate, key }) => {
+        executionRecords.forEach(({ gate, key, command }) => {
           this.log(`   • ${gate.name} (${gate.category}) [${key}]`);
+          this.log(`     Command: ${command.displayCommand}`);
         });
       }
 
@@ -150,14 +189,14 @@ export class QualityGateRunner {
       this.results = [];
       if (parallel) {
         this.log('🚀 Executing gates in parallel...');
-        const promises = gateRecords.map(({ gate, key }) =>
-          this.executeGate(gate, key, environment, { timeout, dryRun, verbose, silent })
+        const promises = executionRecords.map(({ gate, key, command }) =>
+          this.executeGate(gate, key, command, environment, { timeout, dryRun: effectiveDryRun, verbose, silent })
         );
         this.results = await Promise.all(promises);
       } else {
         this.log('⏭️  Executing gates sequentially...');
-        for (const { gate, key } of gateRecords) {
-          const result = await this.executeGate(gate, key, environment, { timeout, dryRun, verbose, silent });
+        for (const { gate, key, command } of executionRecords) {
+          const result = await this.executeGate(gate, key, command, environment, { timeout, dryRun: effectiveDryRun, verbose, silent });
           this.results.push(result);
         }
       }
@@ -181,8 +220,8 @@ export class QualityGateRunner {
       }
       
       // Save report
-      if (!dryRun) {
-        await this.saveReport(report, outputDir, { noHistory });
+      if (!effectiveDryRun) {
+        await this.saveReport(report, resolvedOutputDir.workspaceRelativePath, { noHistory });
       }
 
       // Record metrics
@@ -220,6 +259,7 @@ export class QualityGateRunner {
   private async executeGate(
     gate: QualityGate,
     gateKey: string,
+    approvedCommand: ApprovedQualityGateCommand,
     environment: string,
     options: { timeout: number; dryRun: boolean; verbose: boolean; silent: boolean }
   ): Promise<QualityGateResult> {
@@ -237,13 +277,15 @@ export class QualityGateRunner {
       if (verbose) {
         this.log(`\n🔍 Executing: ${gate.name}`);
         this.log(`   Description: ${gate.description}`);
-        this.log(`   Command: ${gate.commands.test}`);
       }
 
       const threshold = this.policyLoader.getThreshold(gateKey, environment);
+      if (verbose) {
+        this.log(`   Command: ${approvedCommand.displayCommand}`);
+      }
       
       if (dryRun) {
-        this.log(`   🔄 DRY RUN: Would execute '${gate.commands.test}'`);
+        this.log(`   🔄 DRY RUN: Would execute '${approvedCommand.displayCommand}'`);
         return {
           gateKey,
           gateName: gate.name,
@@ -253,13 +295,16 @@ export class QualityGateRunner {
           executionTime: 0,
           environment,
           threshold,
-          details: { dryRun: true },
+          details: {
+            dryRun: true,
+            command: approvedCommand.displayCommand,
+          },
         };
       }
 
       // Execute the gate command
       const startTime = Date.now();
-      const result = await this.executeCommand(gate.commands.test, timeout, { silent });
+      const result = await this.executeCommand(approvedCommand, timeout);
       const executionTime = Date.now() - startTime;
 
       // Parse result based on gate type
@@ -309,60 +354,40 @@ export class QualityGateRunner {
   }
 
   /**
-   * Execute a command with timeout
+   * Execute an allowlisted command with timeout.
    */
   private async executeCommand(
-    command: string,
-    timeout: number,
-    options: { silent?: boolean } = {}
+    command: ApprovedQualityGateCommand,
+    timeout: number
   ): Promise<{ stdout: string; stderr: string; code: number }> {
-    const { silent = false } = options;
     return new Promise((resolve, reject) => {
-      // Check if command needs shell features (pipes, redirects, etc.)
-      const needsShell = command.includes('|') || command.includes('>') || command.includes('<') || 
-                        command.includes('&&') || command.includes('||') || command.includes('$');
-      
-      let process: import('child_process').ChildProcessWithoutNullStreams;
-      
-      if (needsShell) {
-        // Use shell for complex commands with enhanced security validation
-        this.validateShellCommand(command, { silent });
-        process = spawn(command, {
-          shell: true,
-          stdio: ['pipe', 'pipe', 'pipe'],
-          timeout,
-        });
-      } else {
-        // Parse command to avoid shell injection for simple commands
-        const commandParts = this.parseCommand(command);
-        const [execName, ...args] = commandParts as [string, ...string[]];
-        process = spawn(execName, args, {
-          stdio: ['pipe', 'pipe', 'pipe'],
-          timeout,
-        });
-      }
+      const child = this.spawnProcess(command.executable, [...command.args], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout,
+        shell: false,
+      });
 
       let stdout = '';
       let stderr = '';
       let finished = false;
 
-      process.stdout?.on('data', (data) => {
+      child.stdout?.on('data', (data) => {
         stdout += data.toString();
       });
 
-      process.stderr?.on('data', (data) => {
+      child.stderr?.on('data', (data) => {
         stderr += data.toString();
       });
 
-      process.on('close', (code) => {
+      child.on('close', (code) => {
         if (!finished) {
           finished = true;
           clearTimeout(timeoutHandle);
-          resolve({ stdout, stderr, code: code || 0 });
+          resolve({ stdout, stderr, code: command.allowNonZeroExit ? 0 : (code || 0) });
         }
       });
 
-      process.on('error', (error) => {
+      child.on('error', (error) => {
         if (!finished) {
           finished = true;
           clearTimeout(timeoutHandle);
@@ -374,99 +399,11 @@ export class QualityGateRunner {
       const timeoutHandle = setTimeout(() => {
         if (!finished) {
           finished = true;
-          process.kill('SIGTERM');
+          child.kill('SIGTERM');
           reject(new Error(`Command timed out after ${timeout}ms`));
         }
       }, timeout);
     });
-  }
-
-  /**
-   * Parse command string into executable and arguments safely
-   */
-  private parseCommand(command: string): string[] {
-    // Simple command parsing to avoid shell injection
-    // For production use, consider using a proper shell parser library
-    const trimmed = command.trim();
-    
-    // Handle npm/npx commands specially as they are common in quality gates
-    if (trimmed.startsWith('npm ') || trimmed.startsWith('npx ')) {
-      return trimmed.split(/\s+/);
-    }
-    
-    // For other commands, use a basic splitting approach
-    // In a production environment, consider using a library like shell-quote
-    const parts = trimmed.split(/\s+/);
-    
-    // Security validation - use allowlist for common commands, blacklist for dangerous ones
-    const executable = parts[0];
-    if (!executable) {
-      throw new Error('Empty command');
-    }
-    
-    // Allowlist of commonly used quality gate commands
-    const allowedCommands = [
-      'npm', 'npx', 'yarn', 'pnpm', 'node',
-      'jest', 'mocha', 'vitest', 'nyc',
-      'eslint', 'prettier', 'tsc', 'tslint',
-      'lighthouse', 'axe', 'pa11y',
-      'audit', 'license-checker'
-    ];
-    
-    // Dangerous commands that should never be allowed
-    const dangerousCommands = [
-      'rm', 'rmdir', 'del', 'sudo', 'su',
-      'curl', 'wget', 'eval', 'exec',
-      'bash', 'sh', 'zsh', 'fish',
-      'chmod', 'chown', 'kill', 'killall'
-    ];
-    
-    if (dangerousCommands.includes(executable)) {
-      throw new Error(`Command '${executable}' is not allowed for security reasons`);
-    }
-    
-    // For non-allowlisted commands, require they don't start with dangerous prefixes
-    if (!allowedCommands.includes(executable)) {
-      this.warn(`⚠️ Command '${executable}' is not in the allowlist. Proceeding with caution.`);
-      
-      // Additional check for suspicious patterns
-      if (executable.includes('/') || executable.includes('\\') || executable.startsWith('.')) {
-        throw new Error(`Command '${executable}' contains suspicious path characters`);
-      }
-    }
-    return parts;
-  }
-
-  /**
-   * Validate shell commands for security
-   */
-  private validateShellCommand(command: string, options: { silent?: boolean } = {}): void {
-    const { silent = false } = options;
-    // Check for obviously dangerous patterns
-    const dangerousPatterns = [
-      /rm\s+-rf/,           // Dangerous rm commands
-      /sudo\s+/,            // Sudo usage
-      /su\s+/,              // Su usage  
-      /eval\s+/,            // Eval usage
-      /exec\s+/,            // Exec usage
-      /\$\(/,               // Command substitution
-      /`[^`]*`/,            // Backtick command substitution
-      /wget\s+/,            // Network downloads
-      /curl\s+.*-o/,        // Curl with output to file
-      />\s*\/etc/,          // Writing to system directories
-      />\s*\/usr/,
-      />\s*\/bin/,
-    ];
-
-    for (const pattern of dangerousPatterns) {
-      if (pattern.test(command)) {
-        throw new Error(`Command contains dangerous pattern: ${pattern.source}`);
-      }
-    }
-
-    if (!silent) {
-      this.log(`ℹ️ Using shell mode for command: ${command.substring(0, 50)}...`);
-    }
   }
 
   private pickNumericThresholds(input: Record<string, unknown>): Record<string, number | undefined> {
@@ -763,22 +700,24 @@ export class QualityGateRunner {
     options: { noHistory?: boolean } = {}
   ): Promise<void> {
     try {
+      const pathContext = createQualityPathContext();
+      const safeOutputDir = resolveQualityReportOutputDir(outputDir, pathContext).resolvedPath;
       // Ensure output directory exists
-      if (!fs.existsSync(outputDir)) {
-        fs.mkdirSync(outputDir, { recursive: true });
+      if (!fs.existsSync(safeOutputDir)) {
+        fs.mkdirSync(safeOutputDir, { recursive: true });
       }
 
       if (!options.noHistory) {
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
         const filename = `quality-report-${report.environment}-${timestamp}.json`;
-        const filepath = path.join(outputDir, filename);
+        const filepath = path.join(safeOutputDir, filename);
 
         fs.writeFileSync(filepath, JSON.stringify(report, null, 2));
         this.log(`📝 Quality report saved to: ${filepath}`);
       }
 
       // Also save as latest
-      const latestPath = path.join(outputDir, `quality-report-${report.environment}-latest.json`);
+      const latestPath = path.join(safeOutputDir, `quality-report-${report.environment}-latest.json`);
       fs.writeFileSync(latestPath, JSON.stringify(report, null, 2));
       this.log(`📝 Quality report latest updated: ${latestPath}`);
 
@@ -868,12 +807,6 @@ export class QualityGateRunner {
       console.log(message);
     }
   }
-
-  private warn(message: string): void {
-    if (!this.silent) {
-      console.warn(message);
-    }
-  }
 }
 
 // CLI interface for quality gate runner
@@ -917,6 +850,17 @@ export async function runQualityGatesCLI(args: string[]): Promise<void> {
       case '--dry-run':
         options.dryRun = true;
         break;
+      case '--apply':
+        options.apply = true;
+        break;
+      case '--approval-scope': {
+        const val = args[i + 1];
+        if (val !== undefined) {
+          options.approvalScope = val;
+          i++;
+        }
+        break;
+      }
       case '--timeout': {
         const val = args[i + 1];
         if (val !== undefined) {

--- a/tests/cli/quality-cli.test.ts
+++ b/tests/cli/quality-cli.test.ts
@@ -104,6 +104,94 @@ describe('quality CLI format option', () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it('run defaults agent-context execution to dry-run before delegating to the runner', async () => {
+    const previous = process.env['AE_QUALITY_AGENT_CONTEXT'];
+    process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
+    executeGatesMock.mockResolvedValueOnce(createReport());
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const command = createQualityCommand();
+      await command.parseAsync(['node', 'cli', 'run', '--format', 'json']);
+
+      expect(executeGatesMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dryRun: true,
+          apply: false,
+        }),
+      );
+      expect(safeExitMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLogSpy.mockRestore();
+      if (previous === undefined) {
+        delete process.env['AE_QUALITY_AGENT_CONTEXT'];
+      } else {
+        process.env['AE_QUALITY_AGENT_CONTEXT'] = previous;
+      }
+    }
+  });
+
+  it('run rejects agent-context --apply without the trusted approval scope', async () => {
+    const previous = process.env['AE_QUALITY_AGENT_CONTEXT'];
+    process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const command = createQualityCommand();
+      await command.parseAsync(['node', 'cli', 'run', '--apply']);
+
+      expect(executeGatesMock).not.toHaveBeenCalled();
+      expect(safeExitMock).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('approval-scope quality-gate-execution')
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      if (previous === undefined) {
+        delete process.env['AE_QUALITY_AGENT_CONTEXT'];
+      } else {
+        process.env['AE_QUALITY_AGENT_CONTEXT'] = previous;
+      }
+    }
+  });
+
+  it('run forwards trusted agent-context approval for explicit apply', async () => {
+    const previous = process.env['AE_QUALITY_AGENT_CONTEXT'];
+    process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
+    executeGatesMock.mockResolvedValueOnce(createReport());
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const command = createQualityCommand();
+      await command.parseAsync([
+        'node',
+        'cli',
+        'run',
+        '--format',
+        'json',
+        '--apply',
+        '--approval-scope',
+        'quality-gate-execution',
+      ]);
+
+      expect(executeGatesMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dryRun: false,
+          apply: true,
+          approvalScope: 'quality-gate-execution',
+        }),
+      );
+      expect(safeExitMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLogSpy.mockRestore();
+      if (previous === undefined) {
+        delete process.env['AE_QUALITY_AGENT_CONTEXT'];
+      } else {
+        process.env['AE_QUALITY_AGENT_CONTEXT'] = previous;
+      }
+    }
+  });
+
   it('reconcile --format json emits final report JSON and keeps blocker exit code', async () => {
     executeGatesMock.mockResolvedValueOnce(
       createReport({

--- a/tests/quality/quality-command-policy.test.ts
+++ b/tests/quality/quality-command-policy.test.ts
@@ -1,0 +1,321 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { QualityPolicyLoader } from '../../src/quality/policy-loader.js';
+import { QualityGateRunner } from '../../src/quality/quality-gate-runner.js';
+import {
+  QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+  resolveQualityReportOutputDir,
+  createQualityPathContext,
+} from '../../src/quality/quality-command-policy.js';
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+}
+
+const createPolicy = (
+  command: string,
+  securityCommand = 'pnpm audit --prod --json'
+) => ({
+  version: '1.0.0-test',
+  lastUpdated: '2026-06-03T00:00:00Z',
+  description: 'Quality command policy test fixture',
+  environments: {
+    development: {
+      description: 'Development environment',
+      enforcementLevel: 'warning' as const,
+    },
+    testing: {
+      description: 'Testing environment',
+      enforcementLevel: 'blocking' as const,
+    },
+  },
+  qualityGates: {
+    linting: {
+      name: 'Code Linting',
+      description: 'Code-owned lint gate',
+      category: 'code-quality',
+      enabled: true,
+      thresholds: {
+        development: {
+          maxErrors: 0,
+          maxWarnings: 0,
+          blockOnFail: true,
+        },
+        testing: {
+          maxErrors: 0,
+          maxWarnings: 0,
+          blockOnFail: true,
+        },
+      },
+      tools: ['eslint'],
+      commands: {
+        test: command,
+      },
+    },
+    security: {
+      name: 'Security Vulnerabilities',
+      description: 'Code-owned security gate',
+      category: 'security',
+      enabled: true,
+      thresholds: {
+        development: {
+          maxCritical: 0,
+          maxHigh: 0,
+          maxMedium: 0,
+          blockOnFail: true,
+        },
+        testing: {
+          maxCritical: 0,
+          maxHigh: 0,
+          maxMedium: 0,
+          blockOnFail: true,
+        },
+      },
+      tools: ['pnpm audit'],
+      commands: {
+        test: securityCommand,
+      },
+    },
+  },
+  compositeGates: {},
+  integrations: {
+    ci: {
+      githubActions: {
+        enabled: true,
+        workflow: '.github/workflows/quality.yml',
+        triggerOn: ['pull_request'],
+        parallelExecution: true,
+      },
+      preCommitHooks: {
+        enabled: false,
+        hooks: [],
+        blocking: false,
+      },
+    },
+    monitoring: {
+      opentelemetry: {
+        enabled: false,
+        metricsPrefix: 'quality',
+        tracingEnabled: false,
+      },
+      dashboards: {},
+    },
+  },
+  notifications: {},
+  reporting: {
+    formats: ['json'],
+    outputDirectory: 'artifacts/quality/reports',
+    retention: {
+      days: 30,
+      maxReports: 100,
+    },
+    aggregation: {
+      enabled: false,
+      interval: 'daily',
+      metrics: ['pass_rate'],
+    },
+  },
+});
+
+describe('quality gate command policy', () => {
+  let testRoot: string;
+  let policyPath: string;
+  let previousQualityAgentContext: string | undefined;
+  let previousAgentContext: string | undefined;
+
+  const writePolicy = (
+    command = 'node scripts/quality/check-lint-summary.mjs',
+    securityCommand = 'pnpm audit --prod --json'
+  ) => {
+    policyPath = join(process.cwd(), testRoot, 'quality-policy.json');
+    mkdirSync(join(process.cwd(), testRoot), { recursive: true });
+    const policy = createPolicy(command, securityCommand);
+    rmSync(policyPath, { force: true });
+    writeFileSync(policyPath, JSON.stringify(policy, null, 2), 'utf8');
+    return new QualityPolicyLoader(policyPath);
+  };
+
+  const createSpawnMock = () => vi.fn((_command: string, _args?: readonly string[]) => {
+    const child = new FakeChildProcess();
+    queueMicrotask(() => {
+      child.stdout.emit('data', '0 error\n0 warning\n');
+      child.emit('close', 0);
+    });
+    return child;
+  });
+
+  beforeEach(() => {
+    testRoot = ['artifacts', 'quality', `unit-${Date.now()}-${Math.random().toString(16).slice(2)}`].join('/');
+    previousQualityAgentContext = process.env['AE_QUALITY_AGENT_CONTEXT'];
+    previousAgentContext = process.env['AE_AGENT_CONTEXT'];
+    delete process.env['AE_QUALITY_AGENT_CONTEXT'];
+    delete process.env['AE_AGENT_CONTEXT'];
+  });
+
+  afterEach(() => {
+    if (previousQualityAgentContext === undefined) {
+      delete process.env['AE_QUALITY_AGENT_CONTEXT'];
+    } else {
+      process.env['AE_QUALITY_AGENT_CONTEXT'] = previousQualityAgentContext;
+    }
+    if (previousAgentContext === undefined) {
+      delete process.env['AE_AGENT_CONTEXT'];
+    } else {
+      process.env['AE_AGENT_CONTEXT'] = previousAgentContext;
+    }
+    rmSync(join(process.cwd(), testRoot), { recursive: true, force: true });
+  });
+
+  it('executes the code-owned argv for an allowlisted gate without shell mode', async () => {
+    const spawnMock = createSpawnMock();
+    const runner = new QualityGateRunner(writePolicy(), {
+      spawnProcess: spawnMock as unknown as typeof spawn,
+    });
+
+    const report = await runner.executeGates({
+      environment: 'testing',
+      gates: ['linting'],
+      parallel: false,
+      outputDir: `${testRoot}/reports`,
+      noHistory: true,
+      printSummary: false,
+      silent: true,
+    });
+
+    expect(report.failedGates).toBe(0);
+    expect(spawnMock).toHaveBeenCalledWith(
+      'node',
+      ['scripts/quality/check-lint-summary.mjs'],
+      expect.objectContaining({ shell: false })
+    );
+    expect(existsSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'))).toBe(true);
+  });
+
+  it('rejects untrusted repository policy command text before spawning a process', async () => {
+    const spawnMock = createSpawnMock();
+    const runner = new QualityGateRunner(writePolicy('node -e "console.log(process.env)"'), {
+      spawnProcess: spawnMock as unknown as typeof spawn,
+    });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(runner.executeGates({
+        environment: 'testing',
+        gates: ['linting'],
+        parallel: false,
+        outputDir: `${testRoot}/reports`,
+        printSummary: false,
+        silent: true,
+      })).rejects.toThrow('policy command is not trusted');
+      expect(spawnMock).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('preflights all selected gate commands before spawning earlier gates', async () => {
+    const spawnMock = createSpawnMock();
+    const runner = new QualityGateRunner(
+      writePolicy('node scripts/quality/check-lint-summary.mjs', 'node -e "console.log(process.env)"'),
+      {
+        spawnProcess: spawnMock as unknown as typeof spawn,
+      }
+    );
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(runner.executeGates({
+        environment: 'testing',
+        gates: ['linting', 'security'],
+        parallel: false,
+        outputDir: `${testRoot}/reports`,
+        printSummary: false,
+        silent: true,
+      })).rejects.toThrow('policy command is not trusted');
+      expect(spawnMock).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('defaults agent contexts to dry-run and avoids process and report writes', async () => {
+    process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
+    const spawnMock = createSpawnMock();
+    const runner = new QualityGateRunner(writePolicy(), {
+      spawnProcess: spawnMock as unknown as typeof spawn,
+    });
+
+    const report = await runner.executeGates({
+      environment: 'testing',
+      gates: ['linting'],
+      parallel: false,
+      outputDir: `${testRoot}/reports`,
+      printSummary: false,
+      silent: true,
+    });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(report.results[0]?.details).toMatchObject({
+      dryRun: true,
+      command: 'node scripts/quality/check-lint-summary.mjs',
+    });
+    expect(existsSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'))).toBe(false);
+  });
+
+  it('requires trusted approval before agent-context apply can execute', async () => {
+    process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
+    const spawnMock = createSpawnMock();
+    const runner = new QualityGateRunner(writePolicy(), {
+      spawnProcess: spawnMock as unknown as typeof spawn,
+    });
+
+    await expect(runner.executeGates({
+      environment: 'testing',
+      gates: ['linting'],
+      apply: true,
+      outputDir: `${testRoot}/reports`,
+      printSummary: false,
+      silent: true,
+    })).rejects.toThrow(`approval scope '${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE}'`);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('executes in agent context when apply uses the trusted approval scope', async () => {
+    process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
+    const spawnMock = createSpawnMock();
+    const runner = new QualityGateRunner(writePolicy(), {
+      spawnProcess: spawnMock as unknown as typeof spawn,
+    });
+
+    const report = await runner.executeGates({
+      environment: 'testing',
+      gates: ['linting'],
+      apply: true,
+      approvalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+      outputDir: `${testRoot}/reports`,
+      noHistory: true,
+      printSummary: false,
+      silent: true,
+    });
+
+    expect(report.failedGates).toBe(0);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const latest = readFileSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'), 'utf8');
+    expect(JSON.parse(latest).environment).toBe('testing');
+  });
+
+  it('constrains quality report output to the approved artifact root', () => {
+    const context = createQualityPathContext();
+    expect(() => resolveQualityReportOutputDir('reports/quality-gates', context)).toThrow(
+      'approved quality artifact root'
+    );
+    expect(() => resolveQualityReportOutputDir('/tmp/quality-gates', context)).toThrow(
+      'relative to the approved quality artifact root'
+    );
+  });
+});

--- a/tests/quality/quality-gate-runner-output.test.ts
+++ b/tests/quality/quality-gate-runner-output.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { QualityGateRunner } from '../../src/quality/quality-gate-runner.js';
 import type { QualityReport } from '../../src/quality/policy-loader.js';
@@ -23,16 +22,28 @@ const createSampleReport = (): QualityReport => ({
 const hasHistoryReportFile = (files: string[]) =>
   files.some((name) => /^quality-report-development-(?!latest).*\.json$/.test(name));
 
-describe('QualityGateRunner report output options', () => {
-  let tempDir: string;
+  describe('QualityGateRunner report output options', () => {
+    let tempDir: string;
+    let previousWorkspaceRoot: string | undefined;
 
-  beforeEach(() => {
-    tempDir = mkdtempSync(join(tmpdir(), 'quality-report-output-'));
-  });
+    beforeEach(() => {
+      previousWorkspaceRoot = process.env['AE_WORKSPACE_ROOT'];
+      tempDir = [
+        'artifacts',
+        'quality',
+        `quality-report-output-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      ].join('/');
+      mkdirSync(join(process.cwd(), tempDir), { recursive: true });
+    });
 
-  afterEach(() => {
-    rmSync(tempDir, { recursive: true, force: true });
-  });
+    afterEach(() => {
+      if (previousWorkspaceRoot === undefined) {
+        delete process.env['AE_WORKSPACE_ROOT'];
+      } else {
+        process.env['AE_WORKSPACE_ROOT'] = previousWorkspaceRoot;
+      }
+      rmSync(join(process.cwd(), tempDir), { recursive: true, force: true });
+    });
 
   it('writes history + latest by default', async () => {
     const runner = new QualityGateRunner();
@@ -42,24 +53,45 @@ describe('QualityGateRunner report output options', () => {
       saveReport: (r: QualityReport, dir: string, options?: { noHistory?: boolean }) => Promise<void>;
     }).saveReport(report, tempDir);
 
-    const files = readdirSync(tempDir);
+    const files = readdirSync(join(process.cwd(), tempDir));
     expect(files).toContain('quality-report-development-latest.json');
     expect(hasHistoryReportFile(files)).toBe(true);
 
-    const latest = JSON.parse(readFileSync(join(tempDir, 'quality-report-development-latest.json'), 'utf8'));
+    const latest = JSON.parse(readFileSync(join(process.cwd(), tempDir, 'quality-report-development-latest.json'), 'utf8'));
     expect(latest.environment).toBe('development');
   });
 
-  it('writes latest only when --no-history equivalent is enabled', async () => {
-    const runner = new QualityGateRunner();
-    const report = createSampleReport();
+    it('writes latest only when --no-history equivalent is enabled', async () => {
+      const runner = new QualityGateRunner();
+      const report = createSampleReport();
 
     await (runner as unknown as {
       saveReport: (r: QualityReport, dir: string, options?: { noHistory?: boolean }) => Promise<void>;
     }).saveReport(report, tempDir, { noHistory: true });
 
-    const files = readdirSync(tempDir);
-    expect(files).toContain('quality-report-development-latest.json');
-    expect(hasHistoryReportFile(files)).toBe(false);
+      const files = readdirSync(join(process.cwd(), tempDir));
+      expect(files).toContain('quality-report-development-latest.json');
+      expect(hasHistoryReportFile(files)).toBe(false);
+    });
+
+    it('uses the resolved workspace-root anchored path for report writes', async () => {
+      const runner = new QualityGateRunner();
+      const report = createSampleReport();
+      const workspaceRoot = process.cwd();
+      const outputDir = `${tempDir}/anchored-reports`;
+      process.env['AE_WORKSPACE_ROOT'] = workspaceRoot;
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      try {
+        await (runner as unknown as {
+          saveReport: (r: QualityReport, dir: string, options?: { noHistory?: boolean }) => Promise<void>;
+        }).saveReport(report, outputDir, { noHistory: true });
+
+        const latestPath = join(workspaceRoot, outputDir, 'quality-report-development-latest.json');
+        expect(existsSync(latestPath)).toBe(true);
+        expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(latestPath);
+      } finally {
+        consoleLogSpy.mockRestore();
+      }
+    });
   });
-});


### PR DESCRIPTION
## Summary

Closes #3410.

- Adds a code-owned quality gate command policy that maps gate IDs to fixed executable/argv arrays and rejects modified repository-local policy command text before any child process is spawned.
- Defaults `ae quality run` / `quality reconcile` in AI/agent contexts to dry-run unless `--apply --approval-scope quality-gate-execution` is provided.
- Constrains quality report output to the approved `artifacts/quality` root and updates CI artifact/report paths plus docs accordingly.

## Verification

- `pnpm install --offline --frozen-lockfile`
- `pnpm -s exec vitest run tests/quality/quality-command-policy.test.ts tests/cli/quality-cli.test.ts tests/quality/quality-gate-runner-output.test.ts tests/quality/quality-gate-runner-parsing.test.ts --reporter dot`
- `pnpm -s run types:check`
- `pnpm -s exec eslint --quiet src/quality/quality-command-policy.ts src/quality/quality-gate-runner.ts src/cli/quality-cli.ts tests/quality/quality-command-policy.test.ts tests/quality/quality-gate-runner-output.test.ts tests/cli/quality-cli.test.ts`
- `pnpm -s run build`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`
- `pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot`
- `AE_QUALITY_AGENT_CONTEXT=1 pnpm -s exec tsx src/cli/index.ts quality run --env=testing --gates=linting --format=json --no-history` (confirmed dry-run result, no report directory created)
