### PR TITLE
test(ci): validate agent PR assurance metric semantics

### DIFF
--- a/docs/ci/agent-pr-assurance-metrics.md
+++ b/docs/ci/agent-pr-assurance-metrics.md
@@ -38,6 +38,10 @@ Primary review surface:
 | `blocked_to_merge_eligible_mttr` | Time from first blocked state to merge-eligible state. | PR state timeline, `policy-gate-summary`, automation observability reports | Measure from first `blocked`/failed-required-check observation to `mergeStateStatus=CLEAN` or equivalent merge-eligible state. | Trend metric; do not block a PR by itself. |
 | `false_block_rate` | Rate of blocks later judged unnecessary. | manual annotation, automation observability reports, PR comments, policy-decision notes | Initially manual: `false_blocks / total_blocks` for a defined observation window. | Report-only until the annotation taxonomy is stable. |
 
+Semantic validation uses a tolerance of `0.0001` for rounded ratio values. Count-based ratios must keep the numerator less than or equal to the denominator. When `claim_coverage.denominator` or `evidence_completeness.required` is `0`, the corresponding numerator must also be `0` and `ratio` is represented as `1` to mean there were no required items left uncovered. `required_lane_compliance` uses a stricter not-applicable representation: `required=0`, `satisfied=0`, `ratio=null`, and `notApplicable=true`. `false_block_rate.totalBlocks=0` has no meaningful percentage, so the metric uses `ratio=null`; if `annotatedFalseBlocks` is `null`, `annotationRequired=true` records that manual classification is still missing.
+
+`agent_regression_signal.regressed` is producer-supplied rather than derived solely from `currentFailures` and `staleOrSupersededFailures`. Producers may incorporate trend history or external check classifications not represented by the two count fields, so the contract validates the shape and records the counts separately without over-constraining the flag.
+
 ### 3. Connection to existing artifacts
 
 `quality-scorecard/v1` is the preferred aggregation surface when the metric can be expressed as one of its current dimensions:
@@ -115,6 +119,10 @@ Agent PR assurance metrics は、agent が作成またはreviewした pull reque
 | `agent_regression_signal` | agent-created PR のreview loopで test/gate regression が発生したか。 | GitHub checks, `verify-lite-run-summary`, `harness-health`, heavy-test trend summaries, review-gate history | PR head系列の failed gate/test をflagまたは件数化する。stale/superseded failure と current failureを分ける。 | current/stale counts を分けて表示する。 |
 | `blocked_to_merge_eligible_mttr` | blocked から merge eligible に戻るまでの時間。 | PR state timeline, `policy-gate-summary`, automation observability reports | 最初の blocked / failed required check 観測から `mergeStateStatus=CLEAN` 相当までを測る。 | trend metric。単独ではblockしない。 |
 | `false_block_rate` | 後で不要と判断されたblockの割合。 | manual annotation, automation observability reports, PR comments, policy-decision notes | 初期はmanual annotationで `false_blocks / total_blocks` を観測期間ごとに計算する。 | annotation taxonomy が安定するまで report-only。 |
+
+Semantic validation は、丸め済み ratio に `0.0001` の許容差を使います。count-based ratio では numerator が denominator 以下でなければなりません。`claim_coverage.denominator` または `evidence_completeness.required` が `0` の場合、対応する numerator も `0` とし、未充足項目が存在しないことを `ratio=1` で表します。`required_lane_compliance` はより厳密な not-applicable 表現を使い、`required=0`、`satisfied=0`、`ratio=null`、`notApplicable=true` とします。`false_block_rate.totalBlocks=0` は有意な割合を持たないため `ratio=null` とし、`annotatedFalseBlocks` が `null` の場合は manual classification が未実施であることを `annotationRequired=true` で記録します。
+
+`agent_regression_signal.regressed` は `currentFailures` と `staleOrSupersededFailures` だけから導出する値ではなく、producer-supplied な要約flagです。producer は2つのcount fieldに表れないtrend historyや外部check分類を含められるため、contractはshapeとcountを検証し、flagを過度に制約しません。
 
 ### 3. 既存artifactとの接続
 

--- a/scripts/ci/lib/agentic-metrics-contract.mjs
+++ b/scripts/ci/lib/agentic-metrics-contract.mjs
@@ -1,0 +1,228 @@
+const RATIO_TOLERANCE = 0.0001;
+
+function createError(keyword, instancePath, message) {
+  return { keyword, instancePath, message };
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function ratioMatches(actual, expected) {
+  return typeof actual === 'number' && Math.abs(actual - expected) <= RATIO_TOLERANCE;
+}
+
+function validateCountRatioMetric({
+  metric,
+  basePath,
+  numeratorField,
+  denominatorField,
+  ratioField,
+  zeroDenominatorRatio,
+  errors,
+}) {
+  if (!isObject(metric)) {
+    return;
+  }
+
+  const numerator = metric[numeratorField];
+  const denominator = metric[denominatorField];
+  const ratio = metric[ratioField];
+
+  if (!Number.isInteger(numerator) || !Number.isInteger(denominator)) {
+    return;
+  }
+
+  if (numerator > denominator) {
+    errors.push(createError(
+      'metric_count_order',
+      `${basePath}/${numeratorField}`,
+      `${numeratorField} must be less than or equal to ${denominatorField} (${denominator}), got ${numerator}`,
+    ));
+  }
+
+  const expectedRatio = denominator === 0 ? zeroDenominatorRatio : numerator / denominator;
+  if (!ratioMatches(ratio, expectedRatio)) {
+    errors.push(createError(
+      'metric_ratio_mismatch',
+      `${basePath}/${ratioField}`,
+      `${ratioField} must equal ${numeratorField}/${denominatorField} within tolerance ${RATIO_TOLERANCE}; expected ${expectedRatio}, got ${ratio}`,
+    ));
+  }
+}
+
+function validateClaimCoverage(metrics, errors) {
+  validateCountRatioMetric({
+    metric: metrics?.claim_coverage,
+    basePath: '/agentPrAssurance/metrics/claim_coverage',
+    numeratorField: 'numerator',
+    denominatorField: 'denominator',
+    ratioField: 'ratio',
+    zeroDenominatorRatio: 1,
+    errors,
+  });
+}
+
+function validateRequiredLaneCompliance(metrics, errors) {
+  const metric = metrics?.required_lane_compliance;
+  if (!isObject(metric)) {
+    return;
+  }
+
+  const basePath = '/agentPrAssurance/metrics/required_lane_compliance';
+  const satisfied = metric.satisfied;
+  const required = metric.required;
+  const ratio = metric.ratio;
+
+  if (!Number.isInteger(satisfied) || !Number.isInteger(required)) {
+    return;
+  }
+
+  if (satisfied > required) {
+    errors.push(createError(
+      'metric_count_order',
+      `${basePath}/satisfied`,
+      `satisfied must be less than or equal to required (${required}), got ${satisfied}`,
+    ));
+  }
+
+  if (required === 0) {
+    if (satisfied !== 0) {
+      errors.push(createError(
+        'metric_zero_denominator',
+        `${basePath}/satisfied`,
+        `satisfied must be 0 when required is 0, got ${satisfied}`,
+      ));
+    }
+    if (ratio !== null) {
+      errors.push(createError(
+        'metric_not_applicable_ratio',
+        `${basePath}/ratio`,
+        `ratio must be null when required is 0, got ${ratio}`,
+      ));
+    }
+    if (metric.notApplicable !== true) {
+      errors.push(createError(
+        'metric_not_applicable_flag',
+        `${basePath}/notApplicable`,
+        'notApplicable must be true when required is 0',
+      ));
+    }
+  } else {
+    const expectedRatio = satisfied / required;
+    if (!ratioMatches(ratio, expectedRatio)) {
+      errors.push(createError(
+        'metric_ratio_mismatch',
+        `${basePath}/ratio`,
+        `ratio must equal satisfied/required within tolerance ${RATIO_TOLERANCE}; expected ${expectedRatio}, got ${ratio}`,
+      ));
+    }
+    if (metric.notApplicable === true) {
+      errors.push(createError(
+        'metric_not_applicable_flag',
+        `${basePath}/notApplicable`,
+        'notApplicable must be absent or false when required is greater than 0',
+      ));
+    }
+  }
+
+  if (satisfied === required && Array.isArray(metric.missingLanes) && metric.missingLanes.length > 0) {
+    errors.push(createError(
+      'metric_missing_lanes_contradiction',
+      `${basePath}/missingLanes`,
+      'missingLanes must be empty or absent when all required lanes are satisfied',
+    ));
+  }
+}
+
+function validateEvidenceCompleteness(metrics, errors) {
+  validateCountRatioMetric({
+    metric: metrics?.evidence_completeness,
+    basePath: '/agentPrAssurance/metrics/evidence_completeness',
+    numeratorField: 'present',
+    denominatorField: 'required',
+    ratioField: 'ratio',
+    zeroDenominatorRatio: 1,
+    errors,
+  });
+}
+
+function validateFalseBlockRate(metrics, errors) {
+  const metric = metrics?.false_block_rate;
+  if (!isObject(metric)) {
+    return;
+  }
+
+  const basePath = '/agentPrAssurance/metrics/false_block_rate';
+  const annotatedFalseBlocks = metric.annotatedFalseBlocks;
+  const totalBlocks = metric.totalBlocks;
+  const ratio = metric.ratio;
+
+  if (!Number.isInteger(totalBlocks)) {
+    return;
+  }
+
+  if (Number.isInteger(annotatedFalseBlocks)) {
+    if (annotatedFalseBlocks > totalBlocks) {
+      errors.push(createError(
+        'metric_count_order',
+        `${basePath}/annotatedFalseBlocks`,
+        `annotatedFalseBlocks must be less than or equal to totalBlocks (${totalBlocks}), got ${annotatedFalseBlocks}`,
+      ));
+    }
+    if (totalBlocks === 0) {
+      if (ratio !== null) {
+        errors.push(createError(
+          'metric_zero_denominator_ratio',
+          `${basePath}/ratio`,
+          `ratio must be null when totalBlocks is 0, got ${ratio}`,
+        ));
+      }
+    } else {
+      const expectedRatio = annotatedFalseBlocks / totalBlocks;
+      if (!ratioMatches(ratio, expectedRatio)) {
+        errors.push(createError(
+          'metric_ratio_mismatch',
+          `${basePath}/ratio`,
+          `ratio must equal annotatedFalseBlocks/totalBlocks within tolerance ${RATIO_TOLERANCE}; expected ${expectedRatio}, got ${ratio}`,
+        ));
+      }
+    }
+  } else if (annotatedFalseBlocks === null) {
+    if (ratio !== null) {
+      errors.push(createError(
+        'metric_unannotated_ratio',
+        `${basePath}/ratio`,
+        `ratio must be null when annotatedFalseBlocks is null, got ${ratio}`,
+      ));
+    }
+    if (metric.annotationRequired !== true) {
+      errors.push(createError(
+        'metric_annotation_required',
+        `${basePath}/annotationRequired`,
+        'annotationRequired must be true when annotatedFalseBlocks is null',
+      ));
+    }
+  }
+}
+
+export function validateAgenticMetricsSemantics(document) {
+  const errors = [];
+  const extension = document?.agentPrAssurance;
+  if (!isObject(extension)) {
+    return errors;
+  }
+  const metrics = extension.metrics;
+  if (!isObject(metrics)) {
+    return errors;
+  }
+
+  validateClaimCoverage(metrics, errors);
+  validateRequiredLaneCompliance(metrics, errors);
+  validateEvidenceCompleteness(metrics, errors);
+  validateFalseBlockRate(metrics, errors);
+
+  return errors;
+}
+
+export const __testOnly_AGENTIC_METRICS_RATIO_TOLERANCE = RATIO_TOLERANCE;

--- a/scripts/ci/validate-json.mjs
+++ b/scripts/ci/validate-json.mjs
@@ -6,6 +6,7 @@ import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
 import yaml from 'yaml';
 import { runSchemaIdPolicyCheck } from './check-schema-id-policy.mjs';
+import { validateAgenticMetricsSemantics } from './lib/agentic-metrics-contract.mjs';
 import { validateClaimEvidenceManifestSemantics } from './lib/claim-evidence-manifest-contract.mjs';
 import {
   validateSecurityAuditTaskBundleSemantics,
@@ -319,7 +320,8 @@ const checks = [
       'fixtures/agentic-metrics/sample.agentic-metrics.json',
       'fixtures/agentic-metrics/agent-pr-assurance-metrics.example.json',
     ],
-    label: 'Agentic metrics schema validation'
+    label: 'Agentic metrics schema validation',
+    semanticValidate: validateAgenticMetricsSemantics
   },
   {
     schema: 'schema/formal-plan.schema.json',

--- a/tests/contracts/agentic-metrics-contract.test.ts
+++ b/tests/contracts/agentic-metrics-contract.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
+import { validateAgenticMetricsSemantics } from '../../scripts/ci/lib/agentic-metrics-contract.mjs';
 
 const schema = JSON.parse(
   readFileSync(resolve('schema/agentic-metrics.schema.json'), 'utf8'),
@@ -20,12 +21,31 @@ function compileSchema() {
   return ajv.compile(schema);
 }
 
+function expectSemanticError(
+  fixture: Record<string, unknown>,
+  expectedPath: string,
+  expectedKeyword?: string,
+) {
+  const validate = compileSchema();
+
+  expect(validate(fixture), JSON.stringify(validate.errors)).toBe(true);
+
+  const errors = validateAgenticMetricsSemantics(fixture);
+  expect(errors).not.toEqual([]);
+  expect(errors.some((entry) => entry.instancePath === expectedPath)).toBe(true);
+  if (expectedKeyword) {
+    expect(errors.some((entry) => entry.keyword === expectedKeyword)).toBe(true);
+  }
+}
+
 describe('agentic-metrics contract', () => {
   it('validates existing agentic metrics fixtures with and without report-only PR assurance metrics', () => {
     const validate = compileSchema();
 
     expect(validate(sampleFixture), JSON.stringify(validate.errors)).toBe(true);
     expect(validate(agentPrAssuranceFixture), JSON.stringify(validate.errors)).toBe(true);
+    expect(validateAgenticMetricsSemantics(sampleFixture)).toEqual([]);
+    expect(validateAgenticMetricsSemantics(agentPrAssuranceFixture)).toEqual([]);
   });
 
   it('keeps agentPrAssurance report-only', () => {
@@ -65,6 +85,7 @@ describe('agentic-metrics contract', () => {
     };
 
     expect(validate(nAComplianceFixture), JSON.stringify(validate.errors)).toBe(true);
+    expect(validateAgenticMetricsSemantics(nAComplianceFixture as unknown as Record<string, unknown>)).toEqual([]);
   });
 
   it('requires all named report-only agent PR assurance metrics when the extension is present', () => {
@@ -77,5 +98,334 @@ describe('agentic-metrics contract', () => {
 
     expect(validate(invalidFixture)).toBe(false);
     expect(validate.errors?.some((entry) => entry.instancePath === '/agentPrAssurance/metrics')).toBe(true);
+  });
+
+  it.each([
+    {
+      name: 'claim_coverage numerator greater than denominator',
+      expectedPath: '/agentPrAssurance/metrics/claim_coverage/numerator',
+      expectedKeyword: 'metric_count_order',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { claim_coverage: { numerator: number } };
+          }
+        ).metrics.claim_coverage;
+        metric.numerator = 6;
+      },
+    },
+    {
+      name: 'claim_coverage ratio mismatch',
+      expectedPath: '/agentPrAssurance/metrics/claim_coverage/ratio',
+      expectedKeyword: 'metric_ratio_mismatch',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { claim_coverage: { ratio: number } };
+          }
+        ).metrics.claim_coverage;
+        metric.ratio = 0.7;
+      },
+    },
+    {
+      name: 'required_lane_compliance satisfied greater than required',
+      expectedPath: '/agentPrAssurance/metrics/required_lane_compliance/satisfied',
+      expectedKeyword: 'metric_count_order',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { required_lane_compliance: { satisfied: number } };
+          }
+        ).metrics.required_lane_compliance;
+        metric.satisfied = 5;
+      },
+    },
+    {
+      name: 'required_lane_compliance ratio mismatch',
+      expectedPath: '/agentPrAssurance/metrics/required_lane_compliance/ratio',
+      expectedKeyword: 'metric_ratio_mismatch',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { required_lane_compliance: { ratio: number } };
+          }
+        ).metrics.required_lane_compliance;
+        metric.ratio = 0.5;
+      },
+    },
+    {
+      name: 'required_lane_compliance required zero with non-null ratio',
+      expectedPath: '/agentPrAssurance/metrics/required_lane_compliance/ratio',
+      expectedKeyword: 'metric_not_applicable_ratio',
+      mutate: (fixture: Record<string, unknown>) => {
+        (
+          fixture.agentPrAssurance as {
+            metrics: {
+              required_lane_compliance: {
+                satisfied: number;
+                required: number;
+                ratio: number | null;
+                missingLanes: string[];
+                notApplicable: boolean;
+              };
+            };
+          }
+        ).metrics.required_lane_compliance = {
+          satisfied: 0,
+          required: 0,
+          ratio: 0,
+          missingLanes: [],
+          notApplicable: true,
+        };
+      },
+    },
+    {
+      name: 'required_lane_compliance required zero without notApplicable',
+      expectedPath: '/agentPrAssurance/metrics/required_lane_compliance/notApplicable',
+      expectedKeyword: 'metric_not_applicable_flag',
+      mutate: (fixture: Record<string, unknown>) => {
+        (
+          fixture.agentPrAssurance as {
+            metrics: {
+              required_lane_compliance: {
+                satisfied: number;
+                required: number;
+                ratio: number | null;
+                missingLanes: string[];
+              };
+            };
+          }
+        ).metrics.required_lane_compliance = {
+          satisfied: 0,
+          required: 0,
+          ratio: null,
+          missingLanes: [],
+        };
+      },
+    },
+    {
+      name: 'required_lane_compliance required greater than zero with notApplicable',
+      expectedPath: '/agentPrAssurance/metrics/required_lane_compliance/notApplicable',
+      expectedKeyword: 'metric_not_applicable_flag',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { required_lane_compliance: { notApplicable: boolean } };
+          }
+        ).metrics.required_lane_compliance;
+        metric.notApplicable = true;
+      },
+    },
+    {
+      name: 'evidence_completeness present greater than required',
+      expectedPath: '/agentPrAssurance/metrics/evidence_completeness/present',
+      expectedKeyword: 'metric_count_order',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { evidence_completeness: { present: number } };
+          }
+        ).metrics.evidence_completeness;
+        metric.present = 7;
+      },
+    },
+    {
+      name: 'evidence_completeness ratio mismatch',
+      expectedPath: '/agentPrAssurance/metrics/evidence_completeness/ratio',
+      expectedKeyword: 'metric_ratio_mismatch',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { evidence_completeness: { ratio: number } };
+          }
+        ).metrics.evidence_completeness;
+        metric.ratio = 0.8;
+      },
+    },
+    {
+      name: 'false_block_rate annotated false blocks greater than total blocks',
+      expectedPath: '/agentPrAssurance/metrics/false_block_rate/annotatedFalseBlocks',
+      expectedKeyword: 'metric_count_order',
+      mutate: (fixture: Record<string, unknown>) => {
+        (
+          fixture.agentPrAssurance as {
+            metrics: {
+              false_block_rate: {
+                annotatedFalseBlocks: number;
+                totalBlocks: number;
+                ratio: number;
+                annotationRequired: boolean;
+              };
+            };
+          }
+        ).metrics.false_block_rate = {
+          annotatedFalseBlocks: 2,
+          totalBlocks: 1,
+          ratio: 1,
+          annotationRequired: false,
+        };
+      },
+    },
+    {
+      name: 'false_block_rate numeric ratio mismatch',
+      expectedPath: '/agentPrAssurance/metrics/false_block_rate/ratio',
+      expectedKeyword: 'metric_ratio_mismatch',
+      mutate: (fixture: Record<string, unknown>) => {
+        (
+          fixture.agentPrAssurance as {
+            metrics: {
+              false_block_rate: {
+                annotatedFalseBlocks: number;
+                totalBlocks: number;
+                ratio: number;
+                annotationRequired: boolean;
+              };
+            };
+          }
+        ).metrics.false_block_rate = {
+          annotatedFalseBlocks: 1,
+          totalBlocks: 2,
+          ratio: 1,
+          annotationRequired: false,
+        };
+      },
+    },
+    {
+      name: 'false_block_rate unannotated metric with non-null ratio',
+      expectedPath: '/agentPrAssurance/metrics/false_block_rate/ratio',
+      expectedKeyword: 'metric_unannotated_ratio',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { false_block_rate: { ratio: number | null } };
+          }
+        ).metrics.false_block_rate;
+        metric.ratio = 0;
+      },
+    },
+    {
+      name: 'false_block_rate unannotated metric without annotationRequired',
+      expectedPath: '/agentPrAssurance/metrics/false_block_rate/annotationRequired',
+      expectedKeyword: 'metric_annotation_required',
+      mutate: (fixture: Record<string, unknown>) => {
+        const metric = (
+          fixture.agentPrAssurance as {
+            metrics: { false_block_rate: { annotationRequired?: boolean } };
+          }
+        ).metrics.false_block_rate;
+        delete metric.annotationRequired;
+      },
+    },
+  ])('rejects semantic inconsistency: $name', ({ mutate, expectedPath, expectedKeyword }) => {
+    const invalidFixture = structuredClone(agentPrAssuranceFixture);
+
+    mutate(invalidFixture);
+
+    expectSemanticError(invalidFixture, expectedPath, expectedKeyword);
+  });
+
+  it('rejects missing lanes when required lane compliance is fully satisfied', () => {
+    const invalidFixture = structuredClone(agentPrAssuranceFixture) as {
+      agentPrAssurance: {
+        metrics: {
+          required_lane_compliance: {
+            satisfied: number;
+            required: number;
+            ratio: number;
+            missingLanes: string[];
+          };
+        };
+      };
+    };
+
+    invalidFixture.agentPrAssurance.metrics.required_lane_compliance = {
+      satisfied: 4,
+      required: 4,
+      ratio: 1,
+      missingLanes: ['model'],
+    };
+
+    expectSemanticError(
+      invalidFixture as unknown as Record<string, unknown>,
+      '/agentPrAssurance/metrics/required_lane_compliance/missingLanes',
+      'metric_missing_lanes_contradiction',
+    );
+  });
+
+  it('defines zero-denominator behavior for ratio metrics', () => {
+    const zeroDenominatorFixture = structuredClone(agentPrAssuranceFixture) as {
+      agentPrAssurance: {
+        metrics: {
+          claim_coverage: {
+            numerator: number;
+            denominator: number;
+            ratio: number;
+          };
+          evidence_completeness: {
+            present: number;
+            required: number;
+            ratio: number;
+            missingArtifacts: string[];
+          };
+          false_block_rate: {
+            annotatedFalseBlocks: number;
+            totalBlocks: number;
+            ratio: null;
+            annotationRequired: boolean;
+          };
+        };
+      };
+    };
+
+    zeroDenominatorFixture.agentPrAssurance.metrics.claim_coverage = {
+      numerator: 0,
+      denominator: 0,
+      ratio: 1,
+    };
+    zeroDenominatorFixture.agentPrAssurance.metrics.evidence_completeness = {
+      present: 0,
+      required: 0,
+      ratio: 1,
+      missingArtifacts: [],
+    };
+    zeroDenominatorFixture.agentPrAssurance.metrics.false_block_rate = {
+      annotatedFalseBlocks: 0,
+      totalBlocks: 0,
+      ratio: null,
+      annotationRequired: false,
+    };
+
+    const validate = compileSchema();
+
+    expect(validate(zeroDenominatorFixture), JSON.stringify(validate.errors)).toBe(true);
+    expect(validateAgenticMetricsSemantics(zeroDenominatorFixture as unknown as Record<string, unknown>)).toEqual([]);
+  });
+
+  it('rejects numeric false block rates when totalBlocks is zero', () => {
+    const invalidFixture = structuredClone(agentPrAssuranceFixture) as {
+      agentPrAssurance: {
+        metrics: {
+          false_block_rate: {
+            annotatedFalseBlocks: number;
+            totalBlocks: number;
+            ratio: number;
+            annotationRequired: boolean;
+          };
+        };
+      };
+    };
+
+    invalidFixture.agentPrAssurance.metrics.false_block_rate = {
+      annotatedFalseBlocks: 0,
+      totalBlocks: 0,
+      ratio: 0,
+      annotationRequired: false,
+    };
+
+    expectSemanticError(
+      invalidFixture as unknown as Record<string, unknown>,
+      '/agentPrAssurance/metrics/false_block_rate/ratio',
+      'metric_zero_denominator_ratio',
+    );
   });
 });

--- a/tests/contracts/agentic-metrics-contract.test.ts
+++ b/tests/contracts/agentic-metrics-contract.test.ts
@@ -32,10 +32,12 @@ function expectSemanticError(
 
   const errors = validateAgenticMetricsSemantics(fixture);
   expect(errors).not.toEqual([]);
-  expect(errors.some((entry) => entry.instancePath === expectedPath)).toBe(true);
-  if (expectedKeyword) {
-    expect(errors.some((entry) => entry.keyword === expectedKeyword)).toBe(true);
-  }
+  expect(
+    errors.some(
+      (entry) => entry.instancePath === expectedPath
+        && (expectedKeyword === undefined || entry.keyword === expectedKeyword),
+    ),
+  ).toBe(true);
 }
 
 describe('agentic-metrics contract', () => {


### PR DESCRIPTION
## Summary
- add semantic validation for optional report-only `agentPrAssurance` metrics in `agentic-metrics`
- validate count ordering, rounded ratio consistency, lane not-applicable rules, false-block annotation/null behavior, and missing-lane contradictions
- document zero-denominator/null behavior and that `agent_regression_signal.regressed` remains producer-supplied

## Acceptance
- Closes #3448
- Existing valid `agentic-metrics` fixtures pass schema and semantic validation
- Negative tests cover count-order, ratio mismatch, lane `notApplicable`, `missingLanes`, and false-block null/annotation cases
- `agentPrAssurance.reportOnly` remains required/true and no new `policy-gate` blocking condition is introduced

## Verification
- `pnpm -s exec vitest run tests/contracts/agentic-metrics-contract.test.ts --reporter dot` — 20 tests passed
- `node scripts/ci/validate-json.mjs` — passed
- `pnpm -s run check:schemas` — passed
- `pnpm -s run types:check` — passed
- `pnpm -s exec eslint --quiet scripts/ci/lib/agentic-metrics-contract.mjs scripts/ci/validate-json.mjs tests/contracts/agentic-metrics-contract.test.ts` — passed
- `pnpm -s run check:doc-consistency` — passed
- `pnpm -s run docs:lint` — passed
- `pnpm -s run build` — passed
- `git diff --check` — passed

## Rollback
- Remove `scripts/ci/lib/agentic-metrics-contract.mjs` and the `semanticValidate` hook from `scripts/ci/validate-json.mjs`.
- Revert the contract-test additions and semantic-behavior documentation.
