### PR TITLE
fix(security): centralize workspace path containment

### DIFF
--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -2,7 +2,7 @@
 docRole: derived
 canonicalSource:
   - .github/workflows/agent-commands.yml
-lastVerified: '2026-06-06'
+lastVerified: '2026-06-07'
 ---
 
 # Agent Commands Catalog

--- a/scripts/codex/generate-openapi-tests.ts
+++ b/scripts/codex/generate-openapi-tests.ts
@@ -3,7 +3,11 @@
 import { promises as fs } from 'fs'
 import path from 'path'
 import yaml from 'yaml'
-import { resolveWorkspacePath } from '../../src/utils/workspace-path-policy.js'
+import {
+  assertWithinWorkspace,
+  resolveWorkspacePath,
+  toWorkspaceRelativePath,
+} from '../../src/utils/workspace-path-policy.js'
 
 const DEFAULT_REVIEW_OUTPUT_DIR = 'artifacts/codex/generated-tests'
 const REVIEWED_TEST_OUTPUT_APPROVAL = 'reviewed-generated-tests'
@@ -12,44 +16,19 @@ async function exists(p: string) {
   try { await fs.stat(p); return true } catch { return false }
 }
 
-function isPathWithin(baseDir: string, candidatePath: string): boolean {
-  const relative = path.relative(baseDir, candidatePath)
-  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative))
-}
-
 function normalizeWorkspacePath(repo: string, inputPath: string, label: string): { absolutePath: string; relativePath: string } {
   const raw = String(inputPath).trim()
   if (!raw) throw new Error(`${label} must be non-empty`)
-  if (raw.includes('\0')) throw new Error(`${label} must not contain NUL bytes`)
-  if (raw.includes('\\')) throw new Error(`${label} must use POSIX-style '/' separators`)
-  if (/^[A-Za-z]:[\\/]/.test(raw)) throw new Error(`${label} must be inside the approved workspace`)
-  const rawSegments = raw.split('/').filter(Boolean)
-  if (rawSegments.some((segment) => segment === '.' || segment === '..')) {
-    throw new Error(`${label} must not contain dot-segment path components`)
-  }
-  if (rawSegments.some((segment) => segment.toLowerCase() === '.git')) {
-    throw new Error(`${label} must not target Git metadata directories`)
-  }
-
-  const absolutePath = path.isAbsolute(raw) ? path.resolve(raw) : path.resolve(repo, raw)
-  if (!isPathWithin(repo, absolutePath)) {
-    throw new Error(`${label} must stay inside the approved workspace`)
-  }
-  const relativePath = path.relative(repo, absolutePath).replace(/\\/g, '/')
+  const absolutePath = path.isAbsolute(raw)
+    ? assertWithinWorkspace(raw, { workspaceRoot: repo, label })
+    : resolveWorkspacePath(raw, { workspaceRoot: repo, label })
+  const relativePath = toWorkspaceRelativePath(absolutePath, { workspaceRoot: repo, label })
   const segments = relativePath.split('/').filter(Boolean)
   if (segments.length === 0) throw new Error(`${label} must not target the workspace root`)
-  if (segments.some((segment) => segment === '.' || segment === '..')) {
-    throw new Error(`${label} must not contain dot-segment path components`)
-  }
   if (segments.some((segment) => segment.toLowerCase() === '.git')) {
     throw new Error(`${label} must not target Git metadata directories`)
   }
-  const safeRelativePath = segments.join('/')
-  const realpathCheckedPath = resolveWorkspacePath(safeRelativePath, {
-    workspaceRoot: repo,
-    label,
-  })
-  return { absolutePath: realpathCheckedPath, relativePath: safeRelativePath }
+  return { absolutePath, relativePath }
 }
 
 function getArgValue(name: string): string | undefined {

--- a/scripts/codex/generate-openapi-tests.ts
+++ b/scripts/codex/generate-openapi-tests.ts
@@ -23,6 +23,7 @@ function normalizeWorkspacePath(repo: string, inputPath: string, label: string):
     ? assertWithinWorkspace(raw, { workspaceRoot: repo, label })
     : resolveWorkspacePath(raw, { workspaceRoot: repo, label })
   const relativePath = toWorkspaceRelativePath(absolutePath, { workspaceRoot: repo, label })
+  if (relativePath === '.') throw new Error(`${label} must not target the workspace root`)
   const segments = relativePath.split('/').filter(Boolean)
   if (segments.length === 0) throw new Error(`${label} must not target the workspace root`)
   if (segments.some((segment) => segment.toLowerCase() === '.git')) {

--- a/src/cli/cegis-cli.ts
+++ b/src/cli/cegis-cli.ts
@@ -16,6 +16,10 @@ import type { FailureArtifact, AutoFixOptions } from '../cegis/types.js';
 import { toMessage } from '../utils/error-utils.js';
 import { safeExit } from '../utils/safe-exit.js';
 import { loadConfig } from '../core/config.js';
+import {
+  assertWithinWorkspace,
+  resolveWorkspacePath,
+} from '../utils/workspace-path-policy.js';
 
 interface ConformanceViolationInput {
   ruleId?: string;
@@ -67,6 +71,14 @@ export class CEGISCli {
 
   constructor() {
     this.engine = new AutoFixEngine();
+  }
+
+  private resolveCliWorkspacePath(input: string, label: string): string {
+    const workspaceRoot = process.cwd();
+    const raw = String(input).trim();
+    return path.isAbsolute(raw)
+      ? assertWithinWorkspace(raw, { workspaceRoot, label })
+      : resolveWorkspacePath(raw, { workspaceRoot, label });
   }
 
   /**
@@ -370,7 +382,9 @@ export class CEGISCli {
       }
 
       // Save artifact
-      writeFileSync(options.output, JSON.stringify([artifact], null, 2));
+      const outputPath = this.resolveCliWorkspacePath(options.output, 'CEGIS failure artifact output path');
+      mkdirSync(path.dirname(outputPath), { recursive: true });
+      writeFileSync(outputPath, JSON.stringify([artifact], null, 2));
       console.log(`✅ Failure artifact created: ${options.output}`);
 
     } catch (error: unknown) {
@@ -387,11 +401,27 @@ export class CEGISCli {
     try {
       console.log('🧪 Converting conformance violations to failure artifacts...');
 
-      if (!options.input || !existsSync(options.input)) {
+      if (!options.input) {
+        throw new Error('Conformance result file not specified');
+      }
+      if (!options.output) {
+        throw new Error('Conformance failure artifact output file not specified');
+      }
+
+      const inputPath = this.resolveCliWorkspacePath(
+        options.input,
+        'CEGIS conformance result input path',
+      );
+      const outputPath = this.resolveCliWorkspacePath(
+        options.output,
+        'CEGIS conformance failure artifact output path',
+      );
+
+      if (!existsSync(inputPath)) {
         throw new Error(`Conformance result file not found: ${options.input}`);
       }
 
-      const content = readFileSync(options.input, 'utf-8');
+      const content = readFileSync(inputPath, 'utf-8');
       const parsed = JSON.parse(content) as ConformanceVerifyResultInput;
       const violations = Array.isArray(parsed.violations) ? parsed.violations : [];
 
@@ -401,9 +431,9 @@ export class CEGISCli {
         ),
       );
 
-      const outputDir = path.dirname(options.output);
+      const outputDir = path.dirname(outputPath);
       mkdirSync(outputDir, { recursive: true });
-      writeFileSync(options.output, JSON.stringify(failures, null, 2));
+      writeFileSync(outputPath, JSON.stringify(failures, null, 2));
 
       console.log(`📋 Conformance violations: ${violations.length}`);
       console.log(`✅ Generated failure artifacts: ${failures.length}`);
@@ -751,12 +781,13 @@ export class CEGISCli {
       return [];
     }
 
-    if (!existsSync(inputFile)) {
+    const inputPath = this.resolveCliWorkspacePath(inputFile, 'CEGIS failure artifact input path');
+    if (!existsSync(inputPath)) {
       throw new Error(`Input file not found: ${inputFile}`);
     }
 
     try {
-      const content = readFileSync(inputFile, 'utf-8');
+      const content = readFileSync(inputPath, 'utf-8');
       const data = JSON.parse(content);
       
       // Handle both single artifact and array

--- a/src/cli/conformance-ingest.ts
+++ b/src/cli/conformance-ingest.ts
@@ -2,6 +2,11 @@ import { createHash } from 'node:crypto';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { toMessage } from '../utils/error-utils.js';
+import {
+  assertWithinWorkspace,
+  resolveWorkspacePath,
+  toWorkspaceRelativePath,
+} from '../utils/workspace-path-policy.js';
 
 export type TraceRedactionAction = 'remove' | 'mask' | 'hash';
 
@@ -20,6 +25,7 @@ export interface ConformanceIngestOptions {
   inputPath: string;
   outputPath: string;
   summaryOutputPath: string;
+  workspaceRoot?: string;
   sourceEnv?: string;
   sourceService?: string;
   sourceTimeStart?: string;
@@ -133,8 +139,15 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0;
 
-const toRelativePath = (filePath: string): string =>
-  path.relative(process.cwd(), filePath) || '.';
+const resolveConformanceWorkspacePath = (input: string, workspaceRoot: string, label: string): string => {
+  const raw = String(input).trim();
+  return path.isAbsolute(raw)
+    ? assertWithinWorkspace(raw, { workspaceRoot, label })
+    : resolveWorkspacePath(raw, { workspaceRoot, label });
+};
+
+const toRelativePath = (filePath: string, workspaceRoot: string): string =>
+  toWorkspaceRelativePath(filePath, { workspaceRoot, label: 'conformance ingest path' });
 
 const parseSimpleJsonPath = (jsonPath: string): string[] | null => {
   if (!jsonPath.startsWith('$.')) {
@@ -350,9 +363,14 @@ export const runConformanceIngest = (options: ConformanceIngestOptions): {
   bundle: TraceBundle;
   summary: TraceBundleSummary;
 } => {
-  const inputPath = path.resolve(options.inputPath);
-  const outputPath = path.resolve(options.outputPath);
-  const summaryOutputPath = path.resolve(options.summaryOutputPath);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? process.cwd());
+  const inputPath = resolveConformanceWorkspacePath(options.inputPath, workspaceRoot, 'conformance ingest input path');
+  const outputPath = resolveConformanceWorkspacePath(options.outputPath, workspaceRoot, 'conformance ingest output path');
+  const summaryOutputPath = resolveConformanceWorkspacePath(
+    options.summaryOutputPath,
+    workspaceRoot,
+    'conformance ingest summary output path',
+  );
   const sampleRate = toNormalizedSampleRate(options.sampleRate);
   const maxEvents = toNormalizedMaxEvents(options.maxEvents);
   const redactRules = options.redactRules ?? [];
@@ -383,7 +401,7 @@ export const runConformanceIngest = (options: ConformanceIngestOptions): {
       ...(options.sourceBuildId ? { buildId: options.sourceBuildId } : {}),
       ...(options.sourceGitSha ? { gitSha: options.sourceGitSha } : {}),
       input: {
-        path: toRelativePath(inputPath),
+        path: toRelativePath(inputPath, workspaceRoot),
         format,
       },
       timeWindow: resolveTimeWindowFromSortedEvents(sortedEvents, options.sourceTimeStart, options.sourceTimeEnd),
@@ -407,12 +425,12 @@ export const runConformanceIngest = (options: ConformanceIngestOptions): {
     schemaVersion: 'ae-trace-bundle-summary/v1',
     generatedAt,
     input: {
-      path: toRelativePath(inputPath),
+      path: toRelativePath(inputPath, workspaceRoot),
       format,
     },
     output: {
-      bundlePath: toRelativePath(outputPath),
-      summaryPath: toRelativePath(summaryOutputPath),
+      bundlePath: toRelativePath(outputPath, workspaceRoot),
+      summaryPath: toRelativePath(summaryOutputPath, workspaceRoot),
     },
     counts: {
       rawEventCount: rawEvents.length,

--- a/src/integration/path-policy.ts
+++ b/src/integration/path-policy.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import {
-  resolveContainedWorkspacePath,
+  resolveArtifactPath,
   resolveWorkspacePath,
   resolveWorkspaceRoot,
   toWorkspaceRelativePath,
@@ -28,11 +28,6 @@ export interface IntegrationPathContextOptions {
 
 const hasWindowsAbsolutePrefix = (value: string): boolean =>
   path.win32.isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value);
-
-const isPathWithin = (baseDir: string, candidatePath: string): boolean => {
-  const relative = path.relative(baseDir, candidatePath);
-  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
-};
 
 const normalizeWorkspaceRelativePath = (input: string, label: string): string => {
   const raw = String(input).trim();
@@ -104,26 +99,23 @@ export function resolveIntegrationOutputPath(
   context: IntegrationPathContext,
   label = 'integration output path',
 ): ResolvedIntegrationPath {
-  let resolvedPath: string;
-
   if (path.isAbsolute(input) || hasWindowsAbsolutePrefix(input)) {
     throw new WorkspacePathPolicyError(`${label} must be relative to the approved integration artifact root`);
-  } else {
-    const workspaceRelative = normalizeWorkspaceRelativePath(input, label);
-    resolvedPath = resolveWorkspacePath(workspaceRelative, {
-      workspaceRoot: context.workspaceRoot,
-      label,
-    });
   }
 
-  if (!isPathWithin(context.artifactRoot, resolvedPath)) {
+  const workspaceRelative = normalizeWorkspaceRelativePath(input, label);
+  const artifactRootRelative = toWorkspaceRelativePath(context.artifactRoot, {
+    workspaceRoot: context.workspaceRoot,
+    label: 'integration artifact root',
+  });
+  if (workspaceRelative !== artifactRootRelative && !workspaceRelative.startsWith(`${artifactRootRelative}/`)) {
     throw new WorkspacePathPolicyError(`${label} must stay under the approved integration artifact root`);
   }
-
-  const artifactRelative = path.relative(context.artifactRoot, resolvedPath).replace(/\\/g, '/');
-  if (artifactRelative !== '') {
-    resolvedPath = resolveContainedWorkspacePath(context.artifactRoot, artifactRelative, label);
-  }
+  const resolvedPath = resolveArtifactPath(workspaceRelative, {
+    workspaceRoot: context.workspaceRoot,
+    artifactRoot: context.artifactRoot,
+    label,
+  });
 
   return {
     resolvedPath,

--- a/src/utils/workspace-path-policy.ts
+++ b/src/utils/workspace-path-policy.ts
@@ -11,6 +11,11 @@ export interface WorkspacePathOptions {
   label?: string;
 }
 
+export interface ArtifactPathOptions extends WorkspacePathOptions {
+  artifactRoot?: string;
+  allowAbsolute?: boolean;
+}
+
 export class WorkspacePathPolicyError extends Error {
   constructor(message: string) {
     super(message);
@@ -19,7 +24,7 @@ export class WorkspacePathPolicyError extends Error {
 }
 
 const hasWindowsAbsolutePrefix = (value: string): boolean =>
-  path.win32.isAbsolute(value) || /^[A-Za-z]:[\\/]/.test(value);
+  /^[A-Za-z]:[\\/]/.test(value);
 
 const isPathWithin = (baseDir: string, candidatePath: string): boolean => {
   const relative = path.relative(baseDir, candidatePath);
@@ -29,6 +34,41 @@ const isPathWithin = (baseDir: string, candidatePath: string): boolean => {
 const pathPolicyLabel = (label: string | undefined): string => label ?? 'workspace path';
 
 const splitInputPath = (value: string): string[] => value.replace(/\\/g, '/').split('/');
+
+const hasDotSegment = (segments: string[]): boolean =>
+  segments.some((segment) => segment === '.' || segment === '..');
+
+const hasGitMetadataSegment = (segments: string[]): boolean =>
+  segments.some((segment) => segment.toLowerCase() === '.git');
+
+const assertNoUnsafeSegments = (segments: string[], label: string): void => {
+  if (hasDotSegment(segments)) {
+    throw new WorkspacePathPolicyError(`${label} must not contain dot-segment path components`);
+  }
+  if (hasGitMetadataSegment(segments)) {
+    throw new WorkspacePathPolicyError(`${label} must not target Git metadata directories`);
+  }
+};
+
+const normalizeWorkspaceRelativeInput = (input: string, label: string): string => {
+  const raw = String(input).trim();
+  if (!raw) {
+    throw new WorkspacePathPolicyError(`${label} must be a non-empty workspace-relative path`);
+  }
+  if (raw.includes('\0')) {
+    throw new WorkspacePathPolicyError(`${label} must not contain NUL bytes`);
+  }
+  if (raw.includes('\\')) {
+    throw new WorkspacePathPolicyError(`${label} must use POSIX-style '/' separators`);
+  }
+  if (raw.startsWith('//') || path.isAbsolute(raw) || hasWindowsAbsolutePrefix(raw)) {
+    throw new WorkspacePathPolicyError(`${label} must be relative to the approved workspace`);
+  }
+
+  const segments = splitInputPath(raw);
+  assertNoUnsafeSegments(segments, label);
+  return raw;
+};
 
 const nearestExistingAncestor = (resolvedPath: string): string | null => {
   let current = path.resolve(resolvedPath);
@@ -66,11 +106,11 @@ export function resolveWorkspaceRoot(options: WorkspaceRootOptions = {}): string
   return path.resolve(fromEnv && fromEnv.length > 0 ? fromEnv : (options.defaultRoot ?? process.cwd()));
 }
 
-export function resolveWorkspacePath(input: string, options: WorkspacePathOptions = {}): string {
+export function assertWithinWorkspace(resolvedPath: string, options: WorkspacePathOptions = {}): string {
   const label = pathPolicyLabel(options.label);
-  const raw = String(input).trim();
+  const raw = String(resolvedPath).trim();
   if (!raw) {
-    throw new WorkspacePathPolicyError(`${label} must be a non-empty workspace-relative path`);
+    throw new WorkspacePathPolicyError(`${label} must be a non-empty path`);
   }
   if (raw.includes('\0')) {
     throw new WorkspacePathPolicyError(`${label} must not contain NUL bytes`);
@@ -78,25 +118,27 @@ export function resolveWorkspacePath(input: string, options: WorkspacePathOption
   if (raw.includes('\\')) {
     throw new WorkspacePathPolicyError(`${label} must use POSIX-style '/' separators`);
   }
-  if (raw.startsWith('//') || path.isAbsolute(raw) || hasWindowsAbsolutePrefix(raw)) {
-    throw new WorkspacePathPolicyError(`${label} must be relative to the approved workspace`);
+  if (hasWindowsAbsolutePrefix(raw)) {
+    throw new WorkspacePathPolicyError(`${label} must not use Windows absolute paths`);
   }
-
-  const segments = splitInputPath(raw);
-  if (segments.some((segment) => segment === '.' || segment === '..')) {
-    throw new WorkspacePathPolicyError(`${label} must not contain dot-segment path components`);
-  }
-  if (segments.some((segment) => segment.toLowerCase() === '.git')) {
-    throw new WorkspacePathPolicyError(`${label} must not target Git metadata directories`);
-  }
-
   const workspaceRoot = path.resolve(options.workspaceRoot ?? resolveWorkspaceRoot());
-  const resolved = path.resolve(workspaceRoot, raw);
+  const resolved = path.isAbsolute(raw)
+    ? path.resolve(raw)
+    : path.resolve(workspaceRoot, raw);
+
   if (!isPathWithin(workspaceRoot, resolved)) {
-    throw new WorkspacePathPolicyError(`${label} escaped the approved workspace`);
+    throw new WorkspacePathPolicyError(`${label} is outside the approved workspace`);
   }
   assertExistingAncestorWithin(workspaceRoot, resolved, label);
   return resolved;
+}
+
+export function resolveWorkspacePath(input: string, options: WorkspacePathOptions = {}): string {
+  const label = pathPolicyLabel(options.label);
+  const raw = normalizeWorkspaceRelativeInput(input, label);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? resolveWorkspaceRoot());
+  const resolved = path.resolve(workspaceRoot, raw);
+  return assertWithinWorkspace(resolved, { workspaceRoot, label });
 }
 
 export function resolveContainedWorkspacePath(baseDir: string, relativePath: string, label?: string): string {
@@ -111,13 +153,68 @@ export function resolveContainedWorkspacePath(baseDir: string, relativePath: str
   return resolved;
 }
 
+export function resolveArtifactPath(input: string, options: ArtifactPathOptions = {}): string {
+  const label = pathPolicyLabel(options.label);
+  const workspaceRoot = path.resolve(options.workspaceRoot ?? resolveWorkspaceRoot());
+  const artifactRootInput = String(options.artifactRoot ?? 'artifacts').trim();
+  if (!artifactRootInput) {
+    throw new WorkspacePathPolicyError(`${label} artifact root must be a non-empty path`);
+  }
+  if (artifactRootInput.includes('\0')) {
+    throw new WorkspacePathPolicyError(`${label} artifact root must not contain NUL bytes`);
+  }
+
+  const artifactRoot = path.isAbsolute(artifactRootInput) || hasWindowsAbsolutePrefix(artifactRootInput)
+    ? assertWithinWorkspace(artifactRootInput, { workspaceRoot, label: `${label} artifact root` })
+    : resolveWorkspacePath(artifactRootInput, {
+        workspaceRoot,
+        label: `${label} artifact root`,
+      });
+  const artifactRootRelative = toWorkspaceRelativePath(artifactRoot, {
+    workspaceRoot,
+    label: `${label} artifact root`,
+  });
+
+  const raw = String(input).trim();
+  if (!raw) {
+    throw new WorkspacePathPolicyError(`${label} must be a non-empty artifact path`);
+  }
+  if (raw.includes('\0')) {
+    throw new WorkspacePathPolicyError(`${label} must not contain NUL bytes`);
+  }
+  if (raw.includes('\\')) {
+    throw new WorkspacePathPolicyError(`${label} must use POSIX-style '/' separators`);
+  }
+
+  let resolved: string;
+  if (path.isAbsolute(raw) || hasWindowsAbsolutePrefix(raw) || raw.startsWith('//')) {
+    if (!options.allowAbsolute) {
+      throw new WorkspacePathPolicyError(`${label} must be relative to the approved artifact root`);
+    }
+    resolved = assertWithinWorkspace(raw, { workspaceRoot, label });
+  } else {
+    const segments = splitInputPath(raw);
+    assertNoUnsafeSegments(segments, label);
+    const normalized = segments.join('/');
+    const isWorkspaceRelativeArtifact =
+      normalized === artifactRootRelative || normalized.startsWith(`${artifactRootRelative}/`);
+    resolved = isWorkspaceRelativeArtifact
+      ? path.resolve(workspaceRoot, normalized)
+      : path.resolve(artifactRoot, normalized);
+    resolved = assertWithinWorkspace(resolved, { workspaceRoot, label });
+  }
+
+  if (!isPathWithin(artifactRoot, resolved)) {
+    throw new WorkspacePathPolicyError(`${label} must stay under the approved artifact root`);
+  }
+  assertExistingAncestorWithin(artifactRoot, resolved, label);
+  return resolved;
+}
+
 export function toWorkspaceRelativePath(resolvedPath: string, options: WorkspacePathOptions = {}): string {
   const label = pathPolicyLabel(options.label);
   const workspaceRoot = path.resolve(options.workspaceRoot ?? resolveWorkspaceRoot());
-  const absolutePath = path.resolve(resolvedPath);
-  if (!isPathWithin(workspaceRoot, absolutePath)) {
-    throw new WorkspacePathPolicyError(`${label} is outside the approved workspace`);
-  }
+  const absolutePath = assertWithinWorkspace(resolvedPath, { workspaceRoot, label });
   const relative = path.relative(workspaceRoot, absolutePath);
   return relative === '' ? '.' : relative.replace(/\\/g, '/');
 }

--- a/src/utils/workspace-path-policy.ts
+++ b/src/utils/workspace-path-policy.ts
@@ -35,6 +35,8 @@ const pathPolicyLabel = (label: string | undefined): string => label ?? 'workspa
 
 const splitInputPath = (value: string): string[] => value.replace(/\\/g, '/').split('/');
 
+const isWindowsRuntime = (): boolean => process.platform === 'win32';
+
 const hasDotSegment = (segments: string[]): boolean =>
   segments.some((segment) => segment === '.' || segment === '..');
 
@@ -115,10 +117,10 @@ export function assertWithinWorkspace(resolvedPath: string, options: WorkspacePa
   if (raw.includes('\0')) {
     throw new WorkspacePathPolicyError(`${label} must not contain NUL bytes`);
   }
-  if (raw.includes('\\')) {
+  if (!isWindowsRuntime() && raw.includes('\\')) {
     throw new WorkspacePathPolicyError(`${label} must use POSIX-style '/' separators`);
   }
-  if (hasWindowsAbsolutePrefix(raw)) {
+  if (!isWindowsRuntime() && hasWindowsAbsolutePrefix(raw)) {
     throw new WorkspacePathPolicyError(`${label} must not use Windows absolute paths`);
   }
   const workspaceRoot = path.resolve(options.workspaceRoot ?? resolveWorkspaceRoot());
@@ -128,6 +130,10 @@ export function assertWithinWorkspace(resolvedPath: string, options: WorkspacePa
 
   if (!isPathWithin(workspaceRoot, resolved)) {
     throw new WorkspacePathPolicyError(`${label} is outside the approved workspace`);
+  }
+  const relativePath = path.relative(workspaceRoot, resolved);
+  if (hasGitMetadataSegment(splitInputPath(relativePath).filter(Boolean))) {
+    throw new WorkspacePathPolicyError(`${label} must not target Git metadata directories`);
   }
   assertExistingAncestorWithin(workspaceRoot, resolved, label);
   return resolved;
@@ -182,12 +188,13 @@ export function resolveArtifactPath(input: string, options: ArtifactPathOptions 
   if (raw.includes('\0')) {
     throw new WorkspacePathPolicyError(`${label} must not contain NUL bytes`);
   }
-  if (raw.includes('\\')) {
+  const rawIsAbsolute = path.isAbsolute(raw) || hasWindowsAbsolutePrefix(raw) || raw.startsWith('//');
+  if (!rawIsAbsolute && raw.includes('\\')) {
     throw new WorkspacePathPolicyError(`${label} must use POSIX-style '/' separators`);
   }
 
   let resolved: string;
-  if (path.isAbsolute(raw) || hasWindowsAbsolutePrefix(raw) || raw.startsWith('//')) {
+  if (rawIsAbsolute) {
     if (!options.allowAbsolute) {
       throw new WorkspacePathPolicyError(`${label} must be relative to the approved artifact root`);
     }

--- a/tests/cegis/cegis-cli.test.ts
+++ b/tests/cegis/cegis-cli.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CEGISCli } from '../../src/cli/cegis-cli.js';
 import { writeFileSync, readFileSync, unlinkSync, existsSync } from 'fs';
+import path from 'node:path';
 import { FailureArtifactFactory } from '../../src/cegis/failure-artifact-factory.js';
 
 describe('CEGISCli', () => {
@@ -331,6 +332,21 @@ describe('CEGISCli', () => {
         expect.stringContaining('Unknown artifact type: unknown')
       );
     });
+
+    it('should reject artifact output paths outside the workspace', async () => {
+      const command = cli.createCommand();
+      const args = [
+        'node', 'cli', 'create-artifact',
+        '--type', 'error',
+        '--message', 'Test runtime error',
+        '--output', path.resolve('..', 'outside-failure-artifact.json')
+      ];
+
+      await expect(command.parseAsync(args)).rejects.toThrow();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('outside the approved workspace')
+      );
+    });
   });
 
   describe('from-conformance command', () => {
@@ -426,6 +442,24 @@ describe('CEGISCli', () => {
       await expect(command.parseAsync(args)).rejects.toThrow();
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('Conformance result file not found')
+      );
+    });
+
+    it('should reject conformance input paths outside the workspace', async () => {
+      const command = cli.createCommand();
+      const args = [
+        'node',
+        'cli',
+        'from-conformance',
+        '--input',
+        path.resolve('..', 'outside-conformance-results.json'),
+        '--output',
+        'test-output.json'
+      ];
+
+      await expect(command.parseAsync(args)).rejects.toThrow();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('outside the approved workspace')
       );
     });
   });

--- a/tests/codex/generate-openapi-tests-security.test.ts
+++ b/tests/codex/generate-openapi-tests-security.test.ts
@@ -114,6 +114,20 @@ describe('generate-openapi-tests security policy', () => {
     }
   });
 
+  it('rejects absolute output directories outside the workspace', () => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+    writeSpec();
+
+    try {
+      const result = runGenerator(['--output-dir', outsideRepoDir]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('outside the approved workspace');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
   it('allows writing under tests only with explicit reviewed approval', () => {
     rmSync(fixtureDir, { recursive: true, force: true });
     rmSync(resolve('tests/api/generated/evil-import-fs-from-fs.spec.ts'), { force: true });

--- a/tests/codex/generate-openapi-tests-security.test.ts
+++ b/tests/codex/generate-openapi-tests-security.test.ts
@@ -128,6 +128,20 @@ describe('generate-openapi-tests security policy', () => {
     }
   });
 
+  it('rejects absolute output directories that target the workspace root', () => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+    writeSpec();
+
+    try {
+      const result = runGenerator(['--output-dir', resolve('.')]);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('must not target the workspace root');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
   it('allows writing under tests only with explicit reviewed approval', () => {
     rmSync(fixtureDir, { recursive: true, force: true });
     rmSync(resolve('tests/api/generated/evil-import-fs-from-fs.spec.ts'), { force: true });

--- a/tests/unit/cli/conformance-ingest.test.ts
+++ b/tests/unit/cli/conformance-ingest.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
 import { parseTraceRedactionRule, runConformanceIngest } from '../../../src/cli/conformance-ingest.js';
 
 const workdirs: string[] = [];
 
 const createWorkdir = async (): Promise<string> => {
-  const workdir = await mkdtemp(join(tmpdir(), 'ae-trace-ingest-'));
+  const root = join(process.cwd(), 'artifacts', 'conformance-ingest-tests');
+  await mkdir(root, { recursive: true });
+  const workdir = await mkdtemp(join(root, 'ae-trace-ingest-'));
   workdirs.push(workdir);
   return workdir;
 };
@@ -65,6 +66,7 @@ describe('conformance ingest utilities', () => {
     );
 
     const { bundle, summary } = runConformanceIngest({
+      workspaceRoot: workdir,
       inputPath,
       outputPath,
       summaryOutputPath,
@@ -114,6 +116,7 @@ describe('conformance ingest utilities', () => {
     );
 
     const sampledOut = runConformanceIngest({
+      workspaceRoot: workdir,
       inputPath,
       outputPath,
       summaryOutputPath,
@@ -123,6 +126,7 @@ describe('conformance ingest utilities', () => {
     expect(sampledOut.bundle.summary.sampledOutCount).toBe(3);
 
     const capped = runConformanceIngest({
+      workspaceRoot: workdir,
       inputPath,
       outputPath,
       summaryOutputPath,
@@ -151,6 +155,7 @@ describe('conformance ingest utilities', () => {
     );
 
     const { bundle } = runConformanceIngest({
+      workspaceRoot: workdir,
       inputPath,
       outputPath,
       summaryOutputPath,
@@ -171,11 +176,64 @@ describe('conformance ingest utilities', () => {
 
     expect(() =>
       runConformanceIngest({
+        workspaceRoot: workdir,
         inputPath,
         outputPath,
         summaryOutputPath,
       }),
     ).toThrowError();
+  });
+
+  it('rejects absolute ingest paths outside the configured workspace root', async () => {
+    const workdir = await createWorkdir();
+    const outside = await mkdtemp(join(process.cwd(), 'artifacts', 'conformance-ingest-outside-'));
+    workdirs.push(outside);
+    const inputPath = join(outside, 'trace.json');
+    const outputPath = join(workdir, 'trace-bundle.json');
+    const summaryOutputPath = join(workdir, 'trace-bundle-summary.json');
+    await writeFile(
+      inputPath,
+      `${JSON.stringify([
+        { traceId: 'a', timestamp: '2026-02-27T00:00:00.000Z', actor: 'svc', event: 'E1' },
+      ])}\n`,
+      'utf-8',
+    );
+
+    expect(() =>
+      runConformanceIngest({
+        workspaceRoot: workdir,
+        inputPath,
+        outputPath,
+        summaryOutputPath,
+      }),
+    ).toThrowError(/outside the approved workspace/);
+  });
+
+  it('rejects ingest paths that traverse symlink ancestors outside the workspace', async () => {
+    const workdir = await createWorkdir();
+    const outside = await mkdtemp(join(process.cwd(), 'artifacts', 'conformance-ingest-linked-outside-'));
+    workdirs.push(outside);
+    await writeFile(
+      join(outside, 'trace.json'),
+      `${JSON.stringify([
+        { traceId: 'a', timestamp: '2026-02-27T00:00:00.000Z', actor: 'svc', event: 'E1' },
+      ])}\n`,
+      'utf-8',
+    );
+    try {
+      await symlink(outside, join(workdir, 'linked-outside'), 'dir');
+    } catch {
+      return;
+    }
+
+    expect(() =>
+      runConformanceIngest({
+        workspaceRoot: workdir,
+        inputPath: 'linked-outside/trace.json',
+        outputPath: 'trace-bundle.json',
+        summaryOutputPath: 'trace-bundle-summary.json',
+      }),
+    ).toThrowError(/resolves through a filesystem entry outside the approved workspace/);
   });
 
   it('fails when JSON input is malformed', async () => {
@@ -187,6 +245,7 @@ describe('conformance ingest utilities', () => {
 
     expect(() =>
       runConformanceIngest({
+        workspaceRoot: workdir,
         inputPath,
         outputPath,
         summaryOutputPath,
@@ -203,6 +262,7 @@ describe('conformance ingest utilities', () => {
 
     expect(() =>
       runConformanceIngest({
+        workspaceRoot: workdir,
         inputPath,
         outputPath,
         summaryOutputPath,
@@ -226,6 +286,7 @@ describe('conformance ingest utilities', () => {
 
     expect(() =>
       runConformanceIngest({
+        workspaceRoot: workdir,
         inputPath,
         outputPath: join(outputPath, 'trace-bundle.json'),
         summaryOutputPath,

--- a/tests/unit/utils/workspace-path-policy.test.ts
+++ b/tests/unit/utils/workspace-path-policy.test.ts
@@ -48,6 +48,12 @@ describe('workspace path policy', () => {
         label: 'candidate path',
       }),
     ).toThrow(WorkspacePathPolicyError);
+    expect(() =>
+      assertWithinWorkspace(path.join(workspaceRoot, '.git', 'config'), {
+        workspaceRoot,
+        label: 'candidate path',
+      }),
+    ).toThrow(WorkspacePathPolicyError);
   });
 
   it('rejects absolute paths and dot-segment traversal before filesystem access', () => {

--- a/tests/unit/utils/workspace-path-policy.test.ts
+++ b/tests/unit/utils/workspace-path-policy.test.ts
@@ -2,6 +2,8 @@ import path from 'node:path';
 import { mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
+  assertWithinWorkspace,
+  resolveArtifactPath,
   resolveContainedWorkspacePath,
   resolveWorkspacePath,
   toWorkspaceRelativePath,
@@ -19,6 +21,33 @@ describe('workspace path policy', () => {
 
     expect(resolved).toBe(path.join(workspaceRoot, 'generated', 'typescript'));
     expect(toWorkspaceRelativePath(resolved, { workspaceRoot })).toBe('generated/typescript');
+  });
+
+  it('asserts absolute or normalized candidate paths stay inside the approved workspace', () => {
+    const resolved = assertWithinWorkspace(path.join(workspaceRoot, 'generated', '..', 'reports'), {
+      workspaceRoot,
+      label: 'candidate path',
+    });
+
+    expect(resolved).toBe(path.join(workspaceRoot, 'reports'));
+    expect(() =>
+      assertWithinWorkspace(path.join(workspaceRoot, '..', 'outside'), {
+        workspaceRoot,
+        label: 'candidate path',
+      }),
+    ).toThrow(WorkspacePathPolicyError);
+    expect(() =>
+      assertWithinWorkspace('C:\\temp\\outside', {
+        workspaceRoot,
+        label: 'candidate path',
+      }),
+    ).toThrow(WorkspacePathPolicyError);
+    expect(() =>
+      assertWithinWorkspace('C:/temp/outside', {
+        workspaceRoot,
+        label: 'candidate path',
+      }),
+    ).toThrow(WorkspacePathPolicyError);
   });
 
   it('rejects absolute paths and dot-segment traversal before filesystem access', () => {
@@ -51,6 +80,44 @@ describe('workspace path policy', () => {
     );
   });
 
+  it('resolves artifact paths under an approved artifact root', () => {
+    expect(resolveArtifactPath('reports/summary.json', { workspaceRoot, label: 'artifact output' })).toBe(
+      path.join(workspaceRoot, 'artifacts', 'reports', 'summary.json'),
+    );
+    expect(resolveArtifactPath('artifacts/reports/summary.json', { workspaceRoot, label: 'artifact output' })).toBe(
+      path.join(workspaceRoot, 'artifacts', 'reports', 'summary.json'),
+    );
+    expect(
+      resolveArtifactPath('summary.json', {
+        workspaceRoot,
+        artifactRoot: 'reports/conformance',
+        label: 'custom artifact output',
+      }),
+    ).toBe(path.join(workspaceRoot, 'reports', 'conformance', 'summary.json'));
+  });
+
+  it('rejects artifact paths outside the approved artifact root', () => {
+    expect(() =>
+      resolveArtifactPath(path.join(workspaceRoot, 'artifacts', 'summary.json'), {
+        workspaceRoot,
+        label: 'artifact output',
+      }),
+    ).toThrow(WorkspacePathPolicyError);
+    expect(() =>
+      resolveArtifactPath(path.join(workspaceRoot, 'reports', 'summary.json'), {
+        workspaceRoot,
+        allowAbsolute: true,
+        label: 'artifact output',
+      }),
+    ).toThrow(WorkspacePathPolicyError);
+    expect(() =>
+      resolveArtifactPath('../summary.json', {
+        workspaceRoot,
+        label: 'artifact output',
+      }),
+    ).toThrow(WorkspacePathPolicyError);
+  });
+
   it('rejects existing symlink ancestors that resolve outside the workspace', () => {
     const root = path.join(workspaceRoot, `symlink-${Date.now()}`);
     const outside = path.join(process.cwd(), 'artifacts', `workspace-path-policy-outside-${Date.now()}`);
@@ -69,6 +136,35 @@ describe('workspace path policy', () => {
       expect(() => resolveWorkspacePath('linked-outside/generated', { workspaceRoot: root })).toThrow(
         WorkspacePathPolicyError,
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects artifact symlink ancestors that resolve outside the approved artifact root', () => {
+    const root = path.join(workspaceRoot, `artifact-symlink-${Date.now()}`);
+    const artifactRoot = path.join(root, 'artifacts');
+    const outside = path.join(process.cwd(), 'artifacts', `workspace-artifact-policy-outside-${Date.now()}`);
+    mkdirSync(artifactRoot, { recursive: true });
+    mkdirSync(outside, { recursive: true });
+
+    try {
+      symlinkSync(outside, path.join(artifactRoot, 'linked-outside'), 'dir');
+    } catch {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+      return;
+    }
+
+    try {
+      expect(() =>
+        resolveArtifactPath('linked-outside/report.json', {
+          workspaceRoot: root,
+          artifactRoot,
+          label: 'artifact output',
+        }),
+      ).toThrow(WorkspacePathPolicyError);
     } finally {
       rmSync(root, { recursive: true, force: true });
       rmSync(outside, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Add shared `assertWithinWorkspace()` and `resolveArtifactPath()` APIs on top of the existing workspace path policy, preserving symlink-aware ancestor checks and workspace-relative input validation.
- Apply the common policy to representative CEGIS, conformance ingest, CodeX generated-test, and integration artifact paths while keeping installer/MCP coverage on the shared utility.
- Add regression tests for absolute/outside paths, symlink escapes, artifact-root containment, and CodeX/CEGIS/conformance traversal cases.
- Refresh the generated agent command catalog for the current UTC date so doc consistency remains green.

## Scope
- Security hardening for Issue #3463 / AEF-002.
- No broad container runtime changes; container isolation remains targeted by Issue #3467.
- No high-impact action approval policy changes; those remain targeted by Issue #3462.

## Acceptance
- [x] path normalization is symlink-aware through shared realpath ancestor validation.
- [x] workspace outside read/write paths are rejected in representative CEGIS, conformance, CodeX, installer/MCP/integration paths.
- [x] CEGIS/conformance/CodeX/installer/integration representative path handling uses the common workspace path utility surface.
- [x] path traversal and symlink escape regression tests are added.

## Validation
- `pnpm -s exec vitest run tests/unit/utils/workspace-path-policy.test.ts tests/unit/cli/conformance-ingest.test.ts tests/cegis/cegis-cli.test.ts tests/codex/generate-openapi-tests-security.test.ts tests/integration/integration-cli.test.ts tests/integration/test-orchestrator.test.ts tests/utils/installer-manager.test.ts tests/commands/installer-command.test.ts tests/unit/mcp-server/spec-synthesis-path-policy.test.ts --reporter dot`
- `pnpm -s run types:check`
- `pnpm -s exec eslint --quiet src/utils/workspace-path-policy.ts src/cli/conformance-ingest.ts src/cli/cegis-cli.ts src/integration/path-policy.ts scripts/codex/generate-openapi-tests.ts tests/unit/utils/workspace-path-policy.test.ts tests/unit/cli/conformance-ingest.test.ts tests/cegis/cegis-cli.test.ts tests/codex/generate-openapi-tests-security.test.ts tests/integration/integration-cli.test.ts tests/integration/test-orchestrator.test.ts tests/utils/installer-manager.test.ts tests/commands/installer-command.test.ts tests/unit/mcp-server/spec-synthesis-path-policy.test.ts`
- `pnpm -s run build`
- `pnpm -s run check:doc-consistency`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `git diff --check`

## Rollback
- Revert this PR to restore the previous path policy helpers and representative CLI path handling.

Closes #3463
