### PR TITLE
fix(codegen): constrain generated code artifacts

### DIFF
--- a/docs/getting-started/QUICK-START-GUIDE.md
+++ b/docs/getting-started/QUICK-START-GUIDE.md
@@ -333,7 +333,10 @@ pnpm run start:server
 
 # Generate minimal API tests from OpenAPI (prefer operationId in names)
 pnpm run codex:generate:tests -- --use-operation-id
-# Files are written under tests/api/generated/
+# Files are written under artifacts/codex/generated-tests/ for review.
+# To intentionally promote into the active test tree after review:
+# CODEX_GENERATE_TESTS_APPROVAL=reviewed-generated-tests \
+#   pnpm run codex:generate:tests -- --use-operation-id --output-dir tests/api/generated --approve-generated-tests
 ```
 
 #### Scenario 2: Legacy System Partial Modernization

--- a/docs/integrations/CODEX-INTEGRATION.md
+++ b/docs/integrations/CODEX-INTEGRATION.md
@@ -211,9 +211,11 @@ Flow suggestion:
 - CI integration and PR summary details are described in `docs/verify/FORMAL-CHECKS.md` and `docs/verify/TRACEABILITY-GUIDE.md`.
 
 ### OpenAPI Test Generator
-- Script: `pnpm run codex:generate:tests [-- --use-operation-id] [--with-input]`
+- Script: `pnpm run codex:generate:tests [-- --use-operation-id] [--with-input] [--output-dir <dir>]`
 - Reads `artifacts/codex/openapi.(json|yaml)` (or `CONTRACTS_OPENAPI_PATH`).
-- Generates minimal tests under `tests/api/generated/` using:
+- Generates minimal tests under `artifacts/codex/generated-tests/` by default so generated executable tests are review artifacts before they enter the active test tree.
+- Writing directly under `tests/` requires both `--approve-generated-tests` and `CODEX_GENERATE_TESTS_APPROVAL=reviewed-generated-tests`.
+- Uses:
   - OperationId in file/test names when `--use-operation-id` is provided
   - Minimal sample input from requestBody schema when `--with-input` is provided
 
@@ -369,7 +371,8 @@ set CODEX_RUN_FORMAL=1 && pnpm run build && pnpm run codex:quickstart
 - `docs/verify/RUNTIME-CONTRACTS.md` 参照
 
 ### OpenAPI テストジェネレーター
-- `pnpm run codex:generate:tests` で `tests/api/generated/` に最小テンプレートを生成
+- `pnpm run codex:generate:tests` で `artifacts/codex/generated-tests/` にレビュー用の最小テンプレートを生成
+- `tests/` 配下へ直接書く場合は `--output-dir tests/api/generated --approve-generated-tests` と `CODEX_GENERATE_TESTS_APPROVAL=reviewed-generated-tests` を併用
 - `--use-operation-id` / `--with-input` で命名/最小入力を調整
 
 ### Codegen オプション（OpenAPI）

--- a/scripts/codex/generate-openapi-tests.ts
+++ b/scripts/codex/generate-openapi-tests.ts
@@ -3,6 +3,7 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import yaml from 'yaml'
+import { resolveWorkspacePath } from '../../src/utils/workspace-path-policy.js'
 
 const DEFAULT_REVIEW_OUTPUT_DIR = 'artifacts/codex/generated-tests'
 const REVIEWED_TEST_OUTPUT_APPROVAL = 'reviewed-generated-tests'
@@ -43,7 +44,12 @@ function normalizeWorkspacePath(repo: string, inputPath: string, label: string):
   if (segments.some((segment) => segment.toLowerCase() === '.git')) {
     throw new Error(`${label} must not target Git metadata directories`)
   }
-  return { absolutePath, relativePath: segments.join('/') }
+  const safeRelativePath = segments.join('/')
+  const realpathCheckedPath = resolveWorkspacePath(safeRelativePath, {
+    workspaceRoot: repo,
+    label,
+  })
+  return { absolutePath: realpathCheckedPath, relativePath: safeRelativePath }
 }
 
 function getArgValue(name: string): string | undefined {
@@ -76,7 +82,7 @@ async function main() {
   const withInput = process.argv.includes('--with-input') || process.argv.includes('--sample')
   const requestedOutputDir = getArgValue('--output-dir') || process.env.CODEX_GENERATE_TESTS_OUTPUT_DIR || DEFAULT_REVIEW_OUTPUT_DIR
   const outputDir = normalizeWorkspacePath(repo, requestedOutputDir, 'generated test output directory')
-  if (outputDir.relativePath.startsWith('tests/') && !hasReviewedTestsApproval()) {
+  if ((outputDir.relativePath === 'tests' || outputDir.relativePath.startsWith('tests/')) && !hasReviewedTestsApproval()) {
     throw new Error(
       `Writing generated tests under tests/ requires --approve-generated-tests and CODEX_GENERATE_TESTS_APPROVAL=${REVIEWED_TEST_OUTPUT_APPROVAL}`
     )

--- a/scripts/codex/generate-openapi-tests.ts
+++ b/scripts/codex/generate-openapi-tests.ts
@@ -4,21 +4,87 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import yaml from 'yaml'
 
+const DEFAULT_REVIEW_OUTPUT_DIR = 'artifacts/codex/generated-tests'
+const REVIEWED_TEST_OUTPUT_APPROVAL = 'reviewed-generated-tests'
+
 async function exists(p: string) {
   try { await fs.stat(p); return true } catch { return false }
+}
+
+function isPathWithin(baseDir: string, candidatePath: string): boolean {
+  const relative = path.relative(baseDir, candidatePath)
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+function normalizeWorkspacePath(repo: string, inputPath: string, label: string): { absolutePath: string; relativePath: string } {
+  const raw = String(inputPath).trim()
+  if (!raw) throw new Error(`${label} must be non-empty`)
+  if (raw.includes('\0')) throw new Error(`${label} must not contain NUL bytes`)
+  if (raw.includes('\\')) throw new Error(`${label} must use POSIX-style '/' separators`)
+  if (/^[A-Za-z]:[\\/]/.test(raw)) throw new Error(`${label} must be inside the approved workspace`)
+  const rawSegments = raw.split('/').filter(Boolean)
+  if (rawSegments.some((segment) => segment === '.' || segment === '..')) {
+    throw new Error(`${label} must not contain dot-segment path components`)
+  }
+  if (rawSegments.some((segment) => segment.toLowerCase() === '.git')) {
+    throw new Error(`${label} must not target Git metadata directories`)
+  }
+
+  const absolutePath = path.isAbsolute(raw) ? path.resolve(raw) : path.resolve(repo, raw)
+  if (!isPathWithin(repo, absolutePath)) {
+    throw new Error(`${label} must stay inside the approved workspace`)
+  }
+  const relativePath = path.relative(repo, absolutePath).replace(/\\/g, '/')
+  const segments = relativePath.split('/').filter(Boolean)
+  if (segments.length === 0) throw new Error(`${label} must not target the workspace root`)
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new Error(`${label} must not contain dot-segment path components`)
+  }
+  if (segments.some((segment) => segment.toLowerCase() === '.git')) {
+    throw new Error(`${label} must not target Git metadata directories`)
+  }
+  return { absolutePath, relativePath: segments.join('/') }
+}
+
+function getArgValue(name: string): string | undefined {
+  const inline = process.argv.find((arg) => arg.startsWith(`${name}=`))
+  if (inline) return inline.slice(name.length + 1)
+  const index = process.argv.indexOf(name)
+  if (index < 0) return undefined
+  const value = process.argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${name} requires a value`)
+  }
+  return value
+}
+
+function hasReviewedTestsApproval(): boolean {
+  return process.argv.includes('--approve-generated-tests') &&
+    process.env.CODEX_GENERATE_TESTS_APPROVAL === REVIEWED_TEST_OUTPUT_APPROVAL
 }
 
 async function main() {
   const repo = process.cwd()
   const defaultYaml = path.join(repo, 'artifacts', 'codex', 'openapi.yaml')
   const defaultJson = path.join(repo, 'artifacts', 'codex', 'openapi.json')
-  const openapiPath = process.env.CONTRACTS_OPENAPI_PATH || (await exists(defaultJson) ? defaultJson : defaultYaml)
+  const openapiPath = normalizeWorkspacePath(
+    repo,
+    process.env.CONTRACTS_OPENAPI_PATH || (await exists(defaultJson) ? defaultJson : defaultYaml),
+    'OpenAPI input path',
+  )
   const useOpId = process.argv.includes('--use-operation-id') || process.argv.includes('--opid')
   const withInput = process.argv.includes('--with-input') || process.argv.includes('--sample')
+  const requestedOutputDir = getArgValue('--output-dir') || process.env.CODEX_GENERATE_TESTS_OUTPUT_DIR || DEFAULT_REVIEW_OUTPUT_DIR
+  const outputDir = normalizeWorkspacePath(repo, requestedOutputDir, 'generated test output directory')
+  if (outputDir.relativePath.startsWith('tests/') && !hasReviewedTestsApproval()) {
+    throw new Error(
+      `Writing generated tests under tests/ requires --approve-generated-tests and CODEX_GENERATE_TESTS_APPROVAL=${REVIEWED_TEST_OUTPUT_APPROVAL}`
+    )
+  }
 
-  const specTxt = await fs.readFile(openapiPath, 'utf8')
+  const specTxt = await fs.readFile(openapiPath.absolutePath, 'utf8')
   let jsonSpecStr: string
-  if (openapiPath.endsWith('.json')) {
+  if (openapiPath.relativePath.endsWith('.json')) {
     // Normalize JSON string
     jsonSpecStr = JSON.stringify(JSON.parse(specTxt))
   } else {
@@ -30,16 +96,22 @@ async function main() {
   // Lazy import to avoid build step
   const { CodeGenerationAgent } = await import(path.join(repo, 'src', 'agents', 'code-generation-agent.ts'))
   const agent = new (CodeGenerationAgent as any)()
-  const files = await agent.generateTestsFromOpenAPI(jsonSpecStr, { useOperationIdForTestNames: useOpId, includeSampleInput: withInput })
+  const files = await agent.generateTestsFromOpenAPI(jsonSpecStr, {
+    useOperationIdForTestNames: useOpId,
+    includeSampleInput: withInput,
+    outputRoot: outputDir.relativePath,
+  })
 
-  const outDir = path.join(repo, 'tests', 'api', 'generated')
-  await fs.mkdir(outDir, { recursive: true })
   for (const f of files) {
-    const abs = path.join(repo, f.path)
+    const safeFile = normalizeWorkspacePath(repo, f.path, 'generated test file path')
+    if (safeFile.relativePath !== outputDir.relativePath && !safeFile.relativePath.startsWith(`${outputDir.relativePath}/`)) {
+      throw new Error(`generated test file path escaped output directory: ${f.path}`)
+    }
+    const abs = safeFile.absolutePath
     await fs.mkdir(path.dirname(abs), { recursive: true })
     await fs.writeFile(abs, f.content, 'utf8')
   }
-  console.log(`Generated ${files.length} test files under tests/api/generated/ (useOperationId=${useOpId}, includeSampleInput=${withInput})`)
+  console.log(`Generated ${files.length} test files under ${outputDir.relativePath}/ (useOperationId=${useOpId}, includeSampleInput=${withInput})`)
 }
 
 main().catch((e) => { console.error('generate-openapi-tests failed:', e); process.exit(1) })

--- a/src/agents/code-generation-agent.ts
+++ b/src/agents/code-generation-agent.ts
@@ -49,6 +49,11 @@ import {
   getTestExtension,
 } from './code-generation-language.js';
 
+const toRelativeImportSpecifier = (fromDirectory: string, targetModule: string): string => {
+  const relative = path.posix.relative(fromDirectory, targetModule);
+  return relative.startsWith('.') ? relative : `./${relative}`;
+};
+
 export type {
   CodeGenerationRequest,
   TestFile,
@@ -158,6 +163,9 @@ export class CodeGenerationAgent {
         ? toSafeFileSlug(opIdRaw, 'operation')
         : `${safeName}-${method}`;
       const routeImport = toSafeFileSlug(fileBase, 'route');
+      const generatedPath = buildSafeRelativePath(outputRoot, `${fileBase}.spec.ts`, 'generated OpenAPI test path');
+      const routeModulePath = buildSafeRelativePath('src/routes', routeImport, 'generated route import path');
+      const routeImportSpecifier = toRelativeImportSpecifier(path.posix.dirname(generatedPath), routeModulePath);
       const titleLiteral = toTsStringLiteral(title);
       const operationComment = toSafeLineCommentText(opIdRaw);
       // Try to derive minimal input from requestBody schema when requested
@@ -174,9 +182,9 @@ export class CodeGenerationAgent {
         }
         sample = buildSampleLiteral(schema, ep?.components || {});
       }
-      const content = `import { describe, it, expect } from 'vitest'\nimport { handler } from '../../src/routes/${routeImport}'\n\n// OperationId: ${operationComment}\ndescribe(${titleLiteral}, () => {\n  it('returns success on minimal input (skeleton)', async () => {\n    const res: any = await handler(${sample})\n    expect(typeof res.status).toBe('number')\n  })\n})\n`;
+      const content = `import { describe, it, expect } from 'vitest'\nimport { handler } from '${routeImportSpecifier}'\n\n// OperationId: ${operationComment}\ndescribe(${titleLiteral}, () => {\n  it('returns success on minimal input (skeleton)', async () => {\n    const res: any = await handler(${sample})\n    expect(typeof res.status).toBe('number')\n  })\n})\n`;
       out.push({
-        path: buildSafeRelativePath(outputRoot, `${fileBase}.spec.ts`, 'generated OpenAPI test path'),
+        path: generatedPath,
         content,
         purpose: `Test for ${toSafeLineCommentText(title)}`,
         tests: [],

--- a/src/agents/code-generation-agent.ts
+++ b/src/agents/code-generation-agent.ts
@@ -26,6 +26,13 @@ import type {
 } from './code-generation-agent.types.js';
 import type { OpenApiGenerationOptions } from './code-generation-openapi.js';
 import {
+  buildSafeRelativePath,
+  toSafeFileSlug,
+  toSafeIdentifier,
+  toSafeLineCommentText,
+  toTsStringLiteral,
+} from './code-generation-safety.js';
+import {
   buildSampleLiteral,
   generateAuthMiddleware,
   generateModel,
@@ -135,17 +142,24 @@ export class CodeGenerationAgent {
   /**
    * Optionally generate minimal test skeletons from OpenAPI using operationId or path+method.
    */
-  async generateTestsFromOpenAPI(spec: string, options?: { useOperationIdForTestNames?: boolean; includeSampleInput?: boolean }): Promise<CodeFile[]> {
+  async generateTestsFromOpenAPI(
+    spec: string,
+    options?: { useOperationIdForTestNames?: boolean; includeSampleInput?: boolean; outputRoot?: string }
+  ): Promise<CodeFile[]> {
     const api = parseOpenAPI(spec);
     const out: CodeFile[] = [];
+    const outputRoot = options?.outputRoot ?? 'artifacts/codex/generated-tests';
     for (const ep of api.endpoints) {
       const opIdRaw = (ep?.definition as any)?.operationId as string | undefined;
       const title = options?.useOperationIdForTestNames && opIdRaw ? opIdRaw : `${ep.method} ${ep.path}`;
-      const safeName = String(ep.path).replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+      const safeName = toSafeFileSlug(String(ep.path), 'route');
       const method = String(ep.method).toLowerCase();
       const fileBase = (options?.useOperationIdForTestNames && opIdRaw)
-        ? opIdRaw.replace(/[^a-zA-Z0-9]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').toLowerCase()
+        ? toSafeFileSlug(opIdRaw, 'operation')
         : `${safeName}-${method}`;
+      const routeImport = toSafeFileSlug(fileBase, 'route');
+      const titleLiteral = toTsStringLiteral(title);
+      const operationComment = toSafeLineCommentText(opIdRaw);
       // Try to derive minimal input from requestBody schema when requested
       let sample = '{}';
       if (options?.includeSampleInput) {
@@ -160,8 +174,13 @@ export class CodeGenerationAgent {
         }
         sample = buildSampleLiteral(schema, ep?.components || {});
       }
-      const content = `import { describe, it, expect } from 'vitest'\nimport { handler } from '../../src/routes/${fileBase}'\n\n// OperationId: ${opIdRaw ?? 'N/A'}\ndescribe('${title}', () => {\n  it('returns success on minimal input (skeleton)', async () => {\n    const res: any = await handler(${sample})\n    expect(typeof res.status).toBe('number')\n  })\n})\n`;
-      out.push({ path: `tests/api/generated/${fileBase}.spec.ts`, content, purpose: `Test for ${title}`, tests: [] });
+      const content = `import { describe, it, expect } from 'vitest'\nimport { handler } from '../../src/routes/${routeImport}'\n\n// OperationId: ${operationComment}\ndescribe(${titleLiteral}, () => {\n  it('returns success on minimal input (skeleton)', async () => {\n    const res: any = await handler(${sample})\n    expect(typeof res.status).toBe('number')\n  })\n})\n`;
+      out.push({
+        path: buildSafeRelativePath(outputRoot, `${fileBase}.spec.ts`, 'generated OpenAPI test path'),
+        content,
+        purpose: `Test for ${toSafeLineCommentText(title)}`,
+        tests: [],
+      });
     }
     return out;
   }
@@ -419,11 +438,11 @@ export class CodeGenerationAgent {
     for (const test of tests) {
       // Extract function names being tested
       const funcMatches = test.content.match(/describe\s*\(['"]([^'"]+)/g) || [];
-      functions.push(...funcMatches.map(m => m.replace(/describe\s*\(['"]/, '')));
+      functions.push(...funcMatches.map(m => toSafeIdentifier(m.replace(/describe\s*\(['"]/, ''), 'generatedFunction')));
       
       // Extract expected behaviors
       const itMatches = test.content.match(/it\s*\(['"]([^'"]+)/g) || [];
-      expectedBehaviors.push(...itMatches.map(m => m.replace(/it\s*\(['"]/, '')));
+      expectedBehaviors.push(...itMatches.map(m => toSafeLineCommentText(m.replace(/it\s*\(['"]/, ''))));
     }
     
     return { functions, classes, expectedBehaviors };
@@ -466,11 +485,22 @@ export class CodeGenerationAgent {
       const fileExtension = getFileExtension(request.language);
       const testExtension = getTestExtension(request.language);
       
+      const implementationPath = buildSafeRelativePath(
+        getSourceDirectory(request.language),
+        `${toSafeFileSlug(func, 'generated')}.${fileExtension}`,
+        'generated implementation path'
+      );
+      const testPath = buildSafeRelativePath(
+        getTestDirectory(request.language),
+        `${toSafeFileSlug(func, 'generated')}.${testExtension}`,
+        'generated test reference path'
+      );
+
       files.push({
-        path: `${getSourceDirectory(request.language)}/${func}.${fileExtension}`,
+        path: implementationPath,
         content: implementation,
         purpose: `Implementation of ${func}`,
-        tests: [`${getTestDirectory(request.language)}/${func}.${testExtension}`],
+        tests: [testPath],
       });
     }
     

--- a/src/agents/code-generation-openapi.ts
+++ b/src/agents/code-generation-openapi.ts
@@ -1,4 +1,10 @@
 import type { CodeFile } from './code-generation-agent.types.js';
+import {
+  buildSafeRelativePath,
+  toSafeFileSlug,
+  toSafeLineCommentText,
+  toSafePascalIdentifier,
+} from './code-generation-safety.js';
 
 export interface OpenApiEndpoint {
   path: string;
@@ -102,13 +108,7 @@ function pickErrorStatus(codes: number[], kind: 'client' | 'server'): number {
   return fivexx[0] ?? 500;
 }
 
-function toPascalCase(input: string): string {
-  return input
-    .split('-')
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join('');
-}
+const OPENAPI_HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace']);
 
 export function parseOpenAPI(spec: string): ParsedOpenApiDocument {
   try {
@@ -121,9 +121,13 @@ export function parseOpenAPI(spec: string): ParsedOpenApiDocument {
     for (const [path, methodsRaw] of Object.entries(paths)) {
       const methods = asRecord(methodsRaw);
       for (const [method, definitionRaw] of Object.entries(methods)) {
+        const normalizedMethod = method.toLowerCase();
+        if (!OPENAPI_HTTP_METHODS.has(normalizedMethod)) {
+          continue;
+        }
         endpoints.push({
           path,
-          method,
+          method: normalizedMethod,
           definition: asRecord(definitionRaw),
           components,
         });
@@ -278,35 +282,34 @@ export function generateRouteHandler(
   endpoint: OpenApiEndpoint,
   options: Pick<OpenApiGenerationOptions, 'includeContracts' | 'useOperationIdForFilenames'>,
 ): CodeFile {
-  const safePathName = String(endpoint.path)
-    .replace(/[^a-zA-Z0-9]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-  const method = String(endpoint.method || 'get').toLowerCase();
+  const safePathName = toSafeFileSlug(endpoint.path, 'route');
+  const method = OPENAPI_HTTP_METHODS.has(String(endpoint.method).toLowerCase())
+    ? String(endpoint.method).toLowerCase()
+    : 'get';
   const operationId = typeof endpoint.definition['operationId'] === 'string'
     ? endpoint.definition['operationId']
     : undefined;
   const operationIdSafe = operationId
-    ? operationId
-      .replace(/[^a-zA-Z0-9]+/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-|-$/g, '')
+    ? toSafeFileSlug(operationId, '')
     : '';
   const fileSafe = options.useOperationIdForFilenames && operationIdSafe
-    ? operationIdSafe.toLowerCase()
+    ? operationIdSafe
     : `${safePathName}-${method}`;
-  const contractBase = operationIdSafe
-    ? toPascalCase(operationIdSafe)
-    : `${toPascalCase(safePathName)}${method.charAt(0).toUpperCase()}${method.slice(1)}`;
+  const contractBase = toSafePascalIdentifier(
+    operationId ?? `${safePathName}-${method}`,
+    'GeneratedRoute'
+  );
+  const routeComment = toSafeLineCommentText(`${method.toUpperCase()} ${endpoint.path}`);
+  const operationComment = toSafeLineCommentText(operationId);
 
-  const base = `// Route handler implementation for ${endpoint.method} ${endpoint.path}\n`;
+  const base = `// Route handler implementation for ${routeComment}\n`;
   let content = base;
 
   if (options.includeContracts) {
     content += `import { z } from 'zod';\n`;
     content += `import { ${contractBase}Input, ${contractBase}Output } from '../contracts/schemas';\n`;
     content += `import { pre, post } from '../contracts/conditions';\n`;
-    content += `\n// OperationId: ${operationId ?? 'N/A'}\n`;
+    content += `\n// OperationId: ${operationComment}\n`;
     content += `export async function handler(input: unknown): Promise<unknown> {\n`;
     content += `  try {\n`;
     content += `    // Validate input and pre-condition (skeleton)\n`;
@@ -339,18 +342,22 @@ export function generateRouteHandler(
   }
 
   return {
-    path: `src/routes/${fileSafe}.ts`,
+    path: buildSafeRelativePath('src/routes', `${fileSafe}.ts`, 'route handler path'),
     content,
-    purpose: `Handle ${endpoint.method} ${endpoint.path}`,
+    purpose: `Handle ${routeComment}`,
     tests: [],
   };
 }
 
 export function generateModel(schema: OpenApiSchemaModel, database?: string): CodeFile {
+  const modelName = toSafeLineCommentText(schema.name, 'model');
+  const fileSlug = toSafeFileSlug(schema.name, 'model');
+  const modelPath = buildSafeRelativePath('src/models', `${fileSlug}.ts`, 'model path');
+  const databaseNote = database ? ` (${toSafeLineCommentText(database)})` : '';
   return {
-    path: `src/models/${schema.name}.ts`,
-    content: '// Model implementation',
-    purpose: `Model for ${schema.name}`,
+    path: modelPath,
+    content: `// Model implementation for ${modelName}${databaseNote}`,
+    purpose: `Model for ${modelName}`,
     tests: [],
   };
 }

--- a/src/agents/code-generation-safety.ts
+++ b/src/agents/code-generation-safety.ts
@@ -111,11 +111,10 @@ export function toTsStringLiteral(input: string): string {
 export function toSafeLineCommentText(input: string | undefined, fallback = 'N/A'): string {
   const normalized = String(input ?? '')
     .replace(/\r\n?/g, '\n')
-    .replace(/[\u0000-\u001F\u007F]/g, ' ')
     .replace(/\*\//g, '*\\/');
   const singleLine = normalized
     .split('\n')
-    .map((part) => part.trim())
+    .map((part) => part.replace(/[\u0000-\u0009\u000B-\u001F\u007F]/g, ' ').trim())
     .filter(Boolean)
     .join(' | ');
   return singleLine || fallback;

--- a/src/agents/code-generation-safety.ts
+++ b/src/agents/code-generation-safety.ts
@@ -1,0 +1,158 @@
+import path from 'node:path';
+
+export class CodeGenerationSafetyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CodeGenerationSafetyError';
+  }
+}
+
+const RESERVED_TS_IDENTIFIERS = new Set([
+  'arguments',
+  'await',
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'eval',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'instanceof',
+  'interface',
+  'let',
+  'new',
+  'null',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'return',
+  'static',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'undefined',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+]);
+
+const normalizeAsciiWords = (input: string): string[] =>
+  String(input)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .split(/[^A-Za-z0-9]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+const capitalizeWord = (value: string): string =>
+  value.length === 0 ? value : `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+
+const ensureIdentifier = (candidate: string, fallback: string): string => {
+  let identifier = candidate.replace(/[^A-Za-z0-9_$]/g, '');
+  if (!identifier) {
+    identifier = fallback;
+  }
+  if (!/^[A-Za-z_$]/.test(identifier)) {
+    identifier = `${fallback}${identifier}`;
+  }
+  if (RESERVED_TS_IDENTIFIERS.has(identifier.toLowerCase())) {
+    identifier = `${identifier}Generated`;
+  }
+  return identifier;
+};
+
+export function toSafeFileSlug(input: string, fallback = 'generated'): string {
+  const slug = normalizeAsciiWords(input).join('-').toLowerCase();
+  return slug || fallback;
+}
+
+export function toSafeIdentifier(input: string, fallback = 'generatedIdentifier'): string {
+  const words = normalizeAsciiWords(input);
+  const [first, ...rest] = words;
+  const candidate = first
+    ? `${first.charAt(0).toLowerCase()}${first.slice(1)}${rest.map(capitalizeWord).join('')}`
+    : fallback;
+  return ensureIdentifier(candidate, fallback);
+}
+
+export function toSafePascalIdentifier(input: string, fallback = 'GeneratedIdentifier'): string {
+  const words = normalizeAsciiWords(input);
+  const candidate = words.length > 0 ? words.map(capitalizeWord).join('') : fallback;
+  return ensureIdentifier(candidate, fallback);
+}
+
+export function toTsStringLiteral(input: string): string {
+  return JSON.stringify(String(input));
+}
+
+export function toSafeLineCommentText(input: string | undefined, fallback = 'N/A'): string {
+  const normalized = String(input ?? '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/[\u0000-\u001F\u007F]/g, ' ')
+    .replace(/\*\//g, '*\\/');
+  const singleLine = normalized
+    .split('\n')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(' | ');
+  return singleLine || fallback;
+}
+
+export function assertSafeRelativePath(input: string, label = 'generated path'): string {
+  const raw = String(input).trim();
+  if (!raw) {
+    throw new CodeGenerationSafetyError(`${label} must be non-empty`);
+  }
+  if (raw.includes('\0')) {
+    throw new CodeGenerationSafetyError(`${label} must not contain NUL bytes`);
+  }
+  if (raw.includes('\\')) {
+    throw new CodeGenerationSafetyError(`${label} must use POSIX-style '/' separators`);
+  }
+  if (raw.startsWith('//') || path.posix.isAbsolute(raw) || path.isAbsolute(raw) || /^[A-Za-z]:[\\/]/.test(raw)) {
+    throw new CodeGenerationSafetyError(`${label} must be workspace-relative`);
+  }
+
+  const segments = raw.split('/').filter((segment) => segment.length > 0);
+  if (segments.some((segment) => segment === '.' || segment === '..')) {
+    throw new CodeGenerationSafetyError(`${label} must not contain dot-segment path components`);
+  }
+  if (segments.some((segment) => segment.toLowerCase() === '.git')) {
+    throw new CodeGenerationSafetyError(`${label} must not target Git metadata directories`);
+  }
+  return path.posix.join(...segments);
+}
+
+export function buildSafeRelativePath(root: string, filename: string, label = 'generated path'): string {
+  const safeRoot = String(root).trim() === ''
+    ? ''
+    : String(root).trim() === '.'
+      ? ''
+      : assertSafeRelativePath(root, `${label} root`);
+  const safeFilename = assertSafeRelativePath(filename, `${label} filename`);
+  const joined = safeRoot ? path.posix.join(safeRoot, safeFilename) : safeFilename;
+  return assertSafeRelativePath(joined, label);
+}

--- a/tests/codex/generate-openapi-tests-security.test.ts
+++ b/tests/codex/generate-openapi-tests-security.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
 const scriptPath = resolve('scripts/codex/generate-openapi-tests.ts');
@@ -8,6 +8,7 @@ const tsxBin = resolve('node_modules/.bin/tsx');
 const fixturePath = 'artifacts/codex/generate-openapi-tests-security/openapi.json';
 const defaultOutputDir = resolve('artifacts/codex/generated-tests');
 const fixtureDir = resolve(dirname(fixturePath));
+const outsideRepoDir = resolve('..', 'generate-openapi-tests-security-outside');
 
 const writeSpec = () => {
   mkdirSync(fixtureDir, { recursive: true });
@@ -71,6 +72,45 @@ describe('generate-openapi-tests security policy', () => {
       expect(result.stderr).toContain('Writing generated tests under tests/ requires');
     } finally {
       rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects writing generated tests directly to the tests directory without explicit reviewed approval', () => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+    writeSpec();
+
+    try {
+      const result = runGenerator(['--output-dir', 'tests']);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Writing generated tests under tests/ requires');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects output directories that resolve through symlinks outside the workspace', () => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+    rmSync(outsideRepoDir, { recursive: true, force: true });
+    writeSpec();
+    mkdirSync(outsideRepoDir, { recursive: true });
+    const symlinkPath = resolve('artifacts/codex/generate-openapi-tests-security/symlink-out');
+    try {
+      symlinkSync(outsideRepoDir, symlinkPath, 'dir');
+    } catch {
+      rmSync(fixtureDir, { recursive: true, force: true });
+      rmSync(outsideRepoDir, { recursive: true, force: true });
+      return;
+    }
+
+    try {
+      const result = runGenerator(['--output-dir', 'artifacts/codex/generate-openapi-tests-security/symlink-out']);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('resolves through a filesystem entry outside the approved workspace');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+      rmSync(outsideRepoDir, { recursive: true, force: true });
     }
   });
 

--- a/tests/codex/generate-openapi-tests-security.test.ts
+++ b/tests/codex/generate-openapi-tests-security.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const scriptPath = resolve('scripts/codex/generate-openapi-tests.ts');
+const tsxBin = resolve('node_modules/.bin/tsx');
+const fixturePath = 'artifacts/codex/generate-openapi-tests-security/openapi.json';
+const defaultOutputDir = resolve('artifacts/codex/generated-tests');
+const fixtureDir = resolve(dirname(fixturePath));
+
+const writeSpec = () => {
+  mkdirSync(fixtureDir, { recursive: true });
+  writeFileSync(resolve(fixturePath), JSON.stringify({
+    openapi: '3.0.0',
+    paths: {
+      '/orders\n../escape': {
+        get: {
+          operationId: "evil');\nimport fs from 'fs';/*",
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  schema: { type: 'object' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  }), 'utf8');
+};
+
+const runGenerator = (args: string[] = [], env: Record<string, string | undefined> = {}) => spawnSync(tsxBin, [scriptPath, ...args], {
+  encoding: 'utf8',
+  env: {
+    ...process.env,
+    CONTRACTS_OPENAPI_PATH: fixturePath,
+    ...env,
+  },
+  timeout: 60_000,
+});
+
+describe('generate-openapi-tests security policy', () => {
+  it('writes generated tests to review artifacts by default with sanitized filenames', () => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+    rmSync(defaultOutputDir, { recursive: true, force: true });
+    writeSpec();
+
+    try {
+      const result = runGenerator(['--use-operation-id']);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('artifacts/codex/generated-tests/');
+      expect(existsSync(resolve('artifacts/codex/generated-tests/evil-import-fs-from-fs.spec.ts'))).toBe(true);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+      rmSync(defaultOutputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects writing generated tests under tests without explicit reviewed approval', () => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+    writeSpec();
+
+    try {
+      const result = runGenerator(['--output-dir', 'tests/api/generated']);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Writing generated tests under tests/ requires');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows writing under tests only with explicit reviewed approval', () => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+    rmSync(resolve('tests/api/generated/evil-import-fs-from-fs.spec.ts'), { force: true });
+    writeSpec();
+
+    try {
+      const result = runGenerator(
+        ['--use-operation-id', '--output-dir', 'tests/api/generated', '--approve-generated-tests'],
+        { CODEX_GENERATE_TESTS_APPROVAL: 'reviewed-generated-tests' },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('tests/api/generated/');
+      expect(existsSync(resolve('tests/api/generated/evil-import-fs-from-fs.spec.ts'))).toBe(true);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+      rmSync(resolve('tests/api/generated/evil-import-fs-from-fs.spec.ts'), { force: true });
+    }
+  });
+});

--- a/tests/unit/agents/code-generation-agent-security.test.ts
+++ b/tests/unit/agents/code-generation-agent-security.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { CodeGenerationAgent } from '../../../src/agents/code-generation-agent';
+import { toSafeLineCommentText } from '../../../src/agents/code-generation-safety';
 
 describe('CodeGenerationAgent generated output safety', () => {
+  it('preserves readable line delimiters while removing line comment injection characters', () => {
+    expect(toSafeLineCommentText('alpha\nbeta */\rgamma\u0007')).toBe('alpha | beta *\\/ | gamma');
+  });
+
   it('sanitizes test-derived describe and it text before generating implementation code', async () => {
     const agent = new CodeGenerationAgent();
 
@@ -56,9 +61,33 @@ describe('../evil'); import fs from "fs"', () => {
 
     expect(files).toHaveLength(1);
     expect(files[0]?.path).toBe('artifacts/codex/generated-tests/evil-import-fs-from-fs.spec.ts');
+    expect(files[0]?.content).toContain("import { handler } from '../../../src/routes/evil-import-fs-from-fs'");
     expect(files[0]?.content).toContain('describe("evil');
     expect(files[0]?.content).not.toContain("describe('");
     expect(files[0]?.content).not.toContain("evil');\nimport fs");
     expect(files[0]?.content.split('\n').filter((line) => line.startsWith('// OperationId:'))).toHaveLength(1);
+  });
+
+  it('derives route imports from custom generated test output roots', async () => {
+    const agent = new CodeGenerationAgent();
+    const spec = JSON.stringify({
+      openapi: '3.0.0',
+      paths: {
+        '/orders': {
+          get: {
+            operationId: 'listOrders',
+            responses: { 200: { content: { 'application/json': { schema: { type: 'object' } } } } },
+          },
+        },
+      },
+    });
+
+    const files = await agent.generateTestsFromOpenAPI(spec, {
+      useOperationIdForTestNames: true,
+      outputRoot: 'artifacts/codex/generated-tests/deep/review',
+    });
+
+    expect(files[0]?.path).toBe('artifacts/codex/generated-tests/deep/review/listorders.spec.ts');
+    expect(files[0]?.content).toContain("import { handler } from '../../../../../src/routes/listorders'");
   });
 });

--- a/tests/unit/agents/code-generation-agent-security.test.ts
+++ b/tests/unit/agents/code-generation-agent-security.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { CodeGenerationAgent } from '../../../src/agents/code-generation-agent';
+
+describe('CodeGenerationAgent generated output safety', () => {
+  it('sanitizes test-derived describe and it text before generating implementation code', async () => {
+    const agent = new CodeGenerationAgent();
+
+    const generated = await agent.generateCodeFromTests({
+      language: 'typescript',
+      tests: [{
+        path: 'tests/evil.test.ts',
+        type: 'unit',
+        content: `
+describe('../evil'); import fs from "fs"', () => {
+  it('return value */\\nconsole.log("comment injection")', () => {})
+})
+`,
+      }],
+    });
+
+    expect(generated.files).toHaveLength(1);
+    expect(generated.files[0]?.path).toBe('src/evil.ts');
+    expect(generated.files[0]?.tests).toEqual(['tests/evil.test.ts']);
+    expect(generated.files[0]?.content).toContain('export function evil');
+    expect(generated.files[0]?.content).not.toContain('import fs');
+    expect(generated.files[0]?.content).not.toContain('*/\n');
+  });
+
+  it('emits OpenAPI test skeletons under review artifacts with safe literals and paths', async () => {
+    const agent = new CodeGenerationAgent();
+    const spec = JSON.stringify({
+      openapi: '3.0.0',
+      paths: {
+        '/orders\n../escape': {
+          get: {
+            operationId: "evil');\nimport fs from 'fs';/*",
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { type: 'object' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const files = await agent.generateTestsFromOpenAPI(spec, {
+      useOperationIdForTestNames: true,
+      includeSampleInput: true,
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0]?.path).toBe('artifacts/codex/generated-tests/evil-import-fs-from-fs.spec.ts');
+    expect(files[0]?.content).toContain('describe("evil');
+    expect(files[0]?.content).not.toContain("describe('");
+    expect(files[0]?.content).not.toContain("evil');\nimport fs");
+    expect(files[0]?.content.split('\n').filter((line) => line.startsWith('// OperationId:'))).toHaveLength(1);
+  });
+});

--- a/tests/unit/agents/code-generation-openapi.test.ts
+++ b/tests/unit/agents/code-generation-openapi.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildSampleLiteral,
   generateAuthMiddleware,
+  generateModel,
   generateRouteHandler,
   generateServerSetup,
   generateValidationMiddleware,
@@ -78,6 +79,50 @@ describe('code-generation-openapi helpers', () => {
     expect(route.path).toBe('src/routes/create-user.ts');
     expect(route.content).toContain('CreateUserInput.parse');
     expect(route.content).toContain('return { status: 201, data: output }');
+  });
+
+  it('sanitizes OpenAPI operation identifiers, comments, and route paths before code emission', () => {
+    const endpoint = {
+      path: '/users\n*/\nconsole.log("path injection")',
+      method: 'post',
+      components: {},
+      definition: {
+        operationId: "class */\n../evil'); import fs from 'fs'",
+        responses: {
+          200: {
+            content: {
+              'application/json': {
+                schema: { type: 'object' },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const route = generateRouteHandler(endpoint, {
+      includeContracts: true,
+      useOperationIdForFilenames: true,
+    });
+
+    expect(route.path).toBe('src/routes/class-evil-import-fs-from-fs.ts');
+    expect(route.content).toContain('ClassEvilImportFsFromFsInput.parse');
+    expect(route.content).not.toContain('*/\n');
+    const operationLines = route.content.split('\n').filter((line) => line.startsWith('// OperationId:'));
+    expect(operationLines).toHaveLength(1);
+    expect(operationLines[0]).toContain('*\\/');
+  });
+
+  it('sanitizes schema names before generating model paths and metadata', () => {
+    const model = generateModel({
+      name: '../Admin\n*/\nInjected',
+      schema: { type: 'object' },
+    });
+
+    expect(model.path).toBe('src/models/admin-injected.ts');
+    expect(model.content).toContain('Admin');
+    expect(model.content).toContain('Injected');
+    expect(model.content).not.toContain('\nInjected');
   });
 
   it('falls back to string sample for XML responses without schema', () => {


### PR DESCRIPTION
## Summary

- Add shared code-generation safety helpers for generated file slugs, TypeScript identifiers, string literals, comments, and relative paths.
- Sanitize OpenAPI-derived route/model paths, contract identifiers, operation comments, and generated test skeleton titles before emitting code artifacts.
- Sanitize test-derived `describe` / `it` text before generating implementation identifiers, paths, and comments.
- Move `codex:generate:tests` default output to `artifacts/codex/generated-tests/` and require explicit reviewed approval before writing generated tests under `tests/`.
- Update Codex integration docs for the new generated-test review artifact workflow.

Closes #3424.

## Acceptance

- [x] Generated identifiers use strict ASCII allowlists and reserved-word handling.
- [x] Generated TypeScript string literals use `JSON.stringify`-based serialization.
- [x] Generated line comments remove control/newline injection and escape comment terminators.
- [x] Generated `CodeFile.path` values are built from constrained POSIX workspace-relative fragments.
- [x] `codex:generate:tests` writes to review artifacts by default and rejects direct `tests/` writes without explicit approval.
- [x] Regression tests cover quotes, newlines, comment delimiters, path/dot-segment attempts, invalid identifiers, and unsafe OpenAPI/test names.

## Verification

- `pnpm -s exec vitest run tests/unit/agents/code-generation-openapi.test.ts tests/unit/agents/code-generation-agent-security.test.ts tests/codex/generate-openapi-tests-security.test.ts --reporter dot`
- `pnpm -s run types:check`
- `pnpm -s exec eslint --quiet src/agents/code-generation-safety.ts src/agents/code-generation-openapi.ts src/agents/code-generation-agent.ts scripts/codex/generate-openapi-tests.ts tests/unit/agents/code-generation-openapi.test.ts tests/unit/agents/code-generation-agent-security.test.ts tests/codex/generate-openapi-tests-security.test.ts`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

Revert this PR to restore the previous code-generation behavior. If rollback is required, avoid running `pnpm run codex:generate:tests` on unreviewed repository-controlled OpenAPI content until an equivalent escaping/path policy is restored.
