### PR TITLE
docs(governance): normalize assurance verification metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 docRole: narrative
-lastVerified: '2026-03-09'
+lastVerified: '2026-06-06'
 ---
 
 # ae-framework: Agent-Neutral Assurance Control Plane for Agent-Driven SDLC

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 docRole: narrative
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 ---
 
 # ae-framework: Agent-Neutral Assurance Control Plane for Agent-Driven SDLC

--- a/docs/ci/agent-pr-assurance-metrics.md
+++ b/docs/ci/agent-pr-assurance-metrics.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---

--- a/docs/ci/agent-pr-assurance-metrics.md
+++ b/docs/ci/agent-pr-assurance-metrics.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-06-05'
+lastVerified: '2026-06-06'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---

--- a/docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
+++ b/docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-05-08'
+lastVerified: '2026-06-06'
 owner: product-assurance
 verificationCommand: pnpm -s run check:doc-consistency
 ---

--- a/docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
+++ b/docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 owner: product-assurance
 verificationCommand: pnpm -s run check:doc-consistency
 ---

--- a/docs/product/ASSURANCE-CONTROL-PLANE.md
+++ b/docs/product/ASSURANCE-CONTROL-PLANE.md
@@ -4,7 +4,7 @@ canonicalSource:
 - docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
 - docs/quality/ASSURANCE-MODEL.md
 - docs/architecture/CURRENT-SYSTEM-OVERVIEW.md
-lastVerified: '2026-05-08'
+lastVerified: '2026-06-06'
 ---
 # Assurance Control Plane
 

--- a/docs/product/ASSURANCE-CONTROL-PLANE.md
+++ b/docs/product/ASSURANCE-CONTROL-PLANE.md
@@ -4,7 +4,7 @@ canonicalSource:
 - docs/product/ASSURANCE-CONTROL-PLANE-POLICY.md
 - docs/quality/ASSURANCE-MODEL.md
 - docs/architecture/CURRENT-SYSTEM-OVERVIEW.md
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 ---
 # Assurance Control Plane
 

--- a/docs/quality/ASSURANCE-MODEL.md
+++ b/docs/quality/ASSURANCE-MODEL.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-04-05'
+lastVerified: '2026-06-06'
 owner: assurance-model
 verificationCommand: pnpm -s run check:doc-consistency
 ---

--- a/docs/quality/ASSURANCE-MODEL.md
+++ b/docs/quality/ASSURANCE-MODEL.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 owner: assurance-model
 verificationCommand: pnpm -s run check:doc-consistency
 ---

--- a/docs/quality/doc-consistency-lint.md
+++ b/docs/quality/doc-consistency-lint.md
@@ -3,7 +3,7 @@ docRole: derived
 canonicalSource:
 - docs/reference/DOC-GOVERNANCE.md
 - scripts/docs/check-doc-consistency-all.mjs
-lastVerified: '2026-03-26'
+lastVerified: '2026-06-06'
 ---
 # Doc Consistency Lint
 
@@ -36,6 +36,7 @@ Checks:
 - TODO/FIXME markers under `docs/ci/*` require issue references such as `TODO(#<issue>)` or `FIXME(#<issue>)`.
 - Governed docs must provide valid `docRole`, `canonicalSource`, and `lastVerified` front matter.
 - `docs/legacy/**/*.md` and `docs/notes/*.md` are treated as archival / working-note narrative, so narrative warnings intentionally ignore historical wording and issue-memo language.
+- `lastVerified` means the documented verification command or an equivalent docs-governance validation suite last passed for that document slice; it is not a last-edited date.
 
 Current default targets:
 - Base: the repository-root README file, `docs/README.md`, and the primary documents listed in `DEFAULT_DOC_FILES` such as the Getting Started, Product, and Integrations guides
@@ -116,6 +117,7 @@ If a new docs section needs additional exclusions, update `scripts/docs/check-do
 - `docs/ci/*` の TODO/FIXME marker が Issue 参照付きであること（`TODO(#<issue>)` / `FIXME(#<issue>)`）
 - governed docs の `docRole` / `canonicalSource` / `lastVerified` front matter を検証すること
 - `docs/legacy/**/*.md` と `docs/notes/*.md` を archival / working-note narrative として扱い、歴史的文言や issue memo の文言に対する narrative warning を除外すること
+- `lastVerified` は、記載された verification command または同等の docs-governance 検証がその文書スライスで最後に通過した日付であり、最終編集日ではないこと
 
 既定の対象:
 - Base: リポジトリルートの README ファイル、`docs/README.md`、および `DEFAULT_DOC_FILES` に含まれる Getting Started / Product / Integrations の主要ドキュメント

--- a/docs/quality/doc-consistency-lint.md
+++ b/docs/quality/doc-consistency-lint.md
@@ -3,7 +3,7 @@ docRole: derived
 canonicalSource:
 - docs/reference/DOC-GOVERNANCE.md
 - scripts/docs/check-doc-consistency-all.mjs
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 ---
 # Doc Consistency Lint
 
@@ -36,7 +36,7 @@ Checks:
 - TODO/FIXME markers under `docs/ci/*` require issue references such as `TODO(#<issue>)` or `FIXME(#<issue>)`.
 - Governed docs must provide valid `docRole`, `canonicalSource`, and `lastVerified` front matter.
 - `docs/legacy/**/*.md` and `docs/notes/*.md` are treated as archival / working-note narrative, so narrative warnings intentionally ignore historical wording and issue-memo language.
-- `lastVerified` means the documented verification command or an equivalent docs-governance validation suite last passed for that document slice; it is not a last-edited date.
+- `lastVerified` means the UTC date when the documented verification command or an equivalent docs-governance validation suite last passed for that document slice; it is not a last-edited date.
 
 Current default targets:
 - Base: the repository-root README file, `docs/README.md`, and the primary documents listed in `DEFAULT_DOC_FILES` such as the Getting Started, Product, and Integrations guides
@@ -117,7 +117,7 @@ If a new docs section needs additional exclusions, update `scripts/docs/check-do
 - `docs/ci/*` の TODO/FIXME marker が Issue 参照付きであること（`TODO(#<issue>)` / `FIXME(#<issue>)`）
 - governed docs の `docRole` / `canonicalSource` / `lastVerified` front matter を検証すること
 - `docs/legacy/**/*.md` と `docs/notes/*.md` を archival / working-note narrative として扱い、歴史的文言や issue memo の文言に対する narrative warning を除外すること
-- `lastVerified` は、記載された verification command または同等の docs-governance 検証がその文書スライスで最後に通過した日付であり、最終編集日ではないこと
+- `lastVerified` は、記載された verification command または同等の docs-governance 検証がその文書スライスで最後に通過した UTC 日付であり、最終編集日ではないこと
 
 既定の対象:
 - Base: リポジトリルートの README ファイル、`docs/README.md`、および `DEFAULT_DOC_FILES` に含まれる Getting Started / Product / Integrations の主要ドキュメント

--- a/docs/reference/CONTRACT-CATALOG.md
+++ b/docs/reference/CONTRACT-CATALOG.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-05-08'
+lastVerified: '2026-06-06'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -25,7 +25,7 @@ This document is the baseline inventory created for Issue #2406. It classifies t
 
 Some schemas are dual-role. This catalog records the primary role used in the current implementation.
 
-### 3. Schema inventory (snapshot: 2026-05-08)
+### 3. Schema inventory (snapshot: 2026-06-06)
 
 #### 3.1 input
 

--- a/docs/reference/CONTRACT-CATALOG.md
+++ b/docs/reference/CONTRACT-CATALOG.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -25,7 +25,7 @@ This document is the baseline inventory created for Issue #2406. It classifies t
 
 Some schemas are dual-role. This catalog records the primary role used in the current implementation.
 
-### 3. Schema inventory (snapshot: 2026-06-06)
+### 3. Schema inventory (snapshot: 2026-06-05)
 
 #### 3.1 input
 

--- a/docs/reference/DOC-GOVERNANCE.md
+++ b/docs/reference/DOC-GOVERNANCE.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-03-21'
+lastVerified: '2026-06-06'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -29,6 +29,8 @@ owner: team-or-doc-owner        # required for ssot
 verificationCommand: pnpm ...   # required for ssot
 ---
 ```
+
+`lastVerified` records the date when the listed `verificationCommand` or an equivalent docs-governance validation suite last passed for the document slice. It is not a "last edited" timestamp and does not, by itself, claim a full assurance audit or maintainer sign-off. If a document has an explicit inventory or snapshot date, that date records the source data snapshot for that section; keep it separate from `lastVerified` and update it only when that inventory is rechecked.
 
 ### 3. Roles
 
@@ -138,6 +140,8 @@ owner: team-or-doc-owner        # ssot のとき必須
 verificationCommand: pnpm ...   # ssot のとき必須
 ---
 ```
+
+`lastVerified` は、その文書スライスに対して記載済みの `verificationCommand` または同等の docs-governance 検証が最後に通過した日付です。「最終編集日」ではなく、それだけで full assurance audit や maintainer sign-off を意味しません。文書内に inventory / snapshot date がある場合、その日付は当該セクションの入力データのスナップショットを表します。`lastVerified` とは分け、inventory を再確認した場合のみ更新します。
 
 ## 3. Roles
 

--- a/docs/reference/DOC-GOVERNANCE.md
+++ b/docs/reference/DOC-GOVERNANCE.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 owner: docs-governance
 verificationCommand: pnpm -s run check:doc-consistency
 ---
@@ -30,7 +30,7 @@ verificationCommand: pnpm ...   # required for ssot
 ---
 ```
 
-`lastVerified` records the date when the listed `verificationCommand` or an equivalent docs-governance validation suite last passed for the document slice. It is not a "last edited" timestamp and does not, by itself, claim a full assurance audit or maintainer sign-off. If a document has an explicit inventory or snapshot date, that date records the source data snapshot for that section; keep it separate from `lastVerified` and update it only when that inventory is rechecked.
+`lastVerified` records the UTC date when the listed `verificationCommand` or an equivalent docs-governance validation suite last passed for the document slice. It is not a "last edited" timestamp and does not, by itself, claim a full assurance audit or maintainer sign-off. If a document has an explicit inventory or snapshot date, that date records the source data snapshot for that section; keep it separate from `lastVerified` and update it only when that inventory is rechecked.
 
 ### 3. Roles
 
@@ -141,7 +141,7 @@ verificationCommand: pnpm ...   # ssot のとき必須
 ---
 ```
 
-`lastVerified` は、その文書スライスに対して記載済みの `verificationCommand` または同等の docs-governance 検証が最後に通過した日付です。「最終編集日」ではなく、それだけで full assurance audit や maintainer sign-off を意味しません。文書内に inventory / snapshot date がある場合、その日付は当該セクションの入力データのスナップショットを表します。`lastVerified` とは分け、inventory を再確認した場合のみ更新します。
+`lastVerified` は、その文書スライスに対して記載済みの `verificationCommand` または同等の docs-governance 検証が最後に通過した UTC 日付です。「最終編集日」ではなく、それだけで full assurance audit や maintainer sign-off を意味しません。文書内に inventory / snapshot date がある場合、その日付は当該セクションの入力データのスナップショットを表します。`lastVerified` とは分け、inventory を再確認した場合のみ更新します。
 
 ## 3. Roles
 

--- a/docs/spec/context-pack.md
+++ b/docs/spec/context-pack.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-03-24'
+lastVerified: '2026-06-06'
 owner: context-pack-ops
 verificationCommand: pnpm -s run check:doc-consistency
 ---

--- a/docs/spec/context-pack.md
+++ b/docs/spec/context-pack.md
@@ -1,6 +1,6 @@
 ---
 docRole: ssot
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-05'
 owner: context-pack-ops
 verificationCommand: pnpm -s run check:doc-consistency
 ---


### PR DESCRIPTION
## Summary
- define `lastVerified` as the date the listed verification command or equivalent docs-governance suite last passed, not a last-edited or full-audit date
- update assurance-control-plane rollout docs and the root README metadata to the current verification date
- refresh the Contract Catalog schema-inventory snapshot date after `check:doc-consistency` confirmed the catalog coverage

## Acceptance
- Closes #3450
- `README.md` and `docs/reference/CONTRACT-CATALOG.md` no longer mix updated assurance positioning with stale-looking verification metadata
- snapshot-date semantics are documented separately from `lastVerified`
- changes are limited to assurance-control-plane rollout docs and docs-governance references

## Verification
- `pnpm -s run check:doc-consistency` — passed
- `pnpm -s run docs:lint` — passed
- `node scripts/docs/check-doc-governance.mjs` — passed
- `pnpm -s run check:schemas` — passed
- metadata grep for the updated target docs and Contract Catalog snapshot — verified
- `git diff --check` — passed

## Rollback
- Revert the frontmatter date updates and the two docs-governance clarification paragraphs.
