### PR TITLE
fix(quality): constrain reconcile auto-fix paths

### DIFF
--- a/src/cegis/auto-fix-engine.ts
+++ b/src/cegis/auto-fix-engine.ts
@@ -5,6 +5,11 @@
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import {
+  resolveWorkspacePath,
+  toWorkspaceRelativePath,
+  WorkspacePathPolicyError,
+} from '../utils/workspace-path-policy.js';
 import type {
   FailureArtifact,
   FixStrategy,
@@ -25,6 +30,11 @@ import { TestFailureFixStrategy } from './strategies/test-failure-strategy.js';
 import { ContractViolationFixStrategy } from './strategies/contract-violation-strategy.js';
 
 const DEFAULT_CEGIS_REPORT_DIR = path.join('temp-reports', 'cegis');
+
+interface ResolvedAutoFixPath {
+  resolvedPath: string;
+  workspaceRelativePath: string;
+}
 
 export class AutoFixEngine {
   private strategies: Map<FailureCategory, FixStrategy[]> = new Map();
@@ -52,6 +62,7 @@ export class AutoFixEngine {
       timeoutMs: 30000,
       backupFiles: true,
       generateReport: true,
+      workspaceRoot: process.cwd(),
       ...config
     };
 
@@ -68,12 +79,18 @@ export class AutoFixEngine {
   ): Promise<FixResult> {
     const startTime = Date.now();
     const effectiveConfig: AutoFixConfig & AutoFixOptions = { ...this.config, ...options };
+    if (effectiveConfig.workspaceRoot !== undefined) {
+      effectiveConfig.workspaceRoot = path.resolve(effectiveConfig.workspaceRoot);
+    }
     
     console.log(`🔧 Starting auto-fix process for ${failures.length} failures...`);
     
     try {
       // 1. Filter and validate failures
-      const validFailures = this.filterValidFailures(failures, effectiveConfig);
+      const validFailures = this.constrainFailurePaths(
+        this.filterValidFailures(failures, effectiveConfig),
+        effectiveConfig
+      );
       console.log(`📋 Processing ${validFailures.length} valid failures`);
       
       // 2. Analyze failure patterns
@@ -108,7 +125,7 @@ export class AutoFixEngine {
           skippedFixes,
           summary,
           recommendations,
-          effectiveConfig.outputDir
+          effectiveConfig
         );
       }
       
@@ -229,6 +246,64 @@ export class AutoFixEngine {
       }
       
       return true;
+    });
+  }
+
+  private shouldEnforceWorkspacePathPolicy(config: AutoFixConfig): boolean {
+    return !config.dryRun && !!config.workspaceRoot?.trim();
+  }
+
+  private resolveAutoFixWorkspacePath(
+    filePath: string,
+    config: AutoFixConfig,
+    label: string
+  ): ResolvedAutoFixPath {
+    if (!this.shouldEnforceWorkspacePathPolicy(config)) {
+      return {
+        resolvedPath: filePath,
+        workspaceRelativePath: filePath,
+      };
+    }
+
+    const workspaceRoot = path.resolve(config.workspaceRoot!);
+    const resolvedPath = resolveWorkspacePath(filePath, {
+      workspaceRoot,
+      label,
+    });
+    return {
+      resolvedPath,
+      workspaceRelativePath: toWorkspaceRelativePath(resolvedPath, {
+        workspaceRoot,
+        label,
+      }),
+    };
+  }
+
+  private constrainFailurePaths(
+    failures: FailureArtifact[],
+    config: AutoFixConfig
+  ): FailureArtifact[] {
+    if (!this.shouldEnforceWorkspacePathPolicy(config)) {
+      return failures;
+    }
+
+    return failures.map((failure) => {
+      if (!failure.location?.filePath) {
+        return failure;
+      }
+
+      const resolved = this.resolveAutoFixWorkspacePath(
+        failure.location.filePath,
+        config,
+        `failure artifact location for ${failure.id}`
+      );
+      return {
+        ...failure,
+        location: {
+          ...failure.location,
+          filePath: resolved.workspaceRelativePath,
+        },
+      };
     });
   }
 
@@ -353,27 +428,52 @@ export class AutoFixEngine {
     
     for (const failure of failures) {
       // Skip if file already processed
-      if (failure.location?.filePath && processedFiles.has(failure.location.filePath)) {
-        warnings.push(`File already processed: ${failure.location.filePath}`);
+      const failureFileKey = failure.location?.filePath
+        ? this.resolveAutoFixWorkspacePath(
+            failure.location.filePath,
+            config,
+            `failure artifact location for ${failure.id}`
+          ).workspaceRelativePath
+        : undefined;
+      if (failureFileKey && processedFiles.has(failureFileKey)) {
+        warnings.push(`File already processed: ${failureFileKey}`);
         continue;
       }
       
       const actions = await strategy.generateFix(failure);
-      allActions.push(...actions);
       
       for (const action of actions) {
         try {
+          let recordAction = action;
+          let resolvedActionPath: ResolvedAutoFixPath | undefined;
+          if (action.filePath) {
+            resolvedActionPath = this.resolveAutoFixWorkspacePath(
+              action.filePath,
+              config,
+              `auto-fix action target for ${strategy.name}`
+            );
+            recordAction = {
+              ...action,
+              filePath: resolvedActionPath.workspaceRelativePath,
+            };
+          }
+          allActions.push(recordAction);
+
           if (action.filePath && !config.dryRun) {
+            if (!resolvedActionPath) {
+              throw new WorkspacePathPolicyError(`auto-fix action target for ${strategy.name} is missing`);
+            }
+
             // Backup file if requested
             if (config.backupFiles) {
-              await this.backupFile(action.filePath);
+              await this.backupFile(resolvedActionPath.resolvedPath);
             }
             
             // Apply the fix
-            await this.applyAction(action);
+            await this.applyAction(action, resolvedActionPath.resolvedPath);
             
-            if (action.filePath && !filesModified.includes(action.filePath)) {
-              filesModified.push(action.filePath);
+            if (!filesModified.includes(resolvedActionPath.workspaceRelativePath)) {
+              filesModified.push(resolvedActionPath.workspaceRelativePath);
             }
           }
         } catch (error) {
@@ -400,10 +500,9 @@ export class AutoFixEngine {
     };
   }
 
-  private async applyAction(action: RepairAction): Promise<void> {
+  private async applyAction(action: RepairAction, resolvedFilePath: string): Promise<void> {
     if (action.type === 'code_change' && action.codeChange && action.filePath) {
-      const fs = await import('fs');
-      const content = await fs.promises.readFile(action.filePath, 'utf-8');
+      const content = await fs.readFile(resolvedFilePath, 'utf-8');
       const lines = content.split('\n');
       
       // Replace the specified lines
@@ -412,17 +511,15 @@ export class AutoFixEngine {
       
       lines.splice(startIdx, endIdx - startIdx, action.codeChange.newCode);
       
-      await fs.promises.writeFile(action.filePath, lines.join('\n'));
+      await fs.writeFile(resolvedFilePath, lines.join('\n'));
     }
     
     // Handle other action types as needed
   }
 
   private async backupFile(filePath: string): Promise<void> {
-    const fs = await import('fs');
-
     const backupPath = `${filePath}.backup.${Date.now()}`;
-    await fs.promises.copyFile(filePath, backupPath);
+    await fs.copyFile(filePath, backupPath);
   }
 
   private groupByCategory(failures: FailureArtifact[]): Map<FailureCategory, FailureArtifact[]> {
@@ -541,12 +638,17 @@ export class AutoFixEngine {
     skippedFixes: SkippedFix[],
     summary: FixResult['summary'],
     recommendations: string[],
-    outputDir?: string
+    config: AutoFixConfig & AutoFixOptions
   ): Promise<string> {
-    const configuredDir = outputDir?.trim() || process.env['AE_CEGIS_REPORT_DIR']?.trim();
-    const reportDir = configuredDir && configuredDir.length > 0
+    const configuredDir = config.outputDir?.trim() || process.env['AE_CEGIS_REPORT_DIR']?.trim();
+    const rawReportDir = configuredDir && configuredDir.length > 0
       ? configuredDir
       : DEFAULT_CEGIS_REPORT_DIR;
+    const reportDir = this.resolveAutoFixWorkspacePath(
+      rawReportDir,
+      config,
+      'auto-fix report output directory'
+    ).resolvedPath;
     const reportPath = path.join(reportDir, `cegis-report-${Date.now()}.json`);
     
     const report = {

--- a/src/cegis/types.ts
+++ b/src/cegis/types.ts
@@ -180,6 +180,7 @@ export interface AutoFixConfig {
   timeoutMs: number;
   backupFiles: boolean;
   generateReport: boolean;
+  workspaceRoot?: string;
 }
 
 // Fix execution result
@@ -224,6 +225,7 @@ export interface AutoFixOptions {
   timeoutMs?: number;
   maxIterations?: number;
   outputDir?: string;
+  workspaceRoot?: string;
 }
 
 // Pattern analysis result

--- a/src/cli/quality-cli.ts
+++ b/src/cli/quality-cli.ts
@@ -12,8 +12,11 @@ import { QualityGateRunner, type QualityGateExecutionOptions } from '../quality/
 import {
   createQualityPathContext,
   getDefaultQualityReportDir,
+  isQualityCiContext,
   isQualityAgentContext,
   QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+  resolveQualityWorkspacePath,
+  type QualityPathContext,
 } from '../quality/quality-command-policy.js';
 import { AutoFixEngine } from '../cegis/auto-fix-engine.js';
 import type { FailureArtifact as EngineFailureArtifact, FailureCategory as EngineFailureCategory } from '../cegis/types.js';
@@ -92,7 +95,31 @@ const normalizePhase = (phase?: string): 'intent' | 'formal' | 'test' | 'code' |
   return allowed.includes(phase as (typeof allowed)[number]) ? (phase as (typeof allowed)[number]) : undefined;
 };
 
-const convertLegacyFailureArtifact = (legacy: LegacyFailureArtifact): EngineFailureArtifact => {
+const constrainEngineFailureArtifactPath = (
+  failure: EngineFailureArtifact,
+  pathContext: QualityPathContext
+): EngineFailureArtifact => {
+  if (!failure.location?.filePath) {
+    return failure;
+  }
+  const resolved = resolveQualityWorkspacePath(
+    failure.location.filePath,
+    pathContext,
+    `failure artifact location for ${failure.id}`
+  );
+  return {
+    ...failure,
+    location: {
+      ...failure.location,
+      filePath: resolved.workspaceRelativePath,
+    },
+  };
+};
+
+const convertLegacyFailureArtifact = (
+  legacy: LegacyFailureArtifact,
+  pathContext: QualityPathContext
+): EngineFailureArtifact => {
   const now = new Date().toISOString();
   const createdAt = legacy.createdAt ?? legacy.context.timestamp ?? now;
   const updatedAt = legacy.updatedAt ?? legacy.context.timestamp ?? createdAt;
@@ -112,7 +139,7 @@ const convertLegacyFailureArtifact = (legacy: LegacyFailureArtifact): EngineFail
       }
     : undefined;
 
-  return EngineFailureArtifactSchema.parse({
+  return constrainEngineFailureArtifactPath(EngineFailureArtifactSchema.parse({
     id: legacy.id,
     title: legacy.title,
     description: legacy.description,
@@ -144,28 +171,49 @@ const convertLegacyFailureArtifact = (legacy: LegacyFailureArtifact): EngineFail
       tags: legacy.tags ?? [],
       source: legacy.context.component ?? 'failure-artifact-schema',
     },
-  });
+  }), pathContext);
 };
 
-const normalizeFailureArtifact = (item: unknown): EngineFailureArtifact => {
-  try {
-    return EngineFailureArtifactSchema.parse(item);
-  } catch {
-    const legacy = validateFailureArtifact(item);
-    return convertLegacyFailureArtifact(legacy);
+const normalizeFailureArtifact = (
+  item: unknown,
+  pathContext: QualityPathContext
+): EngineFailureArtifact => {
+  const parsed = EngineFailureArtifactSchema.safeParse(item);
+  if (parsed.success) {
+    return constrainEngineFailureArtifactPath(parsed.data, pathContext);
   }
+  const legacy = validateFailureArtifact(item);
+  return convertLegacyFailureArtifact(legacy, pathContext);
 };
 
-const loadFailureArtifacts = (inputPath?: string): EngineFailureArtifact[] => {
-  let resolvedPath = inputPath;
-  if (!resolvedPath) {
+const loadFailureArtifacts = (
+  inputPath: string | undefined,
+  pathContext: QualityPathContext
+): EngineFailureArtifact[] => {
+  let artifactPath: string | undefined;
+  let resolvedPath: string | undefined;
+  if (!inputPath) {
     for (const tryPath of COMMON_FAILURE_PATHS) {
-      if (fs.existsSync(tryPath)) {
-        resolvedPath = tryPath;
-        console.log(chalk.gray(`📁 Found failure artifacts at: ${tryPath}`));
+      const candidate = resolveQualityWorkspacePath(
+        tryPath,
+        pathContext,
+        'failure artifact input file'
+      );
+      if (fs.existsSync(candidate.resolvedPath)) {
+        artifactPath = candidate.workspaceRelativePath;
+        resolvedPath = candidate.resolvedPath;
+        console.log(chalk.gray(`📁 Found failure artifacts at: ${candidate.workspaceRelativePath}`));
         break;
       }
     }
+  } else {
+    const resolved = resolveQualityWorkspacePath(
+      inputPath,
+      pathContext,
+      'failure artifact input file'
+    );
+    artifactPath = resolved.workspaceRelativePath;
+    resolvedPath = resolved.resolvedPath;
   }
 
   if (!resolvedPath) {
@@ -176,18 +224,18 @@ const loadFailureArtifacts = (inputPath?: string): EngineFailureArtifact[] => {
   }
 
   if (!fs.existsSync(resolvedPath)) {
-    throw new Error(`Input file not found: ${resolvedPath}`);
+    throw new Error(`Input file not found: ${artifactPath ?? inputPath ?? resolvedPath}`);
   }
 
   const data = JSON.parse(fs.readFileSync(resolvedPath, 'utf8')) as unknown;
   if (Array.isArray(data)) {
-    return data.map((item) => normalizeFailureArtifact(item));
+    return data.map((item) => normalizeFailureArtifact(item, pathContext));
   }
   if (data && typeof data === 'object' && 'failures' in data) {
     const legacyCollection = validateFailureArtifactCollection(data as LegacyFailureArtifactCollection);
-    return legacyCollection.failures.map((failure) => convertLegacyFailureArtifact(failure));
+    return legacyCollection.failures.map((failure) => convertLegacyFailureArtifact(failure, pathContext));
   }
-  return [normalizeFailureArtifact(data)];
+  return [normalizeFailureArtifact(data, pathContext)];
 };
 
 type QualityOutputFormat = 'text' | 'json';
@@ -209,12 +257,15 @@ const normalizeQualityOutputFormat = (rawFormat: string | undefined): QualityOut
 
 const getDefaultQualityOutputDir = (): string => getDefaultQualityReportDir(createQualityPathContext());
 
-const getQualityExecutionPolicy = (options: { dryRun?: boolean; apply?: boolean; approvalScope?: string }): QualityExecutionPolicy => {
-  const agentContext = isQualityAgentContext();
+const getQualityExecutionPolicy = (
+  options: { dryRun?: boolean; apply?: boolean; approvalScope?: string },
+  policyOptions: { protectCi?: boolean } = {}
+): QualityExecutionPolicy => {
+  const guardedAutomationContext = isQualityAgentContext() || (policyOptions.protectCi === true && isQualityCiContext());
   const apply = options.apply === true;
   const approvalScope = options.approvalScope;
-  const dryRun = options.dryRun === true || (agentContext && !apply);
-  const approvalRequired = agentContext && apply && approvalScope !== QUALITY_GATE_EXECUTION_APPROVAL_SCOPE;
+  const dryRun = options.dryRun === true || (guardedAutomationContext && !apply);
+  const approvalRequired = guardedAutomationContext && apply && approvalScope !== QUALITY_GATE_EXECUTION_APPROVAL_SCOPE;
   const policy: QualityExecutionPolicy = {
     dryRun,
     apply,
@@ -354,13 +405,19 @@ export function createQualityCommand(): Command {
 
       const printJson = outputFormat === 'json';
       try {
-        const executionPolicy = getQualityExecutionPolicy(options);
+        const executionPolicy = getQualityExecutionPolicy(options, { protectCi: true });
         if (executionPolicy.approvalRequired) {
-          console.error(chalk.red(`❌ Quality gate execution requires --approval-scope ${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE} when --apply is used in an agent context`));
+          console.error(chalk.red(`❌ Quality reconciliation requires --approval-scope ${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE} when --apply is used in an agent or CI context`));
           safeExit(1);
           return;
         }
 
+        const pathContext = createQualityPathContext();
+        const fixOutput = resolveQualityWorkspacePath(
+          options.fixOutput,
+          pathContext,
+          'auto-fix output directory'
+        );
         const maxRounds = Math.max(1, parseInt(options.maxRounds, 10) || 1);
         const runner = new QualityGateRunner();
         let lastReport: Awaited<ReturnType<QualityGateRunner['executeGates']>> | null = null;
@@ -430,7 +487,7 @@ export function createQualityCommand(): Command {
 
           let failures: EngineFailureArtifact[];
           try {
-            failures = loadFailureArtifacts(options.fixInput);
+            failures = loadFailureArtifacts(options.fixInput, pathContext);
           } catch (error) {
             console.error(chalk.red('\n❌ Unable to load failure artifacts for auto-fix.'));
             if (!printJson) {
@@ -443,9 +500,10 @@ export function createQualityCommand(): Command {
 
           const engine = new AutoFixEngine();
           const fixResult = await engine.executeFixes(failures, {
-            outputDir: options.fixOutput,
+            outputDir: fixOutput.workspaceRelativePath,
             maxIterations: parseInt(options.fixIterations, 10) || 10,
             confidenceThreshold: parseFloat(options.fixConfidence) || 0.7,
+            workspaceRoot: pathContext.workspaceRoot,
           });
 
           const appliedFixCount = fixResult.appliedFixes?.length ?? 0;

--- a/src/quality/quality-command-policy.ts
+++ b/src/quality/quality-command-policy.ts
@@ -215,8 +215,35 @@ export function resolveQualityReportOutputDir(
   };
 }
 
+export function resolveQualityWorkspacePath(
+  input: string,
+  context: QualityPathContext,
+  label = 'quality workspace path'
+): ResolvedQualityPath {
+  const resolvedPath = resolveWorkspacePath(input, {
+    workspaceRoot: context.workspaceRoot,
+    label,
+  });
+
+  return {
+    resolvedPath,
+    workspaceRelativePath: toWorkspaceRelativePath(resolvedPath, {
+      workspaceRoot: context.workspaceRoot,
+      label,
+    }),
+  };
+}
+
+const isTruthyFlag = (value: string | undefined): boolean => {
+  if (!value) return false;
+  return ['1', 'true', 'yes', 'y'].includes(value.trim().toLowerCase());
+};
+
 export function isQualityAgentContext(): boolean {
   const raw = process.env['AE_QUALITY_AGENT_CONTEXT'] ?? process.env['AE_AGENT_CONTEXT'];
-  if (!raw) return false;
-  return ['1', 'true', 'yes', 'y'].includes(raw.trim().toLowerCase());
+  return isTruthyFlag(raw);
+}
+
+export function isQualityCiContext(): boolean {
+  return isTruthyFlag(process.env['CI']);
 }

--- a/tests/cegis/auto-fix-engine.test.ts
+++ b/tests/cegis/auto-fix-engine.test.ts
@@ -178,6 +178,76 @@ describe('AutoFixEngine', () => {
       expect(result).toBeDefined();
       expect(result.summary.success).toBeDefined();
     });
+
+    it('should reject non-dry-run artifact paths outside the workspace before strategies run', async () => {
+      const constrainedEngine = new AutoFixEngine({
+        generateReport: false,
+        backupFiles: false,
+        confidenceThreshold: 0.1,
+        maxRiskLevel: 5,
+        workspaceRoot: process.cwd()
+      });
+      const problematicFailure = FailureArtifactFactory.fromTypeError(
+        "Cannot find name 'outsideValue'",
+        '../outside.ts',
+        1,
+        1,
+        'const value = outsideValue;'
+      );
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        await expect(constrainedEngine.executeFixes([problematicFailure], {
+          dryRun: false
+        })).rejects.toThrow('dot-segment path components');
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    });
+
+    it('should reject generated repair actions outside the workspace before file writes', async () => {
+      const constrainedEngine = new AutoFixEngine({
+        generateReport: false,
+        backupFiles: false,
+        confidenceThreshold: 0.1,
+        maxRiskLevel: 5,
+        workspaceRoot: process.cwd()
+      });
+      constrainedEngine.addStrategy({
+        name: 'Unsafe Runtime Strategy',
+        category: 'runtime_error',
+        confidence: 1,
+        riskLevel: 1,
+        description: 'Returns an unsafe target path',
+        canApply: vi.fn().mockResolvedValue(true),
+        generateFix: vi.fn().mockResolvedValue([{
+          type: 'code_change',
+          description: 'Unsafe write',
+          confidence: 1,
+          riskLevel: 1,
+          estimatedEffort: 'low',
+          filePath: '../outside.ts',
+          codeChange: {
+            oldCode: '',
+            newCode: 'unsafe',
+            startLine: 1,
+            endLine: 1
+          },
+          dependencies: [],
+          prerequisites: []
+        }])
+      });
+
+      const result = await constrainedEngine.executeFixes(
+        [FailureArtifactFactory.fromError(new Error('Runtime failure'))],
+        { dryRun: false }
+      );
+
+      expect(result.summary.filesModified).toBe(0);
+      expect(result.summary.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining('dot-segment path components')])
+      );
+    });
   });
 
   describe('strategy management', () => {

--- a/tests/cli/quality-cli.test.ts
+++ b/tests/cli/quality-cli.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const safeExitMock = vi.fn();
@@ -51,6 +53,52 @@ const createReport = (overrides: Partial<Record<string, unknown>> = {}) => ({
   },
   ...overrides,
 });
+
+const createBlockingReport = () => createReport({
+  overallScore: 70,
+  passedGates: 0,
+  failedGates: 1,
+  summary: {
+    byCategory: {},
+    executionTime: 1000,
+    blockers: ['coverage'],
+  },
+});
+
+const createLegacyFailure = (file: string) => ({
+  id: '00000000-0000-4000-8000-000000000001',
+  title: 'Type error',
+  description: "Cannot find name 'missingValue'",
+  severity: 'major',
+  category: 'type_error',
+  location: {
+    file,
+    line: 1,
+    column: 1,
+  },
+  context: {
+    environment: 'development',
+    phase: 'code',
+    timestamp: '2026-06-05T00:00:00.000Z',
+    component: 'quality-reconcile-test',
+  },
+  evidence: {
+    logs: [],
+  },
+  createdAt: '2026-06-05T00:00:00.000Z',
+  updatedAt: '2026-06-05T00:00:00.000Z',
+  tags: [],
+  status: 'open',
+  schemaVersion: '1.0.0',
+});
+
+const writeFailureInput = (testRoot: string, file: string): string => {
+  const relativePath = path.posix.join(testRoot, 'failures.json');
+  const absolutePath = path.join(process.cwd(), relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, JSON.stringify([createLegacyFailure(file)], null, 2), 'utf8');
+  return relativePath;
+};
 
 const findJsonPayload = (calls: Array<[unknown, ...unknown[]]>): Record<string, unknown> => {
   for (const call of calls) {
@@ -229,5 +277,161 @@ describe('quality CLI format option', () => {
     expect(payload['failedGates']).toBe(1);
     expect(safeExitMock).toHaveBeenCalledWith(1);
     consoleLogSpy.mockRestore();
+  });
+
+  it('reconcile defaults CI automation to dry-run and skips auto-fix without explicit apply', async () => {
+    const previousCi = process.env['CI'];
+    process.env['CI'] = 'true';
+    executeGatesMock.mockResolvedValueOnce(createBlockingReport());
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const command = createQualityCommand();
+      await command.parseAsync([
+        'node',
+        'cli',
+        'reconcile',
+        '--format',
+        'json',
+        '--max-rounds',
+        '2',
+      ]);
+
+      expect(executeGatesMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dryRun: true,
+          apply: false,
+        }),
+      );
+      expect(executeFixesMock).not.toHaveBeenCalled();
+      expect(safeExitMock).toHaveBeenCalledWith(1);
+    } finally {
+      consoleLogSpy.mockRestore();
+      if (previousCi === undefined) {
+        delete process.env['CI'];
+      } else {
+        process.env['CI'] = previousCi;
+      }
+    }
+  });
+
+  it('reconcile rejects CI --apply without trusted approval before running gates', async () => {
+    const previousCi = process.env['CI'];
+    process.env['CI'] = 'true';
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const command = createQualityCommand();
+      await command.parseAsync(['node', 'cli', 'reconcile', '--apply']);
+
+      expect(executeGatesMock).not.toHaveBeenCalled();
+      expect(executeFixesMock).not.toHaveBeenCalled();
+      expect(safeExitMock).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('agent or CI context')
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      if (previousCi === undefined) {
+        delete process.env['CI'];
+      } else {
+        process.env['CI'] = previousCi;
+      }
+    }
+  });
+
+  it('reconcile rejects artifact-derived traversal paths before invoking auto-fix', async () => {
+    const testRoot = ['artifacts', 'quality', `quality-cli-invalid-${Date.now()}-${Math.random().toString(16).slice(2)}`].join('/');
+    const inputPath = writeFailureInput(testRoot, '../outside.ts');
+    executeGatesMock.mockResolvedValueOnce(createBlockingReport());
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const command = createQualityCommand();
+      await command.parseAsync([
+        'node',
+        'cli',
+        'reconcile',
+        '--apply',
+        '--approval-scope',
+        'quality-gate-execution',
+        '--max-rounds',
+        '2',
+        '--fix-input',
+        inputPath,
+        '--fix-output',
+        path.posix.join(testRoot, 'auto-fix'),
+      ]);
+
+      expect(executeFixesMock).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unable to load failure artifacts')
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dot-segment path components')
+      );
+      expect(safeExitMock).toHaveBeenCalledWith(1);
+    } finally {
+      consoleLogSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+      rmSync(path.join(process.cwd(), testRoot), { recursive: true, force: true });
+    }
+  });
+
+  it('reconcile passes normalized workspace-relative artifact paths and workspace root to auto-fix', async () => {
+    const testRoot = ['artifacts', 'quality', `quality-cli-valid-${Date.now()}-${Math.random().toString(16).slice(2)}`].join('/');
+    const targetPath = 'src/cli/quality-cli.ts';
+    const inputPath = writeFailureInput(testRoot, targetPath);
+    executeGatesMock.mockResolvedValueOnce(createBlockingReport());
+    executeFixesMock.mockResolvedValueOnce({
+      appliedFixes: [],
+      skippedFixes: [],
+      summary: {
+        totalFailures: 1,
+        fixesApplied: 0,
+        fixesSkipped: 0,
+        filesModified: 0,
+        success: true,
+        errors: [],
+        warnings: [],
+      },
+      recommendations: [],
+      success: false,
+      appliedActions: [],
+      generatedFiles: [],
+      backupFiles: [],
+      errors: [],
+    });
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const command = createQualityCommand();
+      await command.parseAsync([
+        'node',
+        'cli',
+        'reconcile',
+        '--apply',
+        '--approval-scope',
+        'quality-gate-execution',
+        '--max-rounds',
+        '2',
+        '--fix-input',
+        inputPath,
+        '--fix-output',
+        path.posix.join(testRoot, 'auto-fix'),
+      ]);
+
+      expect(executeFixesMock).toHaveBeenCalledTimes(1);
+      const [failures, options] = executeFixesMock.mock.calls[0] as [Array<{ location?: { filePath?: string } }>, Record<string, unknown>];
+      expect(failures[0]?.location?.filePath).toBe(targetPath);
+      expect(options).toEqual(expect.objectContaining({
+        outputDir: path.posix.join(testRoot, 'auto-fix'),
+        workspaceRoot: process.cwd(),
+      }));
+    } finally {
+      consoleLogSpy.mockRestore();
+      rmSync(path.join(process.cwd(), testRoot), { recursive: true, force: true });
+    }
   });
 });

--- a/tests/quality/quality-command-policy.test.ts
+++ b/tests/quality/quality-command-policy.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, existsSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
 import { QualityPolicyLoader } from '../../src/quality/policy-loader.js';
@@ -8,7 +8,9 @@ import { QualityGateRunner } from '../../src/quality/quality-gate-runner.js';
 import {
   QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
   resolveQualityReportOutputDir,
+  resolveQualityWorkspacePath,
   createQualityPathContext,
+  isQualityCiContext,
 } from '../../src/quality/quality-command-policy.js';
 
 class FakeChildProcess extends EventEmitter {
@@ -127,6 +129,7 @@ describe('quality gate command policy', () => {
   let policyPath: string;
   let previousQualityAgentContext: string | undefined;
   let previousAgentContext: string | undefined;
+  let previousCiContext: string | undefined;
 
   const writePolicy = (
     command = 'node scripts/quality/check-lint-summary.mjs',
@@ -153,8 +156,10 @@ describe('quality gate command policy', () => {
     testRoot = ['artifacts', 'quality', `unit-${Date.now()}-${Math.random().toString(16).slice(2)}`].join('/');
     previousQualityAgentContext = process.env['AE_QUALITY_AGENT_CONTEXT'];
     previousAgentContext = process.env['AE_AGENT_CONTEXT'];
+    previousCiContext = process.env['CI'];
     delete process.env['AE_QUALITY_AGENT_CONTEXT'];
     delete process.env['AE_AGENT_CONTEXT'];
+    delete process.env['CI'];
   });
 
   afterEach(() => {
@@ -167,6 +172,11 @@ describe('quality gate command policy', () => {
       delete process.env['AE_AGENT_CONTEXT'];
     } else {
       process.env['AE_AGENT_CONTEXT'] = previousAgentContext;
+    }
+    if (previousCiContext === undefined) {
+      delete process.env['CI'];
+    } else {
+      process.env['CI'] = previousCiContext;
     }
     rmSync(join(process.cwd(), testRoot), { recursive: true, force: true });
   });
@@ -317,5 +327,46 @@ describe('quality gate command policy', () => {
     expect(() => resolveQualityReportOutputDir('/tmp/quality-gates', context)).toThrow(
       'relative to the approved quality artifact root'
     );
+  });
+
+  it('constrains quality workspace paths to relative non-traversing paths', () => {
+    const context = createQualityPathContext();
+
+    expect(resolveQualityWorkspacePath('src/index.ts', context, 'auto-fix target')).toMatchObject({
+      workspaceRelativePath: 'src/index.ts',
+    });
+    expect(() => resolveQualityWorkspacePath('/tmp/outside.ts', context, 'auto-fix target')).toThrow(
+      'relative to the approved workspace'
+    );
+    expect(() => resolveQualityWorkspacePath('../outside.ts', context, 'auto-fix target')).toThrow(
+      'dot-segment path components'
+    );
+    expect(() => resolveQualityWorkspacePath('.git/config', context, 'auto-fix target')).toThrow(
+      'Git metadata'
+    );
+  });
+
+  it('rejects quality workspace paths that escape through symlinks', () => {
+    const root = join(process.cwd(), testRoot, 'workspace');
+    const outside = join(process.cwd(), testRoot, 'outside');
+    mkdirSync(root, { recursive: true });
+    mkdirSync(outside, { recursive: true });
+    try {
+      symlinkSync(outside, join(root, 'escape'), 'dir');
+    } catch {
+      return;
+    }
+
+    const context = createQualityPathContext({ workspaceRoot: root });
+
+    expect(() => resolveQualityWorkspacePath('escape/file.ts', context, 'auto-fix target')).toThrow(
+      'outside the approved workspace'
+    );
+  });
+
+  it('detects CI automation context without changing agent-context detection', () => {
+    expect(isQualityCiContext()).toBe(false);
+    process.env['CI'] = 'true';
+    expect(isQualityCiContext()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Constrain `ae quality reconcile` failure-artifact input, auto-fix output, and artifact-derived target paths to the approved workspace.
- Normalize legacy and engine failure artifact locations before passing them to `AutoFixEngine`.
- Add non-dry-run workspace path enforcement inside `AutoFixEngine` before generated actions can read, back up, or write files.
- Default `quality reconcile` in CI automation to dry-run unless `--apply --approval-scope quality-gate-execution` is provided.

Closes #3426.

## Acceptance

- [x] Artifact-derived target paths reject absolute paths, `..` traversal, Git metadata paths, and symlink escapes under the quality workspace path policy.
- [x] `quality reconcile` passes only workspace-relative target paths to auto-fix and supplies the approved workspace root.
- [x] CI/agent reconciliation defaults to dry-run and requires the trusted approval scope before apply.
- [x] Auto-fix engine rejects unsafe non-dry-run failure/action target paths before filesystem sinks.

## Verification

- `pnpm -s exec vitest run tests/quality/quality-command-policy.test.ts tests/cli/quality-cli.test.ts tests/cegis/auto-fix-engine.test.ts --reporter dot`
- `pnpm -s run types:check`
- `pnpm -s exec eslint --quiet src/quality/quality-command-policy.ts src/cli/quality-cli.ts src/cegis/auto-fix-engine.ts src/cegis/types.ts tests/quality/quality-command-policy.test.ts tests/cli/quality-cli.test.ts tests/cegis/auto-fix-engine.test.ts`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

Revert this PR to restore the previous quality reconciliation and auto-fix path handling. If rollback is needed, keep `quality reconcile` in dry-run mode for AI/CI-driven contexts until a replacement path policy is in place.
