### PR TITLE
fix(security): isolate PR security analyzer credentials

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,6 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
   actions: read
 
 jobs:
@@ -46,6 +45,9 @@ jobs:
     name: Security Scanning
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: read
+      actions: read
     
     steps:
       - name: Checkout code
@@ -53,11 +55,16 @@ jobs:
         with:
           # Fetch full history for gitleaks
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Setup Node + pnpm
-        uses: ./.github/actions/setup-node-pnpm
+      - name: Prepare pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'pnpm'
 
       - name: Install dependencies
         env:
@@ -200,7 +207,7 @@ jobs:
 
   codeql-analysis:
     needs: gate
-    if: ${{ needs.gate.outputs.run_security == 'true' }}
+    if: ${{ needs.gate.outputs.run_security == 'true' && github.event_name != 'pull_request' }}
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     # schedule は別トリガーで動く
@@ -218,6 +225,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -352,11 +361,17 @@ jobs:
     name: Container Security
     runs-on: ubuntu-latest
     needs: gate
-    if: ${{ needs.gate.outputs.run_security == 'true' }}
+    if: ${{ needs.gate.outputs.run_security == 'true' && github.event_name != 'pull_request' }}
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Detect container manifest
         id: container_manifest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Prepare pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -2,7 +2,7 @@
 docRole: derived
 canonicalSource:
   - .github/workflows/agent-commands.yml
-lastVerified: '2026-06-04'
+lastVerified: '2026-06-05'
 ---
 
 # Agent Commands Catalog

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -705,6 +705,61 @@ describe('workflow permission boundaries', () => {
     expect(commentSteps.filter((step: any) => step?.uses === 'actions/github-script@v7')).toHaveLength(1);
   });
 
+  it('security analyzer pull request runs stay read-only and isolate security-events writes', () => {
+    const security = parseWorkflow('security.yml');
+
+    expect(security.permissions).toMatchObject({
+      contents: 'read',
+      actions: 'read',
+    });
+    expect(security.permissions).not.toMatchObject({
+      'security-events': 'write',
+    });
+
+    const securityScanJob = security.jobs?.['security-scan'];
+    const securityScanSteps = Array.isArray(securityScanJob?.steps) ? securityScanJob.steps : [];
+    const securityScanCheckout = securityScanSteps.find((step: any) => step?.uses === 'actions/checkout@v4');
+
+    expect(securityScanJob?.permissions).toMatchObject({
+      contents: 'read',
+      actions: 'read',
+    });
+    expect(Object.values(securityScanJob?.permissions ?? {})).not.toContain('write');
+    expect(securityScanCheckout?.with).toMatchObject({
+      'persist-credentials': false,
+    });
+    expect(securityScanSteps.some((step: any) => String(step?.uses ?? '').startsWith('./'))).toBe(false);
+    expect(securityScanSteps.some((step: any) => String(step?.run ?? '').includes('pnpm run security:analyze')))
+      .toBe(true);
+
+    const codeqlJob = security.jobs?.['codeql-analysis'];
+    const codeqlSteps = Array.isArray(codeqlJob?.steps) ? codeqlJob.steps : [];
+    const codeqlCheckout = codeqlSteps.find((step: any) => step?.uses === 'actions/checkout@v4');
+    expect(codeqlJob?.if).toContain("github.event_name != 'pull_request'");
+    expect(codeqlJob?.permissions).toMatchObject({
+      contents: 'read',
+      actions: 'read',
+      'security-events': 'write',
+    });
+    expect(codeqlCheckout?.with).toMatchObject({
+      'persist-credentials': false,
+    });
+
+    const containerJob = security.jobs?.['container-security'];
+    const containerSteps = Array.isArray(containerJob?.steps) ? containerJob.steps : [];
+    const containerCheckout = containerSteps.find((step: any) => step?.uses === 'actions/checkout@v4');
+    expect(containerJob?.if).toContain("github.event_name != 'pull_request'");
+    expect(containerJob?.permissions).toMatchObject({
+      contents: 'read',
+      actions: 'read',
+      'security-events': 'write',
+    });
+    expect(containerCheckout?.with).toMatchObject({
+      'persist-credentials': false,
+    });
+    expect(containerSteps.some((step: any) => step?.uses === 'github/codeql-action/upload-sarif@v3')).toBe(true);
+  });
+
   it('dependency-track SBOM upload validates allowlisted HTTPS destinations before API-key use', () => {
     const sbom = parseWorkflow('sbom-generation.yml');
     const sbomSteps = sbom.jobs?.['sbom-publication']?.steps ?? [];

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -716,24 +716,16 @@ describe('workflow permission boundaries', () => {
       'security-events': 'write',
     });
 
-    const securityScanJob = security.jobs?.['security-scan'];
-    const securityScanSteps = Array.isArray(securityScanJob?.steps) ? securityScanJob.steps : [];
-    const securityScanCheckout = securityScanSteps.find((step: any) => step?.uses === 'actions/checkout@v4');
+    const securityScanSteps = jobSteps(security, 'security-scan');
 
-    expect(securityScanJob?.permissions).toMatchObject({
-      contents: 'read',
-      actions: 'read',
-    });
-    expect(Object.values(securityScanJob?.permissions ?? {})).not.toContain('write');
-    expect(securityScanCheckout?.with).toMatchObject({
-      'persist-credentials': false,
-    });
+    expectReadOnlyJobPermissions(security, 'security-scan');
+    expectCheckoutCredentialsDisabled(securityScanSteps);
     expect(securityScanSteps.some((step: any) => String(step?.uses ?? '').startsWith('./'))).toBe(false);
     expect(securityScanSteps.some((step: any) => String(step?.run ?? '').includes('pnpm run security:analyze')))
       .toBe(true);
 
     const codeqlJob = security.jobs?.['codeql-analysis'];
-    const codeqlSteps = Array.isArray(codeqlJob?.steps) ? codeqlJob.steps : [];
+    const codeqlSteps = jobSteps(security, 'codeql-analysis');
     const codeqlCheckout = codeqlSteps.find((step: any) => step?.uses === 'actions/checkout@v4');
     expect(codeqlJob?.if).toContain("github.event_name != 'pull_request'");
     expect(codeqlJob?.permissions).toMatchObject({
@@ -746,7 +738,7 @@ describe('workflow permission boundaries', () => {
     });
 
     const containerJob = security.jobs?.['container-security'];
-    const containerSteps = Array.isArray(containerJob?.steps) ? containerJob.steps : [];
+    const containerSteps = jobSteps(security, 'container-security');
     const containerCheckout = containerSteps.find((step: any) => step?.uses === 'actions/checkout@v4');
     expect(containerJob?.if).toContain("github.event_name != 'pull_request'");
     expect(containerJob?.permissions).toMatchObject({


### PR DESCRIPTION
## Summary

- Remove top-level `security-events: write` from `security.yml` so PR-triggered analyzer jobs inherit read-only credentials.
- Make `security-scan` explicitly read-only, disable persisted checkout credentials, and avoid PR-controlled local setup actions in the analyzer job.
- Restrict SARIF upload-capable CodeQL and container-security jobs to non-`pull_request` events while keeping their `security-events: write` permissions job-local.
- Add workflow permission-boundary regression coverage for PR security analyzer isolation.

## Acceptance

- Closes #3422.
- `security-scan` can still run on eligible non-fork PRs with `run-security`, but only with `contents: read` / `actions: read`.
- PR checkout credentials are not persisted in `security-scan`.
- `security-events: write` remains available only in dedicated non-PR CodeQL / container SARIF jobs.
- The analyzer job no longer executes checked-out local setup actions.

## Verification

- `/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint-bin .github/workflows/security.yml`
- `pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot` — 24 tests passed
- `pnpm -s exec eslint --quiet tests/unit/ci/workflow-permission-boundary.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `node scripts/ci/validate-json.mjs && pnpm -s run check:schemas && pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

- Revert this PR to restore prior `security.yml` permissions and PR CodeQL/container behavior.
- If rollback is required, keep `run-security` limited to trusted PRs until a replacement credential boundary is available.
