### PR TITLE
fix(security): run copilot auto-fix from trusted code

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -13,9 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-fix:
@@ -32,13 +30,23 @@ jobs:
         || contains(format(',{0},', vars.COPILOT_ACTORS || ''), format(',{0},', github.actor))
       )
     runs-on: ubuntu-latest
+    # This job can write to the same-repository PR branch, so execute only
+    # trusted automation code from the base commit and treat the PR checkout as
+    # data with persisted credentials disabled.
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout trusted automation code
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted
           fetch-depth: 0
-      - name: Setup Node + pnpm
-        uses: ./.github/actions/setup-node-pnpm
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
       - name: Resolve automation config
@@ -65,12 +73,20 @@ jobs:
           COPILOT_REVIEW_WAIT_MINUTES: ${{ vars.COPILOT_REVIEW_WAIT_MINUTES || '' }}
           COPILOT_REVIEW_MAX_ATTEMPTS: ${{ vars.COPILOT_REVIEW_MAX_ATTEMPTS || '' }}
         run: |
-          node scripts/ci/lib/automation-config.mjs --format github-env >> "$GITHUB_ENV"
-          node scripts/ci/lib/automation-config.mjs --format summary >> "$GITHUB_STEP_SUMMARY"
+          node trusted/scripts/ci/lib/automation-config.mjs --format github-env >> "$GITHUB_ENV"
+          node trusted/scripts/ci/lib/automation-config.mjs --format summary >> "$GITHUB_STEP_SUMMARY"
+      - name: Checkout PR head workspace
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          fetch-depth: 0
+          persist-credentials: false
       - name: Apply Copilot suggestions
+        working-directory: pr
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: node scripts/ci/copilot-auto-fix.mjs
+        run: node ../trusted/scripts/ci/copilot-auto-fix.mjs

--- a/scripts/ci/copilot-auto-fix.mjs
+++ b/scripts/ci/copilot-auto-fix.mjs
@@ -140,6 +140,33 @@ const upsertComment = (number, body) => {
   execGh(['api', `repos/${repo}/issues/${number}/comments`, '--input', '-'], { input: payload });
 };
 
+const buildAuthenticatedGitEnv = () => {
+  const token = String(process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '').trim();
+  if (!token) {
+    throw new Error('GH_TOKEN is required for authenticated git push');
+  }
+  const existingConfigCount = Number.parseInt(String(process.env.GIT_CONFIG_COUNT || '0'), 10);
+  const configIndex = Number.isFinite(existingConfigCount) && existingConfigCount >= 0
+    ? existingConfigCount
+    : 0;
+  const authHeader = Buffer.from(`x-access-token:${token}`, 'utf8').toString('base64');
+  return {
+    ...process.env,
+    GIT_CONFIG_COUNT: String(configIndex + 1),
+    [`GIT_CONFIG_KEY_${configIndex}`]: `http.https://github.com/${repo}.git.extraheader`,
+    [`GIT_CONFIG_VALUE_${configIndex}`]: `AUTHORIZATION: basic ${authHeader}`,
+  };
+};
+
+const pushHeadToPrBranch = () => {
+  const remoteUrl = `https://github.com/${repo}.git`;
+  const refspec = prHeadRef ? `HEAD:${prHeadRef}` : 'HEAD';
+  execFileSync('git', ['push', remoteUrl, refspec], {
+    stdio: 'inherit',
+    env: buildAuthenticatedGitEnv(),
+  });
+};
+
 const listPullFiles = async (number) => {
   const files = [];
   let page = 1;
@@ -529,11 +556,7 @@ const main = async () => {
     execFileSync('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
     execFileSync('git', ['add', ...changedFiles], { stdio: 'inherit' });
     execFileSync('git', ['commit', '-m', `chore(copilot): apply suggestions (#${prNumber})`], { stdio: 'inherit' });
-    if (prHeadRef) {
-      execFileSync('git', ['push', 'origin', `HEAD:${prHeadRef}`], { stdio: 'inherit' });
-    } else {
-      execFileSync('git', ['push'], { stdio: 'inherit' });
-    }
+    pushHeadToPrBranch();
   }
 
   // Resolve only automation-only threads where every automation comment was handled

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -150,6 +150,54 @@ describe('workflow permission boundaries', () => {
     expect(workflow).toContain('AE_AUTOMATION_GLOBAL_DISABLE');
   });
 
+  it('copilot-auto-fix runs trusted automation code in its write-scoped job', () => {
+    const workflow = readWorkflow('copilot-auto-fix.yml');
+    const parsed = parseWorkflow('copilot-auto-fix.yml');
+    const autoFixJob = parsed.jobs?.['auto-fix'];
+    const autoFixBlock = extractJobBlock(workflow, 'auto-fix');
+    const steps = Array.isArray(autoFixJob?.steps) ? autoFixJob.steps : [];
+
+    expect(parsed.permissions).toEqual({ contents: 'read' });
+    expect(autoFixJob?.permissions).toEqual({
+      contents: 'write',
+      issues: 'write',
+      'pull-requests': 'write',
+    });
+
+    const trustedCheckout = steps.find((step: any) => step?.name === 'Checkout trusted automation code');
+    expect(trustedCheckout?.uses).toBe('actions/checkout@v4');
+    expect(trustedCheckout?.with).toMatchObject({
+      ref: '${{ github.event.pull_request.base.sha }}',
+      path: 'trusted',
+      'persist-credentials': false,
+    });
+
+    const prCheckout = steps.find((step: any) => step?.name === 'Checkout PR head workspace');
+    expect(prCheckout?.uses).toBe('actions/checkout@v4');
+    expect(prCheckout?.with).toMatchObject({
+      ref: '${{ github.event.pull_request.head.sha }}',
+      path: 'pr',
+      'persist-credentials': false,
+    });
+
+    expect(autoFixBlock).not.toContain('uses: ./.github/actions/setup-node-pnpm');
+    expect(autoFixBlock).toContain('uses: actions/setup-node@v4');
+    expect(autoFixBlock).toContain('node trusted/scripts/ci/lib/automation-config.mjs');
+    expect(autoFixBlock).toContain('working-directory: pr');
+    expect(autoFixBlock).toContain('node ../trusted/scripts/ci/copilot-auto-fix.mjs');
+    expect(autoFixBlock).not.toContain('run: node scripts/ci/copilot-auto-fix.mjs');
+
+    const autoFixSource = fs.readFileSync(
+      path.resolve(process.cwd(), 'scripts/ci/copilot-auto-fix.mjs'),
+      'utf8',
+    );
+    expect(autoFixSource).toContain('const buildAuthenticatedGitEnv = () =>');
+    expect(autoFixSource).toContain('GIT_CONFIG_COUNT');
+    expect(autoFixSource).toContain('http.https://github.com/${repo}.git.extraheader');
+    expect(autoFixSource).toContain("execFileSync('git', ['push', remoteUrl, refspec]");
+    expect(autoFixSource).not.toContain("['push', 'origin'");
+  });
+
   it('codex-autopilot-lane issue_comment path requires trusted command + association + kill-switch', () => {
     const workflow = readWorkflow('codex-autopilot-lane.yml');
     expect(workflow).toContain("github.event.issue.pull_request");


### PR DESCRIPTION
## Summary

- Run Copilot auto-fix automation code from the trusted PR base commit instead of the PR head checkout.
- Disable persisted checkout credentials for both trusted and PR workspaces; keep the PR checkout as data only.
- Replace the PR-controlled local setup action with `actions/setup-node@v4` and push fixes with an explicit temporary git auth header from the trusted script.
- Add workflow permission-boundary regression coverage for the trusted checkout, PR checkout, and authenticated push path.

## Acceptance

- Closes #3416.
- The workflow default token permissions are read-only.
- The write-scoped job executes `trusted/scripts/ci/copilot-auto-fix.mjs` from `${{ github.event.pull_request.base.sha }}`.
- No PR-head local action or PR-head script is executed in the write-scoped job.
- Checkout credentials are not persisted in either workspace.

## Verification

- `/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint-bin .github/workflows/copilot-auto-fix.yml`
- `node --check scripts/ci/copilot-auto-fix.mjs`
- `pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot` — 23 tests passed
- `pnpm -s exec eslint --quiet scripts/ci/copilot-auto-fix.mjs tests/unit/ci/workflow-permission-boundary.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `node scripts/ci/validate-json.mjs && pnpm -s run check:schemas && pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

- Revert this PR to restore the previous Copilot auto-fix checkout and push behavior.
- If rollback is needed, disable `AE_COPILOT_AUTO_FIX` until a corrected trusted-runner path is available.
