### PR TITLE
fix(security): restrict lighthouse collect targets

### DIFF
--- a/configs/lighthouserc.cjs
+++ b/configs/lighthouserc.cjs
@@ -4,6 +4,8 @@ const DEFAULT_LIGHTHOUSE_URLS = [
   'http://localhost:3000/ja/health',
   'http://localhost:3000/ja/e2e/semantic-form'
 ];
+const APPROVED_LIGHTHOUSE_HOSTS = new Set(['localhost', '127.0.0.1']);
+const APPROVED_LIGHTHOUSE_PORT = '3000';
 
 function remapLegacyLighthouseUrl(rawUrl) {
   try {
@@ -26,9 +28,34 @@ function remapLegacyLighthouseUrl(rawUrl) {
   }
 }
 
+function isApprovedLocalLighthouseUrl(rawUrl) {
+  try {
+    const parsedUrl = new URL(rawUrl);
+    const hostname = parsedUrl.hostname.toLowerCase();
+
+    return parsedUrl.protocol === 'http:'
+      && APPROVED_LIGHTHOUSE_HOSTS.has(hostname)
+      && parsedUrl.port === APPROVED_LIGHTHOUSE_PORT
+      && parsedUrl.username === ''
+      && parsedUrl.password === '';
+  } catch {
+    return false;
+  }
+}
+
+function normalizeApprovedLighthouseUrl(rawUrl) {
+  const remappedUrl = remapLegacyLighthouseUrl(rawUrl);
+  if (!remappedUrl || !isApprovedLocalLighthouseUrl(remappedUrl)) {
+    return null;
+  }
+  const parsedUrl = new URL(remappedUrl);
+  parsedUrl.hash = '';
+  return parsedUrl.toString();
+}
+
 function resolveCollectUrls(configuredUrls) {
   const normalizedUrls = (configuredUrls || [])
-    .map(remapLegacyLighthouseUrl)
+    .map(normalizeApprovedLighthouseUrl)
     .filter(Boolean);
 
   return normalizedUrls.length > 0

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -2,7 +2,7 @@
 docRole: derived
 canonicalSource:
   - .github/workflows/agent-commands.yml
-lastVerified: '2026-06-03'
+lastVerified: '2026-06-04'
 ---
 
 # Agent Commands Catalog

--- a/tests/unit/ci/lighthouserc-security.test.ts
+++ b/tests/unit/ci/lighthouserc-security.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const configPath = resolve(repoRoot, 'configs/lighthouserc.cjs');
+const DEFAULT_LOCAL_URLS = [
+  'http://localhost:3000/ja/health',
+  'http://localhost:3000/ja/e2e/semantic-form',
+];
+
+const writeQualityPolicy = (workdir: string, urls: string[]): void => {
+  mkdirSync(join(workdir, 'policy'), { recursive: true });
+  writeFileSync(
+    join(workdir, 'policy', 'quality.json'),
+    JSON.stringify({
+      version: 'test',
+      environments: {},
+      quality: {
+        lighthouse: {
+          description: 'test lighthouse policy',
+          enforcement: 'warn',
+          thresholds: {
+            performance: 90,
+            accessibility: 95,
+            bestPractices: 85,
+            seo: 80,
+            pwa: 'off',
+          },
+          config: {
+            numberOfRuns: 1,
+            urls,
+          },
+        },
+      },
+    }),
+  );
+};
+
+const loadLighthouseConfigForUrls = (urls: string[]): string[] => {
+  const workdir = mkdtempSync(join(tmpdir(), 'lighthouserc-security-'));
+  try {
+    writeQualityPolicy(workdir, urls);
+    const script = [
+      `const config = require(${JSON.stringify(configPath)});`,
+      `process.stdout.write('\\n__COLLECT_URLS__' + JSON.stringify(config.ci.collect.url) + '\\n');`,
+    ].join('\n');
+    const output = execFileSync(process.execPath, ['-e', script], {
+      cwd: workdir,
+      encoding: 'utf8',
+    });
+    const markerLine = output.split(/\r?\n/).find((line) => line.startsWith('__COLLECT_URLS__'));
+    if (!markerLine) {
+      throw new Error(`Missing collect URL marker in lighthouserc output: ${output}`);
+    }
+    return JSON.parse(markerLine.slice('__COLLECT_URLS__'.length)) as string[];
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+};
+
+describe('lighthouserc collect URL security policy', () => {
+  it('accepts only the locally started Lighthouse app origin after legacy route remapping', () => {
+    const urls = loadLighthouseConfigForUrls([
+      'http://localhost:3000',
+      'http://127.0.0.1:3000/health',
+    ]);
+
+    expect(urls).toEqual([
+      'http://localhost:3000/ja/e2e/semantic-form',
+      'http://127.0.0.1:3000/ja/health',
+    ]);
+  });
+
+  it('does not pass repository-configured non-local or non-http targets to LHCI', () => {
+    const urls = loadLighthouseConfigForUrls([
+      'https://example.com/',
+      'http://localhost.evil.test:3000/health',
+      'http://127.0.0.1.evil.test:3000/health',
+      'http://localhost:3001/health',
+      'file:///etc/passwd',
+    ]);
+
+    expect(urls).toEqual(DEFAULT_LOCAL_URLS);
+    expect(urls).not.toContain('https://example.com/');
+    expect(urls.every((url) => new URL(url).origin === 'http://localhost:3000')).toBe(true);
+  });
+
+  it('keeps approved local targets and drops unapproved targets from mixed policy input', () => {
+    const urls = loadLighthouseConfigForUrls([
+      'https://example.com/private',
+      'http://localhost:3000/ja/health',
+      'http://localhost:3000/ja/health#fragment',
+    ]);
+
+    expect(urls).toEqual(['http://localhost:3000/ja/health']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3413.

- Constrains Lighthouse CI collect URLs from repository policy to the locally started app origin only.
- Drops non-local, non-HTTP, wrong-port, credential-bearing, and otherwise unapproved policy URLs before LHCI receives `ci.collect.url`.
- Adds regression tests for accepted local legacy route remapping, all-unapproved fallback, and mixed local/unapproved policy inputs.
- Refreshes the derived agent command catalog date required by doc consistency checks.

## Verification

- `pnpm install --offline --frozen-lockfile`
- `pnpm -s exec vitest run tests/unit/ci/lighthouserc-security.test.ts tests/unit/ci/phase6-validation-workflow-security.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet configs/lighthouserc.cjs tests/unit/ci/lighthouserc-security.test.ts tests/unit/ci/phase6-validation-workflow-security.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Acceptance

- Repository-controlled Lighthouse policy cannot make LHCI collect non-local URLs.
- Local `localhost:3000` / `127.0.0.1:3000` app targets continue to work, including legacy `/` and `/health` route remapping.
- Phase 6 workflow remains read-only and checkout credentials remain disabled.

## Rollback

Revert this PR to restore the previous Lighthouse policy URL handling. The rollback would re-open #3413 because repository policy URLs would again flow into LHCI without the local-origin allowlist.