### PR TITLE
fix(security): centralize high-impact action policy

### DIFF
--- a/src/agents/codex-task-adapter.ts
+++ b/src/agents/codex-task-adapter.ts
@@ -10,6 +10,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { trace } from '@opentelemetry/api';
 import { z } from 'zod';
+import {
+  createHighImpactChildEnv,
+  evaluateHighImpactActionPolicy,
+  formatHighImpactDecisionMessage,
+} from '../utils/high-impact-action-policy.js';
 
 export type Phase = 'intent' | 'formal' | 'stories' | 'validation' | 'modeling' | 'ui';
 
@@ -230,6 +235,15 @@ function hasTrustedUIApproval(context: Record<string, unknown>): boolean {
   return approvalRecord['approved'] === true && approvalRecord['scope'] === 'ui-scaffold';
 }
 
+function getUIApprovalScope(context: Record<string, unknown>): string | undefined {
+  const approval = context['approval'];
+  if (!approval || typeof approval !== 'object') {
+    return undefined;
+  }
+  const approvalRecord = approval as Record<string, unknown>;
+  return typeof approvalRecord['scope'] === 'string' ? approvalRecord['scope'] : undefined;
+}
+
 function hasUnsafePathSegment(value: string): boolean {
   return value.split(/[\\/]+/u).some((segment) => segment === '..' || segment.toLowerCase() === '.git');
 }
@@ -315,11 +329,39 @@ async function handleUI(request: TaskRequest, parentSpan?: any): Promise<TaskRes
     if (env === '0') dryRun = false;
     else if (env === '1') dryRun = true;
   }
-  if (!trustedApproval) {
-    if (dryRun === false) {
-      policyWarnings.push('untrusted-ui-request-forced-dry-run: context.approval.scope=ui-scaffold with approved=true is required before file writes');
+  const approvalCandidate = typeof ctx.approval === 'object' && ctx.approval !== null
+    ? ctx.approval as { approved?: boolean; scope?: string }
+    : undefined;
+  const uiWritePolicy = evaluateHighImpactActionPolicy({
+    actionKind: 'codegen-materialize',
+    actionName: 'codex-ui-scaffold',
+    apply: trustedApproval && dryRun === false,
+    dryRun,
+    approvalScope: getUIApprovalScope(ctx),
+    ...(approvalCandidate !== undefined ? { approval: approvalCandidate } : {}),
+    requiredApprovalScope: 'ui-scaffold',
+    env: createHighImpactChildEnv(),
+    agentContext: true,
+  });
+  if (uiWritePolicy.dryRun) {
+    if (dryRun === false || !trustedApproval) {
+      policyWarnings.push(`untrusted-ui-request-forced-dry-run: ${formatHighImpactDecisionMessage(uiWritePolicy)}`);
     }
     dryRun = true;
+  } else if (!uiWritePolicy.allowed) {
+    return {
+      summary: 'Blocked: UI scaffold write policy not satisfied',
+      analysis: formatHighImpactDecisionMessage(uiWritePolicy),
+      recommendations: [
+        'Run UI scaffolding in dry-run mode for untrusted agent requests',
+        'Use context.dryRun=false only with context.approval.scope=ui-scaffold and approved=true in a trusted workspace/ref',
+      ],
+      nextActions: ['Provide explicit UI scaffold approval or rerun with dry-run enabled'],
+      warnings: [uiWritePolicy.reason],
+      shouldBlockProgress: true,
+      blockingReason: 'high-impact-ui-write-policy',
+      requiredHumanInput: 'explicit ui-scaffold approval for trusted write-capable run',
+    };
   }
   if (dryRun === undefined && (!phaseState?.entities || Object.keys(phaseState.entities).length === 0)) {
     dryRun = true;

--- a/src/agents/codex-task-adapter.ts
+++ b/src/agents/codex-task-adapter.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import { trace } from '@opentelemetry/api';
 import { z } from 'zod';
 import {
-  createHighImpactChildEnv,
   evaluateHighImpactActionPolicy,
   formatHighImpactDecisionMessage,
 } from '../utils/high-impact-action-policy.js';
@@ -340,15 +339,9 @@ async function handleUI(request: TaskRequest, parentSpan?: any): Promise<TaskRes
     approvalScope: getUIApprovalScope(ctx),
     ...(approvalCandidate !== undefined ? { approval: approvalCandidate } : {}),
     requiredApprovalScope: 'ui-scaffold',
-    env: createHighImpactChildEnv(),
     agentContext: true,
   });
-  if (uiWritePolicy.dryRun) {
-    if (dryRun === false || !trustedApproval) {
-      policyWarnings.push(`untrusted-ui-request-forced-dry-run: ${formatHighImpactDecisionMessage(uiWritePolicy)}`);
-    }
-    dryRun = true;
-  } else if (!uiWritePolicy.allowed) {
+  if (uiWritePolicy.blocked || uiWritePolicy.approvalRequired || (!uiWritePolicy.allowed && !uiWritePolicy.dryRun)) {
     return {
       summary: 'Blocked: UI scaffold write policy not satisfied',
       analysis: formatHighImpactDecisionMessage(uiWritePolicy),
@@ -362,6 +355,12 @@ async function handleUI(request: TaskRequest, parentSpan?: any): Promise<TaskRes
       blockingReason: 'high-impact-ui-write-policy',
       requiredHumanInput: 'explicit ui-scaffold approval for trusted write-capable run',
     };
+  }
+  if (uiWritePolicy.dryRun) {
+    if (dryRun === false || !trustedApproval) {
+      policyWarnings.push(`untrusted-ui-request-forced-dry-run: ${formatHighImpactDecisionMessage(uiWritePolicy)}`);
+    }
+    dryRun = true;
   }
   if (dryRun === undefined && (!phaseState?.entities || Object.keys(phaseState.entities).length === 0)) {
     dryRun = true;

--- a/src/cli/cegis-cli.ts
+++ b/src/cli/cegis-cli.ts
@@ -20,6 +20,13 @@ import {
   assertWithinWorkspace,
   resolveWorkspacePath,
 } from '../utils/workspace-path-policy.js';
+import {
+  createHighImpactChildEnv,
+  evaluateHighImpactActionPolicy,
+  formatHighImpactDecisionMessage,
+} from '../utils/high-impact-action-policy.js';
+
+export const CEGIS_AUTO_FIX_APPROVAL_SCOPE = 'cegis-auto-fix' as const;
 
 interface ConformanceViolationInput {
   ruleId?: string;
@@ -97,6 +104,7 @@ export class CEGISCli {
       .option('-o, --output <dir>', 'Output directory for fixed files', './cegis-output')
       .option('--dry-run', 'Show proposed fixes without applying them')
       .option('--apply', 'Apply fixes even when mode=copilot')
+      .option('--approval-scope <scope>', `Trusted auto-fix approval scope (${CEGIS_AUTO_FIX_APPROVAL_SCOPE})`)
       .option('--confidence <threshold>', 'Minimum confidence threshold (0.0-1.0)', '0.7')
       .option('--max-risk <level>', 'Maximum risk level (1-5)', '3')
       .option('--max-fixes <count>', 'Maximum number of fixes to apply', '10')
@@ -179,10 +187,28 @@ export class CEGISCli {
       const config = await loadConfig();
       const mode = config.mode ?? 'copilot';
       const enforcedDryRun = mode === 'copilot' && !options.apply;
-      const dryRun = Boolean(options.dryRun || enforcedDryRun);
+      const requestedDryRun = Boolean(options.dryRun || enforcedDryRun);
+      const policyDecision = evaluateHighImpactActionPolicy({
+        actionKind: 'auto-fix',
+        actionName: 'cegis-auto-fix-apply',
+        apply: options.apply === true,
+        dryRun: requestedDryRun,
+        approvalScope: options.approvalScope,
+        requiredApprovalScope: CEGIS_AUTO_FIX_APPROVAL_SCOPE,
+        env: createHighImpactChildEnv(),
+      });
+      if (policyDecision.approvalRequired || policyDecision.blocked) {
+        console.error(chalk.red(`❌ ${formatHighImpactDecisionMessage(policyDecision)}`));
+        safeExit(1);
+        return;
+      }
+      const dryRun = policyDecision.dryRun;
       options.dryRun = dryRun;
       if (enforcedDryRun) {
         console.log('[ae:fix] copilot mode defaults to dry-run. Use --apply to execute fixes.');
+      }
+      if (dryRun && !requestedDryRun) {
+        console.log(`[ae:fix] ${formatHighImpactDecisionMessage(policyDecision)}`);
       }
 
       console.log('🔧 Starting CEGIS auto-fix process...');
@@ -237,7 +263,7 @@ export class CEGISCli {
         console.log(chalk.blue(`🔍 Running verify profile: ${profile}`));
         const verifyResult = spawnSync(process.execPath, [verifyScript, '--profile', profile], {
           stdio: 'inherit',
-          env: process.env,
+          env: createHighImpactChildEnv(),
         });
         if (verifyResult.error) {
           console.error(chalk.red(`❌ verify failed to start: ${toMessage(verifyResult.error)}`));

--- a/src/cli/cegis-cli.ts
+++ b/src/cli/cegis-cli.ts
@@ -195,7 +195,6 @@ export class CEGISCli {
         dryRun: requestedDryRun,
         approvalScope: options.approvalScope,
         requiredApprovalScope: CEGIS_AUTO_FIX_APPROVAL_SCOPE,
-        env: createHighImpactChildEnv(),
       });
       if (policyDecision.approvalRequired || policyDecision.blocked) {
         console.error(chalk.red(`❌ ${formatHighImpactDecisionMessage(policyDecision)}`));

--- a/src/cli/guards/GuardRunner.ts
+++ b/src/cli/guards/GuardRunner.ts
@@ -92,7 +92,7 @@ export function getGuardScriptExecutionPolicy(options: GuardRunnerOptions = {}):
     dryRun: options.dryRun,
     approvalScope,
     requiredApprovalScope: GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE,
-    env: createGuardProcessEnv(env),
+    env,
     agentContext,
     untrustedCheckout,
     enforceApproval: protectedContext,

--- a/src/cli/guards/GuardRunner.ts
+++ b/src/cli/guards/GuardRunner.ts
@@ -4,6 +4,10 @@ import { glob } from 'glob';
 import type { AEFrameworkConfig, Guard, GuardResult } from '../types.js';
 import { toMessage } from '../../utils/error-utils.js';
 import { getCurrentPhase, shouldEnforceGate, getThreshold } from '../../utils/quality-policy-loader.js';
+import {
+  evaluateHighImpactActionPolicy,
+  isHighImpactUntrustedCheckout,
+} from '../../utils/high-impact-action-policy.js';
 
 
 export const GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE = 'guard-script-execution' as const;
@@ -23,6 +27,7 @@ export interface GuardScriptExecutionPolicy {
   approvalRequired: boolean;
   approvalScope?: string;
   agentContext: boolean;
+  reason: string;
 }
 
 type GuardCommandResult = {
@@ -74,15 +79,30 @@ const isGuardAgentContext = (env: NodeJS.ProcessEnv = process.env): boolean => (
 export function getGuardScriptExecutionPolicy(options: GuardRunnerOptions = {}): GuardScriptExecutionPolicy {
   const env = options.env ?? process.env;
   const agentContext = options.agentContext ?? isGuardAgentContext(env);
-  const apply = options.apply === true;
+  const untrustedCheckout = isHighImpactUntrustedCheckout(env);
+  const protectedContext = agentContext || untrustedCheckout;
+  // Preserve trusted local operator compatibility while enforcing explicit approval
+  // for agent/untrusted contexts where repository-controlled commands are high impact.
+  const apply = options.apply === true || !protectedContext;
   const approvalScope = options.approvalScope;
-  const dryRun = options.dryRun === true || (agentContext && !apply);
-  const approvalRequired = agentContext && apply && approvalScope !== GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE;
-  const policy: GuardScriptExecutionPolicy = {
-    dryRun,
+  const decision = evaluateHighImpactActionPolicy({
+    actionKind: 'package-manager',
+    actionName: 'guard-script-execution',
     apply,
-    approvalRequired,
+    dryRun: options.dryRun,
+    approvalScope,
+    requiredApprovalScope: GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE,
+    env: createGuardProcessEnv(env),
     agentContext,
+    untrustedCheckout,
+    enforceApproval: protectedContext,
+  });
+  const policy: GuardScriptExecutionPolicy = {
+    dryRun: decision.dryRun,
+    apply,
+    approvalRequired: decision.approvalRequired || decision.blocked,
+    agentContext,
+    reason: decision.reason,
   };
   if (approvalScope !== undefined) {
     policy.approvalScope = approvalScope;

--- a/src/cli/quality-cli.ts
+++ b/src/cli/quality-cli.ts
@@ -25,6 +25,7 @@ import type { FailureArtifact as LegacyFailureArtifact, FailureArtifactCollectio
 import { validateFailureArtifact, validateFailureArtifactCollection } from '../cegis/failure-artifact-schema.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { evaluateHighImpactActionPolicy } from '../utils/high-impact-action-policy.js';
 
 const isErrnoException = (value: unknown): value is NodeJS.ErrnoException => {
   if (!value || typeof value !== 'object') {
@@ -262,14 +263,26 @@ const getQualityExecutionPolicy = (
   policyOptions: { protectCi?: boolean } = {}
 ): QualityExecutionPolicy => {
   const guardedAutomationContext = isQualityAgentContext() || (policyOptions.protectCi === true && isQualityCiContext());
-  const apply = options.apply === true;
+  // Trusted local invocations keep the historical execute-by-default behavior.
+  // Agent contexts and CI-protected entry points require explicit apply/approval.
+  const apply = options.apply === true || !guardedAutomationContext;
   const approvalScope = options.approvalScope;
-  const dryRun = options.dryRun === true || (guardedAutomationContext && !apply);
-  const approvalRequired = guardedAutomationContext && apply && approvalScope !== QUALITY_GATE_EXECUTION_APPROVAL_SCOPE;
-  const policy: QualityExecutionPolicy = {
-    dryRun,
+  const decision = evaluateHighImpactActionPolicy({
+    actionKind: 'package-manager',
+    actionName: 'quality-gate-execution',
     apply,
-    approvalRequired,
+    dryRun: options.dryRun,
+    approvalScope,
+    requiredApprovalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+    agentContext: isQualityAgentContext(),
+    ciContext: policyOptions.protectCi === true && isQualityCiContext(),
+    blockAmbientSecrets: false,
+    enforceApproval: guardedAutomationContext,
+  });
+  const policy: QualityExecutionPolicy = {
+    dryRun: decision.dryRun,
+    apply,
+    approvalRequired: decision.approvalRequired || decision.blocked,
   };
   if (approvalScope !== undefined) {
     policy.approvalScope = approvalScope;

--- a/src/cli/quality-cli.ts
+++ b/src/cli/quality-cli.ts
@@ -258,6 +258,19 @@ const normalizeQualityOutputFormat = (rawFormat: string | undefined): QualityOut
 
 const getDefaultQualityOutputDir = (): string => getDefaultQualityReportDir(createQualityPathContext());
 
+const isExplicitQualityUntrustedCheckout = (env: NodeJS.ProcessEnv = process.env): boolean => {
+  const markers = [
+    env['AE_UNTRUSTED_CHECKOUT'],
+    env['AE_QUALITY_UNTRUSTED_CHECKOUT'],
+    env['AE_CI_UNTRUSTED_CHECKOUT'],
+  ];
+  return markers.some(value => {
+    if (value === undefined) return false;
+    const normalized = value.trim().toLowerCase();
+    return normalized.length > 0 && !['0', 'false', 'no', 'off'].includes(normalized);
+  });
+};
+
 const getQualityExecutionPolicy = (
   options: { dryRun?: boolean; apply?: boolean; approvalScope?: string },
   policyOptions: { protectCi?: boolean } = {}
@@ -267,6 +280,7 @@ const getQualityExecutionPolicy = (
   // Agent contexts and CI-protected entry points require explicit apply/approval.
   const apply = options.apply === true || !guardedAutomationContext;
   const approvalScope = options.approvalScope;
+  const explicitUntrustedCheckout = isExplicitQualityUntrustedCheckout();
   const decision = evaluateHighImpactActionPolicy({
     actionKind: 'package-manager',
     actionName: 'quality-gate-execution',
@@ -276,6 +290,11 @@ const getQualityExecutionPolicy = (
     requiredApprovalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
     agentContext: isQualityAgentContext(),
     ciContext: policyOptions.protectCi === true && isQualityCiContext(),
+    ...(guardedAutomationContext ? {} : {
+      untrustedCheckout: explicitUntrustedCheckout,
+      trustedWorkspace: !explicitUntrustedCheckout,
+      trustedRef: !explicitUntrustedCheckout,
+    }),
     blockAmbientSecrets: false,
     enforceApproval: guardedAutomationContext,
   });

--- a/src/mcp-server/tdd-execution-policy.ts
+++ b/src/mcp-server/tdd-execution-policy.ts
@@ -63,7 +63,6 @@ export function ensureTDDTestExecutionApproved(
     dryRun,
     approvalScope: approval,
     requiredApprovalScope: APPROVED_TDD_TEST_EXECUTION,
-    env: createHighImpactChildEnv(),
     agentContext: true,
   });
 

--- a/src/mcp-server/tdd-execution-policy.ts
+++ b/src/mcp-server/tdd-execution-policy.ts
@@ -1,4 +1,8 @@
 import { execFileSync } from 'child_process';
+import {
+  createHighImpactChildEnv,
+  evaluateHighImpactActionPolicy,
+} from '../utils/high-impact-action-policy.js';
 
 export type TDDTestCommand = 'npm test' | 'pnpm test' | 'yarn test';
 export type TDDTestExecutionApproval = 'none' | 'approved-tdd-test-execution';
@@ -11,7 +15,7 @@ export interface ResolvedTDDTestCommand {
 export type TDDTestExecutor = (
   executable: string,
   args: string[],
-  options: { encoding: 'utf8'; stdio: 'pipe'; shell: false; cwd?: string }
+  options: { encoding: 'utf8'; stdio: 'pipe'; shell: false; cwd?: string; env?: NodeJS.ProcessEnv }
 ) => string | Buffer;
 
 export const APPROVED_TDD_TEST_EXECUTION = 'approved-tdd-test-execution' as const;
@@ -52,18 +56,30 @@ export function ensureTDDTestExecutionApproved(
   approval: TDDTestExecutionApproval,
   dryRun: boolean
 ): { approved: boolean; reason?: string } {
-  if (dryRun) {
+  const decision = evaluateHighImpactActionPolicy({
+    actionKind: 'package-manager',
+    actionName: 'mcp-tdd-test-execution',
+    apply: dryRun === false,
+    dryRun,
+    approvalScope: approval,
+    requiredApprovalScope: APPROVED_TDD_TEST_EXECUTION,
+    env: createHighImpactChildEnv(),
+    agentContext: true,
+  });
+
+  if (decision.allowed) {
+    return { approved: true };
+  }
+  if (decision.reason === 'explicit-dry-run') {
     return { approved: false, reason: 'dry-run mode is enabled' };
   }
-
-  if (approval !== APPROVED_TDD_TEST_EXECUTION) {
+  if (decision.approvalRequired) {
     return {
       approved: false,
       reason: `test execution requires approval token '${APPROVED_TDD_TEST_EXECUTION}'`,
     };
   }
-
-  return { approved: true };
+  return { approved: false, reason: decision.reason };
 }
 
 export function runSafeTDDTestCommand(
@@ -76,10 +92,11 @@ export function runSafeTDDTestCommand(
 ): string | Buffer {
   const resolved = resolveSafeTDDTestCommand(testCommand, options.platform);
   const executor = options.executor ?? execFileSync;
-  const execOptions: { encoding: 'utf8'; stdio: 'pipe'; shell: false; cwd?: string } = {
+  const execOptions: { encoding: 'utf8'; stdio: 'pipe'; shell: false; cwd?: string; env?: NodeJS.ProcessEnv } = {
     encoding: 'utf8',
     stdio: 'pipe',
     shell: false,
+    env: createHighImpactChildEnv(),
   };
 
   if (options.cwd) {

--- a/src/quality/quality-gate-runner.ts
+++ b/src/quality/quality-gate-runner.ts
@@ -14,9 +14,14 @@ import {
   getApprovedQualityGateCommand,
   getDefaultQualityReportDir,
   isQualityAgentContext,
+  isQualityCiContext,
   QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
   resolveQualityReportOutputDir,
 } from './quality-command-policy.js';
+import {
+  createHighImpactChildEnv,
+  evaluateHighImpactActionPolicy,
+} from '../utils/high-impact-action-policy.js';
 
 type CoverageThreshold = { lines?: number; functions?: number; branches?: number; statements?: number };
 type LintThreshold = { maxErrors?: number; maxWarnings?: number };
@@ -96,12 +101,29 @@ export class QualityGateRunner {
     const outputDir = options.outputDir ?? getDefaultQualityReportDir(pathContext);
     const resolvedOutputDir = resolveQualityReportOutputDir(outputDir, pathContext);
     const agentContext = isQualityAgentContext();
-    if (agentContext && apply && approvalScope !== QUALITY_GATE_EXECUTION_APPROVAL_SCOPE) {
+    const ciContext = isQualityCiContext();
+    const protectedContext = agentContext;
+    // The runner preserves trusted local/CI compatibility; the CLI reconcile path
+    // opts CI into approval enforcement when needed via protectCi.
+    const requestedApply = apply || !protectedContext;
+    const executionDecision = evaluateHighImpactActionPolicy({
+      actionKind: 'package-manager',
+      actionName: 'quality-gate-runner',
+      apply: requestedApply,
+      dryRun,
+      approvalScope,
+      requiredApprovalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+      agentContext,
+      ciContext,
+      blockAmbientSecrets: false,
+      enforceApproval: protectedContext,
+    });
+    if (executionDecision.approvalRequired || executionDecision.blocked) {
       throw new Error(
         `Quality gate execution requires approval scope '${QUALITY_GATE_EXECUTION_APPROVAL_SCOPE}' when --apply is used in an agent context`
       );
     }
-    const effectiveDryRun = dryRun || (agentContext && !apply);
+    const effectiveDryRun = executionDecision.dryRun;
 
     const timer = mockTelemetry.createTimer('quality_gates.execution.total', {
       [TELEMETRY_ATTRIBUTES.SERVICE_COMPONENT]: 'quality-gates',
@@ -364,6 +386,7 @@ export class QualityGateRunner {
       const child = this.spawnProcess(command.executable, [...command.args], {
         stdio: ['pipe', 'pipe', 'pipe'],
         timeout,
+        env: createHighImpactChildEnv(),
         shell: false,
       });
 

--- a/src/quality/quality-gate-runner.ts
+++ b/src/quality/quality-gate-runner.ts
@@ -34,6 +34,19 @@ type QualityGateExecutionRecord = {
   command: ApprovedQualityGateCommand;
 };
 
+const isExplicitUntrustedCheckout = (env: NodeJS.ProcessEnv = process.env): boolean => {
+  const markers = [
+    env['AE_UNTRUSTED_CHECKOUT'],
+    env['AE_QUALITY_UNTRUSTED_CHECKOUT'],
+    env['AE_CI_UNTRUSTED_CHECKOUT'],
+  ];
+  return markers.some(value => {
+    if (value === undefined) return false;
+    const normalized = value.trim().toLowerCase();
+    return normalized.length > 0 && !['0', 'false', 'no', 'off'].includes(normalized);
+  });
+};
+
 // Mock telemetry for main branch compatibility
 type Attributes = Record<string, unknown>;
 const mockTelemetry = {
@@ -106,6 +119,7 @@ export class QualityGateRunner {
     // The runner preserves trusted local/CI compatibility; the CLI reconcile path
     // opts CI into approval enforcement when needed via protectCi.
     const requestedApply = apply || !protectedContext;
+    const explicitUntrustedCheckout = isExplicitUntrustedCheckout();
     const executionDecision = evaluateHighImpactActionPolicy({
       actionKind: 'package-manager',
       actionName: 'quality-gate-runner',
@@ -115,6 +129,9 @@ export class QualityGateRunner {
       requiredApprovalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
       agentContext,
       ciContext,
+      untrustedCheckout: explicitUntrustedCheckout,
+      trustedWorkspace: !explicitUntrustedCheckout,
+      trustedRef: !explicitUntrustedCheckout,
       blockAmbientSecrets: false,
       enforceApproval: protectedContext,
     });

--- a/src/utils/high-impact-action-policy.ts
+++ b/src/utils/high-impact-action-policy.ts
@@ -1,0 +1,318 @@
+export type HighImpactActionKind =
+  | 'process'
+  | 'package-manager'
+  | 'container'
+  | 'filesystem-write'
+  | 'github-write'
+  | 'auto-fix'
+  | 'codegen-materialize';
+
+export interface HighImpactActionApproval {
+  approved?: boolean | undefined;
+  scope?: string | undefined;
+  approvedBy?: string | undefined;
+  reason?: string | undefined;
+}
+
+export interface HighImpactActionPolicyInput {
+  actionKind: HighImpactActionKind;
+  actionName: string;
+  apply?: boolean | undefined;
+  dryRun?: boolean | undefined;
+  approvalScope?: string | undefined;
+  requiredApprovalScope?: string | undefined;
+  approval?: HighImpactActionApproval | undefined;
+  env?: NodeJS.ProcessEnv | undefined;
+  agentContext?: boolean | undefined;
+  ciContext?: boolean | undefined;
+  untrustedCheckout?: boolean | undefined;
+  trustedWorkspace?: boolean | undefined;
+  trustedRef?: boolean | undefined;
+  blockAmbientSecrets?: boolean | undefined;
+  allowAmbientSecrets?: boolean | undefined;
+  enforceApproval?: boolean | undefined;
+}
+
+export interface HighImpactActionPolicyDecision {
+  actionKind: HighImpactActionKind;
+  actionName: string;
+  apply: boolean;
+  dryRun: boolean;
+  allowed: boolean;
+  approvalRequired: boolean;
+  blocked: boolean;
+  reason: string;
+  requiredApprovalScope: string;
+  approvalScope?: string | undefined;
+  trustedWorkspace: boolean;
+  trustedRef: boolean;
+  agentContext: boolean;
+  ciContext: boolean;
+  untrustedCheckout: boolean;
+  ambientSecretNames: string[];
+}
+
+export const DEFAULT_HIGH_IMPACT_APPROVAL_SCOPES: Readonly<Record<HighImpactActionKind, string>> = {
+  process: 'high-impact:process',
+  'package-manager': 'high-impact:package-manager',
+  container: 'high-impact:container',
+  'filesystem-write': 'high-impact:filesystem-write',
+  'github-write': 'high-impact:github-write',
+  'auto-fix': 'high-impact:auto-fix',
+  'codegen-materialize': 'high-impact:codegen-materialize',
+};
+
+const SECRET_ENV_NAME_PATTERN = /(?:^|_)(?:token|secret|password|passwd|credential|credentials|cookie|session|authorization|auth|private(?:_key)?|access_key|api_key)(?:_|$)/i;
+const SECRET_ENV_EXACT_NAMES = new Set([
+  'ACTIONS_ID_TOKEN_REQUEST_TOKEN',
+  'GH_TOKEN',
+  'GITHUB_TOKEN',
+  'NODE_AUTH_TOKEN',
+  'NPM_TOKEN',
+]);
+
+const isTruthyEnvValue = (value: string | undefined): boolean => {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 && !['0', 'false', 'no', 'off'].includes(normalized);
+};
+
+const isPullRequestEvent = (env: NodeJS.ProcessEnv): boolean => {
+  const eventName = env['GITHUB_EVENT_NAME'];
+  return eventName === 'pull_request' || eventName === 'pull_request_target';
+};
+
+export function isHighImpactAgentContext(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthyEnvValue(env['AE_AGENT_CONTEXT'])
+    || isTruthyEnvValue(env['CODEX_AGENT_CONTEXT'])
+    || isTruthyEnvValue(env['AE_QUALITY_AGENT_CONTEXT'])
+    || isTruthyEnvValue(env['AE_GUARD_AGENT_CONTEXT'])
+    || isTruthyEnvValue(env['AE_MCP_AGENT_CONTEXT'])
+    || isTruthyEnvValue(env['AE_CODEX_AGENT_CONTEXT']);
+}
+
+export function isHighImpactCiContext(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthyEnvValue(env['CI']) || isTruthyEnvValue(env['GITHUB_ACTIONS']);
+}
+
+export function isHighImpactUntrustedCheckout(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isTruthyEnvValue(env['AE_UNTRUSTED_CHECKOUT'])
+    || isTruthyEnvValue(env['AE_GUARD_UNTRUSTED_CHECKOUT'])
+    || isTruthyEnvValue(env['AE_CI_UNTRUSTED_CHECKOUT'])
+    || (isPullRequestEvent(env) && env['GITHUB_REF_PROTECTED'] !== 'true');
+}
+
+export function findAmbientSecretNames(env: NodeJS.ProcessEnv = process.env): string[] {
+  const names: string[] = [];
+  for (const [name, value] of Object.entries(env)) {
+    if (value === undefined || value.length === 0) continue;
+    if (SECRET_ENV_EXACT_NAMES.has(name) || SECRET_ENV_NAME_PATTERN.test(name)) {
+      names.push(name);
+    }
+  }
+  return names.sort();
+}
+
+export function createHighImpactChildEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    if (SECRET_ENV_EXACT_NAMES.has(name) || SECRET_ENV_NAME_PATTERN.test(name)) {
+      continue;
+    }
+    env[name] = value;
+  }
+  return env;
+}
+
+const getEffectiveApprovalScope = (input: HighImpactActionPolicyInput): string | undefined => {
+  if (input.approvalScope !== undefined) {
+    return input.approvalScope;
+  }
+  return input.approval?.scope;
+};
+
+const hasExplicitApproval = (
+  input: HighImpactActionPolicyInput,
+  requiredApprovalScope: string,
+): boolean => {
+  if (input.approval !== undefined) {
+    return input.approval.approved === true && input.approval.scope === requiredApprovalScope;
+  }
+  return input.approvalScope === requiredApprovalScope;
+};
+
+const inferTrustedWorkspace = (
+  input: HighImpactActionPolicyInput,
+  env: NodeJS.ProcessEnv,
+  untrustedCheckout: boolean,
+): boolean => {
+  if (input.trustedWorkspace !== undefined) {
+    return input.trustedWorkspace;
+  }
+  if (untrustedCheckout) {
+    return false;
+  }
+  if (isTruthyEnvValue(env['AE_TRUSTED_WORKSPACE']) || isTruthyEnvValue(env['AE_HIGH_IMPACT_TRUSTED_WORKSPACE'])) {
+    return true;
+  }
+  return true;
+};
+
+const inferTrustedRef = (
+  input: HighImpactActionPolicyInput,
+  env: NodeJS.ProcessEnv,
+  untrustedCheckout: boolean,
+): boolean => {
+  if (input.trustedRef !== undefined) {
+    return input.trustedRef;
+  }
+  if (untrustedCheckout) {
+    return false;
+  }
+  if (isTruthyEnvValue(env['AE_TRUSTED_REF']) || isTruthyEnvValue(env['AE_HIGH_IMPACT_TRUSTED_REF'])) {
+    return true;
+  }
+  if (isTruthyEnvValue(env['GITHUB_ACTIONS'])) {
+    return env['GITHUB_REF_PROTECTED'] === 'true' && !isPullRequestEvent(env);
+  }
+  return true;
+};
+
+const buildDecision = (
+  input: HighImpactActionPolicyInput,
+  values: Omit<HighImpactActionPolicyDecision, 'actionKind' | 'actionName' | 'requiredApprovalScope'> & { requiredApprovalScope: string },
+): HighImpactActionPolicyDecision => {
+  const decision: HighImpactActionPolicyDecision = {
+    actionKind: input.actionKind,
+    actionName: input.actionName,
+    apply: values.apply,
+    dryRun: values.dryRun,
+    allowed: values.allowed,
+    approvalRequired: values.approvalRequired,
+    blocked: values.blocked,
+    reason: values.reason,
+    requiredApprovalScope: values.requiredApprovalScope,
+    trustedWorkspace: values.trustedWorkspace,
+    trustedRef: values.trustedRef,
+    agentContext: values.agentContext,
+    ciContext: values.ciContext,
+    untrustedCheckout: values.untrustedCheckout,
+    ambientSecretNames: values.ambientSecretNames,
+  };
+  if (values.approvalScope !== undefined) {
+    decision.approvalScope = values.approvalScope;
+  }
+  return decision;
+};
+
+export function evaluateHighImpactActionPolicy(input: HighImpactActionPolicyInput): HighImpactActionPolicyDecision {
+  const env = input.env ?? process.env;
+  const requiredApprovalScope = input.requiredApprovalScope ?? DEFAULT_HIGH_IMPACT_APPROVAL_SCOPES[input.actionKind];
+  const approvalScope = getEffectiveApprovalScope(input);
+  const apply = input.apply === true;
+  const explicitDryRun = input.dryRun === true;
+  const agentContext = input.agentContext ?? isHighImpactAgentContext(env);
+  const ciContext = input.ciContext ?? isHighImpactCiContext(env);
+  const untrustedCheckout = input.untrustedCheckout ?? isHighImpactUntrustedCheckout(env);
+  const trustedWorkspace = inferTrustedWorkspace(input, env, untrustedCheckout);
+  const trustedRef = inferTrustedRef(input, env, untrustedCheckout);
+  const ambientSecretNames = findAmbientSecretNames(env);
+  const shouldBlockAmbientSecrets = input.blockAmbientSecrets ?? (agentContext || ciContext || untrustedCheckout);
+  const enforceApproval = input.enforceApproval ?? true;
+  const approved = hasExplicitApproval(input, requiredApprovalScope);
+
+  const common = {
+    apply,
+    requiredApprovalScope,
+    approvalScope,
+    trustedWorkspace,
+    trustedRef,
+    agentContext,
+    ciContext,
+    untrustedCheckout,
+    ambientSecretNames,
+  };
+
+  if (explicitDryRun) {
+    return buildDecision(input, {
+      ...common,
+      dryRun: true,
+      allowed: false,
+      approvalRequired: false,
+      blocked: false,
+      reason: 'explicit-dry-run',
+    });
+  }
+
+  if (!apply) {
+    return buildDecision(input, {
+      ...common,
+      dryRun: true,
+      allowed: false,
+      approvalRequired: false,
+      blocked: false,
+      reason: 'plan-only-without-explicit-apply',
+    });
+  }
+
+  if (untrustedCheckout || !trustedWorkspace || !trustedRef) {
+    return buildDecision(input, {
+      ...common,
+      dryRun: true,
+      allowed: false,
+      approvalRequired: false,
+      blocked: false,
+      reason: 'untrusted-workspace-or-ref-forces-dry-run',
+    });
+  }
+
+  if (enforceApproval && !approved) {
+    return buildDecision(input, {
+      ...common,
+      dryRun: false,
+      allowed: false,
+      approvalRequired: true,
+      blocked: false,
+      reason: `missing-explicit-approval:${requiredApprovalScope}`,
+    });
+  }
+
+  if (shouldBlockAmbientSecrets && input.allowAmbientSecrets !== true && ambientSecretNames.length > 0) {
+    return buildDecision(input, {
+      ...common,
+      dryRun: true,
+      allowed: false,
+      approvalRequired: false,
+      blocked: true,
+      reason: 'ambient-secrets-present',
+    });
+  }
+
+  return buildDecision(input, {
+    ...common,
+    dryRun: false,
+    allowed: true,
+    approvalRequired: false,
+    blocked: false,
+    reason: approved ? 'approved-trusted-execution' : 'trusted-execution-without-enforced-approval',
+  });
+}
+
+export function formatHighImpactDecisionMessage(decision: HighImpactActionPolicyDecision): string {
+  switch (decision.reason) {
+    case 'explicit-dry-run':
+      return `${decision.actionName} is in explicit dry-run mode; ${decision.actionKind} action will not execute.`;
+    case 'plan-only-without-explicit-apply':
+      return `${decision.actionName} defaults to dry-run; rerun with explicit apply and approval scope '${decision.requiredApprovalScope}' to execute ${decision.actionKind} action.`;
+    case 'untrusted-workspace-or-ref-forces-dry-run':
+      return `${decision.actionName} is running from an untrusted workspace/ref; ${decision.actionKind} action is forced to dry-run.`;
+    case 'ambient-secrets-present':
+      return `${decision.actionName} cannot execute ${decision.actionKind} action while ambient secrets are present: ${decision.ambientSecretNames.join(', ')}`;
+    default:
+      if (decision.approvalRequired) {
+        return `${decision.actionName} requires explicit approval scope '${decision.requiredApprovalScope}' before executing ${decision.actionKind} action.`;
+      }
+      return `${decision.actionName} ${decision.reason}`;
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,22 @@ export { TokenOptimizer } from './token-optimizer.js';
 export { ContextManager } from './context-manager.js';
 export { compare, parseComparator, strictest } from './comparator.js';
 export type { ComparatorBaseUnit, ComparatorOperator, ParsedComparator } from './comparator.js';
+export {
+  DEFAULT_HIGH_IMPACT_APPROVAL_SCOPES,
+  createHighImpactChildEnv,
+  evaluateHighImpactActionPolicy,
+  findAmbientSecretNames,
+  formatHighImpactDecisionMessage,
+  isHighImpactAgentContext,
+  isHighImpactCiContext,
+  isHighImpactUntrustedCheckout,
+} from './high-impact-action-policy.js';
+export type {
+  HighImpactActionApproval,
+  HighImpactActionKind,
+  HighImpactActionPolicyDecision,
+  HighImpactActionPolicyInput,
+} from './high-impact-action-policy.js';
 
 // Smart Persona System (Phase 2)
 export { PersonaManager } from './persona-manager.js';

--- a/src/utils/installer-manager.ts
+++ b/src/utils/installer-manager.ts
@@ -12,6 +12,11 @@ import {
   resolveWorkspacePath,
   WorkspacePathPolicyError,
 } from './workspace-path-policy.js';
+import {
+  createHighImpactChildEnv,
+  evaluateHighImpactActionPolicy,
+  formatHighImpactDecisionMessage,
+} from './high-impact-action-policy.js';
 
 export const INSTALLER_APPROVAL_SCOPE = 'installer-apply' as const;
 
@@ -229,16 +234,20 @@ export class InstallerManager {
     try {
       await this.collectPlannedChanges(template, installContext, result);
 
-      if (installContext.dryRun === true) {
+      const applyPolicy = this.evaluateInstallerApplyPolicy(installContext);
+      if (applyPolicy.dryRun) {
+        result.dryRun = true;
         result.message = `Dry-run preview for ${template.name}; no installer changes were applied`;
         result.duration = Date.now() - startTime;
         return result;
       }
 
-      if (!this.hasTrustedApproval(installContext)) {
+      if (!applyPolicy.allowed) {
         result.success = false;
-        result.approvalRequired = true;
-        result.message = `Installation requires explicit ${INSTALLER_APPROVAL_SCOPE} approval`;
+        result.approvalRequired = applyPolicy.approvalRequired;
+        result.message = applyPolicy.approvalRequired
+          ? `Installation requires explicit ${INSTALLER_APPROVAL_SCOPE} approval`
+          : formatHighImpactDecisionMessage(applyPolicy);
         result.errors.push(result.message);
         result.duration = Date.now() - startTime;
         return result;
@@ -807,6 +816,30 @@ end
     return context.approval?.approved === true && context.approval.scope === INSTALLER_APPROVAL_SCOPE;
   }
 
+  private evaluateInstallerApplyPolicy(context: InstallationContext): ReturnType<typeof evaluateHighImpactActionPolicy> {
+    return evaluateHighImpactActionPolicy({
+      actionKind: 'package-manager',
+      actionName: 'installer-template-apply',
+      apply: context.dryRun === false,
+      dryRun: context.dryRun,
+      approval: context.approval,
+      requiredApprovalScope: INSTALLER_APPROVAL_SCOPE,
+      env: createHighImpactChildEnv(),
+    });
+  }
+
+  private canProbePackageManager(context: Partial<InstallationContext>, dryRun: boolean, trustedApproval: boolean): boolean {
+    return evaluateHighImpactActionPolicy({
+      actionKind: 'package-manager',
+      actionName: 'installer-package-manager-probe',
+      apply: dryRun !== true && trustedApproval,
+      dryRun,
+      approval: context.approval,
+      requiredApprovalScope: INSTALLER_APPROVAL_SCOPE,
+      env: createHighImpactChildEnv(),
+    }).allowed;
+  }
+
   private resolveProjectPath(context: InstallationContext, relativePath: string, label: string): string {
     return resolveWorkspacePath(relativePath, {
       workspaceRoot: context.projectRoot,
@@ -826,8 +859,9 @@ end
 
     const trustedApproval = this.hasTrustedApproval(context);
     const dryRun = context.dryRun ?? !trustedApproval;
+    const allowExecutableProbe = this.canProbePackageManager(context, dryRun, trustedApproval);
     const packageManager = context.packageManager
-      || await this.detectPackageManagerInternal({ allowExecutableProbe: dryRun !== true && trustedApproval });
+      || await this.detectPackageManagerInternal({ allowExecutableProbe });
     const projectName = context.projectName || path.basename(this.projectRoot);
     
     let existingPackageJson;
@@ -1186,6 +1220,7 @@ end
       
       const process = spawn(command, args, {
         cwd: this.projectRoot,
+        env: createHighImpactChildEnv(),
         shell: false,
         stdio: options.silent ? 'pipe' : 'inherit'
       });

--- a/src/utils/installer-manager.ts
+++ b/src/utils/installer-manager.ts
@@ -235,20 +235,20 @@ export class InstallerManager {
       await this.collectPlannedChanges(template, installContext, result);
 
       const applyPolicy = this.evaluateInstallerApplyPolicy(installContext);
-      if (applyPolicy.dryRun) {
-        result.dryRun = true;
-        result.message = `Dry-run preview for ${template.name}; no installer changes were applied`;
-        result.duration = Date.now() - startTime;
-        return result;
-      }
-
-      if (!applyPolicy.allowed) {
+      if (applyPolicy.approvalRequired || applyPolicy.blocked || (!applyPolicy.allowed && !applyPolicy.dryRun)) {
         result.success = false;
         result.approvalRequired = applyPolicy.approvalRequired;
         result.message = applyPolicy.approvalRequired
           ? `Installation requires explicit ${INSTALLER_APPROVAL_SCOPE} approval`
           : formatHighImpactDecisionMessage(applyPolicy);
         result.errors.push(result.message);
+        result.duration = Date.now() - startTime;
+        return result;
+      }
+
+      if (applyPolicy.dryRun) {
+        result.dryRun = true;
+        result.message = `Dry-run preview for ${template.name}; no installer changes were applied`;
         result.duration = Date.now() - startTime;
         return result;
       }
@@ -824,7 +824,6 @@ end
       dryRun: context.dryRun,
       approval: context.approval,
       requiredApprovalScope: INSTALLER_APPROVAL_SCOPE,
-      env: createHighImpactChildEnv(),
     });
   }
 
@@ -836,7 +835,6 @@ end
       dryRun,
       approval: context.approval,
       requiredApprovalScope: INSTALLER_APPROVAL_SCOPE,
-      env: createHighImpactChildEnv(),
     }).allowed;
   }
 

--- a/tests/cegis/cegis-cli.test.ts
+++ b/tests/cegis/cegis-cli.test.ts
@@ -14,8 +14,15 @@ describe('CEGISCli', () => {
   let consoleLogSpy: any;
   let consoleErrorSpy: any;
   let testFiles: string[] = [];
+  let previousEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
+    previousEnv = { ...process.env };
+    process.env = {
+      PATH: previousEnv['PATH'],
+      HOME: previousEnv['HOME'],
+      NODE_ENV: previousEnv['NODE_ENV'],
+    };
     cli = new CEGISCli();
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -23,6 +30,7 @@ describe('CEGISCli', () => {
   });
 
   afterEach(() => {
+    process.env = previousEnv;
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
     
@@ -217,6 +225,39 @@ describe('CEGISCli', () => {
           process.env['AE_UNTRUSTED_CHECKOUT'] = previousUntrustedCheckout;
         }
       }
+    });
+
+    it('should block approved auto-fix apply when ambient secrets are present in agent context', async () => {
+      process.env['AE_AGENT_CONTEXT'] = '1';
+      process.env['GITHUB_TOKEN'] = 'ghs-secret';
+      const failures = [
+        FailureArtifactFactory.fromError(new Error('test error'))
+      ];
+
+      const inputFile = 'test-apply-ambient-secret.json';
+      writeFileSync(inputFile, JSON.stringify(failures, null, 2));
+      testFiles.push(inputFile);
+
+      const command = cli.createCommand();
+      const args = [
+        'node',
+        'cli',
+        'apply',
+        '--input',
+        inputFile,
+        '--apply',
+        '--approval-scope',
+        'cegis-auto-fix',
+      ];
+
+      await command.parseAsync(args);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ambient secrets')
+      );
+      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Starting CEGIS auto-fix process')
+      );
     });
   });
 

--- a/tests/cegis/cegis-cli.test.ts
+++ b/tests/cegis/cegis-cli.test.ts
@@ -155,6 +155,69 @@ describe('CEGISCli', () => {
         expect.stringContaining('No input file specified')
       );
     });
+
+    it('should reject --apply without explicit auto-fix approval before executing fixes', async () => {
+      const failures = [
+        FailureArtifactFactory.fromError(new Error('test error'))
+      ];
+
+      const inputFile = 'test-apply-without-approval.json';
+      writeFileSync(inputFile, JSON.stringify(failures, null, 2));
+      testFiles.push(inputFile);
+
+      const command = cli.createCommand();
+      const args = ['node', 'cli', 'apply', '--input', inputFile, '--apply'];
+
+      await command.parseAsync(args);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("approval scope 'cegis-auto-fix'")
+      );
+      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Starting CEGIS auto-fix process')
+      );
+    });
+
+    it('should force approved auto-fix apply to dry-run in untrusted checkouts', async () => {
+      const previousUntrustedCheckout = process.env['AE_UNTRUSTED_CHECKOUT'];
+      process.env['AE_UNTRUSTED_CHECKOUT'] = '1';
+      const failures = [
+        FailureArtifactFactory.fromError(new Error('test error'))
+      ];
+
+      const inputFile = 'test-apply-untrusted-dry-run.json';
+      writeFileSync(inputFile, JSON.stringify(failures, null, 2));
+      testFiles.push(inputFile);
+
+      try {
+        const command = cli.createCommand();
+        const args = [
+          'node',
+          'cli',
+          'apply',
+          '--input',
+          inputFile,
+          '--apply',
+          '--approval-scope',
+          'cegis-auto-fix',
+        ];
+
+        await command.parseAsync(args);
+
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('forced to dry-run')
+        );
+        expect(consoleLogSpy).toHaveBeenCalledWith(
+          expect.stringContaining('DRY RUN - No changes were applied')
+        );
+      } finally {
+        if (previousUntrustedCheckout === undefined) {
+          delete process.env['AE_UNTRUSTED_CHECKOUT'];
+        } else {
+          process.env['AE_UNTRUSTED_CHECKOUT'] = previousUntrustedCheckout;
+        }
+      }
+    });
   });
 
   describe('analyze command', () => {

--- a/tests/cli/quality-cli.test.ts
+++ b/tests/cli/quality-cli.test.ts
@@ -190,6 +190,29 @@ describe('quality CLI format option', () => {
     }
   });
 
+  it('run preserves CI execution for direct quality gates without explicit untrusted marker', async () => {
+    process.env['GITHUB_ACTIONS'] = 'true';
+    process.env['GITHUB_EVENT_NAME'] = 'pull_request';
+    process.env['GITHUB_REF_PROTECTED'] = 'false';
+    executeGatesMock.mockResolvedValueOnce(createReport());
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    try {
+      const command = createQualityCommand();
+      await command.parseAsync(['node', 'cli', 'run', '--format', 'json']);
+
+      expect(executeGatesMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dryRun: false,
+          apply: true,
+        }),
+      );
+      expect(safeExitMock).not.toHaveBeenCalled();
+    } finally {
+      consoleLogSpy.mockRestore();
+    }
+  });
+
   it('run rejects agent-context --apply without the trusted approval scope', async () => {
     const previous = process.env['AE_QUALITY_AGENT_CONTEXT'];
     process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';

--- a/tests/cli/quality-cli.test.ts
+++ b/tests/cli/quality-cli.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const safeExitMock = vi.fn();
 const executeGatesMock = vi.fn();
@@ -27,15 +27,26 @@ vi.mock('../../src/cegis/auto-fix-engine.js', () => ({
 }));
 
 let createQualityCommand: () => any;
+let previousEnv: NodeJS.ProcessEnv;
 
 beforeAll(async () => {
   ({ createQualityCommand } = await import('../../src/cli/quality-cli.js'));
 });
 
 beforeEach(() => {
+  previousEnv = { ...process.env };
+  process.env = {
+    PATH: previousEnv['PATH'],
+    HOME: previousEnv['HOME'],
+    NODE_ENV: previousEnv['NODE_ENV'],
+  };
   safeExitMock.mockReset();
   executeGatesMock.mockReset();
   executeFixesMock.mockReset();
+});
+
+afterEach(() => {
+  process.env = previousEnv;
 });
 
 const createReport = (overrides: Partial<Record<string, unknown>> = {}) => ({

--- a/tests/quality/quality-command-policy.test.ts
+++ b/tests/quality/quality-command-policy.test.ts
@@ -130,6 +130,7 @@ describe('quality gate command policy', () => {
   let previousQualityAgentContext: string | undefined;
   let previousAgentContext: string | undefined;
   let previousCiContext: string | undefined;
+  let previousUntrustedCheckout: string | undefined;
 
   const writePolicy = (
     command = 'node scripts/quality/check-lint-summary.mjs',
@@ -157,9 +158,11 @@ describe('quality gate command policy', () => {
     previousQualityAgentContext = process.env['AE_QUALITY_AGENT_CONTEXT'];
     previousAgentContext = process.env['AE_AGENT_CONTEXT'];
     previousCiContext = process.env['CI'];
+    previousUntrustedCheckout = process.env['AE_UNTRUSTED_CHECKOUT'];
     delete process.env['AE_QUALITY_AGENT_CONTEXT'];
     delete process.env['AE_AGENT_CONTEXT'];
     delete process.env['CI'];
+    delete process.env['AE_UNTRUSTED_CHECKOUT'];
   });
 
   afterEach(() => {
@@ -177,6 +180,11 @@ describe('quality gate command policy', () => {
       delete process.env['CI'];
     } else {
       process.env['CI'] = previousCiContext;
+    }
+    if (previousUntrustedCheckout === undefined) {
+      delete process.env['AE_UNTRUSTED_CHECKOUT'];
+    } else {
+      process.env['AE_UNTRUSTED_CHECKOUT'] = previousUntrustedCheckout;
     }
     rmSync(join(process.cwd(), testRoot), { recursive: true, force: true });
   });
@@ -277,6 +285,30 @@ describe('quality gate command policy', () => {
     expect(existsSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'))).toBe(false);
   });
 
+  it('forces untrusted checkouts to dry-run and avoids process and report writes', async () => {
+    process.env['AE_UNTRUSTED_CHECKOUT'] = '1';
+    const spawnMock = createSpawnMock();
+    const runner = new QualityGateRunner(writePolicy(), {
+      spawnProcess: spawnMock as unknown as typeof spawn,
+    });
+
+    const report = await runner.executeGates({
+      environment: 'testing',
+      gates: ['linting'],
+      parallel: false,
+      outputDir: `${testRoot}/reports`,
+      printSummary: false,
+      silent: true,
+    });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(report.results[0]?.details).toMatchObject({
+      dryRun: true,
+      command: 'node scripts/quality/check-lint-summary.mjs',
+    });
+    expect(existsSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'))).toBe(false);
+  });
+
   it('requires trusted approval before agent-context apply can execute', async () => {
     process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
     const spawnMock = createSpawnMock();
@@ -297,26 +329,40 @@ describe('quality gate command policy', () => {
 
   it('executes in agent context when apply uses the trusted approval scope', async () => {
     process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
+    const previousGithubToken = process.env['GITHUB_TOKEN'];
+    const previousNpmToken = process.env['NPM_TOKEN'];
+    process.env['GITHUB_TOKEN'] = 'ghs-secret';
+    process.env['NPM_TOKEN'] = 'npm-secret';
     const spawnMock = createSpawnMock();
     const runner = new QualityGateRunner(writePolicy(), {
       spawnProcess: spawnMock as unknown as typeof spawn,
     });
 
-    const report = await runner.executeGates({
-      environment: 'testing',
-      gates: ['linting'],
-      apply: true,
-      approvalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
-      outputDir: `${testRoot}/reports`,
-      noHistory: true,
-      printSummary: false,
-      silent: true,
-    });
+    try {
+      const report = await runner.executeGates({
+        environment: 'testing',
+        gates: ['linting'],
+        apply: true,
+        approvalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+        outputDir: `${testRoot}/reports`,
+        noHistory: true,
+        printSummary: false,
+        silent: true,
+      });
 
-    expect(report.failedGates).toBe(0);
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    const latest = readFileSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'), 'utf8');
-    expect(JSON.parse(latest).environment).toBe('testing');
+      expect(report.failedGates).toBe(0);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+      expect(spawnOptions.env?.['GITHUB_TOKEN']).toBeUndefined();
+      expect(spawnOptions.env?.['NPM_TOKEN']).toBeUndefined();
+      const latest = readFileSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'), 'utf8');
+      expect(JSON.parse(latest).environment).toBe('testing');
+    } finally {
+      if (previousGithubToken === undefined) delete process.env['GITHUB_TOKEN'];
+      else process.env['GITHUB_TOKEN'] = previousGithubToken;
+      if (previousNpmToken === undefined) delete process.env['NPM_TOKEN'];
+      else process.env['NPM_TOKEN'] = previousNpmToken;
+    }
   });
 
   it('constrains quality report output to the approved artifact root', () => {

--- a/tests/quality/quality-command-policy.test.ts
+++ b/tests/quality/quality-command-policy.test.ts
@@ -131,6 +131,12 @@ describe('quality gate command policy', () => {
   let previousAgentContext: string | undefined;
   let previousCiContext: string | undefined;
   let previousUntrustedCheckout: string | undefined;
+  let previousGithubActions: string | undefined;
+  let previousGithubEventName: string | undefined;
+  let previousGithubRefProtected: string | undefined;
+  let previousGithubToken: string | undefined;
+  let previousNpmToken: string | undefined;
+  let previousActionsRuntimeToken: string | undefined;
 
   const writePolicy = (
     command = 'node scripts/quality/check-lint-summary.mjs',
@@ -159,10 +165,22 @@ describe('quality gate command policy', () => {
     previousAgentContext = process.env['AE_AGENT_CONTEXT'];
     previousCiContext = process.env['CI'];
     previousUntrustedCheckout = process.env['AE_UNTRUSTED_CHECKOUT'];
+    previousGithubActions = process.env['GITHUB_ACTIONS'];
+    previousGithubEventName = process.env['GITHUB_EVENT_NAME'];
+    previousGithubRefProtected = process.env['GITHUB_REF_PROTECTED'];
+    previousGithubToken = process.env['GITHUB_TOKEN'];
+    previousNpmToken = process.env['NPM_TOKEN'];
+    previousActionsRuntimeToken = process.env['ACTIONS_RUNTIME_TOKEN'];
     delete process.env['AE_QUALITY_AGENT_CONTEXT'];
     delete process.env['AE_AGENT_CONTEXT'];
     delete process.env['CI'];
     delete process.env['AE_UNTRUSTED_CHECKOUT'];
+    delete process.env['GITHUB_ACTIONS'];
+    delete process.env['GITHUB_EVENT_NAME'];
+    delete process.env['GITHUB_REF_PROTECTED'];
+    delete process.env['GITHUB_TOKEN'];
+    delete process.env['NPM_TOKEN'];
+    delete process.env['ACTIONS_RUNTIME_TOKEN'];
   });
 
   afterEach(() => {
@@ -185,6 +203,36 @@ describe('quality gate command policy', () => {
       delete process.env['AE_UNTRUSTED_CHECKOUT'];
     } else {
       process.env['AE_UNTRUSTED_CHECKOUT'] = previousUntrustedCheckout;
+    }
+    if (previousGithubActions === undefined) {
+      delete process.env['GITHUB_ACTIONS'];
+    } else {
+      process.env['GITHUB_ACTIONS'] = previousGithubActions;
+    }
+    if (previousGithubEventName === undefined) {
+      delete process.env['GITHUB_EVENT_NAME'];
+    } else {
+      process.env['GITHUB_EVENT_NAME'] = previousGithubEventName;
+    }
+    if (previousGithubRefProtected === undefined) {
+      delete process.env['GITHUB_REF_PROTECTED'];
+    } else {
+      process.env['GITHUB_REF_PROTECTED'] = previousGithubRefProtected;
+    }
+    if (previousGithubToken === undefined) {
+      delete process.env['GITHUB_TOKEN'];
+    } else {
+      process.env['GITHUB_TOKEN'] = previousGithubToken;
+    }
+    if (previousNpmToken === undefined) {
+      delete process.env['NPM_TOKEN'];
+    } else {
+      process.env['NPM_TOKEN'] = previousNpmToken;
+    }
+    if (previousActionsRuntimeToken === undefined) {
+      delete process.env['ACTIONS_RUNTIME_TOKEN'];
+    } else {
+      process.env['ACTIONS_RUNTIME_TOKEN'] = previousActionsRuntimeToken;
     }
     rmSync(join(process.cwd(), testRoot), { recursive: true, force: true });
   });
@@ -309,6 +357,30 @@ describe('quality gate command policy', () => {
     expect(existsSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'))).toBe(false);
   });
 
+  it('preserves direct quality execution in CI when no explicit untrusted marker is set', async () => {
+    process.env['GITHUB_ACTIONS'] = 'true';
+    process.env['GITHUB_EVENT_NAME'] = 'push';
+    process.env['GITHUB_REF_PROTECTED'] = 'false';
+    const spawnMock = createSpawnMock();
+    const runner = new QualityGateRunner(writePolicy(), {
+      spawnProcess: spawnMock as unknown as typeof spawn,
+    });
+
+    const report = await runner.executeGates({
+      environment: 'testing',
+      gates: ['linting'],
+      parallel: false,
+      outputDir: `${testRoot}/reports`,
+      noHistory: true,
+      printSummary: false,
+      silent: true,
+    });
+
+    expect(report.failedGates).toBe(0);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(existsSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'))).toBe(true);
+  });
+
   it('requires trusted approval before agent-context apply can execute', async () => {
     process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
     const spawnMock = createSpawnMock();
@@ -329,8 +401,6 @@ describe('quality gate command policy', () => {
 
   it('executes in agent context when apply uses the trusted approval scope', async () => {
     process.env['AE_QUALITY_AGENT_CONTEXT'] = '1';
-    const previousGithubToken = process.env['GITHUB_TOKEN'];
-    const previousNpmToken = process.env['NPM_TOKEN'];
     process.env['GITHUB_TOKEN'] = 'ghs-secret';
     process.env['NPM_TOKEN'] = 'npm-secret';
     const spawnMock = createSpawnMock();
@@ -338,31 +408,24 @@ describe('quality gate command policy', () => {
       spawnProcess: spawnMock as unknown as typeof spawn,
     });
 
-    try {
-      const report = await runner.executeGates({
-        environment: 'testing',
-        gates: ['linting'],
-        apply: true,
-        approvalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
-        outputDir: `${testRoot}/reports`,
-        noHistory: true,
-        printSummary: false,
-        silent: true,
-      });
+    const report = await runner.executeGates({
+      environment: 'testing',
+      gates: ['linting'],
+      apply: true,
+      approvalScope: QUALITY_GATE_EXECUTION_APPROVAL_SCOPE,
+      outputDir: `${testRoot}/reports`,
+      noHistory: true,
+      printSummary: false,
+      silent: true,
+    });
 
-      expect(report.failedGates).toBe(0);
-      expect(spawnMock).toHaveBeenCalledTimes(1);
-      const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
-      expect(spawnOptions.env?.['GITHUB_TOKEN']).toBeUndefined();
-      expect(spawnOptions.env?.['NPM_TOKEN']).toBeUndefined();
-      const latest = readFileSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'), 'utf8');
-      expect(JSON.parse(latest).environment).toBe('testing');
-    } finally {
-      if (previousGithubToken === undefined) delete process.env['GITHUB_TOKEN'];
-      else process.env['GITHUB_TOKEN'] = previousGithubToken;
-      if (previousNpmToken === undefined) delete process.env['NPM_TOKEN'];
-      else process.env['NPM_TOKEN'] = previousNpmToken;
-    }
+    expect(report.failedGates).toBe(0);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(spawnOptions.env?.['GITHUB_TOKEN']).toBeUndefined();
+    expect(spawnOptions.env?.['NPM_TOKEN']).toBeUndefined();
+    const latest = readFileSync(join(process.cwd(), testRoot, 'reports', 'quality-report-testing-latest.json'), 'utf8');
+    expect(JSON.parse(latest).environment).toBe('testing');
   });
 
   it('constrains quality report output to the approved artifact root', () => {

--- a/tests/unit/cli/guard-runner-execution-policy.test.ts
+++ b/tests/unit/cli/guard-runner-execution-policy.test.ts
@@ -96,9 +96,6 @@ describe('GuardRunner process-starting guard execution policy', () => {
       env: {
         PATH: '/usr/bin',
         HOME: '/home/operator',
-        GITHUB_TOKEN: 'ghs-secret',
-        SECRET_VALUE: 'secret',
-        NPM_TOKEN: 'npm-secret',
       },
     });
 
@@ -115,6 +112,50 @@ describe('GuardRunner process-starting guard execution policy', () => {
         stdio: 'pipe',
       })
     );
+    const spawnOptions = childProcessMock.spawnSync.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(spawnOptions.env).toMatchObject({ PATH: '/usr/bin', HOME: '/home/operator' });
+  });
+
+  it('blocks approved agent-context guard scripts when ambient secrets are present', async () => {
+    const runner = new GuardRunner(config, {
+      agentContext: true,
+      apply: true,
+      approvalScope: GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE,
+      cwd: '/repo',
+      env: {
+        PATH: '/usr/bin',
+        GITHUB_TOKEN: 'ghs-secret',
+      },
+    });
+
+    const result = await runner.run(testExecutionGuard);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain(`--approval-scope ${GUARD_SCRIPT_EXECUTION_APPROVAL_SCOPE}`);
+    expect(childProcessMock.spawnSync).not.toHaveBeenCalled();
+  });
+
+  it('redacts secret variables from trusted local guard process environments', async () => {
+    childProcessMock.spawnSync.mockReturnValueOnce({
+      status: 0,
+      stdout: '2 passing\n',
+      stderr: '',
+    });
+
+    const runner = new GuardRunner(config, {
+      cwd: '/repo',
+      env: {
+        PATH: '/usr/bin',
+        HOME: '/home/operator',
+        GITHUB_TOKEN: 'ghs-secret',
+        SECRET_VALUE: 'secret',
+        NPM_TOKEN: 'npm-secret',
+      },
+    });
+
+    const result = await runner.run(testExecutionGuard);
+
+    expect(result).toEqual({ success: true, message: 'All tests pass' });
     const spawnOptions = childProcessMock.spawnSync.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
     expect(spawnOptions.env).toMatchObject({ PATH: '/usr/bin', HOME: '/home/operator' });
     expect(spawnOptions.env?.['GITHUB_TOKEN']).toBeUndefined();

--- a/tests/unit/cli/guard-runner-execution-policy.test.ts
+++ b/tests/unit/cli/guard-runner-execution-policy.test.ts
@@ -170,8 +170,9 @@ describe('GuardRunner process-starting guard execution policy', () => {
     });
     expect(getGuardScriptExecutionPolicy({ apply: true, env: { AE_UNTRUSTED_CHECKOUT: '1' } })).toMatchObject({
       agentContext: true,
-      dryRun: false,
-      approvalRequired: true,
+      dryRun: true,
+      approvalRequired: false,
+      reason: 'untrusted-workspace-or-ref-forces-dry-run',
     });
   });
 

--- a/tests/unit/mcp-server/tdd-execution-policy.test.ts
+++ b/tests/unit/mcp-server/tdd-execution-policy.test.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import * as path from 'path';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { RedGreenCycleArgsSchema } from '../../../src/mcp-server/schemas.js';
 import { TDDGuardServer } from '../../../src/mcp-server/tdd-server.js';
 import {
@@ -15,6 +15,13 @@ import {
 describe('TDD MCP execution policy', () => {
   const testRoots: string[] = [];
   const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = {
+      PATH: originalEnv.PATH,
+      HOME: originalEnv.HOME,
+    };
+  });
 
   afterEach(async () => {
     process.env = { ...originalEnv };
@@ -55,6 +62,15 @@ describe('TDD MCP execution policy', () => {
       reason: `test execution requires approval token '${APPROVED_TDD_TEST_EXECUTION}'`,
     });
     expect(ensureTDDTestExecutionApproved(APPROVED_TDD_TEST_EXECUTION, false)).toEqual({ approved: true });
+  });
+
+  test('approved agent execution is blocked when the raw environment contains ambient secrets', () => {
+    process.env['GITHUB_TOKEN'] = 'ghs-secret';
+
+    expect(ensureTDDTestExecutionApproved(APPROVED_TDD_TEST_EXECUTION, false)).toEqual({
+      approved: false,
+      reason: 'ambient-secrets-present',
+    });
   });
 
   test('runs approved commands through an executable and argv array with shell disabled', () => {

--- a/tests/unit/security/codex-task-ui-security.test.ts
+++ b/tests/unit/security/codex-task-ui-security.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { existsSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { createCodexTaskAdapter } from '../../../src/agents/codex-task-adapter.js';
@@ -44,8 +44,18 @@ function makeRequest(context: TaskRequest['context']): TaskRequest {
 
 describe('CodeX Task UI scaffold security boundary', () => {
   let cleanup: (() => void) | undefined;
+  let previousEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    previousEnv = { ...process.env };
+    process.env = {
+      PATH: previousEnv['PATH'],
+      HOME: previousEnv['HOME'],
+    };
+  });
 
   afterEach(() => {
+    process.env = previousEnv;
     cleanup?.();
     cleanup = undefined;
   });
@@ -151,5 +161,24 @@ describe('CodeX Task UI scaffold security boundary', () => {
     expect(response.analysis).toContain('apps/web/app/admin-panel/page.tsx');
     expect(existsSync(join(output.absoluteDir, 'apps', 'web', 'app', 'admin-panel', 'page.tsx'))).toBe(true);
     expect(existsSync(join(output.absoluteDir, '..', 'Admin Panel', 'page.tsx'))).toBe(false);
+  });
+
+  it('blocks approved UI materialization when ambient secrets are present', async () => {
+    process.env['GITHUB_TOKEN'] = 'ghs-secret';
+    const output = makeOutputDir();
+    cleanup = output.cleanup;
+    const adapter = createCodexTaskAdapter();
+
+    const response = await adapter.handleTask(makeRequest({
+      phaseState: makePhaseState(),
+      outputDir: output.relativeDir,
+      dryRun: false,
+      approval: { approved: true, scope: 'ui-scaffold', actor: 'operator' },
+    }));
+
+    expect(response.shouldBlockProgress).toBe(true);
+    expect(response.blockingReason).toBe('high-impact-ui-write-policy');
+    expect(response.warnings).toEqual(expect.arrayContaining(['ambient-secrets-present']));
+    expect(existsSync(join(output.absoluteDir, 'apps', 'web', 'app', 'admin-panel', 'page.tsx'))).toBe(false);
   });
 });

--- a/tests/unit/utils/high-impact-action-policy.test.ts
+++ b/tests/unit/utils/high-impact-action-policy.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createHighImpactChildEnv,
+  evaluateHighImpactActionPolicy,
+  findAmbientSecretNames,
+  formatHighImpactDecisionMessage,
+  isHighImpactUntrustedCheckout,
+  type HighImpactActionKind,
+} from '../../../src/utils/high-impact-action-policy.js';
+
+describe('high-impact action approval policy', () => {
+  it('TGT-020-F001: forces package-manager execution in untrusted checkouts to dry-run even with approval', () => {
+    const decision = evaluateHighImpactActionPolicy({
+      actionKind: 'package-manager',
+      actionName: 'npm test --silent',
+      apply: true,
+      approvalScope: 'guard-script-execution',
+      requiredApprovalScope: 'guard-script-execution',
+      env: { AE_UNTRUSTED_CHECKOUT: '1' },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      dryRun: true,
+      approvalRequired: false,
+      reason: 'untrusted-workspace-or-ref-forces-dry-run',
+      untrustedCheckout: true,
+    });
+  });
+
+  it('TGT-AGENT-025-F001: defaults agent-context high-impact actions to plan-only dry-run without apply', () => {
+    const decision = evaluateHighImpactActionPolicy({
+      actionKind: 'process',
+      actionName: 'agent spawned verifier',
+      env: { AE_AGENT_CONTEXT: '1' },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      dryRun: true,
+      reason: 'plan-only-without-explicit-apply',
+      agentContext: true,
+    });
+  });
+
+  it('requires explicit approval before npm/cargo/docker/GitHub write/auto-fix actions are allowed', () => {
+    const cases: Array<{ kind: HighImpactActionKind; name: string }> = [
+      { kind: 'package-manager', name: 'npm install' },
+      { kind: 'package-manager', name: 'cargo test' },
+      { kind: 'container', name: 'docker run' },
+      { kind: 'github-write', name: 'gh api --method POST repos/o/r/issues/1/comments' },
+      { kind: 'auto-fix', name: 'fix apply' },
+    ];
+
+    for (const { kind, name } of cases) {
+      const decision = evaluateHighImpactActionPolicy({
+        actionKind: kind,
+        actionName: name,
+        apply: true,
+        env: {},
+      });
+      expect(decision.allowed, name).toBe(false);
+      expect(decision.approvalRequired, name).toBe(true);
+      expect(decision.reason, name).toContain('missing-explicit-approval');
+    }
+  });
+
+  it('allows trusted execution only when the required approval scope matches', () => {
+    const decision = evaluateHighImpactActionPolicy({
+      actionKind: 'auto-fix',
+      actionName: 'cegis-auto-fix-apply',
+      apply: true,
+      approvalScope: 'cegis-auto-fix',
+      requiredApprovalScope: 'cegis-auto-fix',
+      env: {},
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      dryRun: false,
+      approvalRequired: false,
+      reason: 'approved-trusted-execution',
+    });
+  });
+
+  it('records trusted local compatibility when approval enforcement is intentionally disabled', () => {
+    const decision = evaluateHighImpactActionPolicy({
+      actionKind: 'package-manager',
+      actionName: 'trusted-local-quality-gate',
+      apply: true,
+      enforceApproval: false,
+      env: {},
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      dryRun: false,
+      approvalRequired: false,
+      reason: 'trusted-execution-without-enforced-approval',
+    });
+  });
+
+  it('TGT-AGENT-041-F001: treats unprotected pull_request refs as untrusted for GitHub write actions', () => {
+    const env = {
+      GITHUB_ACTIONS: 'true',
+      GITHUB_EVENT_NAME: 'pull_request',
+      GITHUB_REF_PROTECTED: 'false',
+    };
+    expect(isHighImpactUntrustedCheckout(env)).toBe(true);
+
+    const decision = evaluateHighImpactActionPolicy({
+      actionKind: 'github-write',
+      actionName: 'gh pr merge --auto',
+      apply: true,
+      approvalScope: 'github-write',
+      requiredApprovalScope: 'github-write',
+      env,
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      dryRun: true,
+      reason: 'untrusted-workspace-or-ref-forces-dry-run',
+    });
+  });
+
+  it('blocks approved agent-context execution when ambient secrets are present and redacts child environments', () => {
+    const env = {
+      PATH: '/usr/bin',
+      HOME: '/home/operator',
+      GITHUB_TOKEN: 'ghs-secret-value',
+      NPM_TOKEN: 'npm-secret-value',
+      CUSTOM_API_KEY: 'api-secret-value',
+    };
+
+    expect(findAmbientSecretNames(env)).toEqual(['CUSTOM_API_KEY', 'GITHUB_TOKEN', 'NPM_TOKEN']);
+
+    const decision = evaluateHighImpactActionPolicy({
+      actionKind: 'process',
+      actionName: 'agent verifier process',
+      apply: true,
+      approvalScope: 'high-impact:process',
+      env,
+      agentContext: true,
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      blocked: true,
+      dryRun: true,
+      reason: 'ambient-secrets-present',
+    });
+    expect(formatHighImpactDecisionMessage(decision)).not.toContain('ghs-secret-value');
+    expect(createHighImpactChildEnv(env)).toEqual({ PATH: '/usr/bin', HOME: '/home/operator' });
+  });
+
+  it('TGT-AGENT-233-F001: codegen materialization can be explicitly approved on a trusted workspace/ref', () => {
+    const decision = evaluateHighImpactActionPolicy({
+      actionKind: 'codegen-materialize',
+      actionName: 'spec codegen materialize',
+      apply: true,
+      approval: {
+        approved: true,
+        scope: 'spec-codegen-materialize',
+      },
+      requiredApprovalScope: 'spec-codegen-materialize',
+      env: {},
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.dryRun).toBe(false);
+  });
+});

--- a/tests/utils/installer-manager.test.ts
+++ b/tests/utils/installer-manager.test.ts
@@ -15,6 +15,7 @@ vi.mock('child_process');
 
 describe('InstallerManager', () => {
   let installerManager: InstallerManager;
+  let previousEnv: NodeJS.ProcessEnv;
   const testProjectRoot = '/test/project';
   const approvedContext = {
     dryRun: false,
@@ -25,6 +26,11 @@ describe('InstallerManager', () => {
   } as const;
 
   beforeEach(() => {
+    previousEnv = { ...process.env };
+    process.env = {
+      PATH: previousEnv['PATH'],
+      HOME: previousEnv['HOME'],
+    };
     vi.clearAllMocks();
     
     // Mock file system operations
@@ -38,6 +44,7 @@ describe('InstallerManager', () => {
   });
 
   afterEach(() => {
+    process.env = previousEnv;
     vi.restoreAllMocks();
   });
 
@@ -320,12 +327,8 @@ describe('InstallerManager', () => {
     });
 
     test('should redact ambient secret variables from package-manager child environments', async () => {
-      const previousGithubToken = process.env['GITHUB_TOKEN'];
-      const previousNpmToken = process.env['NPM_TOKEN'];
-      const previousCi = process.env['CI'];
       process.env['GITHUB_TOKEN'] = 'ghs-secret';
       process.env['NPM_TOKEN'] = 'npm-secret';
-      process.env['CI'] = 'true';
       const mockProcess = {
         stdout: { on: vi.fn() },
         stderr: { on: vi.fn() },
@@ -335,24 +338,30 @@ describe('InstallerManager', () => {
       };
       vi.mocked(spawn).mockReturnValue(mockProcess as any);
 
-      try {
-        const result = await installerManager.installTemplate('react-vite', {
-          ...approvedContext,
-          packageManager: 'npm',
-        });
+      const result = await installerManager.installTemplate('react-vite', {
+        ...approvedContext,
+        packageManager: 'npm',
+      });
 
-        expect(result.success).toBe(true);
-        const spawnOptions = vi.mocked(spawn).mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
-        expect(spawnOptions.env?.['GITHUB_TOKEN']).toBeUndefined();
-        expect(spawnOptions.env?.['NPM_TOKEN']).toBeUndefined();
-      } finally {
-        if (previousGithubToken === undefined) delete process.env['GITHUB_TOKEN'];
-        else process.env['GITHUB_TOKEN'] = previousGithubToken;
-        if (previousNpmToken === undefined) delete process.env['NPM_TOKEN'];
-        else process.env['NPM_TOKEN'] = previousNpmToken;
-        if (previousCi === undefined) delete process.env['CI'];
-        else process.env['CI'] = previousCi;
-      }
+      expect(result.success).toBe(true);
+      const spawnOptions = vi.mocked(spawn).mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+      expect(spawnOptions.env?.['GITHUB_TOKEN']).toBeUndefined();
+      expect(spawnOptions.env?.['NPM_TOKEN']).toBeUndefined();
+    });
+
+    test('should block approved CI apply when ambient secrets are present', async () => {
+      process.env['CI'] = 'true';
+      process.env['GITHUB_TOKEN'] = 'ghs-secret';
+
+      const result = await installerManager.installTemplate('react-vite', {
+        ...approvedContext,
+        packageManager: 'npm',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('ambient secrets');
+      expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+      expect(vi.mocked(fs.writeFile)).not.toHaveBeenCalled();
     });
 
     test('should validate template file paths before applying package or file writes', async () => {

--- a/tests/utils/installer-manager.test.ts
+++ b/tests/utils/installer-manager.test.ts
@@ -253,6 +253,31 @@ describe('InstallerManager', () => {
       expect(vi.mocked(fs.mkdir)).not.toHaveBeenCalled();
     });
 
+    test('should force approved apply to dry-run in an untrusted checkout', async () => {
+      const previous = process.env['AE_UNTRUSTED_CHECKOUT'];
+      process.env['AE_UNTRUSTED_CHECKOUT'] = '1';
+      vi.mocked(fs.access).mockRejectedValue(new Error('not found'));
+
+      try {
+        const result = await installerManager.installTemplate('react-vite', {
+          ...approvedContext,
+        });
+
+        expect(result.success).toBe(true);
+        expect(result.dryRun).toBe(true);
+        expect(result.message).toContain('Dry-run preview');
+        expect(result.plannedChanges?.length).toBeGreaterThan(0);
+        expect(vi.mocked(spawn)).not.toHaveBeenCalled();
+        expect(vi.mocked(fs.writeFile)).not.toHaveBeenCalled();
+      } finally {
+        if (previous === undefined) {
+          delete process.env['AE_UNTRUSTED_CHECKOUT'];
+        } else {
+          process.env['AE_UNTRUSTED_CHECKOUT'] = previous;
+        }
+      }
+    });
+
     test('should install dependencies with argv-safe spawn and lifecycle scripts suppressed by default', async () => {
       const mockProcess = {
         stdout: { on: vi.fn() },
@@ -292,6 +317,42 @@ describe('InstallerManager', () => {
         ],
         expect.objectContaining({ shell: false, cwd: path.resolve(testProjectRoot) })
       );
+    });
+
+    test('should redact ambient secret variables from package-manager child environments', async () => {
+      const previousGithubToken = process.env['GITHUB_TOKEN'];
+      const previousNpmToken = process.env['NPM_TOKEN'];
+      const previousCi = process.env['CI'];
+      process.env['GITHUB_TOKEN'] = 'ghs-secret';
+      process.env['NPM_TOKEN'] = 'npm-secret';
+      process.env['CI'] = 'true';
+      const mockProcess = {
+        stdout: { on: vi.fn() },
+        stderr: { on: vi.fn() },
+        on: vi.fn().mockImplementation((event, callback) => {
+          if (event === 'close') callback(0);
+        })
+      };
+      vi.mocked(spawn).mockReturnValue(mockProcess as any);
+
+      try {
+        const result = await installerManager.installTemplate('react-vite', {
+          ...approvedContext,
+          packageManager: 'npm',
+        });
+
+        expect(result.success).toBe(true);
+        const spawnOptions = vi.mocked(spawn).mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+        expect(spawnOptions.env?.['GITHUB_TOKEN']).toBeUndefined();
+        expect(spawnOptions.env?.['NPM_TOKEN']).toBeUndefined();
+      } finally {
+        if (previousGithubToken === undefined) delete process.env['GITHUB_TOKEN'];
+        else process.env['GITHUB_TOKEN'] = previousGithubToken;
+        if (previousNpmToken === undefined) delete process.env['NPM_TOKEN'];
+        else process.env['NPM_TOKEN'] = previousNpmToken;
+        if (previousCi === undefined) delete process.env['CI'];
+        else process.env['CI'] = previousCi;
+      }
     });
 
     test('should validate template file paths before applying package or file writes', async () => {


### PR DESCRIPTION
## Summary
- Add a shared `high-impact-action-policy` module for process/package-manager/container/filesystem/GitHub-write/auto-fix/codegen materialization decisions.
- Wire representative CLI/MCP/agent high-impact surfaces through the shared policy: installer apply/probes, guard script execution, quality gate execution, MCP TDD test execution, CEGIS auto-fix apply/verify, and Codex UI scaffold materialization.
- Force untrusted checkouts and unprotected PR refs to dry-run, require explicit scoped approval for protected automation/apply paths, and redact ambient secrets from child-process environments.

## Scope and compatibility
- Trusted local operator execution for existing guard/quality commands is intentionally preserved to avoid a breaking CLI behavior change. The shared decision records this as `trusted-execution-without-enforced-approval`; agent, untrusted checkout, and CI-protected entry points enforce dry-run/approval.
- CI write-token publisher separation and full workflow `gh`/container/cargo hardening are tracked by follow-up issues (notably #3464) and are not broadened in this compatibility-preserving policy foundation PR.
- Ambient secrets are blocked by the shared policy when evaluated on raw high-impact agent/CI environments, and child-process integrations pass a redacted env to prevent token leakage into spawned commands.

## Acceptance
- [x] CLI/MCP/agent entry points call the shared high-impact policy module.
- [x] Untrusted checkout / unprotected PR ref high-impact actions are forced to dry-run.
- [x] Explicit approval is required for protected npm/package-manager, auto-fix, TDD execution, and codegen materialization paths covered by this PR.
- [x] Regression coverage includes `TGT-020-F001`, `TGT-AGENT-025-F001`, `TGT-AGENT-041-F001`, and `TGT-AGENT-233-F001` perspectives.

## Validation
- `pnpm -s run types:check`
- `pnpm -s exec vitest run tests/unit/utils/high-impact-action-policy.test.ts tests/unit/cli/guard-runner-execution-policy.test.ts tests/quality/quality-command-policy.test.ts tests/cli/quality-cli.test.ts tests/unit/mcp-server/tdd-execution-policy.test.ts tests/utils/installer-manager.test.ts tests/unit/security/codex-task-ui-security.test.ts tests/cegis/cegis-cli.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet src/utils/high-impact-action-policy.ts src/utils/index.ts src/utils/installer-manager.ts src/cli/guards/GuardRunner.ts src/cli/quality-cli.ts src/quality/quality-gate-runner.ts src/mcp-server/tdd-execution-policy.ts src/cli/cegis-cli.ts src/agents/codex-task-adapter.ts tests/unit/utils/high-impact-action-policy.test.ts tests/unit/cli/guard-runner-execution-policy.test.ts tests/quality/quality-command-policy.test.ts tests/utils/installer-manager.test.ts tests/cegis/cegis-cli.test.ts`
- `pnpm -s exec vitest run tests/commands/installer-command.test.ts tests/cli/setup-cli.test.ts tests/quality/quality-gate-runner-output.test.ts tests/quality/quality-gate-runner-parsing.test.ts --reporter dot`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run docs:lint`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run check:schemas`
- `pnpm -s run build`
- `git diff --check`

## Rollback
- Revert this PR to restore the prior per-surface approval/dry-run behavior. No schema or migration state is introduced.

Closes #3462
