### PR TITLE
fix(security): isolate PR summary publish evidence

### DIFF
--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -36,8 +36,6 @@ concurrency:
 permissions:
   actions: read
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   update-branch:
@@ -204,6 +202,9 @@ jobs:
       && github.event_name == 'pull_request'
       && !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/github-script@v7
         with:
@@ -235,6 +236,11 @@ jobs:
       && !github.event.pull_request.head.repo.fork
       && github.event.action != 'edited'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+      pull-requests: read
     steps:
       - name: Determine summary language
         id: lang
@@ -386,7 +392,7 @@ jobs:
       - name: Build harness health summary
         if: ${{ always() }}
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           SUMMARY_MODE: ${{ steps.mode.outputs.mode }}
         run: |
           if [ ! -f artifacts/summary/PR_SUMMARY.md ]; then
@@ -578,21 +584,6 @@ jobs:
             artifacts/agents/hook-feedback.md
           if-no-files-found: warn
           retention-days: 14
-      - name: Post or update PR comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('artifacts/summary/PR_SUMMARY.md','utf-8');
-            const header = '<!-- AE-PR-SUMMARY -->\n' + body;
-            const { owner, repo, number } = context.issue;
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
-            const mine = comments.data.find(c => c.body && c.body.startsWith('<!-- AE-PR-SUMMARY -->'));
-            if (mine) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body: header });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: number, body: header });
-            }
       - name: Generate progress summary
         run: node scripts/progress/aggregate-progress.mjs
       - name: Load previous progress summary
@@ -618,23 +609,18 @@ jobs:
         env:
           PROGRESS_SUMMARY_PREVIOUS: artifacts/progress/summary.prev.json
         run: node scripts/progress/render-progress-summary.mjs
-      - name: Post or update progress comment
-        uses: actions/github-script@v7
+      - name: Upload PR summary publish artifact
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            const marker = '<!-- AE-PR-PROGRESS -->';
-            const summary = JSON.parse(fs.readFileSync('artifacts/progress/summary.json','utf-8'));
-            const body = fs.readFileSync('artifacts/progress/PR_PROGRESS.md','utf-8');
-            const payload = `${marker}\n\n${body}\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(summary)} -->`;
-            const { owner, repo, number } = context.issue;
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
-            const existing = comments.data.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: number, body: payload });
-            }
+          name: pr-summary-publish-pr-${{ github.event.pull_request.number }}
+          path: |
+            artifacts/summary/PR_SUMMARY.md
+            artifacts/progress/PR_PROGRESS.md
+            artifacts/progress/summary.json
+            artifacts/change-package/change-package-validation.json
+            artifacts/change-package/change-package-v2-validation.json
+          if-no-files-found: warn
+          retention-days: 14
       - name: Write job summary
         run: |
           cat artifacts/summary/PR_SUMMARY.md >> "$GITHUB_STEP_SUMMARY"
@@ -642,6 +628,122 @@ jobs:
             printf "\n\n" >> "$GITHUB_STEP_SUMMARY"
             cat artifacts/progress/PR_PROGRESS.md >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  publish-summary:
+    needs: summarize
+    if: >-
+      !contains(fromJSON('["1","true","yes","on","TRUE","YES","ON","True","Yes","On"]'), vars.AE_AUTOMATION_GLOBAL_DISABLE)
+      && github.event_name == 'pull_request'
+      && !github.event.pull_request.head.repo.fork
+      && github.event.action != 'edited'
+      && needs.summarize.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Download PR summary publish artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-summary-publish-pr-${{ github.event.pull_request.number }}
+          path: artifacts/publish/pr-summary
+      - name: Publish PR summary, progress, and Change Package check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { owner, repo, number } = context.issue;
+            const pr = context.payload.pull_request;
+            const headSha = pr?.head?.sha;
+            if (!headSha) {
+              core.setFailed('No pull_request head SHA found; cannot publish summary artifacts.');
+              return;
+            }
+
+            const artifactRoot = 'artifacts/publish/pr-summary';
+            const MAX_COMMENT_BYTES = 60000;
+            const readText = (relativePath) => {
+              const filePath = path.join(artifactRoot, relativePath);
+              if (!fs.existsSync(filePath)) return null;
+              return fs.readFileSync(filePath, 'utf8').replace(/\u0000/g, '\uFFFD');
+            };
+            const limitComment = (text, label) => {
+              const bytes = Buffer.byteLength(text, 'utf8');
+              if (bytes <= MAX_COMMENT_BYTES) return text;
+              const truncated = Buffer.from(text, 'utf8').subarray(0, MAX_COMMENT_BYTES).toString('utf8');
+              return `${truncated}\n\n_[${label} truncated to ${MAX_COMMENT_BYTES} bytes before publication.]_`;
+            };
+            const upsertComment = async (marker, body) => {
+              const payload = limitComment(`${marker}\n\n${body}`, marker);
+              const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
+              const existing = comments.data.find((comment) => typeof comment.body === 'string' && comment.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: number, body: payload });
+              }
+            };
+
+            const summaryBody = readText('PR_SUMMARY.md');
+            if (summaryBody) {
+              await upsertComment('<!-- AE-PR-SUMMARY -->', summaryBody);
+            } else {
+              core.warning('PR_SUMMARY.md was not present in the publish artifact.');
+            }
+
+            const progressBody = readText('PR_PROGRESS.md');
+            const progressJsonText = readText('summary.json');
+            if (progressBody && progressJsonText) {
+              const progressJson = JSON.parse(progressJsonText);
+              await upsertComment(
+                '<!-- AE-PR-PROGRESS -->',
+                `${progressBody}\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(progressJson)} -->`,
+              );
+            } else {
+              core.warning('Progress summary files were not both present in the publish artifact.');
+            }
+
+            const readJson = (relativePath) => {
+              const text = readText(relativePath);
+              if (!text) return null;
+              return JSON.parse(text);
+            };
+            const validation = readJson('change-package-validation.json');
+            const result = String(validation?.result || '').trim().toLowerCase();
+            const conclusion = result === 'pass'
+              ? 'success'
+              : (result === 'warn' ? 'neutral' : 'failure');
+            const title = result
+              ? `Change Package Validation: ${result.toUpperCase()}`
+              : 'Change Package Validation: MISSING';
+            const summary = validation
+              ? [
+                  `schemaVersion: ${validation.schemaVersion || 'unknown'}`,
+                  `result: ${result || 'missing'}`,
+                  `strict: ${validation.strict ?? 'unknown'}`,
+                  `errors: ${Array.isArray(validation.errors) ? validation.errors.length : 'unknown'}`,
+                  `warnings: ${Array.isArray(validation.warnings) ? validation.warnings.length : 'unknown'}`,
+                  `workflowRunId: ${context.runId}`,
+                  `headSha: ${headSha}`,
+                ].join('\n')
+              : `No structured change-package-validation.json artifact was available for head ${headSha}.`;
+
+            await github.rest.checks.create({
+              owner,
+              repo,
+              name: 'Change Package Validation',
+              head_sha: headSha,
+              status: 'completed',
+              conclusion,
+              output: {
+                title,
+                summary,
+              },
+            });
+
 
   post-status:
     if: >-
@@ -651,8 +753,14 @@ jobs:
         || (github.event_name == 'workflow_dispatch' && (inputs.mode == 'status' || inputs.mode == 'both'))
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -690,13 +798,18 @@ jobs:
     if: >-
       !contains(fromJSON('["1","true","yes","on","TRUE","YES","ON","True","Yes","On"]'), vars.AE_AUTOMATION_GLOBAL_DISABLE)
       && (
-        (github.event_name == 'pull_request' && github.event.action != 'edited' && github.event.pull_request.head.repo.fork == false)
-        || (github.event_name == 'schedule')
+        (github.event_name == 'schedule')
         || (github.event_name == 'workflow_dispatch' && (inputs.mode == 'auto-merge' || inputs.mode == 'both'))
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -737,8 +850,14 @@ jobs:
       && (inputs.mode == 'eligibility')
       && (inputs.pr_number != '')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -704,15 +704,15 @@ jobs:
               }
             };
 
-            const summaryBody = readText('artifacts/summary/PR_SUMMARY.md');
+            const summaryBody = readText('summary/PR_SUMMARY.md');
             if (summaryBody) {
               await upsertComment('<!-- AE-PR-SUMMARY -->', summaryBody);
             } else {
               core.warning('PR_SUMMARY.md was not present in the publish artifact.');
             }
 
-            const progressBody = readText('artifacts/progress/PR_PROGRESS.md');
-            const progressJsonText = readText('artifacts/progress/summary.json');
+            const progressBody = readText('progress/PR_PROGRESS.md');
+            const progressJsonText = readText('progress/summary.json');
             if (progressBody && progressJsonText) {
               const progressJson = JSON.parse(progressJsonText);
               const progressJsonBlock = `\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(progressJson)} -->`;
@@ -738,7 +738,7 @@ jobs:
               if (!text) return null;
               return JSON.parse(text);
             };
-            const validation = readJson('artifacts/change-package/change-package-validation.json');
+            const validation = readJson('change-package/change-package-validation.json');
             const result = String(validation?.result || '').trim().toLowerCase();
             const conclusion = result === 'pass'
               ? 'success'

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -676,10 +676,27 @@ jobs:
               const truncated = Buffer.from(text, 'utf8').subarray(0, MAX_COMMENT_BYTES).toString('utf8');
               return `${truncated}\n\n_[${label} truncated to ${MAX_COMMENT_BYTES} bytes before publication.]_`;
             };
+            const isCommentPayloadWithinLimit = (marker, body) =>
+              Buffer.byteLength(`${marker}\n\n${body}`, 'utf8') <= MAX_COMMENT_BYTES;
+            const listAllIssueComments = async () => {
+              const comments = [];
+              for (let page = 1; ; page += 1) {
+                const response = await github.rest.issues.listComments({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  per_page: 100,
+                  page,
+                });
+                comments.push(...response.data);
+                if (response.data.length < 100) break;
+              }
+              return comments;
+            };
             const upsertComment = async (marker, body) => {
               const payload = limitComment(`${marker}\n\n${body}`, marker);
-              const comments = await github.rest.issues.listComments({ owner, repo, issue_number: number, per_page: 100 });
-              const existing = comments.data.find((comment) => typeof comment.body === 'string' && comment.body.includes(marker));
+              const comments = await listAllIssueComments();
+              const existing = comments.find((comment) => typeof comment.body === 'string' && comment.body.includes(marker));
               if (existing) {
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
               } else {
@@ -687,20 +704,30 @@ jobs:
               }
             };
 
-            const summaryBody = readText('PR_SUMMARY.md');
+            const summaryBody = readText('artifacts/summary/PR_SUMMARY.md');
             if (summaryBody) {
               await upsertComment('<!-- AE-PR-SUMMARY -->', summaryBody);
             } else {
               core.warning('PR_SUMMARY.md was not present in the publish artifact.');
             }
 
-            const progressBody = readText('PR_PROGRESS.md');
-            const progressJsonText = readText('summary.json');
+            const progressBody = readText('artifacts/progress/PR_PROGRESS.md');
+            const progressJsonText = readText('artifacts/progress/summary.json');
             if (progressBody && progressJsonText) {
               const progressJson = JSON.parse(progressJsonText);
+              const progressJsonBlock = `\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(progressJson)} -->`;
+              const progressCommentBody = isCommentPayloadWithinLimit(
+                '<!-- AE-PR-PROGRESS -->',
+                `${progressBody}${progressJsonBlock}`,
+              )
+                ? `${progressBody}${progressJsonBlock}`
+                : progressBody;
+              if (progressCommentBody === progressBody) {
+                core.warning('Progress summary JSON omitted because it would exceed the PR comment size cap.');
+              }
               await upsertComment(
                 '<!-- AE-PR-PROGRESS -->',
-                `${progressBody}\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(progressJson)} -->`,
+                progressCommentBody,
               );
             } else {
               core.warning('Progress summary files were not both present in the publish artifact.');
@@ -711,7 +738,7 @@ jobs:
               if (!text) return null;
               return JSON.parse(text);
             };
-            const validation = readJson('change-package-validation.json');
+            const validation = readJson('artifacts/change-package/change-package-validation.json');
             const result = String(validation?.result || '').trim().toLowerCase();
             const conclusion = result === 'pass'
               ? 'success'

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -204,7 +204,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
     steps:
       - uses: actions/github-script@v7
         with:
@@ -672,11 +671,24 @@ jobs:
               if (!fs.existsSync(filePath)) return null;
               return fs.readFileSync(filePath, 'utf8').replace(/\u0000/g, '\uFFFD');
             };
+            const truncateUtf8 = (text, maxBytes) => {
+              let truncated = Buffer.from(text, 'utf8')
+                .subarray(0, Math.max(0, maxBytes))
+                .toString('utf8');
+              while (Buffer.byteLength(truncated, 'utf8') > maxBytes) {
+                truncated = truncated.slice(0, -1);
+              }
+              return truncated;
+            };
             const limitComment = (text, label) => {
               const bytes = Buffer.byteLength(text, 'utf8');
               if (bytes <= MAX_COMMENT_BYTES) return text;
-              const truncated = Buffer.from(text, 'utf8').subarray(0, MAX_COMMENT_BYTES).toString('utf8');
-              return `${truncated}\n\n_[${label} truncated to ${MAX_COMMENT_BYTES} bytes before publication.]_`;
+              const notice = `\n\n_[${label} truncated to ${MAX_COMMENT_BYTES} bytes before publication.]_`;
+              const availableBytes = Math.max(
+                0,
+                MAX_COMMENT_BYTES - Buffer.byteLength(notice, 'utf8'),
+              );
+              return `${truncateUtf8(text, availableBytes)}${notice}`;
             };
             const isCommentPayloadWithinLimit = (marker, body) =>
               Buffer.byteLength(`${marker}\n\n${body}`, 'utf8') <= MAX_COMMENT_BYTES;
@@ -755,7 +767,12 @@ jobs:
             const readJson = (relativePath) => {
               const text = readText(relativePath);
               if (!text) return null;
-              return JSON.parse(text);
+              try {
+                return JSON.parse(text);
+              } catch (error) {
+                core.warning(`${relativePath} could not be parsed; treating as missing structured JSON: ${error.message}`);
+                return null;
+              }
             };
             const validation = readJson('change-package/change-package-validation.json');
             const result = String(validation?.result || '').trim().toLowerCase();

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -258,6 +258,8 @@ jobs:
             const detailed = labels.includes('pr-summary:detailed');
             core.setOutput('mode', detailed ? 'detailed' : 'digest');
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -651,6 +651,8 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
         with:
           node-version: '20'
+      - name: Install trusted validation dependencies
+        run: pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true
       - name: Download PR summary publish artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -692,6 +692,7 @@ jobs:
             };
             const isCommentPayloadWithinLimit = (marker, body) =>
               Buffer.byteLength(`${marker}\n\n${body}`, 'utf8') <= MAX_COMMENT_BYTES;
+            let issueCommentsCache = null;
             const listAllIssueComments = async () => {
               const comments = [];
               for (let page = 1; ; page += 1) {
@@ -707,6 +708,12 @@ jobs:
               }
               return comments;
             };
+            const getIssueComments = async () => {
+              if (!issueCommentsCache) {
+                issueCommentsCache = await listAllIssueComments();
+              }
+              return issueCommentsCache;
+            };
             const isTrustedAutomationComment = (comment, marker) => {
               const login = String(comment?.user?.login || '').trim().toLowerCase();
               const body = typeof comment?.body === 'string' ? comment.body : '';
@@ -717,8 +724,8 @@ jobs:
             };
             const upsertComment = async (marker, body) => {
               const payload = limitComment(`${marker}\n\n${body}`, marker);
-              const comments = await listAllIssueComments();
-              const existing = comments.find((comment) => isTrustedAutomationComment(comment, marker));
+              const comments = await getIssueComments();
+              const existing = [...comments].reverse().find((comment) => isTrustedAutomationComment(comment, marker));
               if (existing) {
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
               } else {

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -695,10 +695,18 @@ jobs:
               }
               return comments;
             };
+            const isTrustedAutomationComment = (comment, marker) => {
+              const login = String(comment?.user?.login || '').trim().toLowerCase();
+              const body = typeof comment?.body === 'string' ? comment.body : '';
+              return (
+                (login === 'github-actions' || login === 'github-actions[bot]')
+                && body.startsWith(marker)
+              );
+            };
             const upsertComment = async (marker, body) => {
               const payload = limitComment(`${marker}\n\n${body}`, marker);
               const comments = await listAllIssueComments();
-              const existing = comments.find((comment) => typeof comment.body === 'string' && comment.body.includes(marker));
+              const existing = comments.find((comment) => isTrustedAutomationComment(comment, marker));
               if (existing) {
                 await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
               } else {
@@ -715,24 +723,33 @@ jobs:
 
             const progressBody = readText('progress/PR_PROGRESS.md');
             const progressJsonText = readText('progress/summary.json');
-            if (progressBody && progressJsonText) {
-              const progressJson = JSON.parse(progressJsonText);
-              const progressJsonBlock = `\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(progressJson)} -->`;
-              const progressCommentBody = isCommentPayloadWithinLimit(
-                '<!-- AE-PR-PROGRESS -->',
-                `${progressBody}${progressJsonBlock}`,
-              )
-                ? `${progressBody}${progressJsonBlock}`
-                : progressBody;
-              if (progressCommentBody === progressBody) {
-                core.warning('Progress summary JSON omitted because it would exceed the PR comment size cap.');
+            if (progressBody) {
+              let progressCommentBody = progressBody;
+              if (progressJsonText) {
+                try {
+                  const progressJson = JSON.parse(progressJsonText);
+                  const progressJsonBlock = `\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(progressJson)} -->`;
+                  progressCommentBody = isCommentPayloadWithinLimit(
+                    '<!-- AE-PR-PROGRESS -->',
+                    `${progressBody}${progressJsonBlock}`,
+                  )
+                    ? `${progressBody}${progressJsonBlock}`
+                    : progressBody;
+                  if (progressCommentBody === progressBody) {
+                    core.warning('Progress summary JSON omitted because it would exceed the PR comment size cap.');
+                  }
+                } catch (error) {
+                  core.warning(`Progress summary JSON could not be parsed; publishing Markdown without embedded JSON: ${error.message}`);
+                }
+              } else {
+                core.warning('Progress summary JSON was not present in the publish artifact; publishing Markdown only.');
               }
               await upsertComment(
                 '<!-- AE-PR-PROGRESS -->',
                 progressCommentBody,
               );
             } else {
-              core.warning('Progress summary files were not both present in the publish artifact.');
+              core.warning('Progress summary Markdown was not present in the publish artifact.');
             }
 
             const readJson = (relativePath) => {

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -642,7 +642,9 @@ jobs:
       actions: read
       checks: write
       issues: write
-      pull-requests: read
+      # GitHub PR issue-comment creation can require pull_requests=write;
+      # this writer job remains checkout-free and does not execute local code.
+      pull-requests: write
     steps:
       - name: Download PR summary publish artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -616,6 +616,8 @@ jobs:
             artifacts/summary/PR_SUMMARY.md
             artifacts/progress/PR_PROGRESS.md
             artifacts/progress/summary.json
+            artifacts/change-package/change-package.json
+            artifacts/change-package/change-package-v2.json
             artifacts/change-package/change-package-validation.json
             artifacts/change-package/change-package-v2-validation.json
           if-no-files-found: warn
@@ -628,7 +630,7 @@ jobs:
             cat artifacts/progress/PR_PROGRESS.md >> "$GITHUB_STEP_SUMMARY"
           fi
 
-  publish-summary:
+  validate-change-package:
     needs: summarize
     if: >-
       !contains(fromJSON('["1","true","yes","on","TRUE","YES","ON","True","Yes","On"]'), vars.AE_AUTOMATION_GLOBAL_DISABLE)
@@ -636,6 +638,135 @@ jobs:
       && !github.event.pull_request.head.repo.fork
       && github.event.action != 'edited'
       && needs.summarize.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+      - name: Setup Node + pnpm
+        uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: '20'
+      - name: Download PR summary publish artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-summary-publish-pr-${{ github.event.pull_request.number }}
+          path: artifacts/publish/pr-summary
+      - name: Validate Change Package with trusted base code
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+        run: |
+          mkdir -p artifacts/trusted-change-package
+          input="artifacts/publish/pr-summary/change-package/change-package.json"
+          output_json="artifacts/trusted-change-package/change-package-validation.json"
+          output_md="artifacts/trusted-change-package/change-package-validation.md"
+          if [ -f "$input" ]; then
+            set +e
+            node scripts/change-package/validate.mjs \
+              --file "$input" \
+              --schema schema/change-package.schema.json \
+              --artifact-root artifacts/publish/pr-summary \
+              --output-json "$output_json" \
+              --output-md "$output_md"
+            validation_exit=$?
+            set -e
+            if [ ! -f "$output_json" ]; then
+              printf '%s\n' "Trusted Change Package validation did not produce $output_json; creating fail-closed report." >&2
+            fi
+          else
+            validation_exit=1
+            printf '%s\n' "PR-produced change-package.json artifact missing; creating fail-closed report." >&2
+          fi
+          if [ ! -f "$output_json" ]; then
+          node <<'JS'
+          const fs = require('fs');
+          const report = {
+            schemaVersion: 'change-package-validation/v1',
+            generatedAt: new Date().toISOString(),
+            strict: false,
+            result: 'fail',
+            schema: {
+              path: 'schema/change-package.schema.json',
+              ok: false,
+              errors: ['PR-produced change-package.json artifact is missing or could not be validated by trusted base-ref code'],
+            },
+            evidence: {
+              requiredEvidenceIds: [],
+              missingRequiredEvidence: [],
+              itemCount: 0,
+              presentCountActual: 0,
+              missingCountActual: 0,
+            },
+            v2: {
+              checked: false,
+              claimCount: 0,
+              proofObligationCount: 0,
+              waiverCount: 0,
+              missingArtifactRefs: [],
+              errors: [],
+              warnings: [],
+              policyDecision: { checked: false, errors: [], warnings: [] },
+            },
+            errors: [`No trusted Change Package validation result could be produced for head ${process.env.PR_HEAD_SHA || 'unknown'}.`],
+            warnings: [],
+          };
+          fs.writeFileSync('artifacts/trusted-change-package/change-package-validation.json', `${JSON.stringify(report, null, 2)}\n`);
+          fs.writeFileSync(
+            'artifacts/trusted-change-package/change-package-validation.md',
+            [
+              '### Change Package Validation',
+              '- result: FAIL',
+              '- strict: false',
+              '- schema: FAIL',
+              '- required evidence: (none)',
+              '- missing required evidence: (none)',
+              '- evidence present/missing(actual): 0/0',
+              '- errors:',
+              `  - ${report.errors[0]}`,
+            ].join('\n') + '\n',
+          );
+          JS
+          fi
+          node <<'JS'
+          const fs = require('fs');
+          const jsonPath = 'artifacts/trusted-change-package/change-package-validation.json';
+          const report = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+          report.trustedValidation = {
+            source: 'base-ref-code',
+            baseSha: process.env.PR_BASE_SHA || 'unknown',
+            headSha: process.env.PR_HEAD_SHA || 'unknown',
+            workflowRunId: process.env.WORKFLOW_RUN_ID || 'unknown',
+          };
+          fs.writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+          JS
+          if [ "$validation_exit" -ne 0 ]; then
+            printf '%s\n' "Trusted Change Package validation result is not pass; check run will publish the fail/warn result."
+          fi
+      - name: Upload trusted Change Package validation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trusted-change-package-validation-pr-${{ github.event.pull_request.number }}
+          path: |
+            artifacts/trusted-change-package/change-package-validation.json
+            artifacts/trusted-change-package/change-package-validation.md
+          if-no-files-found: error
+          retention-days: 14
+
+  publish-summary:
+    needs: [summarize, validate-change-package]
+    if: >-
+      !contains(fromJSON('["1","true","yes","on","TRUE","YES","ON","True","Yes","On"]'), vars.AE_AUTOMATION_GLOBAL_DISABLE)
+      && github.event_name == 'pull_request'
+      && !github.event.pull_request.head.repo.fork
+      && github.event.action != 'edited'
+      && needs.summarize.result == 'success'
+      && needs.validate-change-package.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -650,6 +781,11 @@ jobs:
         with:
           name: pr-summary-publish-pr-${{ github.event.pull_request.number }}
           path: artifacts/publish/pr-summary
+      - name: Download trusted Change Package validation artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: trusted-change-package-validation-pr-${{ github.event.pull_request.number }}
+          path: artifacts/publish/trusted-change-package
       - name: Publish PR summary, progress, and Change Package check
         uses: actions/github-script@v7
         with:
@@ -665,9 +801,10 @@ jobs:
             }
 
             const artifactRoot = 'artifacts/publish/pr-summary';
+            const trustedArtifactRoot = 'artifacts/publish/trusted-change-package';
             const MAX_COMMENT_BYTES = 60000;
-            const readText = (relativePath) => {
-              const filePath = path.join(artifactRoot, relativePath);
+            const readText = (relativePath, root = artifactRoot) => {
+              const filePath = path.join(root, relativePath);
               if (!fs.existsSync(filePath)) return null;
               return fs.readFileSync(filePath, 'utf8').replace(/\u0000/g, '\uFFFD');
             };
@@ -722,8 +859,15 @@ jobs:
                 && body.startsWith(marker)
               );
             };
+            const markerDisplayLabel = (marker) => {
+              const label = String(marker || '')
+                .replace(/^<!--\s*/, '')
+                .replace(/\s*-->$/, '')
+                .trim();
+              return label || 'PR comment';
+            };
             const upsertComment = async (marker, body) => {
-              const payload = limitComment(`${marker}\n\n${body}`, marker);
+              const payload = limitComment(`${marker}\n\n${body}`, markerDisplayLabel(marker));
               const comments = await getIssueComments();
               const existing = [...comments].reverse().find((comment) => isTrustedAutomationComment(comment, marker));
               if (existing) {
@@ -771,8 +915,8 @@ jobs:
               core.warning('Progress summary Markdown was not present in the publish artifact.');
             }
 
-            const readJson = (relativePath) => {
-              const text = readText(relativePath);
+            const readJson = (relativePath, root = artifactRoot) => {
+              const text = readText(relativePath, root);
               if (!text) return null;
               try {
                 return JSON.parse(text);
@@ -781,7 +925,7 @@ jobs:
                 return null;
               }
             };
-            const validation = readJson('change-package/change-package-validation.json');
+            const validation = readJson('change-package-validation.json', trustedArtifactRoot);
             const result = String(validation?.result || '').trim().toLowerCase();
             const conclusion = result === 'pass'
               ? 'success'

--- a/scripts/ci/auto-merge-eligible.mjs
+++ b/scripts/ci/auto-merge-eligible.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execGh, execGhJson } from './lib/gh-exec.mjs';
-import { resolveChangePackageValidationStatus } from './lib/change-package-gate.mjs';
+import { resolveChangePackageValidationStatusFromChecks } from './lib/change-package-gate.mjs';
 
 const repo = process.env.GITHUB_REPOSITORY;
 const prNumber = process.env.PR_NUMBER;
@@ -163,22 +163,6 @@ const summarizeChecks = (rollup = [], requiredContexts = []) => {
   return { counts, failed };
 };
 
-const listComments = (repoName, number) => {
-  const comments = [];
-  let page = 1;
-  while (true) {
-    const chunk = execJson([
-      'api',
-      `repos/${repoName}/issues/${number}/comments?per_page=100&page=${page}`,
-    ]);
-    if (!Array.isArray(chunk) || chunk.length === 0) break;
-    comments.push(...chunk);
-    if (chunk.length < 100) break;
-    page += 1;
-  }
-  return comments;
-};
-
 const pr = execJson([
   'pr',
   'view',
@@ -203,7 +187,7 @@ if (protectionSummary === null) {
 const { requiredContexts, reviewRequirement } = protectionSummary;
 const { counts, failed } = summarizeChecks(pr.statusCheckRollup || [], requiredContexts);
 const labels = Array.isArray(pr.labels) ? pr.labels.map((l) => l && l.name).filter(Boolean) : [];
-const changePackageStatus = resolveChangePackageValidationStatus(listComments(repo, pr.number));
+const changePackageStatus = resolveChangePackageValidationStatusFromChecks(pr.statusCheckRollup || []);
 const labelEligible = (() => {
   if (autoMergeMode === 'all') return true;
   if (autoMergeMode !== 'label') return false;
@@ -215,6 +199,8 @@ const riskEligible = !requireRiskLow || labels.includes(riskLowLabel);
 const changePackageEligible = (() => {
   if (!requireChangePackage) return true;
   if (changePackageStatus.status === 'missing') return false;
+  if (changePackageStatus.status === 'pending') return false;
+  if (changePackageStatus.status === 'ambiguous') return false;
   if (changePackageStatus.status === 'fail') return false;
   if (changePackageStatus.status === 'warn' && !allowChangePackageWarn) return false;
   return true;
@@ -227,7 +213,11 @@ if (!reviewEligible) reasons.push(`review=${pr.reviewDecision || 'NONE'}`);
 if (!riskEligible) reasons.push(`missing risk label=${riskLowLabel}`);
 if (!changePackageEligible) {
   if (changePackageStatus.status === 'missing') {
-    reasons.push('change-package validation summary missing');
+    reasons.push('missing change-package validation check');
+  } else if (changePackageStatus.status === 'pending') {
+    reasons.push('change-package validation check pending');
+  } else if (changePackageStatus.status === 'ambiguous') {
+    reasons.push('ambiguous change-package validation checks');
   } else if (changePackageStatus.status === 'fail') {
     reasons.push('change-package validation failed');
   } else {

--- a/scripts/ci/auto-merge-enabler.mjs
+++ b/scripts/ci/auto-merge-enabler.mjs
@@ -2,7 +2,7 @@
 import { execGh, execGhJson } from './lib/gh-exec.mjs';
 import { emitAutomationReport } from './lib/automation-report.mjs';
 import { hasLabel, normalizeLabelNames } from './lib/automation-guards.mjs';
-import { resolveChangePackageValidationStatus } from './lib/change-package-gate.mjs';
+import { resolveChangePackageValidationStatusFromChecks } from './lib/change-package-gate.mjs';
 import { sleep } from './lib/timing.mjs';
 
 const repo = process.env.GITHUB_REPOSITORY;
@@ -330,7 +330,7 @@ const main = async () => {
         ? summarizeChecks(view.statusCheckRollup || [], requiredContexts)
         : { counts: { success: 0, failure: 0, pending: 0, skipped: 0, neutral: 0 }, failed: [] };
       const comments = listComments(pr.number);
-      const changePackageStatus = resolveChangePackageValidationStatus(comments);
+      const changePackageStatus = resolveChangePackageValidationStatusFromChecks(view.statusCheckRollup || []);
       const reasons = [];
       if (view.isDraft) reasons.push('draft');
       if (view.mergeable !== 'MERGEABLE') reasons.push(`mergeable=${view.mergeable || 'UNKNOWN'}`);
@@ -352,7 +352,11 @@ const main = async () => {
       }
       if (AUTO_MERGE_REQUIRE_CHANGE_PACKAGE) {
         if (changePackageStatus.status === 'missing') {
-          reasons.push('missing change-package validation summary');
+          reasons.push('missing change-package validation check');
+        } else if (changePackageStatus.status === 'pending') {
+          reasons.push('change-package validation check pending');
+        } else if (changePackageStatus.status === 'ambiguous') {
+          reasons.push('ambiguous change-package validation checks');
         } else if (changePackageStatus.status === 'fail') {
           reasons.push('change-package validation failed');
         } else if (changePackageStatus.status === 'warn' && !AUTO_MERGE_CHANGE_PACKAGE_ALLOW_WARN) {

--- a/scripts/ci/lib/change-package-gate.mjs
+++ b/scripts/ci/lib/change-package-gate.mjs
@@ -1,5 +1,9 @@
 const PR_SUMMARY_MARKER = '<!-- AE-PR-SUMMARY -->';
 const DEFAULT_TRUSTED_SUMMARY_AUTHORS = new Set(['github-actions', 'github-actions[bot]']);
+const CHANGE_PACKAGE_VALIDATION_CHECK_NAMES = new Set([
+  'Change Package Validation',
+  'change-package-validation',
+]);
 
 function normalizeTimestamp(comment) {
   const raw = comment?.created_at ?? comment?.createdAt ?? '';
@@ -44,6 +48,82 @@ function parseChangePackageValidationResult(body) {
   return null;
 }
 
+function normalizeCheckRunTimestamp(checkRun) {
+  const raw = checkRun?.completedAt
+    ?? checkRun?.completed_at
+    ?? checkRun?.startedAt
+    ?? checkRun?.started_at
+    ?? '';
+  const ts = Date.parse(String(raw));
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+function normalizeCheckRunName(checkRun) {
+  return String(checkRun?.name ?? '').trim();
+}
+
+function isChangePackageValidationCheck(checkRun) {
+  return CHANGE_PACKAGE_VALIDATION_CHECK_NAMES.has(normalizeCheckRunName(checkRun));
+}
+
+function checkRunSourceUrl(checkRun) {
+  return typeof checkRun?.detailsUrl === 'string'
+    ? checkRun.detailsUrl
+    : (typeof checkRun?.details_url === 'string'
+      ? checkRun.details_url
+      : (typeof checkRun?.html_url === 'string'
+        ? checkRun.html_url
+        : (typeof checkRun?.url === 'string' ? checkRun.url : null)));
+}
+
+function mapCheckRunToChangePackageStatus(checkRun) {
+  const status = String(checkRun?.status ?? '').trim().toUpperCase();
+  if (status !== 'COMPLETED') {
+    return 'pending';
+  }
+
+  switch (String(checkRun?.conclusion ?? '').trim().toUpperCase()) {
+    case 'SUCCESS':
+      return 'pass';
+    case 'NEUTRAL':
+      return 'warn';
+    case 'FAILURE':
+    case 'CANCELLED':
+    case 'TIMED_OUT':
+    case 'ACTION_REQUIRED':
+    case 'STALE':
+      return 'fail';
+    default:
+      return 'missing';
+  }
+}
+
+function resolveChangePackageValidationStatusFromChecks(checkRuns = []) {
+  if (!Array.isArray(checkRuns) || checkRuns.length === 0) {
+    return { status: 'missing', sourceUrl: null };
+  }
+
+  const candidates = checkRuns.filter(isChangePackageValidationCheck);
+  if (candidates.length === 0) {
+    return { status: 'missing', sourceUrl: null };
+  }
+
+  const latestTimestamp = Math.max(...candidates.map(normalizeCheckRunTimestamp));
+  const latestCandidates = candidates.filter(
+    (candidate) => normalizeCheckRunTimestamp(candidate) === latestTimestamp,
+  );
+  const latestStatuses = new Set(latestCandidates.map(mapCheckRunToChangePackageStatus));
+  if (latestStatuses.size > 1) {
+    return { status: 'ambiguous', sourceUrl: null };
+  }
+
+  const latest = latestCandidates[latestCandidates.length - 1];
+  return {
+    status: mapCheckRunToChangePackageStatus(latest),
+    sourceUrl: checkRunSourceUrl(latest),
+  };
+}
+
 function resolveChangePackageValidationStatus(comments = []) {
   if (!Array.isArray(comments) || comments.length === 0) {
     return { status: 'missing', sourceUrl: null };
@@ -64,7 +144,9 @@ function resolveChangePackageValidationStatus(comments = []) {
 }
 
 export {
+  CHANGE_PACKAGE_VALIDATION_CHECK_NAMES,
   isTrustedSummaryAuthor,
   parseChangePackageValidationResult,
   resolveChangePackageValidationStatus,
+  resolveChangePackageValidationStatusFromChecks,
 };

--- a/scripts/ci/lib/change-package-gate.mjs
+++ b/scripts/ci/lib/change-package-gate.mjs
@@ -89,6 +89,7 @@ function mapCheckRunToChangePackageStatus(checkRun) {
       return 'warn';
     case 'FAILURE':
     case 'CANCELLED':
+    case 'SKIPPED':
     case 'TIMED_OUT':
     case 'ACTION_REQUIRED':
     case 'STALE':

--- a/scripts/ci/lib/change-package-gate.mjs
+++ b/scripts/ci/lib/change-package-gate.mjs
@@ -1,7 +1,7 @@
 const PR_SUMMARY_MARKER = '<!-- AE-PR-SUMMARY -->';
 const DEFAULT_TRUSTED_SUMMARY_AUTHORS = new Set(['github-actions', 'github-actions[bot]']);
 const CHANGE_PACKAGE_VALIDATION_CHECK_NAMES = new Set([
-  'Change Package Validation',
+  'change package validation',
   'change-package-validation',
 ]);
 
@@ -59,7 +59,7 @@ function normalizeCheckRunTimestamp(checkRun) {
 }
 
 function normalizeCheckRunName(checkRun) {
-  return String(checkRun?.name ?? '').trim();
+  return String(checkRun?.name ?? '').trim().toLowerCase();
 }
 
 function isChangePackageValidationCheck(checkRun) {

--- a/scripts/ci/lib/change-package-gate.mjs
+++ b/scripts/ci/lib/change-package-gate.mjs
@@ -63,17 +63,20 @@ function normalizeCheckRunName(checkRun) {
 }
 
 function isChangePackageValidationCheck(checkRun) {
+  if (checkRun?.__typename !== 'CheckRun') {
+    return false;
+  }
   return CHANGE_PACKAGE_VALIDATION_CHECK_NAMES.has(normalizeCheckRunName(checkRun));
 }
 
 function checkRunSourceUrl(checkRun) {
-  return typeof checkRun?.detailsUrl === 'string'
-    ? checkRun.detailsUrl
-    : (typeof checkRun?.details_url === 'string'
-      ? checkRun.details_url
-      : (typeof checkRun?.html_url === 'string'
-        ? checkRun.html_url
-        : (typeof checkRun?.url === 'string' ? checkRun.url : null)));
+  for (const key of ['detailsUrl', 'details_url', 'html_url', 'url']) {
+    const value = checkRun?.[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function mapCheckRunToChangePackageStatus(checkRun) {
@@ -91,11 +94,12 @@ function mapCheckRunToChangePackageStatus(checkRun) {
     case 'CANCELLED':
     case 'SKIPPED':
     case 'TIMED_OUT':
+    case 'STARTUP_FAILURE':
     case 'ACTION_REQUIRED':
     case 'STALE':
       return 'fail';
     default:
-      return 'missing';
+      return 'fail';
   }
 }
 
@@ -107,6 +111,15 @@ function resolveChangePackageValidationStatusFromChecks(checkRuns = []) {
   const candidates = checkRuns.filter(isChangePackageValidationCheck);
   if (candidates.length === 0) {
     return { status: 'missing', sourceUrl: null };
+  }
+
+  const timestampLessPendingCandidates = candidates.filter(
+    (candidate) => normalizeCheckRunTimestamp(candidate) === 0
+      && mapCheckRunToChangePackageStatus(candidate) === 'pending',
+  );
+  if (timestampLessPendingCandidates.length > 0) {
+    const latestPending = timestampLessPendingCandidates[timestampLessPendingCandidates.length - 1];
+    return { status: 'pending', sourceUrl: checkRunSourceUrl(latestPending) };
   }
 
   const latestTimestamp = Math.max(...candidates.map(normalizeCheckRunTimestamp));

--- a/tests/unit/ci/change-package-gate.test.ts
+++ b/tests/unit/ci/change-package-gate.test.ts
@@ -124,6 +124,16 @@ describe('change-package gate helpers', () => {
         completedAt: '2026-06-04T00:00:00Z',
       },
     ])).toEqual({ status: 'fail', sourceUrl: null });
+
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'SKIPPED',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'fail', sourceUrl: null });
   });
 
   it('fails closed for missing, pending, and ambiguous check-run evidence', () => {

--- a/tests/unit/ci/change-package-gate.test.ts
+++ b/tests/unit/ci/change-package-gate.test.ts
@@ -98,6 +98,16 @@ describe('change-package gate helpers', () => {
     expect(resolveChangePackageValidationStatusFromChecks([
       {
         __typename: 'CheckRun',
+        name: 'cHaNgE pAcKaGe VaLiDaTiOn',
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'pass', sourceUrl: null });
+
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
         name: 'Change Package Validation',
         status: 'COMPLETED',
         conclusion: 'NEUTRAL',

--- a/tests/unit/ci/change-package-gate.test.ts
+++ b/tests/unit/ci/change-package-gate.test.ts
@@ -3,6 +3,7 @@ import {
   isTrustedSummaryAuthor,
   parseChangePackageValidationResult,
   resolveChangePackageValidationStatus,
+  resolveChangePackageValidationStatusFromChecks,
 } from '../../../scripts/ci/lib/change-package-gate.mjs';
 
 describe('change-package gate helpers', () => {
@@ -77,4 +78,74 @@ describe('change-package gate helpers', () => {
     expect(isTrustedSummaryAuthor({ author: { login: 'github-actions[bot]' } })).toBe(true);
     expect(isTrustedSummaryAuthor({ user: { login: 'someone-else' } })).toBe(false);
   });
+
+
+  it('resolves change-package validation from trusted PR-head check runs', () => {
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+        completedAt: '2026-06-04T00:00:00Z',
+        detailsUrl: 'https://example.test/checks/1',
+      },
+    ])).toEqual({
+      status: 'pass',
+      sourceUrl: 'https://example.test/checks/1',
+    });
+
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'NEUTRAL',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'warn', sourceUrl: null });
+
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'FAILURE',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'fail', sourceUrl: null });
+  });
+
+  it('fails closed for missing, pending, and ambiguous check-run evidence', () => {
+    expect(resolveChangePackageValidationStatusFromChecks([])).toEqual({
+      status: 'missing',
+      sourceUrl: null,
+    });
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'IN_PROGRESS',
+        conclusion: '',
+        startedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'pending', sourceUrl: null });
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'FAILURE',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'ambiguous', sourceUrl: null });
+  });
+
 });

--- a/tests/unit/ci/change-package-gate.test.ts
+++ b/tests/unit/ci/change-package-gate.test.ts
@@ -134,6 +134,26 @@ describe('change-package gate helpers', () => {
         completedAt: '2026-06-04T00:00:00Z',
       },
     ])).toEqual({ status: 'fail', sourceUrl: null });
+
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'STARTUP_FAILURE',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'fail', sourceUrl: null });
+
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'UNKNOWN_CONCLUSION',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'fail', sourceUrl: null });
   });
 
   it('fails closed for missing, pending, and ambiguous check-run evidence', () => {
@@ -166,6 +186,37 @@ describe('change-package gate helpers', () => {
         completedAt: '2026-06-04T00:00:00Z',
       },
     ])).toEqual({ status: 'ambiguous', sourceUrl: null });
+  });
+
+  it('treats a timestamp-less queued rerun as pending over older completed evidence', () => {
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+        completedAt: '2026-06-04T00:01:00Z',
+      },
+      {
+        __typename: 'CheckRun',
+        name: 'Change Package Validation',
+        status: 'QUEUED',
+        conclusion: null,
+      },
+    ])).toEqual({ status: 'pending', sourceUrl: null });
+  });
+
+  it('ignores similarly named non-CheckRun status rollup entries', () => {
+    expect(resolveChangePackageValidationStatusFromChecks([
+      {
+        __typename: 'StatusContext',
+        name: 'Change Package Validation',
+        context: 'Change Package Validation',
+        status: 'COMPLETED',
+        conclusion: 'SUCCESS',
+        completedAt: '2026-06-04T00:00:00Z',
+      },
+    ])).toEqual({ status: 'missing', sourceUrl: null });
   });
 
 });

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -291,8 +291,12 @@ describe('workflow permission boundaries', () => {
     expect(publishSummary).toContain("readJson('change-package/change-package-validation.json')");
     expect(publishSummary).toContain('const listAllIssueComments = async () =>');
     expect(publishSummary).toContain('page += 1');
-    expect(publishSummary).toContain('const existing = comments.find');
+    expect(publishSummary).toContain('const isTrustedAutomationComment = (comment, marker) =>');
+    expect(publishSummary).toContain("login === 'github-actions' || login === 'github-actions[bot]'");
+    expect(publishSummary).toContain('body.startsWith(marker)');
+    expect(publishSummary).toContain('const existing = comments.find((comment) => isTrustedAutomationComment(comment, marker))');
     expect(publishSummary).toContain('Progress summary JSON omitted because it would exceed the PR comment size cap.');
+    expect(publishSummary).toContain('Progress summary JSON could not be parsed; publishing Markdown without embedded JSON');
     expect(publishSummary).toContain("name: 'Change Package Validation'");
     expect(publishSummary).toContain('head_sha: headSha');
     expect(enableAutoMerge).not.toContain("github.event_name == 'pull_request'");

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -274,6 +274,9 @@ describe('workflow permission boundaries', () => {
       issues: 'read',
       'pull-requests': 'read',
     });
+    expect(parsed.jobs?.label?.permissions).toEqual({
+      issues: 'write',
+    });
     expect(parsed.jobs?.['publish-summary']?.needs).toBe('summarize');
     expect(parsed.jobs?.['publish-summary']?.permissions).toEqual({
       actions: 'read',
@@ -289,6 +292,9 @@ describe('workflow permission boundaries', () => {
     expect(publishSummary).toContain("readText('summary/PR_SUMMARY.md')");
     expect(publishSummary).toContain("readText('progress/PR_PROGRESS.md')");
     expect(publishSummary).toContain("readJson('change-package/change-package-validation.json')");
+    expect(publishSummary).toContain('const truncateUtf8 = (text, maxBytes) =>');
+    expect(publishSummary).toContain('MAX_COMMENT_BYTES - Buffer.byteLength(notice');
+    expect(publishSummary).toContain('availableBytes');
     expect(publishSummary).toContain('const listAllIssueComments = async () =>');
     expect(publishSummary).toContain('page += 1');
     expect(publishSummary).toContain('const isTrustedAutomationComment = (comment, marker) =>');
@@ -297,6 +303,7 @@ describe('workflow permission boundaries', () => {
     expect(publishSummary).toContain('const existing = comments.find((comment) => isTrustedAutomationComment(comment, marker))');
     expect(publishSummary).toContain('Progress summary JSON omitted because it would exceed the PR comment size cap.');
     expect(publishSummary).toContain('Progress summary JSON could not be parsed; publishing Markdown without embedded JSON');
+    expect(publishSummary).toContain('could not be parsed; treating as missing structured JSON');
     expect(publishSummary).toContain("name: 'Change Package Validation'");
     expect(publishSummary).toContain('head_sha: headSha');
     expect(enableAutoMerge).not.toContain("github.event_name == 'pull_request'");

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -279,7 +279,7 @@ describe('workflow permission boundaries', () => {
       actions: 'read',
       checks: 'write',
       issues: 'write',
-      'pull-requests': 'read',
+      'pull-requests': 'write',
     });
     expect(summarize).toContain('Upload PR summary publish artifact');
     expect(summarize).not.toContain('issues.createComment');

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -259,6 +259,49 @@ describe('workflow permission boundaries', () => {
     expect(rawWorkflow).toContain('environment:\n      name: branch-protection-admin');
   });
 
+  it('pr-maintenance renders PR summary read-only and publishes from a checkout-free writer job', () => {
+    const workflow = readWorkflow('pr-ci-status-comment.yml');
+    const parsed = parseWorkflow('pr-ci-status-comment.yml');
+    const summarize = extractJobBlock(workflow, 'summarize');
+    const publishSummary = extractJobBlock(workflow, 'publish-summary');
+    const enableAutoMerge = extractJobBlock(workflow, 'enable-auto-merge');
+
+    expect(workflowPermission(parsed, 'issues')).toBeUndefined();
+    expect(workflowPermission(parsed, 'pull-requests')).toBeUndefined();
+    expect(parsed.jobs?.summarize?.permissions).toEqual({
+      actions: 'read',
+      contents: 'read',
+      issues: 'read',
+      'pull-requests': 'read',
+    });
+    expect(parsed.jobs?.['publish-summary']?.needs).toBe('summarize');
+    expect(parsed.jobs?.['publish-summary']?.permissions).toEqual({
+      actions: 'read',
+      checks: 'write',
+      issues: 'write',
+      'pull-requests': 'read',
+    });
+    expect(summarize).toContain('Upload PR summary publish artifact');
+    expect(summarize).not.toContain('issues.createComment');
+    expect(summarize).not.toContain('issues.updateComment');
+    expect(publishSummary).not.toContain('actions/checkout@v4');
+    expect(publishSummary).toContain('Download PR summary publish artifact');
+    expect(publishSummary).toContain("name: 'Change Package Validation'");
+    expect(publishSummary).toContain('head_sha: headSha');
+    expect(enableAutoMerge).not.toContain("github.event_name == 'pull_request'");
+  });
+
+  it('auto-merge consumes Change Package check-run evidence instead of PR summary markdown', () => {
+    const source = fs.readFileSync(
+      path.resolve(process.cwd(), 'scripts/ci/auto-merge-enabler.mjs'),
+      'utf8',
+    );
+    expect(source).toContain('resolveChangePackageValidationStatusFromChecks(view.statusCheckRollup || [])');
+    expect(source).not.toContain('resolveChangePackageValidationStatus(comments)');
+    expect(source).toContain('missing change-package validation check');
+    expect(source).toContain('ambiguous change-package validation checks');
+  });
+
   it('pr-maintenance update-branch enforces fork guard, explicit mode, and global kill-switch', () => {
     const workflow = readWorkflow('pr-ci-status-comment.yml');
     const updateBranch = extractJobBlock(workflow, 'update-branch');

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -263,6 +263,7 @@ describe('workflow permission boundaries', () => {
     const workflow = readWorkflow('pr-ci-status-comment.yml');
     const parsed = parseWorkflow('pr-ci-status-comment.yml');
     const summarize = extractJobBlock(workflow, 'summarize');
+    const validateChangePackage = extractJobBlock(workflow, 'validate-change-package');
     const publishSummary = extractJobBlock(workflow, 'publish-summary');
     const enableAutoMerge = extractJobBlock(workflow, 'enable-auto-merge');
 
@@ -277,7 +278,12 @@ describe('workflow permission boundaries', () => {
     expect(parsed.jobs?.label?.permissions).toEqual({
       issues: 'write',
     });
-    expect(parsed.jobs?.['publish-summary']?.needs).toBe('summarize');
+    expect(parsed.jobs?.['validate-change-package']?.needs).toBe('summarize');
+    expect(parsed.jobs?.['validate-change-package']?.permissions).toEqual({
+      actions: 'read',
+      contents: 'read',
+    });
+    expect(parsed.jobs?.['publish-summary']?.needs).toEqual(['summarize', 'validate-change-package']);
     expect(parsed.jobs?.['publish-summary']?.permissions).toEqual({
       actions: 'read',
       checks: 'write',
@@ -285,13 +291,22 @@ describe('workflow permission boundaries', () => {
       'pull-requests': 'write',
     });
     expect(summarize).toContain('Upload PR summary publish artifact');
+    expect(summarize).toContain('artifacts/change-package/change-package.json');
+    expect(validateChangePackage).toContain('ref: ${{ github.event.pull_request.base.sha }}');
+    expect(validateChangePackage).toContain('Download PR summary publish artifact');
+    expect(validateChangePackage).toContain('Validate Change Package with trusted base code');
+    expect(validateChangePackage).toContain('node scripts/change-package/validate.mjs');
+    expect(validateChangePackage).toContain('trusted-change-package-validation-pr-${{ github.event.pull_request.number }}');
+    expect(validateChangePackage).toContain("source: 'base-ref-code'");
     expect(summarize).not.toContain('issues.createComment');
     expect(summarize).not.toContain('issues.updateComment');
     expect(publishSummary).not.toContain('actions/checkout@v4');
     expect(publishSummary).toContain('Download PR summary publish artifact');
+    expect(publishSummary).toContain('Download trusted Change Package validation artifact');
+    expect(publishSummary).toContain("const trustedArtifactRoot = 'artifacts/publish/trusted-change-package'");
     expect(publishSummary).toContain("readText('summary/PR_SUMMARY.md')");
     expect(publishSummary).toContain("readText('progress/PR_PROGRESS.md')");
-    expect(publishSummary).toContain("readJson('change-package/change-package-validation.json')");
+    expect(publishSummary).toContain("readJson('change-package-validation.json', trustedArtifactRoot)");
     expect(publishSummary).toContain('const truncateUtf8 = (text, maxBytes) =>');
     expect(publishSummary).toContain('MAX_COMMENT_BYTES - Buffer.byteLength(notice');
     expect(publishSummary).toContain('availableBytes');
@@ -303,6 +318,9 @@ describe('workflow permission boundaries', () => {
     expect(publishSummary).toContain('const isTrustedAutomationComment = (comment, marker) =>');
     expect(publishSummary).toContain("login === 'github-actions' || login === 'github-actions[bot]'");
     expect(publishSummary).toContain('body.startsWith(marker)');
+    expect(publishSummary).toContain('const markerDisplayLabel = (marker) =>');
+    expect(publishSummary).toContain("return label || 'PR comment';");
+    expect(publishSummary).toContain('limitComment(`${marker}\\n\\n${body}`, markerDisplayLabel(marker))');
     expect(publishSummary).toContain('const comments = await getIssueComments();');
     expect(publishSummary).toContain('const existing = [...comments].reverse().find((comment) => isTrustedAutomationComment(comment, marker))');
     expect(publishSummary).toContain('Progress summary JSON omitted because it would exceed the PR comment size cap.');

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -293,6 +293,8 @@ describe('workflow permission boundaries', () => {
     expect(summarize).toContain('Upload PR summary publish artifact');
     expect(summarize).toContain('artifacts/change-package/change-package.json');
     expect(validateChangePackage).toContain('ref: ${{ github.event.pull_request.base.sha }}');
+    expect(validateChangePackage).toContain('Install trusted validation dependencies');
+    expect(validateChangePackage).toContain('pnpm install --frozen-lockfile --config.use-lockfile=true --config.package-lock=true');
     expect(validateChangePackage).toContain('Download PR summary publish artifact');
     expect(validateChangePackage).toContain('Validate Change Package with trusted base code');
     expect(validateChangePackage).toContain('node scripts/change-package/validate.mjs');

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -297,10 +297,14 @@ describe('workflow permission boundaries', () => {
     expect(publishSummary).toContain('availableBytes');
     expect(publishSummary).toContain('const listAllIssueComments = async () =>');
     expect(publishSummary).toContain('page += 1');
+    expect(publishSummary).toContain('let issueCommentsCache = null;');
+    expect(publishSummary).toContain('const getIssueComments = async () =>');
+    expect(publishSummary).toContain('issueCommentsCache = await listAllIssueComments();');
     expect(publishSummary).toContain('const isTrustedAutomationComment = (comment, marker) =>');
     expect(publishSummary).toContain("login === 'github-actions' || login === 'github-actions[bot]'");
     expect(publishSummary).toContain('body.startsWith(marker)');
-    expect(publishSummary).toContain('const existing = comments.find((comment) => isTrustedAutomationComment(comment, marker))');
+    expect(publishSummary).toContain('const comments = await getIssueComments();');
+    expect(publishSummary).toContain('const existing = [...comments].reverse().find((comment) => isTrustedAutomationComment(comment, marker))');
     expect(publishSummary).toContain('Progress summary JSON omitted because it would exceed the PR comment size cap.');
     expect(publishSummary).toContain('Progress summary JSON could not be parsed; publishing Markdown without embedded JSON');
     expect(publishSummary).toContain('could not be parsed; treating as missing structured JSON');

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -286,8 +286,9 @@ describe('workflow permission boundaries', () => {
     expect(summarize).not.toContain('issues.updateComment');
     expect(publishSummary).not.toContain('actions/checkout@v4');
     expect(publishSummary).toContain('Download PR summary publish artifact');
-    expect(publishSummary).toContain("readText('artifacts/summary/PR_SUMMARY.md')");
-    expect(publishSummary).toContain("readJson('artifacts/change-package/change-package-validation.json')");
+    expect(publishSummary).toContain("readText('summary/PR_SUMMARY.md')");
+    expect(publishSummary).toContain("readText('progress/PR_PROGRESS.md')");
+    expect(publishSummary).toContain("readJson('change-package/change-package-validation.json')");
     expect(publishSummary).toContain('const listAllIssueComments = async () =>');
     expect(publishSummary).toContain('page += 1');
     expect(publishSummary).toContain('const existing = comments.find');

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -275,6 +275,10 @@ describe('workflow permission boundaries', () => {
       issues: 'read',
       'pull-requests': 'read',
     });
+    const summarizeCheckout = parsed.jobs?.summarize?.steps?.find(
+      (step: any) => step?.uses === 'actions/checkout@v4',
+    );
+    expect(summarizeCheckout?.with).toMatchObject({ 'persist-credentials': false });
     expect(parsed.jobs?.label?.permissions).toEqual({
       issues: 'write',
     });

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -286,20 +286,35 @@ describe('workflow permission boundaries', () => {
     expect(summarize).not.toContain('issues.updateComment');
     expect(publishSummary).not.toContain('actions/checkout@v4');
     expect(publishSummary).toContain('Download PR summary publish artifact');
+    expect(publishSummary).toContain("readText('artifacts/summary/PR_SUMMARY.md')");
+    expect(publishSummary).toContain("readJson('artifacts/change-package/change-package-validation.json')");
+    expect(publishSummary).toContain('const listAllIssueComments = async () =>');
+    expect(publishSummary).toContain('page += 1');
+    expect(publishSummary).toContain('const existing = comments.find');
+    expect(publishSummary).toContain('Progress summary JSON omitted because it would exceed the PR comment size cap.');
     expect(publishSummary).toContain("name: 'Change Package Validation'");
     expect(publishSummary).toContain('head_sha: headSha');
     expect(enableAutoMerge).not.toContain("github.event_name == 'pull_request'");
   });
 
-  it('auto-merge consumes Change Package check-run evidence instead of PR summary markdown', () => {
-    const source = fs.readFileSync(
+  it('auto-merge jobs consume Change Package check-run evidence instead of PR summary markdown', () => {
+    const enablerSource = fs.readFileSync(
       path.resolve(process.cwd(), 'scripts/ci/auto-merge-enabler.mjs'),
       'utf8',
     );
-    expect(source).toContain('resolveChangePackageValidationStatusFromChecks(view.statusCheckRollup || [])');
-    expect(source).not.toContain('resolveChangePackageValidationStatus(comments)');
-    expect(source).toContain('missing change-package validation check');
-    expect(source).toContain('ambiguous change-package validation checks');
+    const eligibilitySource = fs.readFileSync(
+      path.resolve(process.cwd(), 'scripts/ci/auto-merge-eligible.mjs'),
+      'utf8',
+    );
+    expect(enablerSource).toContain('resolveChangePackageValidationStatusFromChecks(view.statusCheckRollup || [])');
+    expect(enablerSource).not.toContain('resolveChangePackageValidationStatus(comments)');
+    expect(enablerSource).toContain('missing change-package validation check');
+    expect(enablerSource).toContain('ambiguous change-package validation checks');
+    expect(eligibilitySource).toContain('resolveChangePackageValidationStatusFromChecks(pr.statusCheckRollup || [])');
+    expect(eligibilitySource).not.toContain('resolveChangePackageValidationStatus(listComments');
+    expect(eligibilitySource).not.toContain('const listComments');
+    expect(eligibilitySource).toContain('change-package validation check pending');
+    expect(eligibilitySource).toContain('ambiguous change-package validation checks');
   });
 
   it('pr-maintenance update-branch enforces fork guard, explicit mode, and global kill-switch', () => {


### PR DESCRIPTION
## Summary

Closes #3412.
Closes #3414.

- Splits PR-controlled summary rendering from write-scoped PR comment publication.
- Keeps the `summarize` job read-only, removes write-scoped secrets from local summary/harness script execution, and publishes comments from a checkout-free `publish-summary` job.
- Publishes a head-SHA-bound `Change Package Validation` check run from the structured validation artifact.
- Changes auto-merge gating to consume the PR-head check-run evidence instead of parsing Change Package Validation status from PR summary Markdown.
- Adds regression tests for workflow permission boundaries and fail-closed Change Package check-run interpretation.

## Verification

- `pnpm install --offline --frozen-lockfile`
- `pnpm -s exec vitest run tests/unit/ci/change-package-gate.test.ts tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot`
- `/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint-bin .github/workflows/pr-ci-status-comment.yml`
- `pnpm -s exec eslint --quiet scripts/ci/lib/change-package-gate.mjs scripts/ci/auto-merge-enabler.mjs tests/unit/ci/change-package-gate.test.ts tests/unit/ci/workflow-permission-boundary.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Acceptance

- PR summary rendering can execute checked-out PR code only with read-scoped permissions.
- PR summary/progress comments are published by a separate job that does not checkout or execute repository-local scripts.
- Auto-merge no longer trusts Change Package status parsed from `<!-- AE-PR-SUMMARY -->` Markdown.
- Auto-merge fails closed for missing, pending, failed, or ambiguous `Change Package Validation` check-run evidence.

## Rollback

Revert this PR to restore the previous single-job summary comment publication and Markdown-based auto-merge Change Package gate. That rollback would re-open #3412 and #3414.