### PR TITLE
fix(cli): require approval for guard npm scripts

### DIFF
--- a/src/cli/guards/GuardRunner.ts
+++ b/src/cli/guards/GuardRunner.ts
@@ -1,9 +1,156 @@
-import { execSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import { existsSync } from 'fs';
 import { glob } from 'glob';
 import type { AEFrameworkConfig, Guard, GuardResult } from '../types.js';
 import { toMessage } from '../../utils/error-utils.js';
 import { getCurrentPhase, shouldEnforceGate, getThreshold } from '../../utils/quality-policy-loader.js';
+
+
+export const GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE = 'guard-script-execution' as const;
+
+export interface GuardRunnerOptions {
+  dryRun?: boolean;
+  apply?: boolean;
+  approvalScope?: string;
+  agentContext?: boolean;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface GuardScriptExecutionPolicy {
+  dryRun: boolean;
+  apply: boolean;
+  approvalRequired: boolean;
+  approvalScope?: string;
+  agentContext: boolean;
+}
+
+type GuardCommandResult = {
+  executed: boolean;
+  output: string;
+  message?: string;
+};
+
+type SpawnLikeResult = {
+  status?: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout?: string | Buffer | null;
+  stderr?: string | Buffer | null;
+  error?: Error;
+};
+
+type GuardNpmInvocation = {
+  command: string;
+  args: string[];
+};
+
+export function createGuardNpmInvocation(
+  args: string[],
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): GuardNpmInvocation {
+  if (platform !== 'win32') {
+    return { command: 'npm', args };
+  }
+  return {
+    command: env['ComSpec'] ?? env['COMSPEC'] ?? 'cmd.exe',
+    args: ['/d', '/s', '/c', 'npm.cmd', ...args],
+  };
+}
+
+const isTruthyEnv = (value: string | undefined): boolean => {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 && !['0', 'false', 'no', 'off'].includes(normalized);
+};
+
+const isGuardAgentContext = (env: NodeJS.ProcessEnv = process.env): boolean => (
+  isTruthyEnv(env['AE_GUARD_AGENT_CONTEXT']) ||
+  isTruthyEnv(env['AE_AGENT_CONTEXT']) ||
+  isTruthyEnv(env['AE_GUARD_UNTRUSTED_CHECKOUT']) ||
+  isTruthyEnv(env['AE_UNTRUSTED_CHECKOUT'])
+);
+
+export function getGuardScriptExecutionPolicy(options: GuardRunnerOptions = {}): GuardScriptExecutionPolicy {
+  const env = options.env ?? process.env;
+  const agentContext = options.agentContext ?? isGuardAgentContext(env);
+  const apply = options.apply === true;
+  const approvalScope = options.approvalScope;
+  const dryRun = options.dryRun === true || (agentContext && !apply);
+  const approvalRequired = agentContext && apply && approvalScope !== GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE;
+  const policy: GuardScriptExecutionPolicy = {
+    dryRun,
+    apply,
+    approvalRequired,
+    agentContext,
+  };
+  if (approvalScope !== undefined) {
+    policy.approvalScope = approvalScope;
+  }
+  return policy;
+}
+
+const SENSITIVE_ENV_NAME_PATTERN = /(?:^|_)(?:token|secret|password|passwd|credential|credentials|cookie|session|authorization|auth|private(?:_key)?|access_key|api_key)(?:_|$)/i;
+const SENSITIVE_ENV_EXACT_NAMES = new Set([
+  'GITHUB_TOKEN',
+  'GH_TOKEN',
+  'NPM_TOKEN',
+  'NODE_AUTH_TOKEN',
+  'ACTIONS_ID_TOKEN_REQUEST_TOKEN',
+]);
+
+export function createGuardProcessEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    if (SENSITIVE_ENV_EXACT_NAMES.has(key) || SENSITIVE_ENV_NAME_PATTERN.test(key)) {
+      continue;
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+class GuardScriptApprovalRequiredError extends Error {
+  constructor(command: string) {
+    super(
+      `Guard script execution requires --apply --approval-scope ${GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE} before running ${command} in an agent or untrusted-checkout context`
+    );
+    this.name = 'GuardScriptApprovalRequiredError';
+  }
+}
+
+class GuardCommandFailedError extends Error {
+  readonly stdout?: string;
+  readonly stderr?: string;
+
+  constructor(command: string, result: SpawnLikeResult) {
+    const status = result.status ?? (result.signal ? `signal ${result.signal}` : 'unknown');
+    super(`Guard command failed (${command}) with status ${status}`);
+    this.name = 'GuardCommandFailedError';
+    const stdout = toOutputText(result.stdout);
+    const stderr = toOutputText(result.stderr);
+    if (stdout !== undefined) {
+      this.stdout = stdout;
+    }
+    if (stderr !== undefined) {
+      this.stderr = stderr;
+    }
+  }
+}
+
+const toOutputText = (value: string | Buffer | null | undefined): string | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString('utf8');
+  }
+  if (value === null) {
+    return undefined;
+  }
+  return value;
+};
 
 type ExecErrorOutput = {
   stdout?: string | Buffer;
@@ -43,7 +190,15 @@ const readExecOutput = (error: unknown): string => {
 };
 
 export class GuardRunner {
-  constructor(private config: AEFrameworkConfig) {}
+  private readonly executionPolicy: GuardScriptExecutionPolicy;
+  private readonly cwd: string;
+  private readonly env: NodeJS.ProcessEnv;
+
+  constructor(private config: AEFrameworkConfig, options: GuardRunnerOptions = {}) {
+    this.executionPolicy = getGuardScriptExecutionPolicy(options);
+    this.cwd = options.cwd ?? process.cwd();
+    this.env = options.env ?? process.env;
+  }
 
   async run(guard: Guard): Promise<GuardResult> {
     switch (guard.name) {
@@ -112,7 +267,11 @@ export class GuardRunner {
   private async runTestExecutionGuard(): Promise<GuardResult> {
     try {
       // Check if tests pass
-      const result = execSync('npm test --silent', { encoding: 'utf8', stdio: 'pipe' });
+      const commandResult = this.runNpmScript(['test', '--silent'], 'npm test --silent');
+      if (!commandResult.executed) {
+        return { success: true, message: commandResult.message ?? 'Dry-run preview: npm test --silent was not executed' };
+      }
+      const result = commandResult.output;
       
       // Look for successful test indicators
       const hasPassedTests = result.includes('passing') || result.includes('✓') || !result.includes('failing');
@@ -123,10 +282,13 @@ export class GuardRunner {
         return { success: false, message: 'Some tests are failing' };
       }
     } catch (error: unknown) {
+      if (error instanceof GuardScriptApprovalRequiredError) {
+        return { success: false, message: error.message };
+      }
       const output = readExecOutput(error);
       return {
         success: false,
-        message: `Tests failed: ${output.split('\n').slice(-3).join('\n').trim()}`
+        message: `Tests failed: ${output.split('\n').slice(-3).join('\n').trim() || toMessage(error)}`
       };
     }
   }
@@ -166,19 +328,20 @@ export class GuardRunner {
   private async runCoverageGuard(): Promise<GuardResult> {
     try {
       // Run coverage check
-      let result: string;
+      let commandResult: GuardCommandResult;
       try {
-        result = execSync('npm run coverage --silent', {
-          encoding: 'utf8',
-          stdio: 'pipe'
-        });
-      } catch (e) {
+        commandResult = this.runNpmScript(['run', 'coverage', '--silent'], 'npm run coverage --silent');
+      } catch (error) {
+        if (error instanceof GuardScriptApprovalRequiredError) {
+          throw error;
+        }
         // Fallback to npm test with coverage if npm run coverage fails
-        result = execSync('npm test -- --coverage --silent', {
-          encoding: 'utf8',
-          stdio: 'pipe'
-        });
+        commandResult = this.runNpmScript(['test', '--', '--coverage', '--silent'], 'npm test -- --coverage --silent');
       }
+      if (!commandResult.executed) {
+        return { success: true, message: commandResult.message ?? 'Dry-run preview: coverage guard npm scripts were not executed' };
+      }
+      const result = commandResult.output;
       
       // Parse coverage output
       const coverageMatch = result.match(/All files[^\d]*(\d+(?:\.\d+)?)/);
@@ -196,14 +359,52 @@ export class GuardRunner {
         return { success: false, message: `Coverage: ${coverage}% (< ${threshold}%)` };
       }
     } catch (error: unknown) {
+      if (error instanceof GuardScriptApprovalRequiredError) {
+        return { success: false, message: error.message };
+      }
       // If coverage command fails, check if at least tests exist and pass
       try {
-        await this.runTestExecutionGuard();
-        return { success: true, message: 'Coverage tool not available, but tests pass' };
+        const testResult = await this.runTestExecutionGuard();
+        if (testResult.success) {
+          return { success: true, message: 'Coverage tool not available, but tests pass' };
+        }
+        return { success: false, message: 'Cannot determine coverage and tests fail' };
       } catch {
         return { success: false, message: 'Cannot determine coverage and tests fail' };
       }
     }
+  }
+
+  private runNpmScript(args: string[], displayCommand: string): GuardCommandResult {
+    if (this.executionPolicy.approvalRequired) {
+      throw new GuardScriptApprovalRequiredError(displayCommand);
+    }
+    if (this.executionPolicy.dryRun) {
+      return {
+        executed: false,
+        output: '',
+        message: `Dry-run preview: would execute ${displayCommand}. Use --apply --approval-scope ${GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE} in an agent or untrusted-checkout context to run repository scripts.`,
+      };
+    }
+
+    const invocation = createGuardNpmInvocation(args, process.platform, this.env);
+    const result = spawnSync(invocation.command, invocation.args, {
+      cwd: this.cwd,
+      encoding: 'utf8',
+      env: createGuardProcessEnv(this.env),
+      shell: false,
+      stdio: 'pipe',
+    }) as SpawnLikeResult;
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      throw new GuardCommandFailedError(displayCommand, result);
+    }
+    return {
+      executed: true,
+      output: `${toOutputText(result.stdout) ?? ''}${toOutputText(result.stderr) ?? ''}`,
+    };
   }
 
   // Utility method to check git status for TDD violations

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,7 +8,12 @@ import { createSpecCommand } from './spec-cli.js';
 import { createStateMachineCommand } from './state-machine-cli.js';
 import { createCodegenCommand } from './codegen-cli.js';
 import { CEGISCli } from './cegis-cli.js';
-import { GuardRunner } from './guards/GuardRunner.js';
+import {
+  GuardRunner,
+  GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE,
+  getGuardScriptExecutionPolicy,
+  type GuardRunnerOptions,
+} from './guards/GuardRunner.js';
 import { ConfigLoader } from './config/ConfigLoader.js';
 import type { AEFrameworkConfig, Phase } from './types.js';
 import { createHybridIntentSystem, type HybridIntentSystem } from '../integration/hybrid-intent-system.js';
@@ -56,6 +61,38 @@ const parseCommaSeparatedSources = (value?: string): string[] => {
     .filter(Boolean);
 };
 
+
+interface GuardExecutionCliOptions {
+  dryRun?: boolean;
+  apply?: boolean;
+  approvalScope?: string;
+}
+
+const toGuardRunnerOptions = (options: GuardExecutionCliOptions = {}): GuardRunnerOptions => {
+  const runnerOptions: GuardRunnerOptions = {
+    dryRun: options.dryRun === true,
+    apply: options.apply === true,
+  };
+  if (options.approvalScope !== undefined) {
+    runnerOptions.approvalScope = options.approvalScope;
+  }
+  return runnerOptions;
+};
+
+const prepareGuardScriptExecution = (options: GuardExecutionCliOptions = {}): GuardRunnerOptions | undefined => {
+  const runnerOptions = toGuardRunnerOptions(options);
+  const policy = getGuardScriptExecutionPolicy(runnerOptions);
+  if (policy.approvalRequired) {
+    console.error(chalk.red(`❌ Guard script execution requires --approval-scope ${GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE} when --apply is used in an agent or untrusted-checkout context`));
+    safeExit(1);
+    return undefined;
+  }
+  if (policy.dryRun) {
+    console.log(chalk.yellow('🔎 Dry-run preview: process-starting guards will not run repository npm scripts.'));
+  }
+  return runnerOptions;
+};
+
 const resolveValidationTaskTypeFromOptions = (options: Record<string, unknown>): ValidationTaskType => {
   if (options['requirements']) {
     return 'validate-requirements';
@@ -78,7 +115,6 @@ const resolveValidationTaskTypeFromOptions = (options: Record<string, unknown>):
 class AEFrameworkCLI {
   private config: AEFrameworkConfig;
   private phaseValidator: PhaseValidator;
-  private guardRunner: GuardRunner;
   private intentSystem: HybridIntentSystem;
   public naturalLanguageHandler: TaskHandler;
   public userStoriesHandler: TaskHandler;
@@ -89,7 +125,6 @@ class AEFrameworkCLI {
   constructor() {
     this.config = ConfigLoader.load();
     this.phaseValidator = new PhaseValidator(this.config);
-    this.guardRunner = new GuardRunner(this.config);
     this.intentSystem = createHybridIntentSystem({
       enableCLI: true,
       enableMCPServer: false, // Disabled for CLI mode
@@ -134,7 +169,7 @@ class AEFrameworkCLI {
     }
   }
 
-  async runGuards(guardName?: string): Promise<void> {
+  async runGuards(guardName?: string, options: GuardRunnerOptions = {}): Promise<void> {
     const guards = guardName 
       ? [this.config.guards.find(g => g.name === guardName)].filter(Boolean)
       : this.config.guards;
@@ -148,7 +183,7 @@ class AEFrameworkCLI {
 
     let allPassed = true;
     for (const guard of guards) {
-      const result = await this.guardRunner.run(guard!);
+      const result = await new GuardRunner(this.config, options).run(guard!);
       
       if (result.success) {
         console.log(chalk.green(`✅ ${guard!.name}: PASSED`));
@@ -417,9 +452,14 @@ program
   .command('guard')
   .description('Run guard validations')
   .option('-n, --name <name>', 'Specific guard to run')
+  .option('--dry-run', 'Preview process-starting guards without running repository npm scripts')
+  .option('--apply', 'Execute repository npm scripts in an agent or untrusted-checkout context after trusted approval')
+  .option('--approval-scope <scope>', `Trusted guard script execution approval scope (${GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE})`)
   .action(async (options) => {
+    const runnerOptions = prepareGuardScriptExecution(options);
+    if (!runnerOptions) return;
     const cli = new AEFrameworkCLI();
-    await cli.runGuards(options.name);
+    await cli.runGuards(options.name, runnerOptions);
   });
 
 program
@@ -433,14 +473,19 @@ program
 program
   .command('tdd')
   .description('Run TDD cycle validation')
-  .action(async () => {
+  .option('--dry-run', 'Preview process-starting TDD guards without running repository npm scripts')
+  .option('--apply', 'Execute repository npm scripts in an agent or untrusted-checkout context after trusted approval')
+  .option('--approval-scope <scope>', `Trusted guard script execution approval scope (${GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE})`)
+  .action(async (options) => {
+    const runnerOptions = prepareGuardScriptExecution(options);
+    if (!runnerOptions) return;
     const cli = new AEFrameworkCLI();
     console.log(chalk.blue('🔄 Validating TDD cycle...'));
     
     // Check TDD Guards
-    await cli.runGuards('TDD Guard');
-    await cli.runGuards('Test Execution Guard');
-    await cli.runGuards('RED-GREEN Cycle Guard');
+    await cli.runGuards('TDD Guard', runnerOptions);
+    await cli.runGuards('Test Execution Guard', runnerOptions);
+    await cli.runGuards('RED-GREEN Cycle Guard', runnerOptions);
     
     console.log(chalk.green('✅ TDD cycle validation complete'));
   });

--- a/src/integration/hybrid-tdd-system.ts
+++ b/src/integration/hybrid-tdd-system.ts
@@ -333,7 +333,12 @@ export class HybridTDDSystem {
     if (data.command === 'check') {
       return this.cli?.checkPhase(data.phase || 'current');
     } else if (data.command === 'guard') {
-      return this.cli?.runGuards(data.guardName);
+      return this.cli?.runGuards(data.guardName, {
+        agentContext: true,
+        dryRun: data.dryRun === true,
+        apply: data.apply === true,
+        ...(typeof data.approvalScope === 'string' ? { approvalScope: data.approvalScope } : {}),
+      });
     } else if (data.command === 'next') {
       return this.cli?.nextPhase();
     }

--- a/tests/unit/cli/guard-runner-execution-policy.test.ts
+++ b/tests/unit/cli/guard-runner-execution-policy.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AEFrameworkConfig, Guard } from '../../../src/cli/types.js';
+
+const childProcessMock = vi.hoisted(() => ({
+  execSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  execSync: childProcessMock.execSync,
+  spawnSync: childProcessMock.spawnSync,
+}));
+
+import {
+  createGuardNpmInvocation,
+  createGuardProcessEnv,
+  getGuardScriptExecutionPolicy,
+  GuardRunner,
+  GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE,
+} from '../../../src/cli/guards/GuardRunner.js';
+
+const config = {} as AEFrameworkConfig;
+
+const testExecutionGuard: Guard = {
+  name: 'Test Execution Guard',
+  description: 'Ensure tests pass',
+  rule: 'All tests pass',
+  enforcement: 'strict',
+};
+
+const coverageGuard: Guard = {
+  name: 'Coverage Guard',
+  description: 'Ensure coverage is high enough',
+  rule: 'Coverage threshold is satisfied',
+  enforcement: 'warning',
+};
+
+describe('GuardRunner process-starting guard execution policy', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults agent-context test execution to dry-run without spawning npm scripts', async () => {
+    const runner = new GuardRunner(config, {
+      env: { AE_GUARD_AGENT_CONTEXT: '1', PATH: '/usr/bin' },
+    });
+
+    const result = await runner.run(testExecutionGuard);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Dry-run preview');
+    expect(result.message).toContain('npm test --silent');
+    expect(childProcessMock.spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('defaults untrusted-checkout coverage execution to dry-run without spawning npm scripts', async () => {
+    const runner = new GuardRunner(config, {
+      env: { AE_GUARD_UNTRUSTED_CHECKOUT: 'true', PATH: '/usr/bin' },
+    });
+
+    const result = await runner.run(coverageGuard);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Dry-run preview');
+    expect(result.message).toContain('npm run coverage --silent');
+    expect(childProcessMock.spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects agent-context apply without trusted approval before spawning npm scripts', async () => {
+    const runner = new GuardRunner(config, {
+      agentContext: true,
+      apply: true,
+      env: { PATH: '/usr/bin' },
+    });
+
+    const result = await runner.run(testExecutionGuard);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain(`--approval-scope ${GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE}`);
+    expect(result.message).not.toContain('Tests failed');
+    expect(childProcessMock.spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('executes approved guard scripts with argv-safe spawn and redacted environment', async () => {
+    childProcessMock.spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '2 passing\n',
+      stderr: '',
+    });
+
+    const runner = new GuardRunner(config, {
+      agentContext: true,
+      apply: true,
+      approvalScope: GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE,
+      cwd: '/repo',
+      env: {
+        PATH: '/usr/bin',
+        HOME: '/home/operator',
+        GITHUB_TOKEN: 'ghs-secret',
+        SECRET_VALUE: 'secret',
+        NPM_TOKEN: 'npm-secret',
+      },
+    });
+
+    const result = await runner.run(testExecutionGuard);
+
+    expect(result).toEqual({ success: true, message: 'All tests pass' });
+    expect(childProcessMock.spawnSync).toHaveBeenCalledWith(
+      'npm',
+      ['test', '--silent'],
+      expect.objectContaining({
+        cwd: '/repo',
+        encoding: 'utf8',
+        shell: false,
+        stdio: 'pipe',
+      })
+    );
+    const spawnOptions = childProcessMock.spawnSync.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(spawnOptions.env).toMatchObject({ PATH: '/usr/bin', HOME: '/home/operator' });
+    expect(spawnOptions.env?.['GITHUB_TOKEN']).toBeUndefined();
+    expect(spawnOptions.env?.['SECRET_VALUE']).toBeUndefined();
+    expect(spawnOptions.env?.['NPM_TOKEN']).toBeUndefined();
+  });
+
+
+
+  it('routes Windows npm execution through cmd.exe without enabling shell mode', () => {
+    expect(createGuardNpmInvocation(
+      ['test', '--silent'],
+      'win32',
+      { ComSpec: 'C:\\Windows\\System32\\cmd.exe' }
+    )).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'npm.cmd', 'test', '--silent'],
+    });
+  });
+
+  it('falls back to npm test coverage command through argv-safe spawn', async () => {
+    childProcessMock.spawnSync
+      .mockReturnValueOnce({ status: 1, stdout: 'coverage unavailable', stderr: '' })
+      .mockReturnValueOnce({ status: 0, stdout: 'All files      85\n', stderr: '' });
+
+    const runner = new GuardRunner(config, {
+      env: { PATH: '/usr/bin' },
+    });
+
+    const result = await runner.run(coverageGuard);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain('Coverage: 85%');
+    expect(childProcessMock.spawnSync).toHaveBeenNthCalledWith(
+      1,
+      'npm',
+      ['run', 'coverage', '--silent'],
+      expect.objectContaining({ shell: false })
+    );
+    expect(childProcessMock.spawnSync).toHaveBeenNthCalledWith(
+      2,
+      'npm',
+      ['test', '--', '--coverage', '--silent'],
+      expect.objectContaining({ shell: false })
+    );
+  });
+
+  it('derives dry-run policy from shared agent and untrusted checkout environment markers', () => {
+    expect(getGuardScriptExecutionPolicy({ env: { AE_AGENT_CONTEXT: '1' } })).toMatchObject({
+      agentContext: true,
+      dryRun: true,
+      approvalRequired: false,
+    });
+    expect(getGuardScriptExecutionPolicy({ apply: true, env: { AE_UNTRUSTED_CHECKOUT: '1' } })).toMatchObject({
+      agentContext: true,
+      dryRun: false,
+      approvalRequired: true,
+    });
+  });
+
+  it('filters common ambient secret variables from guard process environments', () => {
+    expect(createGuardProcessEnv({
+      PATH: '/usr/bin',
+      API_KEY: 'api-secret',
+      MY_PASSWORD: 'password',
+      SESSION_COOKIE: 'cookie',
+      npm_config_cache: '.cache',
+    })).toEqual({
+      PATH: '/usr/bin',
+      npm_config_cache: '.cache',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an explicit GuardRunner script-execution policy for process-starting guards.
- Defaults GuardRunner test/coverage script execution to dry-run in AI/agent or untrusted-checkout contexts unless `--apply --approval-scope guard-script-execution` is present.
- Replaces shell-string npm execution for guard scripts with argv-based `spawnSync(..., { shell: false })` and redacts common ambient secret environment variables.
- Adds `guard` / `tdd` CLI approval flags and treats hybrid TDD guard delegation as agent-context by default.

Closes #3429

## Acceptance

- `Test Execution Guard` and `Coverage Guard` do not start repository npm scripts in agent/untrusted contexts without explicit trusted approval.
- Missing approval for agent-context `--apply` is rejected before npm scripts are spawned.
- Approved execution uses argv-safe process invocation with constrained cwd and redacted environment.
- CLI `guard` and `tdd` surfaces expose the same approval boundary.
- Hybrid TDD guard delegation defaults to agent-context dry-run behavior.

## Verification

- `pnpm -s exec vitest run tests/unit/cli/guard-runner-execution-policy.test.ts --reporter dot`
- `pnpm -s exec vitest run tests/unit/cli/guard-runner-execution-policy.test.ts tests/unit/mcp-server/tdd-execution-policy.test.ts tests/self-improvement/tdd-setup.test.ts tests/tdd-setup.test.ts --reporter dot`
- `pnpm -s run types:check`
- `pnpm -s exec eslint --quiet src/cli/guards/GuardRunner.ts src/cli/index.ts src/integration/hybrid-tdd-system.ts tests/unit/cli/guard-runner-execution-policy.test.ts`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `pnpm -s run check:doc-consistency`
- `git diff --check`

## Rollback

Revert this PR to restore previous GuardRunner behavior. This would re-enable direct repository npm script execution from GuardRunner without the new agent/untrusted approval boundary.
