### PR TITLE
fix(security): publish formal aggregate from trusted workflow

### DIFF
--- a/.github/workflows/formal-aggregate-publisher.yml
+++ b/.github/workflows/formal-aggregate-publisher.yml
@@ -1,0 +1,195 @@
+name: Formal Aggregate Publisher
+
+on:
+  workflow_run:
+    workflows: ["Formal Verify"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "Formal Verify workflow run id containing formal-reports-aggregate"
+        required: true
+        type: string
+      pr_number:
+        description: "Pull request number to comment on"
+        required: true
+        type: string
+      pr_head_sha:
+        description: "Expected current pull request head SHA"
+        required: true
+        type: string
+
+concurrency:
+  group: formal-aggregate-publisher-${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.source_run_id || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  publish:
+    name: Publish Formal Reports Aggregate
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0].number != '')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve publish context
+        id: context
+        uses: actions/github-script@v7
+        env:
+          DISPATCH_SOURCE_RUN_ID: ${{ inputs.source_run_id || '' }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          DISPATCH_PR_HEAD_SHA: ${{ inputs.pr_head_sha || '' }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const eventName = context.eventName;
+            const payload = context.payload || {};
+            let sourceRunId = '';
+            let prNumber = '';
+            let expectedHeadSha = '';
+            let workflowHeadRepository = '';
+
+            if (eventName === 'workflow_run') {
+              const workflowRun = payload.workflow_run || {};
+              sourceRunId = String(workflowRun.id || '');
+              prNumber = String((workflowRun.pull_requests || [])[0]?.number || '');
+              expectedHeadSha = String(workflowRun.head_sha || '');
+              workflowHeadRepository = String(workflowRun.head_repository?.full_name || '');
+            } else {
+              sourceRunId = String(process.env.DISPATCH_SOURCE_RUN_ID || '');
+              prNumber = String(process.env.DISPATCH_PR_NUMBER || '');
+              expectedHeadSha = String(process.env.DISPATCH_PR_HEAD_SHA || '');
+            }
+
+            if (!/^\d+$/.test(sourceRunId) || !/^\d+$/.test(prNumber)) {
+              core.warning(`Invalid publish context: sourceRunId=${JSON.stringify(sourceRunId)} prNumber=${JSON.stringify(prNumber)}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
+              core.warning(`Invalid or missing PR head SHA for formal aggregate publication: ${JSON.stringify(expectedHeadSha)}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const issueNumber = Number(prNumber);
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: issueNumber });
+            if (workflowHeadRepository && workflowHeadRepository !== `${owner}/${repo}`) {
+              core.warning(`Skipping formal aggregate publication for non-repository head ${workflowHeadRepository}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head.sha !== expectedHeadSha) {
+              core.warning(`Skipping stale formal aggregate for PR #${issueNumber}: expected ${expectedHeadSha}, current ${pr.head.sha}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            if (eventName === 'workflow_run') {
+              const labels = new Set((pr.labels || []).map((label) => String(label.name || '')));
+              if (!labels.has('run-formal')) {
+                core.info(`PR #${issueNumber} no longer has run-formal; skipping formal aggregate publication.`);
+                core.setOutput('skip', 'true');
+                return;
+              }
+            }
+
+            core.setOutput('skip', 'false');
+            core.setOutput('source_run_id', sourceRunId);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('pr_head_sha', expectedHeadSha);
+
+      - name: Download formal aggregate artifact
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: formal-reports-aggregate
+          path: artifacts/formal
+          run-id: ${{ steps.context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Publish formal aggregate PR comment
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          PR_HEAD_SHA: ${{ steps.context.outputs.pr_head_sha }}
+          SOURCE_RUN_ID: ${{ steps.context.outputs.source_run_id }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER || 0);
+            const sourceRunId = String(process.env.SOURCE_RUN_ID || '');
+            const prHeadSha = String(process.env.PR_HEAD_SHA || '');
+            const FORMAL_AGGREGATE_MARKER = '<!-- AE-FORMAL-AGGREGATE -->';
+            const MAX_COMMENT_BYTES = 60000;
+            const aggregatePath = path.join('artifacts', 'formal', 'formal-aggregate.md');
+
+            if (!issue_number) {
+              core.info('PR number not provided; skipping comment.');
+              return;
+            }
+            if (!fs.existsSync(aggregatePath)) {
+              core.warning(`Formal aggregate markdown artifact not found at ${aggregatePath}; skipping comment.`);
+              return;
+            }
+
+            const sanitizeAggregateMarkdown = (value) => String(value || '')
+              .replace(/\u0000/g, '')
+              .replace(/\r\n/g, '\n')
+              .replace(/\r/g, '\n')
+              .replace(/&/g, '&amp;')
+              .replace(/@/g, '@\u200b')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;');
+            const truncateUtf8 = (text, maxBytes) => {
+              if (Buffer.byteLength(text, 'utf8') <= maxBytes) return text;
+              const suffix = '\n\n_Formal aggregate truncated to stay within the PR comment size limit._\n';
+              const available = Math.max(0, maxBytes - Buffer.byteLength(suffix, 'utf8'));
+              let used = 0;
+              let output = '';
+              for (const char of text) {
+                const size = Buffer.byteLength(char, 'utf8');
+                if (used + size > available) break;
+                output += char;
+                used += size;
+              }
+              return `${output}${suffix}`;
+            };
+            const listAllIssueComments = async () => {
+              const comments = [];
+              for (let page = 1; ; page += 1) {
+                const response = await github.rest.issues.listComments({
+                  owner,
+                  repo,
+                  issue_number,
+                  per_page: 100,
+                  page,
+                });
+                comments.push(...response.data);
+                if (response.data.length < 100) break;
+              }
+              return comments;
+            };
+            const isTrustedAutomationComment = (comment) => {
+              const login = String(comment.user?.login || '');
+              return (login === 'github-actions' || login === 'github-actions[bot]')
+                && String(comment.body || '').startsWith(FORMAL_AGGREGATE_MARKER);
+            };
+
+            const aggregateMarkdown = sanitizeAggregateMarkdown(fs.readFileSync(aggregatePath, 'utf8'));
+            const metadata = `<!-- AE-FORMAL-AGGREGATE-META source_run_id=${sourceRunId} pr_head_sha=${prHeadSha} -->`;
+            const body = truncateUtf8(`${FORMAL_AGGREGATE_MARKER}\n${metadata}\n\n${aggregateMarkdown}`, MAX_COMMENT_BYTES);
+            const comments = await listAllIssueComments();
+            const existing = [...comments].reverse().find(isTrustedAutomationComment);
+            if (existing && existing.body === body) {
+              core.info('Aggregate unchanged; skipping update');
+            } else if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -7,10 +7,6 @@ on:
         description: "Workflow run id to download artifacts from"
         required: false
         type: string
-      pr_number:
-        description: "Pull request number to comment on"
-        required: false
-        type: string
       strict_formal_summary_v1:
         description: "Fail the workflow if Formal Summary v1 is missing/invalid"
         required: false
@@ -22,31 +18,31 @@ on:
         description: "Workflow run id to download artifacts from"
         required: false
         type: string
-      pr_number:
-        description: "Pull request number to comment on"
-        required: false
-        type: string
       strict_formal_summary_v1:
         description: "Fail the workflow if Formal Summary v1 is missing/invalid"
         required: false
         type: boolean
         default: false
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.pr_number || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.source_run_id || github.run_id }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   actions: read
-  issues: write
 
 jobs:
   aggregate:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     continue-on-error: ${{ inputs.strict_formal_summary_v1 != true }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
         with:
@@ -112,28 +108,7 @@ jobs:
         if: always()
         run: |
           node scripts/formal/validate-conformance-summary.mjs || true
-      - name: Comment on PR (upsert)
-        if: (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch') && inputs.pr_number != ''
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const header = '<!-- AE-FORMAL-AGGREGATE -->\n';
-            const body = header + fs.readFileSync('artifacts/formal/formal-aggregate.md','utf-8');
-            const { owner, repo } = context.repo;
-            const issue_number = Number(process.env.PR_NUMBER || 0);
-            if (!issue_number) {
-              core.info('PR number not provided; skipping comment.');
-              return;
-            }
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
-            const mine = comments.data.find(c => c.body && c.body.startsWith('<!-- AE-FORMAL-AGGREGATE -->'));
-            if (mine && mine.body === body) {
-              core.info('Aggregate unchanged; skipping update');
-            } else if (mine) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
-        env:
-          PR_NUMBER: ${{ inputs.pr_number }}
+      # PR comment publication is intentionally handled by
+      # formal-aggregate-publisher.yml from trusted workflow_run or manual
+      # workflow_dispatch code. Keep this reusable aggregation workflow read-only
+      # because workflow_call executions can originate from pull_request runs.

--- a/.github/workflows/formal-verify.yml
+++ b/.github/workflows/formal-verify.yml
@@ -531,8 +531,6 @@ jobs:
     permissions:
       contents: read
       actions: read
-      issues: write
     with:
       source_run_id: ${{ github.run_id }}
-      pr_number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
       strict_formal_summary_v1: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'enforce-formal') }}

--- a/docs/architecture/CURRENT-SYSTEM-OVERVIEW.md
+++ b/docs/architecture/CURRENT-SYSTEM-OVERVIEW.md
@@ -106,7 +106,7 @@ Design implications:
 | Auto-merge lane | `pr-ci-status-comment.yml` | Enables auto-merge when conditions are satisfied |
 | Trace conformance | `spec-generate-model.yml` | Emits `KvOnce Trace Validation` and related trace evidence |
 | Formal verification (opt-in) | `formal-verify.yml` | Heavy verification on `run-formal` label or workflow dispatch |
-| Formal aggregation | `formal-aggregate.yml` | Aggregates formal outputs for PR-facing summaries |
+| Formal aggregation | `formal-aggregate.yml` | Aggregates formal outputs; PR comments are published by trusted `formal-aggregate-publisher.yml` |
 | Security | `security.yml`, `sbom-generation.yml` | Dependency, vulnerability, and SBOM operations |
 | Release verification | `post-deploy-verify.yml` | Workflow-dispatch post-deploy verification with preserved evidence |
 
@@ -335,7 +335,7 @@ Primary implementation sources:
 | 自動マージ（auto-merge） | `pr-ci-status-comment.yml` | 条件成立時に auto-merge を自動有効化し、人手マージを省略（任意） |
 | トレース適合性 | `spec-generate-model.yml` | KvOnce trace conformance と `KvOnce Trace Validation` check を出力 |
 | 形式検証（opt-in） | `formal-verify.yml` | `run-formal` ラベル/dispatchで重い検証を実行 |
-| 形式集約 | `formal-aggregate.yml` | formal出力をPRコメント向けに集約 |
+| 形式集約 | `formal-aggregate.yml` | formal出力を集約し、PRコメント投稿は trusted `formal-aggregate-publisher.yml` が担当 |
 | セキュリティ | `security.yml`, `sbom-generation.yml` | 依存・脆弱性・SBOM運用 |
 | リリース検証 | `post-deploy-verify.yml` | workflow_dispatch 起点の post-deploy verify と証跡保存 |
 

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -86,7 +86,7 @@ CI Extended restores cached heavy test artifacts (`.cache/test-results`) when re
     - `/run-security-dispatch` … sbom-generation（Security/SBOM）を実行
     - `/ci-fast-dispatch` … CI Fast を実行（バッチ系は対応ラベル付与時のみ稼働）
     - `/formal-verify-dispatch` … Formal Verify を実行（`run-formal` との併用推奨）
-    - `/formal-aggregate-dispatch` … Formal Reports Aggregate を実行（`run-formal` 併用時に集約コメントを生成）
+    - `/formal-aggregate-dispatch` … Formal Reports Aggregate のartifact生成を実行（PRコメント投稿は trusted `formal-aggregate-publisher.yml` が担当）
     - `/run-flake-dispatch` … flake-detect を実行
     - `/spec-validation-dispatch` … spec-validation を実行
   - 手動実行（Actions UI）

--- a/tests/formal/aggregate-formal-reports.test.ts
+++ b/tests/formal/aggregate-formal-reports.test.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+const writeJson = (filePath: string, value: unknown) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+describe('aggregate-formal-reports', () => {
+  it('escapes untrusted formal artifact fields before writing PR-facing markdown', () => {
+    const repoRoot = process.cwd();
+    const tmpRoot = path.join(repoRoot, '.codex-local', 'tmp');
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    const workdir = fs.mkdtempSync(path.join(tmpRoot, 'formal-aggregate-'));
+
+    try {
+      writeJson(path.join(workdir, 'artifacts_dl', 'formal-reports-csp', 'csp-summary.json'), {
+        status: '<script>@formal-reviewers</script>',
+        backend: '`fdr` <unsafe>',
+        resultStatus: '@team passed <maybe>',
+        exitCode: 0,
+      });
+      writeJson(path.join(workdir, 'artifacts_dl', 'formal-reports-apalache', 'apalache-summary.json'), {
+        version: '1.0.0',
+        ok: false,
+        ran: true,
+        status: '@ops <failed>',
+        errors: ['<counterexample>@ops should not ping reviewers</counterexample>'],
+      });
+
+      const result = spawnSync(
+        process.execPath,
+        [path.join(repoRoot, 'scripts', 'formal', 'aggregate-formal-reports.mjs')],
+        {
+          cwd: workdir,
+          env: {
+            ...process.env,
+            FORMAL_AGG_LINE_CLAMP: '120',
+            FORMAL_AGG_ERRORS_LIMIT: '1',
+          },
+          encoding: 'utf8',
+        },
+      );
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      const markdown = fs.readFileSync(
+        path.join(workdir, 'artifacts', 'formal', 'formal-aggregate.md'),
+        'utf8',
+      );
+      const escapedFormalMention = '@\u200bformal-reviewers';
+      const escapedOpsMention = '@\u200bops';
+
+      expect(markdown).toContain('&lt;script&gt;');
+      expect(markdown).toContain(escapedFormalMention);
+      expect(markdown).toContain(escapedOpsMention);
+      expect(markdown).not.toContain('<script>');
+      expect(markdown).not.toContain('@formal-reviewers');
+      expect(markdown).not.toContain('@ops should not ping');
+    } finally {
+      fs.rmSync(workdir, { recursive: true, force: true });
+      try {
+        if (fs.existsSync(tmpRoot) && fs.readdirSync(tmpRoot).length === 0) {
+          fs.rmdirSync(tmpRoot);
+        }
+      } catch {
+        // Best-effort cleanup only; test assertions above are authoritative.
+      }
+    }
+  });
+});

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -752,6 +752,56 @@ describe('workflow permission boundaries', () => {
     expect(containerSteps.some((step: any) => step?.uses === 'github/codeql-action/upload-sarif@v3')).toBe(true);
   });
 
+  it('formal aggregate publishes PR comments from a separate trusted workflow-run publisher', () => {
+    const aggregate = parseWorkflow('formal-aggregate.yml');
+    const aggregateRaw = readWorkflow('formal-aggregate.yml');
+    const verifyRaw = readWorkflow('formal-verify.yml');
+    const verifyAggregate = extractJobBlock(verifyRaw, 'formal-aggregate');
+    const publisher = parseWorkflow('formal-aggregate-publisher.yml');
+    const publisherRaw = readWorkflow('formal-aggregate-publisher.yml');
+    const publisherJob = extractJobBlock(publisherRaw, 'publish');
+    const aggregateSteps = jobSteps(aggregate, 'aggregate');
+
+    expect(workflowPermission(aggregate, 'issues')).toBeUndefined();
+    expect(aggregate.on?.workflow_dispatch?.inputs?.pr_number).toBeUndefined();
+    expect(aggregateRaw).not.toContain('Pull request number to comment on');
+    expectReadOnlyJobPermissions(aggregate, 'aggregate');
+    expectCheckoutCredentialsDisabled(aggregateSteps);
+    expect(aggregateRaw).not.toContain('github.rest.issues');
+    expect(aggregateRaw).not.toContain('issues.createComment');
+    expect(aggregateRaw).not.toContain('issues.updateComment');
+    expect(verifyAggregate).toContain('uses: ./.github/workflows/formal-aggregate.yml');
+    expect(verifyAggregate).not.toContain('issues: write');
+
+    expect(publisher.on?.workflow_run?.workflows).toContain('Formal Verify');
+    expect(publisher.permissions).toMatchObject({
+      actions: 'read',
+      issues: 'write',
+      'pull-requests': 'read',
+    });
+    expect(jobSteps(publisher, 'publish').some((step) => step?.uses === 'actions/checkout@v4')).toBe(false);
+    expect(jobSteps(publisher, 'publish').some((step) => String(step?.uses ?? '').startsWith('./'))).toBe(false);
+    expect(publisher.on?.workflow_dispatch?.inputs?.pr_head_sha?.required).toBe(true);
+    expect(publisherJob).toContain("workflowRun.head_sha");
+    expect(publisherJob).toContain('/^[0-9a-f]{40}$/i.test(expectedHeadSha)');
+    expect(publisherJob).toContain('Invalid or missing PR head SHA');
+    expect(publisherJob).toContain('workflowHeadRepository !== `${owner}/${repo}`');
+    expect(publisherJob).toContain('pr.head.sha !== expectedHeadSha');
+    expect(publisherJob).not.toContain('expectedHeadSha || pr.head.sha');
+    expect(publisherJob).toContain("labels.has('run-formal')");
+    expect(publisherJob).toContain('actions/download-artifact@v4');
+    expect(publisherJob).toContain('run-id: ${{ steps.context.outputs.source_run_id }}');
+    expect(publisherJob).toContain('FORMAL_AGGREGATE_MARKER');
+    expect(publisherJob).toContain('MAX_COMMENT_BYTES');
+    expect(publisherJob).toContain('sanitizeAggregateMarkdown');
+    expect(publisherJob).toContain(".replace(/&/g, '&amp;')");
+    expect(publisherJob).toContain('truncateUtf8');
+    expect(publisherJob).toContain('listAllIssueComments');
+    expect(publisherJob).toContain('isTrustedAutomationComment');
+    expect(publisherJob).toContain("login === 'github-actions' || login === 'github-actions[bot]'");
+    expect(publisherJob).toContain('startsWith(FORMAL_AGGREGATE_MARKER)');
+  });
+
   it('dependency-track SBOM upload validates allowlisted HTTPS destinations before API-key use', () => {
     const sbom = parseWorkflow('sbom-generation.yml');
     const sbomSteps = sbom.jobs?.['sbom-publication']?.steps ?? [];


### PR DESCRIPTION
## Summary

Closes #3420.

This PR separates Formal Reports Aggregate generation from PR comment publication:

- keeps `.github/workflows/formal-aggregate.yml` read-only and removes direct `issues: write` PR comment publication from the reusable aggregate workflow;
- removes `issues: write` from the `formal-verify.yml` reusable workflow call path;
- adds `.github/workflows/formal-aggregate-publisher.yml`, a trusted `workflow_run` / explicit manual publisher that downloads the aggregate artifact from the Formal Verify run and publishes the PR comment without checkout or local script execution;
- validates PR number, source run id, same-repository head, current PR head SHA, and `run-formal` label before workflow-run publication;
- sanitizes untrusted aggregate Markdown and applies a PR comment byte cap before upserting the bot-authored formal aggregate comment;
- adds workflow permission-boundary and formal aggregate escaping regression tests.

## Acceptance

- [x] Formal aggregate generation no longer shares `issues: write` with checkout and repository-local script execution.
- [x] PR comment publication runs in a separate publisher workflow with no checkout and no local `./...` action usage.
- [x] Workflow-run publication is bound to the source run, PR number, same-repository head, current head SHA, and `run-formal` label.
- [x] Aggregate Markdown copied into PR comments is treated as untrusted: mentions and angle brackets are neutralized and the comment is capped by byte length.
- [x] Regression coverage fails if the read/write boundary regresses.

## Verification

- `actionlint-bin .github/workflows/formal-aggregate.yml .github/workflows/formal-verify.yml .github/workflows/formal-aggregate-publisher.yml`
- `pnpm -s exec vitest run tests/unit/ci/workflow-permission-boundary.test.ts tests/formal/aggregate-formal-reports.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet tests/unit/ci/workflow-permission-boundary.test.ts tests/formal/aggregate-formal-reports.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

Revert this PR to restore the previous direct formal aggregate comment publication path. If rolled back, PR aggregate comments again share the reusable aggregate workflow permission boundary, so rollback should be paired with temporary suspension of PR-triggered `run-formal` publication or an alternative trusted publisher.
