### PR TITLE
fix(ci): split trusted artifact publishers

### DIFF
--- a/.github/workflows/formal-aggregate-publisher.yml
+++ b/.github/workflows/formal-aggregate-publisher.yml
@@ -10,6 +10,10 @@ on:
         description: "Formal Verify workflow run id containing formal-reports-aggregate"
         required: true
         type: string
+      source_run_attempt:
+        description: "Formal Verify workflow run attempt"
+        required: false
+        type: string
       pr_number:
         description: "Pull request number to comment on"
         required: true
@@ -25,6 +29,7 @@ concurrency:
 
 permissions:
   actions: read
+  contents: read
   issues: write
   pull-requests: read
 
@@ -39,6 +44,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           DISPATCH_SOURCE_RUN_ID: ${{ inputs.source_run_id || '' }}
+          DISPATCH_SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt || '' }}
           DISPATCH_PR_NUMBER: ${{ inputs.pr_number || '' }}
           DISPATCH_PR_HEAD_SHA: ${{ inputs.pr_head_sha || '' }}
         with:
@@ -47,6 +53,7 @@ jobs:
             const eventName = context.eventName;
             const payload = context.payload || {};
             let sourceRunId = '';
+            let sourceRunAttempt = '';
             let prNumber = '';
             let expectedHeadSha = '';
             let workflowHeadRepository = '';
@@ -54,11 +61,13 @@ jobs:
             if (eventName === 'workflow_run') {
               const workflowRun = payload.workflow_run || {};
               sourceRunId = String(workflowRun.id || '');
+              sourceRunAttempt = String(workflowRun.run_attempt || '');
               prNumber = String((workflowRun.pull_requests || [])[0]?.number || '');
               expectedHeadSha = String(workflowRun.head_sha || '');
               workflowHeadRepository = String(workflowRun.head_repository?.full_name || '');
             } else {
               sourceRunId = String(process.env.DISPATCH_SOURCE_RUN_ID || '');
+              sourceRunAttempt = String(process.env.DISPATCH_SOURCE_RUN_ATTEMPT || '');
               prNumber = String(process.env.DISPATCH_PR_NUMBER || '');
               expectedHeadSha = String(process.env.DISPATCH_PR_HEAD_SHA || '');
             }
@@ -98,8 +107,16 @@ jobs:
 
             core.setOutput('skip', 'false');
             core.setOutput('source_run_id', sourceRunId);
+            core.setOutput('source_run_attempt', sourceRunAttempt);
             core.setOutput('pr_number', prNumber);
             core.setOutput('pr_head_sha', expectedHeadSha);
+
+      - name: Checkout trusted publisher code
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
 
       - name: Download formal aggregate artifact
         if: steps.context.outputs.skip != 'true'
@@ -109,6 +126,29 @@ jobs:
           path: artifacts/formal
           run-id: ${{ steps.context.outputs.source_run_id }}
           github-token: ${{ github.token }}
+
+      - name: Validate formal aggregate provenance
+        if: steps.context.outputs.skip != 'true'
+        env:
+          SOURCE_RUN_ATTEMPT: ${{ steps.context.outputs.source_run_attempt }}
+        run: |
+          set -euo pipefail
+          args=(
+            --provenance artifacts/formal/formal-reports-aggregate.provenance.json
+            --root artifacts/formal
+            --artifact-name formal-reports-aggregate
+            --repository "${GITHUB_REPOSITORY}"
+            --workflow "Formal Verify"
+            --run-id "${{ steps.context.outputs.source_run_id }}"
+            --event-name pull_request
+            --head-sha "${{ steps.context.outputs.pr_head_sha }}"
+            --pr-number "${{ steps.context.outputs.pr_number }}"
+            --require-subject formal-aggregate.md
+          )
+          if [ -n "${SOURCE_RUN_ATTEMPT}" ]; then
+            args+=(--run-attempt "${SOURCE_RUN_ATTEMPT}")
+          fi
+          node scripts/ci/validate-artifact-provenance.mjs "${args[@]}"
 
       - name: Publish formal aggregate PR comment
         if: steps.context.outputs.skip != 'true'

--- a/.github/workflows/formal-aggregate.yml
+++ b/.github/workflows/formal-aggregate.yml
@@ -63,12 +63,34 @@ jobs:
         continue-on-error: ${{ inputs.strict_formal_summary_v1 != true }}
         run: |
           node scripts/formal/generate-formal-summary-v1.mjs --in artifacts_dl --out artifacts/formal/formal-summary-v1.json --out-v2 artifacts/formal/formal-summary-v2.json
+      - name: Write formal aggregate provenance
+        if: always()
+        run: |
+          set -euo pipefail
+          subjects=()
+          for subject in formal-aggregate.md formal-aggregate.json; do
+            if [ -f "artifacts/formal/$subject" ]; then
+              subjects+=(--subject "$subject")
+            fi
+          done
+          if [ "${#subjects[@]}" -eq 0 ]; then
+            printf '%s\n' '::error::formal aggregate artifact has no subjects to bind.'
+            exit 1
+          fi
+          node scripts/ci/write-artifact-provenance.mjs \
+            --output artifacts/formal/formal-reports-aggregate.provenance.json \
+            --artifact-name formal-reports-aggregate \
+            --root artifacts/formal \
+            "${subjects[@]}"
       - name: Upload aggregate
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: formal-reports-aggregate
-          path: artifacts/formal/formal-aggregate.md
+          path: |
+            artifacts/formal/formal-aggregate.md
+            artifacts/formal/formal-aggregate.json
+            artifacts/formal/formal-reports-aggregate.provenance.json
       - name: Upload aggregate JSON
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-ci-status-comment.yml
+++ b/.github/workflows/pr-ci-status-comment.yml
@@ -610,12 +610,39 @@ jobs:
         env:
           PROGRESS_SUMMARY_PREVIOUS: artifacts/progress/summary.prev.json
         run: node scripts/progress/render-progress-summary.mjs
+      - name: Write PR summary publish provenance
+        run: |
+          set -euo pipefail
+          subjects=()
+          for subject in \
+            summary/PR_SUMMARY.md \
+            progress/PR_PROGRESS.md \
+            progress/summary.json \
+            change-package/change-package.json \
+            change-package/change-package-v2.json \
+            change-package/change-package-validation.json \
+            change-package/change-package-v2-validation.json
+          do
+            if [ -f "artifacts/$subject" ]; then
+              subjects+=(--subject "$subject")
+            fi
+          done
+          if [ "${#subjects[@]}" -eq 0 ]; then
+            printf '%s\n' '::error::PR summary publish artifact has no subjects to bind.'
+            exit 1
+          fi
+          node scripts/ci/write-artifact-provenance.mjs \
+            --output artifacts/summary/pr-summary-publish.provenance.json \
+            --artifact-name pr-summary-publish-pr-${{ github.event.pull_request.number }} \
+            --root artifacts \
+            "${subjects[@]}"
       - name: Upload PR summary publish artifact
         uses: actions/upload-artifact@v4
         with:
           name: pr-summary-publish-pr-${{ github.event.pull_request.number }}
           path: |
             artifacts/summary/PR_SUMMARY.md
+            artifacts/summary/pr-summary-publish.provenance.json
             artifacts/progress/PR_PROGRESS.md
             artifacts/progress/summary.json
             artifacts/change-package/change-package.json
@@ -761,207 +788,6 @@ jobs:
             artifacts/trusted-change-package/change-package-validation.md
           if-no-files-found: error
           retention-days: 14
-
-  publish-summary:
-    needs: [summarize, validate-change-package]
-    if: >-
-      !contains(fromJSON('["1","true","yes","on","TRUE","YES","ON","True","Yes","On"]'), vars.AE_AUTOMATION_GLOBAL_DISABLE)
-      && github.event_name == 'pull_request'
-      && !github.event.pull_request.head.repo.fork
-      && github.event.action != 'edited'
-      && needs.summarize.result == 'success'
-      && needs.validate-change-package.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: write
-      issues: write
-      # GitHub PR issue-comment creation can require pull_requests=write;
-      # this writer job remains checkout-free and does not execute local code.
-      pull-requests: write
-    steps:
-      - name: Download PR summary publish artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: pr-summary-publish-pr-${{ github.event.pull_request.number }}
-          path: artifacts/publish/pr-summary
-      - name: Download trusted Change Package validation artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: trusted-change-package-validation-pr-${{ github.event.pull_request.number }}
-          path: artifacts/publish/trusted-change-package
-      - name: Publish PR summary, progress, and Change Package check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const { owner, repo, number } = context.issue;
-            const pr = context.payload.pull_request;
-            const headSha = pr?.head?.sha;
-            if (!headSha) {
-              core.setFailed('No pull_request head SHA found; cannot publish summary artifacts.');
-              return;
-            }
-
-            const artifactRoot = 'artifacts/publish/pr-summary';
-            const trustedArtifactRoot = 'artifacts/publish/trusted-change-package';
-            const MAX_COMMENT_BYTES = 60000;
-            const readText = (relativePath, root = artifactRoot) => {
-              const filePath = path.join(root, relativePath);
-              if (!fs.existsSync(filePath)) return null;
-              return fs.readFileSync(filePath, 'utf8').replace(/\u0000/g, '\uFFFD');
-            };
-            const truncateUtf8 = (text, maxBytes) => {
-              let truncated = Buffer.from(text, 'utf8')
-                .subarray(0, Math.max(0, maxBytes))
-                .toString('utf8');
-              while (Buffer.byteLength(truncated, 'utf8') > maxBytes) {
-                truncated = truncated.slice(0, -1);
-              }
-              return truncated;
-            };
-            const limitComment = (text, label) => {
-              const bytes = Buffer.byteLength(text, 'utf8');
-              if (bytes <= MAX_COMMENT_BYTES) return text;
-              const notice = `\n\n_[${label} truncated to ${MAX_COMMENT_BYTES} bytes before publication.]_`;
-              const availableBytes = Math.max(
-                0,
-                MAX_COMMENT_BYTES - Buffer.byteLength(notice, 'utf8'),
-              );
-              return `${truncateUtf8(text, availableBytes)}${notice}`;
-            };
-            const isCommentPayloadWithinLimit = (marker, body) =>
-              Buffer.byteLength(`${marker}\n\n${body}`, 'utf8') <= MAX_COMMENT_BYTES;
-            let issueCommentsCache = null;
-            const listAllIssueComments = async () => {
-              const comments = [];
-              for (let page = 1; ; page += 1) {
-                const response = await github.rest.issues.listComments({
-                  owner,
-                  repo,
-                  issue_number: number,
-                  per_page: 100,
-                  page,
-                });
-                comments.push(...response.data);
-                if (response.data.length < 100) break;
-              }
-              return comments;
-            };
-            const getIssueComments = async () => {
-              if (!issueCommentsCache) {
-                issueCommentsCache = await listAllIssueComments();
-              }
-              return issueCommentsCache;
-            };
-            const isTrustedAutomationComment = (comment, marker) => {
-              const login = String(comment?.user?.login || '').trim().toLowerCase();
-              const body = typeof comment?.body === 'string' ? comment.body : '';
-              return (
-                (login === 'github-actions' || login === 'github-actions[bot]')
-                && body.startsWith(marker)
-              );
-            };
-            const markerDisplayLabel = (marker) => {
-              const label = String(marker || '')
-                .replace(/^<!--\s*/, '')
-                .replace(/\s*-->$/, '')
-                .trim();
-              return label || 'PR comment';
-            };
-            const upsertComment = async (marker, body) => {
-              const payload = limitComment(`${marker}\n\n${body}`, markerDisplayLabel(marker));
-              const comments = await getIssueComments();
-              const existing = [...comments].reverse().find((comment) => isTrustedAutomationComment(comment, marker));
-              if (existing) {
-                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
-              } else {
-                await github.rest.issues.createComment({ owner, repo, issue_number: number, body: payload });
-              }
-            };
-
-            const summaryBody = readText('summary/PR_SUMMARY.md');
-            if (summaryBody) {
-              await upsertComment('<!-- AE-PR-SUMMARY -->', summaryBody);
-            } else {
-              core.warning('PR_SUMMARY.md was not present in the publish artifact.');
-            }
-
-            const progressBody = readText('progress/PR_PROGRESS.md');
-            const progressJsonText = readText('progress/summary.json');
-            if (progressBody) {
-              let progressCommentBody = progressBody;
-              if (progressJsonText) {
-                try {
-                  const progressJson = JSON.parse(progressJsonText);
-                  const progressJsonBlock = `\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(progressJson)} -->`;
-                  progressCommentBody = isCommentPayloadWithinLimit(
-                    '<!-- AE-PR-PROGRESS -->',
-                    `${progressBody}${progressJsonBlock}`,
-                  )
-                    ? `${progressBody}${progressJsonBlock}`
-                    : progressBody;
-                  if (progressCommentBody === progressBody) {
-                    core.warning('Progress summary JSON omitted because it would exceed the PR comment size cap.');
-                  }
-                } catch (error) {
-                  core.warning(`Progress summary JSON could not be parsed; publishing Markdown without embedded JSON: ${error.message}`);
-                }
-              } else {
-                core.warning('Progress summary JSON was not present in the publish artifact; publishing Markdown only.');
-              }
-              await upsertComment(
-                '<!-- AE-PR-PROGRESS -->',
-                progressCommentBody,
-              );
-            } else {
-              core.warning('Progress summary Markdown was not present in the publish artifact.');
-            }
-
-            const readJson = (relativePath, root = artifactRoot) => {
-              const text = readText(relativePath, root);
-              if (!text) return null;
-              try {
-                return JSON.parse(text);
-              } catch (error) {
-                core.warning(`${relativePath} could not be parsed; treating as missing structured JSON: ${error.message}`);
-                return null;
-              }
-            };
-            const validation = readJson('change-package-validation.json', trustedArtifactRoot);
-            const result = String(validation?.result || '').trim().toLowerCase();
-            const conclusion = result === 'pass'
-              ? 'success'
-              : (result === 'warn' ? 'neutral' : 'failure');
-            const title = result
-              ? `Change Package Validation: ${result.toUpperCase()}`
-              : 'Change Package Validation: MISSING';
-            const summary = validation
-              ? [
-                  `schemaVersion: ${validation.schemaVersion || 'unknown'}`,
-                  `result: ${result || 'missing'}`,
-                  `strict: ${validation.strict ?? 'unknown'}`,
-                  `errors: ${Array.isArray(validation.errors) ? validation.errors.length : 'unknown'}`,
-                  `warnings: ${Array.isArray(validation.warnings) ? validation.warnings.length : 'unknown'}`,
-                  `workflowRunId: ${context.runId}`,
-                  `headSha: ${headSha}`,
-                ].join('\n')
-              : `No structured change-package-validation.json artifact was available for head ${headSha}.`;
-
-            await github.rest.checks.create({
-              owner,
-              repo,
-              name: 'Change Package Validation',
-              head_sha: headSha,
-              status: 'completed',
-              conclusion,
-              output: {
-                title,
-                summary,
-              },
-            });
-
 
   post-status:
     if: >-

--- a/.github/workflows/pr-summary-publisher.yml
+++ b/.github/workflows/pr-summary-publisher.yml
@@ -1,0 +1,376 @@
+name: PR Summary Publisher
+
+on:
+  workflow_run:
+    workflows: ["PR Maintenance"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "PR Maintenance workflow run id containing PR summary artifacts"
+        required: true
+        type: string
+      source_run_attempt:
+        description: "PR Maintenance workflow run attempt"
+        required: false
+        type: string
+      pr_number:
+        description: "Pull request number to publish to"
+        required: true
+        type: string
+      pr_head_sha:
+        description: "Expected current pull request head SHA"
+        required: true
+        type: string
+
+concurrency:
+  group: pr-summary-publisher-${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.source_run_id || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  checks: write
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  publish:
+    name: Publish PR summary and Change Package check
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve publish context
+        id: context
+        uses: actions/github-script@v7
+        env:
+          DISPATCH_SOURCE_RUN_ID: ${{ inputs.source_run_id || '' }}
+          DISPATCH_SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt || '' }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          DISPATCH_PR_HEAD_SHA: ${{ inputs.pr_head_sha || '' }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const eventName = context.eventName;
+            const payload = context.payload || {};
+            let sourceRunId = '';
+            let sourceRunAttempt = '';
+            let prNumber = '';
+            let expectedHeadSha = '';
+            let workflowHeadRepository = '';
+            let sourceConclusion = 'success';
+
+            if (eventName === 'workflow_run') {
+              const workflowRun = payload.workflow_run || {};
+              sourceRunId = String(workflowRun.id || '');
+              sourceRunAttempt = String(workflowRun.run_attempt || '');
+              prNumber = String((workflowRun.pull_requests || [])[0]?.number || '');
+              expectedHeadSha = String(workflowRun.head_sha || '');
+              workflowHeadRepository = String(workflowRun.head_repository?.full_name || '');
+              sourceConclusion = String(workflowRun.conclusion || '');
+            } else {
+              sourceRunId = String(process.env.DISPATCH_SOURCE_RUN_ID || '');
+              sourceRunAttempt = String(process.env.DISPATCH_SOURCE_RUN_ATTEMPT || '');
+              prNumber = String(process.env.DISPATCH_PR_NUMBER || '');
+              expectedHeadSha = String(process.env.DISPATCH_PR_HEAD_SHA || '');
+            }
+
+            if (sourceConclusion !== 'success') {
+              core.info(`Skipping PR summary publication for source conclusion=${sourceConclusion}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (!/^\d+$/.test(sourceRunId) || !/^\d+$/.test(prNumber)) {
+              core.warning(`Invalid PR summary publish context: sourceRunId=${JSON.stringify(sourceRunId)} prNumber=${JSON.stringify(prNumber)}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
+              core.warning(`Invalid or missing PR head SHA for PR summary publication: ${JSON.stringify(expectedHeadSha)}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const issueNumber = Number(prNumber);
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: issueNumber });
+            if (workflowHeadRepository && workflowHeadRepository !== `${owner}/${repo}`) {
+              core.warning(`Skipping PR summary publication for non-repository head ${workflowHeadRepository}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head?.repo?.fork || pr.head?.repo?.full_name !== `${owner}/${repo}`) {
+              core.warning(`Skipping PR summary publication for fork or external head repository on PR #${issueNumber}.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head.sha !== expectedHeadSha) {
+              core.warning(`Skipping stale PR summary for PR #${issueNumber}: expected ${expectedHeadSha}, current ${pr.head.sha}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const summaryArtifactName = `pr-summary-publish-pr-${issueNumber}`;
+            const validationArtifactName = `trusted-change-package-validation-pr-${issueNumber}`;
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: Number(sourceRunId),
+              per_page: 100,
+            });
+            const artifactNames = new Set((artifacts.data.artifacts || []).filter((artifact) => !artifact.expired).map((artifact) => artifact.name));
+            for (const required of [summaryArtifactName, validationArtifactName]) {
+              if (!artifactNames.has(required)) {
+                core.info(`Required PR summary publisher artifact ${required} not found for run ${sourceRunId}; skipping publication.`);
+                core.setOutput('skip', 'true');
+                return;
+              }
+            }
+
+            core.setOutput('skip', 'false');
+            core.setOutput('source_run_id', sourceRunId);
+            core.setOutput('source_run_attempt', sourceRunAttempt);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('pr_head_sha', expectedHeadSha);
+            core.setOutput('summary_artifact_name', summaryArtifactName);
+            core.setOutput('validation_artifact_name', validationArtifactName);
+
+      - name: Checkout trusted publisher code
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Download PR summary publish artifact
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.context.outputs.summary_artifact_name }}
+          path: artifacts/publish/pr-summary
+          run-id: ${{ steps.context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download trusted Change Package validation artifact
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.context.outputs.validation_artifact_name }}
+          path: artifacts/publish/trusted-change-package
+          run-id: ${{ steps.context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate PR summary artifact provenance
+        if: steps.context.outputs.skip != 'true'
+        env:
+          SOURCE_RUN_ATTEMPT: ${{ steps.context.outputs.source_run_attempt }}
+        run: |
+          set -euo pipefail
+          args=(
+            --provenance artifacts/publish/pr-summary/summary/pr-summary-publish.provenance.json
+            --root artifacts/publish/pr-summary
+            --artifact-name "${{ steps.context.outputs.summary_artifact_name }}"
+            --repository "${GITHUB_REPOSITORY}"
+            --workflow "PR Maintenance"
+            --run-id "${{ steps.context.outputs.source_run_id }}"
+            --event-name pull_request
+            --head-sha "${{ steps.context.outputs.pr_head_sha }}"
+            --pr-number "${{ steps.context.outputs.pr_number }}"
+            --require-subject summary/PR_SUMMARY.md
+          )
+          if [ -n "${SOURCE_RUN_ATTEMPT}" ]; then
+            args+=(--run-attempt "${SOURCE_RUN_ATTEMPT}")
+          fi
+          node scripts/ci/validate-artifact-provenance.mjs "${args[@]}"
+
+      - name: Publish PR summary, progress, and Change Package check
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          SOURCE_RUN_ID: ${{ steps.context.outputs.source_run_id }}
+          PR_HEAD_SHA: ${{ steps.context.outputs.pr_head_sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { owner, repo } = context.repo;
+            const number = Number('${{ steps.context.outputs.pr_number }}');
+            const headSha = String(process.env.PR_HEAD_SHA || '');
+            const sourceRunId = String(process.env.SOURCE_RUN_ID || '');
+            if (!number || !headSha) {
+              core.setFailed('No PR number or head SHA found; cannot publish summary artifacts.');
+              return;
+            }
+
+            const artifactRoot = 'artifacts/publish/pr-summary';
+            const trustedArtifactRoot = 'artifacts/publish/trusted-change-package';
+            const MAX_COMMENT_BYTES = 60000;
+            const readText = (relativePath, root = artifactRoot) => {
+              const filePath = path.join(root, relativePath);
+              if (!fs.existsSync(filePath)) return null;
+              return fs.readFileSync(filePath, 'utf8').replace(/\u0000/g, '\uFFFD');
+            };
+            const truncateUtf8 = (text, maxBytes) => {
+              let truncated = Buffer.from(text, 'utf8')
+                .subarray(0, Math.max(0, maxBytes))
+                .toString('utf8');
+              while (Buffer.byteLength(truncated, 'utf8') > maxBytes) {
+                truncated = truncated.slice(0, -1);
+              }
+              return truncated;
+            };
+            const limitComment = (text, label) => {
+              const bytes = Buffer.byteLength(text, 'utf8');
+              if (bytes <= MAX_COMMENT_BYTES) return text;
+              const notice = `\n\n_[${label} truncated to ${MAX_COMMENT_BYTES} bytes before publication.]_`;
+              const availableBytes = Math.max(
+                0,
+                MAX_COMMENT_BYTES - Buffer.byteLength(notice, 'utf8'),
+              );
+              return `${truncateUtf8(text, availableBytes)}${notice}`;
+            };
+            const isCommentPayloadWithinLimit = (marker, body) =>
+              Buffer.byteLength(`${marker}\n\n${body}`, 'utf8') <= MAX_COMMENT_BYTES;
+            let issueCommentsCache = null;
+            const listAllIssueComments = async () => {
+              const comments = [];
+              for (let page = 1; ; page += 1) {
+                const response = await github.rest.issues.listComments({
+                  owner,
+                  repo,
+                  issue_number: number,
+                  per_page: 100,
+                  page,
+                });
+                comments.push(...response.data);
+                if (response.data.length < 100) break;
+              }
+              return comments;
+            };
+            const getIssueComments = async () => {
+              if (!issueCommentsCache) {
+                issueCommentsCache = await listAllIssueComments();
+              }
+              return issueCommentsCache;
+            };
+            const isTrustedAutomationComment = (comment, marker) => {
+              const login = String(comment?.user?.login || '').trim().toLowerCase();
+              const body = typeof comment?.body === 'string' ? comment.body : '';
+              return (
+                (login === 'github-actions' || login === 'github-actions[bot]')
+                && body.startsWith(marker)
+              );
+            };
+            const markerDisplayLabel = (marker) => {
+              const label = String(marker || '')
+                .replace(/^<!--\s*/, '')
+                .replace(/\s*-->$/, '')
+                .trim();
+              return label || 'PR comment';
+            };
+            const upsertComment = async (marker, body) => {
+              const payload = limitComment(`${marker}\n\n${body}`, markerDisplayLabel(marker));
+              const comments = await getIssueComments();
+              const existing = [...comments].reverse().find((comment) => isTrustedAutomationComment(comment, marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: payload });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: number, body: payload });
+              }
+            };
+
+            const summaryBody = readText('summary/PR_SUMMARY.md');
+            if (summaryBody) {
+              await upsertComment('<!-- AE-PR-SUMMARY -->', summaryBody);
+            } else {
+              core.warning('PR_SUMMARY.md was not present in the publish artifact.');
+            }
+
+            const progressBody = readText('progress/PR_PROGRESS.md');
+            const progressJsonText = readText('progress/summary.json');
+            if (progressBody) {
+              let progressCommentBody = progressBody;
+              if (progressJsonText) {
+                try {
+                  const progressJson = JSON.parse(progressJsonText);
+                  const progressJsonBlock = `\n\n<!-- AE-PR-PROGRESS-JSON ${JSON.stringify(progressJson)} -->`;
+                  progressCommentBody = isCommentPayloadWithinLimit(
+                    '<!-- AE-PR-PROGRESS -->',
+                    `${progressBody}${progressJsonBlock}`,
+                  )
+                    ? `${progressBody}${progressJsonBlock}`
+                    : progressBody;
+                  if (progressCommentBody === progressBody) {
+                    core.warning('Progress summary JSON omitted because it would exceed the PR comment size cap.');
+                  }
+                } catch (error) {
+                  core.warning(`Progress summary JSON could not be parsed; publishing Markdown without embedded JSON: ${error.message}`);
+                }
+              } else {
+                core.warning('Progress summary JSON was not present in the publish artifact; publishing Markdown only.');
+              }
+              await upsertComment(
+                '<!-- AE-PR-PROGRESS -->',
+                progressCommentBody,
+              );
+            } else {
+              core.warning('Progress summary Markdown was not present in the publish artifact.');
+            }
+
+            const readJson = (relativePath, root = artifactRoot) => {
+              const text = readText(relativePath, root);
+              if (!text) return null;
+              try {
+                return JSON.parse(text);
+              } catch (error) {
+                core.warning(`${relativePath} could not be parsed; treating as missing structured JSON: ${error.message}`);
+                return null;
+              }
+            };
+            const validation = readJson('change-package-validation.json', trustedArtifactRoot);
+            const trusted = validation?.trustedValidation || {};
+            const trustedErrors = [];
+            if (validation && trusted.source !== 'base-ref-code') trustedErrors.push('trustedValidation.source is not base-ref-code');
+            if (validation && String(trusted.headSha || '') !== headSha) trustedErrors.push('trustedValidation.headSha does not match current head');
+            if (validation && String(trusted.workflowRunId || '') !== sourceRunId) trustedErrors.push('trustedValidation.workflowRunId does not match source run');
+            const validationForCheck = trustedErrors.length
+              ? {
+                  schemaVersion: validation?.schemaVersion || 'change-package-validation/v1',
+                  result: 'fail',
+                  strict: validation?.strict ?? false,
+                  errors: [...(Array.isArray(validation?.errors) ? validation.errors : []), ...trustedErrors],
+                  warnings: Array.isArray(validation?.warnings) ? validation.warnings : [],
+                }
+              : validation;
+            const result = String(validationForCheck?.result || '').trim().toLowerCase();
+            const conclusion = result === 'pass'
+              ? 'success'
+              : (result === 'warn' ? 'neutral' : 'failure');
+            const title = result
+              ? `Change Package Validation: ${result.toUpperCase()}`
+              : 'Change Package Validation: MISSING';
+            const summary = validationForCheck
+              ? [
+                  `schemaVersion: ${validationForCheck.schemaVersion || 'unknown'}`,
+                  `result: ${result || 'missing'}`,
+                  `strict: ${validationForCheck.strict ?? 'unknown'}`,
+                  `errors: ${Array.isArray(validationForCheck.errors) ? validationForCheck.errors.length : 'unknown'}`,
+                  `warnings: ${Array.isArray(validationForCheck.warnings) ? validationForCheck.warnings.length : 'unknown'}`,
+                  `sourceWorkflowRunId: ${sourceRunId}`,
+                  `publisherRunId: ${context.runId}`,
+                  `headSha: ${headSha}`,
+                  ...(trustedErrors.length ? ['', 'Trusted validation errors:', ...trustedErrors.map((error) => `- ${error}`)] : []),
+                ].join('\n')
+              : `No structured change-package-validation.json artifact was available for head ${headSha}.`;
+
+            await github.rest.checks.create({
+              owner,
+              repo,
+              name: 'Change Package Validation',
+              head_sha: headSha,
+              status: 'completed',
+              conclusion,
+              output: {
+                title,
+                summary,
+              },
+            });

--- a/.github/workflows/quality-gates-centralized.yml
+++ b/.github/workflows/quality-gates-centralized.yml
@@ -67,6 +67,25 @@ jobs:
         # leave non-required PR checks red. Push/main and workflow_call still enforce DoD.
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: pnpm run quality:run -- --env=testing --gates=dod --sequential
+      - name: Write quality report provenance
+        if: ${{ always() }}
+        run: |
+          set -euo pipefail
+          mapfile -t reports < <(find artifacts/quality/reports -name 'quality-report-*-latest.json' -type f | sort || true)
+          if [ "${#reports[@]}" -eq 0 ]; then
+            printf '%s\n' '::error::quality-gates-report did not contain a latest quality report for provenance binding.'
+            exit 1
+          fi
+          args=(
+            --output quality-gates-report.provenance.json
+            --artifact-name quality-gates-report
+            --root artifacts/quality/reports
+          )
+          for report in "${reports[@]}"; do
+            args+=(--subject "${report#artifacts/quality/reports/}")
+          done
+          node scripts/ci/write-artifact-provenance.mjs "${args[@]}"
+          mv quality-gates-report.provenance.json artifacts/quality/reports/quality-gates-report.provenance.json
       - name: Upload quality report
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
@@ -129,79 +148,6 @@ jobs:
     with:
       node-version: '20'
       run-script: typecov:check:70
-  pr-quality-comment:
-    if: ${{ always() && github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    needs: [dod]
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Download quality report
-        uses: actions/download-artifact@v4
-        with:
-          name: quality-gates-report
-          path: artifacts/quality/reports
-      - name: Locate quality report
-        id: report
-        run: |
-          REPORT=$(find artifacts/quality/reports -name 'quality-report-*-latest.json' | head -n1 || true)
-          printf "report=%s\n" "$REPORT" >> "$GITHUB_OUTPUT"
-      - name: Load previous quality summary
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -e
-          mkdir -p artifacts/quality
-          marker='<!-- AE-PR-QUALITY -->'
-          comment=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .body' | head -n1 || true)
-          if [ -n "$comment" ]; then
-            export BODY="$comment"
-            node - <<'NODE' || true
-            const fs = require('fs');
-            const body = process.env.BODY || '';
-            const match = body.match(/<!-- AE-PR-QUALITY-JSON ([\s\S]*?) -->/);
-            if (match && match[1]) {
-              fs.mkdirSync('artifacts/quality', { recursive: true });
-              fs.writeFileSync('artifacts/quality/summary.prev.json', match[1]);
-              console.log('Loaded previous quality summary');
-            }
-          NODE
-          fi
-      - name: Render quality summary
-        env:
-          QUALITY_REPORT_PATH: ${{ steps.report.outputs.report }}
-          QUALITY_PREVIOUS_SUMMARY: artifacts/quality/summary.prev.json
-        run: node scripts/quality/render-quality-pr-comment.mjs
-      - name: Post or update quality comment
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -e
-          marker='<!-- AE-PR-QUALITY -->'
-          {
-            printf '%s\n\n' "$marker"
-            cat artifacts/quality/PR_QUALITY.md
-            printf '\n\n<!-- AE-PR-QUALITY-JSON '
-            cat artifacts/quality/summary.json
-            printf ' -->\n'
-          } > artifacts/quality/comment-body.txt
-          node - <<'NODE'
-          const fs = require('fs');
-          const body = fs.readFileSync('artifacts/quality/comment-body.txt', 'utf8');
-          fs.writeFileSync('artifacts/quality/comment-body.json', JSON.stringify({ body }));
-          NODE
-          existing_id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .id' | head -n1 || true)
-          if [ -n "$existing_id" ]; then
-            # Use --input with JSON payload so gh api posts file contents, not the literal path string.
-            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing_id" --input artifacts/quality/comment-body.json
-          else
-            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --input artifacts/quality/comment-body.json
-          fi
   types-tests:
     uses: ./.github/workflows/ci-core.yml
     with:

--- a/.github/workflows/quality-gates-publisher.yml
+++ b/.github/workflows/quality-gates-publisher.yml
@@ -58,7 +58,6 @@ jobs:
             let prNumber = '';
             let expectedHeadSha = '';
             let workflowHeadRepository = '';
-            let sourceConclusion = 'success';
 
             if (eventName === 'workflow_run') {
               const workflowRun = payload.workflow_run || {};
@@ -67,7 +66,6 @@ jobs:
               prNumber = String((workflowRun.pull_requests || [])[0]?.number || '');
               expectedHeadSha = String(workflowRun.head_sha || '');
               workflowHeadRepository = String(workflowRun.head_repository?.full_name || '');
-              sourceConclusion = String(workflowRun.conclusion || '');
             } else {
               sourceRunId = String(process.env.DISPATCH_SOURCE_RUN_ID || '');
               sourceRunAttempt = String(process.env.DISPATCH_SOURCE_RUN_ATTEMPT || '');
@@ -75,11 +73,6 @@ jobs:
               expectedHeadSha = String(process.env.DISPATCH_PR_HEAD_SHA || '');
             }
 
-            if (sourceConclusion !== 'success') {
-              core.info(`Skipping quality publication for source conclusion=${sourceConclusion}`);
-              core.setOutput('skip', 'true');
-              return;
-            }
             if (!/^\d+$/.test(sourceRunId) || !/^\d+$/.test(prNumber)) {
               core.warning(`Invalid quality publish context: sourceRunId=${JSON.stringify(sourceRunId)} prNumber=${JSON.stringify(prNumber)}`);
               core.setOutput('skip', 'true');
@@ -182,7 +175,7 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts/quality
           marker='<!-- AE-PR-QUALITY -->'
-          comment=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .body' | head -n1 || true)
+          comment=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .body' | head -n1 || true)
           if [ -n "$comment" ]; then
             export BODY="$comment"
             node - <<'NODE' || true
@@ -224,7 +217,7 @@ jobs:
           const body = fs.readFileSync('artifacts/quality/comment-body.txt', 'utf8');
           fs.writeFileSync('artifacts/quality/comment-body.json', JSON.stringify({ body }));
           NODE
-          existing_id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .id' | head -n1 || true)
+          existing_id=$(gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .id' | head -n1 || true)
           if [ -n "$existing_id" ]; then
             gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing_id" --input artifacts/quality/comment-body.json
           else

--- a/.github/workflows/quality-gates-publisher.yml
+++ b/.github/workflows/quality-gates-publisher.yml
@@ -1,0 +1,232 @@
+name: Quality Gates Publisher
+
+on:
+  workflow_run:
+    workflows: ["Quality Gates"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "Quality Gates workflow run id containing quality-gates-report"
+        required: true
+        type: string
+      source_run_attempt:
+        description: "Quality Gates workflow run attempt"
+        required: false
+        type: string
+      pr_number:
+        description: "Pull request number to comment on"
+        required: true
+        type: string
+      pr_head_sha:
+        description: "Expected current pull request head SHA"
+        required: true
+        type: string
+
+concurrency:
+  group: quality-gates-publisher-${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.source_run_id || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  publish:
+    name: Publish quality gate PR comment
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve publish context
+        id: context
+        uses: actions/github-script@v7
+        env:
+          DISPATCH_SOURCE_RUN_ID: ${{ inputs.source_run_id || '' }}
+          DISPATCH_SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt || '' }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          DISPATCH_PR_HEAD_SHA: ${{ inputs.pr_head_sha || '' }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const eventName = context.eventName;
+            const payload = context.payload || {};
+            const artifactName = 'quality-gates-report';
+            let sourceRunId = '';
+            let sourceRunAttempt = '';
+            let prNumber = '';
+            let expectedHeadSha = '';
+            let workflowHeadRepository = '';
+            let sourceConclusion = 'success';
+
+            if (eventName === 'workflow_run') {
+              const workflowRun = payload.workflow_run || {};
+              sourceRunId = String(workflowRun.id || '');
+              sourceRunAttempt = String(workflowRun.run_attempt || '');
+              prNumber = String((workflowRun.pull_requests || [])[0]?.number || '');
+              expectedHeadSha = String(workflowRun.head_sha || '');
+              workflowHeadRepository = String(workflowRun.head_repository?.full_name || '');
+              sourceConclusion = String(workflowRun.conclusion || '');
+            } else {
+              sourceRunId = String(process.env.DISPATCH_SOURCE_RUN_ID || '');
+              sourceRunAttempt = String(process.env.DISPATCH_SOURCE_RUN_ATTEMPT || '');
+              prNumber = String(process.env.DISPATCH_PR_NUMBER || '');
+              expectedHeadSha = String(process.env.DISPATCH_PR_HEAD_SHA || '');
+            }
+
+            if (sourceConclusion !== 'success') {
+              core.info(`Skipping quality publication for source conclusion=${sourceConclusion}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (!/^\d+$/.test(sourceRunId) || !/^\d+$/.test(prNumber)) {
+              core.warning(`Invalid quality publish context: sourceRunId=${JSON.stringify(sourceRunId)} prNumber=${JSON.stringify(prNumber)}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
+              core.warning(`Invalid or missing PR head SHA for quality publication: ${JSON.stringify(expectedHeadSha)}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const issueNumber = Number(prNumber);
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: issueNumber });
+            if (workflowHeadRepository && workflowHeadRepository !== `${owner}/${repo}`) {
+              core.warning(`Skipping quality publication for non-repository head ${workflowHeadRepository}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head?.repo?.fork || pr.head?.repo?.full_name !== `${owner}/${repo}`) {
+              core.warning(`Skipping quality publication for fork or external head repository on PR #${issueNumber}.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head.sha !== expectedHeadSha) {
+              core.warning(`Skipping stale quality report for PR #${issueNumber}: expected ${expectedHeadSha}, current ${pr.head.sha}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: Number(sourceRunId),
+              per_page: 100,
+            });
+            if (!(artifacts.data.artifacts || []).some((artifact) => artifact.name === artifactName && !artifact.expired)) {
+              core.warning(`Quality report artifact ${artifactName} not found for run ${sourceRunId}; skipping publication.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            core.setOutput('skip', 'false');
+            core.setOutput('source_run_id', sourceRunId);
+            core.setOutput('source_run_attempt', sourceRunAttempt);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('pr_head_sha', expectedHeadSha);
+            core.setOutput('artifact_name', artifactName);
+
+      - name: Checkout trusted publisher code
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Download quality report artifact
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.context.outputs.artifact_name }}
+          path: artifacts/quality/reports
+          run-id: ${{ steps.context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate quality report provenance
+        id: quality_report
+        if: steps.context.outputs.skip != 'true'
+        env:
+          SOURCE_RUN_ATTEMPT: ${{ steps.context.outputs.source_run_attempt }}
+        run: |
+          set -euo pipefail
+          args=(
+            --provenance artifacts/quality/reports/quality-gates-report.provenance.json
+            --root artifacts/quality/reports
+            --artifact-name "${{ steps.context.outputs.artifact_name }}"
+            --repository "${GITHUB_REPOSITORY}"
+            --workflow "Quality Gates"
+            --run-id "${{ steps.context.outputs.source_run_id }}"
+            --event-name pull_request
+            --head-sha "${{ steps.context.outputs.pr_head_sha }}"
+            --pr-number "${{ steps.context.outputs.pr_number }}"
+          )
+          if [ -n "${SOURCE_RUN_ATTEMPT}" ]; then
+            args+=(--run-attempt "${SOURCE_RUN_ATTEMPT}")
+          fi
+          report=$(find artifacts/quality/reports -name 'quality-report-*-latest.json' -type f | sort | head -n1 || true)
+          if [ -z "$report" ]; then
+            printf '%s\n' '::error::quality report missing from downloaded artifact.'
+            exit 1
+          fi
+          args+=(--require-subject "${report#artifacts/quality/reports/}")
+          node scripts/ci/validate-artifact-provenance.mjs "${args[@]}"
+          printf 'report=%s\n' "$report" >> "$GITHUB_OUTPUT"
+
+      - name: Load previous quality summary
+        if: steps.context.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/quality
+          marker='<!-- AE-PR-QUALITY -->'
+          comment=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .body' | head -n1 || true)
+          if [ -n "$comment" ]; then
+            export BODY="$comment"
+            node - <<'NODE' || true
+            const fs = require('fs');
+            const body = process.env.BODY || '';
+            const match = body.match(/<!-- AE-PR-QUALITY-JSON ([\s\S]*?) -->/);
+            if (match && match[1]) {
+              fs.mkdirSync('artifacts/quality', { recursive: true });
+              fs.writeFileSync('artifacts/quality/summary.prev.json', match[1]);
+              console.log('Loaded previous quality summary');
+            }
+          NODE
+          fi
+
+      - name: Render quality summary
+        if: steps.context.outputs.skip != 'true'
+        env:
+          QUALITY_REPORT_PATH: ${{ steps.quality_report.outputs.report }}
+          QUALITY_PREVIOUS_SUMMARY: artifacts/quality/summary.prev.json
+        run: node scripts/quality/render-quality-pr-comment.mjs
+
+      - name: Post or update quality comment
+        if: steps.context.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          marker='<!-- AE-PR-QUALITY -->'
+          {
+            printf '%s\n\n' "$marker"
+            cat artifacts/quality/PR_QUALITY.md
+            printf '\n\n<!-- AE-PR-QUALITY-JSON '
+            cat artifacts/quality/summary.json
+            printf ' -->\n'
+          } > artifacts/quality/comment-body.txt
+          node - <<'NODE'
+          const fs = require('fs');
+          const body = fs.readFileSync('artifacts/quality/comment-body.txt', 'utf8');
+          fs.writeFileSync('artifacts/quality/comment-body.json', JSON.stringify({ body }));
+          NODE
+          existing_id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | select(.body | contains("'"$marker"'")) | .id' | head -n1 || true)
+          if [ -n "$existing_id" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$existing_id" --input artifacts/quality/comment-body.json
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --input artifacts/quality/comment-body.json
+          fi

--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -119,6 +119,15 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
+    - name: Write SBOM provenance
+      run: |
+        set -euo pipefail
+        node scripts/ci/write-artifact-provenance.mjs \
+          --output sbom-files.provenance.json \
+          --artifact-name sbom-files \
+          --subject sbom.json \
+          --subject sbom.xml
+
     - name: Upload SBOM artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -126,6 +135,7 @@ jobs:
         path: |
           sbom.json
           sbom.xml
+          sbom-files.provenance.json
         retention-days: 14
         
     # Security scanning
@@ -166,11 +176,21 @@ jobs:
           echo "::warning::High/critical vulnerabilities detected (non-blocking without enforce-security label)."
         fi
         
+    - name: Write security scan provenance
+      run: |
+        set -euo pipefail
+        node scripts/ci/write-artifact-provenance.mjs \
+          --output security-scan-results.provenance.json \
+          --artifact-name security-scan-results \
+          --subject audit-results.json
+
     - name: Upload security scan results
       uses: actions/upload-artifact@v4
       with:
         name: security-scan-results
-        path: audit-results.json
+        path: |
+          audit-results.json
+          security-scan-results.provenance.json
         retention-days: 14
         
   sbom-publication:
@@ -406,99 +426,6 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
-
-  security-summary-comment:
-    runs-on: ubuntu-latest
-    needs: security-analysis
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run-security') }}
-
-    permissions:
-      contents: read
-      actions: read
-      issues: write
-      pull-requests: read
-
-    steps:
-    - name: Download SBOM artifacts
-      uses: actions/download-artifact@v4
-      continue-on-error: true
-      with:
-        name: sbom-files
-
-    - name: Download security scan results
-      uses: actions/download-artifact@v4
-      continue-on-error: true
-      with:
-        name: security-scan-results
-
-    # Agent B: Security/Compliance 要約コメント（run-security ラベル時のみ、アップサート）
-    - name: Post Security/Compliance summary (Agent B)
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const fs = require('fs');
-          const header = '<!-- AE-SECURITY-SUMMARY -->';
-
-          const readJSONSafe = (f) => {
-            try {
-              if (!fs.existsSync(f)) return null;
-              const raw = fs.readFileSync(f, 'utf8');
-              if (!raw || !raw.trim()) return null;
-              return JSON.parse(raw);
-            } catch (_) {
-              return null;
-            }
-          };
-
-          const audit = readJSONSafe('audit-results.json');
-          const vuln = (audit && audit.metadata && audit.metadata.vulnerabilities) || {};
-          const total = Number(vuln.total || 0);
-          const high = Number(vuln.high || vuln.critical || 0);
-          const moderate = Number(vuln.moderate || 0);
-          const low = Number(vuln.low || 0);
-          const vulnSummary = (audit && ('vulnerabilities' in (audit.metadata || {})))
-            ? `- Total: ${total} (High: ${high}, Moderate: ${moderate}, Low: ${low})`
-            : '- No vulnerabilities found';
-
-          const sbom = readJSONSafe('sbom.json');
-          let licenseLines = ['- No license data available'];
-          if (sbom && Array.isArray(sbom.components)) {
-            const freq = new Map();
-            for (const c of sbom.components) {
-              const ls = Array.isArray(c.licenses) ? c.licenses : [];
-              for (const l of ls) {
-                const key = String(l?.license?.name || l?.expression || '').trim();
-                if (!key) continue;
-                freq.set(key, (freq.get(key) || 0) + 1);
-              }
-            }
-            const sorted = [...freq.entries()].sort((a,b)=>b[1]-a[1]);
-            const take = Math.max(3, Math.min(5, sorted.length));
-            if (take > 0) licenseLines = sorted.slice(0, take).map(([name, count]) => `- ${name}: ${count}`);
-          }
-
-          const body = [
-            header,
-            '## ✅ Security/Compliance Summary',
-            '',
-            '### Dependency Vulnerabilities',
-            vulnSummary,
-            '',
-            '### Top Licenses (3-5)',
-            ...licenseLines,
-            '',
-            '_This is a non-blocking summary for visibility._'
-          ].join('\n');
-
-          const { owner, repo } = context.repo;
-          const issue_number = context.issue.number;
-          const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
-          const existing = comments.find(c => typeof c.body === 'string' && c.body.startsWith(header));
-          if (existing) {
-            await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-          } else {
-            await github.rest.issues.createComment({ owner, repo, issue_number, body });
-          }
 
   # Compliance and attestation (optional)
   compliance:

--- a/.github/workflows/sbom-security-publisher.yml
+++ b/.github/workflows/sbom-security-publisher.yml
@@ -253,7 +253,7 @@ jobs:
 
             const { owner, repo } = context.repo;
             const issue_number = Number('${{ steps.context.outputs.pr_number }}');
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number, per_page: 100 });
             const existing = comments.find(c => typeof c.body === 'string' && c.body.startsWith(header));
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });

--- a/.github/workflows/sbom-security-publisher.yml
+++ b/.github/workflows/sbom-security-publisher.yml
@@ -1,0 +1,262 @@
+name: SBOM Security Publisher
+
+on:
+  workflow_run:
+    workflows: ["SBOM Generation and Security Scanning"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "SBOM Generation and Security Scanning workflow run id"
+        required: true
+        type: string
+      source_run_attempt:
+        description: "Source workflow run attempt"
+        required: false
+        type: string
+      pr_number:
+        description: "Pull request number to publish to"
+        required: true
+        type: string
+      pr_head_sha:
+        description: "Expected current pull request head SHA"
+        required: true
+        type: string
+
+concurrency:
+  group: sbom-security-publisher-${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || inputs.source_run_id || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  publish:
+    name: Publish SBOM security summary
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve publish context
+        id: context
+        uses: actions/github-script@v7
+        env:
+          DISPATCH_SOURCE_RUN_ID: ${{ inputs.source_run_id || '' }}
+          DISPATCH_SOURCE_RUN_ATTEMPT: ${{ inputs.source_run_attempt || '' }}
+          DISPATCH_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          DISPATCH_PR_HEAD_SHA: ${{ inputs.pr_head_sha || '' }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const eventName = context.eventName;
+            const payload = context.payload || {};
+            let sourceRunId = '';
+            let sourceRunAttempt = '';
+            let prNumber = '';
+            let expectedHeadSha = '';
+            let workflowHeadRepository = '';
+            let sourceConclusion = 'success';
+
+            if (eventName === 'workflow_run') {
+              const workflowRun = payload.workflow_run || {};
+              sourceRunId = String(workflowRun.id || '');
+              sourceRunAttempt = String(workflowRun.run_attempt || '');
+              prNumber = String((workflowRun.pull_requests || [])[0]?.number || '');
+              expectedHeadSha = String(workflowRun.head_sha || '');
+              workflowHeadRepository = String(workflowRun.head_repository?.full_name || '');
+              sourceConclusion = String(workflowRun.conclusion || '');
+            } else {
+              sourceRunId = String(process.env.DISPATCH_SOURCE_RUN_ID || '');
+              sourceRunAttempt = String(process.env.DISPATCH_SOURCE_RUN_ATTEMPT || '');
+              prNumber = String(process.env.DISPATCH_PR_NUMBER || '');
+              expectedHeadSha = String(process.env.DISPATCH_PR_HEAD_SHA || '');
+            }
+
+            if (sourceConclusion !== 'success') {
+              core.info(`Skipping SBOM security publication for source conclusion=${sourceConclusion}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (!/^\d+$/.test(sourceRunId) || !/^\d+$/.test(prNumber)) {
+              core.warning(`Invalid SBOM security publish context: sourceRunId=${JSON.stringify(sourceRunId)} prNumber=${JSON.stringify(prNumber)}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/i.test(expectedHeadSha)) {
+              core.warning(`Invalid or missing PR head SHA for SBOM security publication: ${JSON.stringify(expectedHeadSha)}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const issueNumber = Number(prNumber);
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: issueNumber });
+            if (workflowHeadRepository && workflowHeadRepository !== `${owner}/${repo}`) {
+              core.warning(`Skipping SBOM security publication for non-repository head ${workflowHeadRepository}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head?.repo?.fork || pr.head?.repo?.full_name !== `${owner}/${repo}`) {
+              core.warning(`Skipping SBOM security publication for fork or external head repository on PR #${issueNumber}.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            if (pr.head.sha !== expectedHeadSha) {
+              core.warning(`Skipping stale SBOM security artifact for PR #${issueNumber}: expected ${expectedHeadSha}, current ${pr.head.sha}`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+            const labels = new Set((pr.labels || []).map((label) => String(label.name || '')));
+            if (eventName === 'workflow_run' && !labels.has('run-security')) {
+              core.info(`PR #${issueNumber} no longer has run-security; skipping SBOM security publication.`);
+              core.setOutput('skip', 'true');
+              return;
+            }
+
+            const requiredArtifacts = ['sbom-files', 'security-scan-results'];
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner,
+              repo,
+              run_id: Number(sourceRunId),
+              per_page: 100,
+            });
+            const artifactNames = new Set((artifacts.data.artifacts || []).filter((artifact) => !artifact.expired).map((artifact) => artifact.name));
+            for (const required of requiredArtifacts) {
+              if (!artifactNames.has(required)) {
+                core.warning(`Required SBOM security artifact ${required} not found for run ${sourceRunId}; skipping publication.`);
+                core.setOutput('skip', 'true');
+                return;
+              }
+            }
+
+            core.setOutput('skip', 'false');
+            core.setOutput('source_run_id', sourceRunId);
+            core.setOutput('source_run_attempt', sourceRunAttempt);
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('pr_head_sha', expectedHeadSha);
+
+      - name: Checkout trusted publisher code
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Download SBOM artifacts
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: sbom-files
+          path: artifacts/publish/sbom
+          run-id: ${{ steps.context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download security scan results
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: security-scan-results
+          path: artifacts/publish/security-scan
+          run-id: ${{ steps.context.outputs.source_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate SBOM and security scan provenance
+        if: steps.context.outputs.skip != 'true'
+        env:
+          SOURCE_RUN_ATTEMPT: ${{ steps.context.outputs.source_run_attempt }}
+        run: |
+          set -euo pipefail
+          common=(
+            --repository "${GITHUB_REPOSITORY}"
+            --workflow "SBOM Generation and Security Scanning"
+            --run-id "${{ steps.context.outputs.source_run_id }}"
+            --event-name pull_request
+            --head-sha "${{ steps.context.outputs.pr_head_sha }}"
+            --pr-number "${{ steps.context.outputs.pr_number }}"
+          )
+          if [ -n "${SOURCE_RUN_ATTEMPT}" ]; then
+            common+=(--run-attempt "${SOURCE_RUN_ATTEMPT}")
+          fi
+          node scripts/ci/validate-artifact-provenance.mjs \
+            --provenance artifacts/publish/sbom/sbom-files.provenance.json \
+            --root artifacts/publish/sbom \
+            --artifact-name sbom-files \
+            --require-subject sbom.json \
+            --require-subject sbom.xml \
+            "${common[@]}"
+          node scripts/ci/validate-artifact-provenance.mjs \
+            --provenance artifacts/publish/security-scan/security-scan-results.provenance.json \
+            --root artifacts/publish/security-scan \
+            --artifact-name security-scan-results \
+            --require-subject audit-results.json \
+            "${common[@]}"
+
+      - name: Post Security/Compliance summary
+        if: steps.context.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const header = '<!-- AE-SECURITY-SUMMARY -->';
+            const readJSONSafe = (f) => {
+              try {
+                if (!fs.existsSync(f)) return null;
+                const raw = fs.readFileSync(f, 'utf8');
+                if (!raw || !raw.trim()) return null;
+                return JSON.parse(raw);
+              } catch (_) {
+                return null;
+              }
+            };
+
+            const audit = readJSONSafe(path.join('artifacts', 'publish', 'security-scan', 'audit-results.json'));
+            const vuln = (audit && audit.metadata && audit.metadata.vulnerabilities) || {};
+            const total = Number(vuln.total || 0);
+            const high = Number(vuln.high || vuln.critical || 0);
+            const moderate = Number(vuln.moderate || 0);
+            const low = Number(vuln.low || 0);
+            const vulnSummary = (audit && ('vulnerabilities' in (audit.metadata || {})))
+              ? `- Total: ${total} (High: ${high}, Moderate: ${moderate}, Low: ${low})`
+              : '- No vulnerabilities found';
+
+            const sbom = readJSONSafe(path.join('artifacts', 'publish', 'sbom', 'sbom.json'));
+            let licenseLines = ['- No license data available'];
+            if (sbom && Array.isArray(sbom.components)) {
+              const freq = new Map();
+              for (const c of sbom.components) {
+                const ls = Array.isArray(c.licenses) ? c.licenses : [];
+                for (const l of ls) {
+                  const key = String(l?.license?.name || l?.expression || '').trim();
+                  if (!key) continue;
+                  freq.set(key, (freq.get(key) || 0) + 1);
+                }
+              }
+              const sorted = [...freq.entries()].sort((a,b)=>b[1]-a[1]);
+              const take = Math.max(3, Math.min(5, sorted.length));
+              if (take > 0) licenseLines = sorted.slice(0, take).map(([name, count]) => `- ${name}: ${count}`);
+            }
+
+            const body = [
+              header,
+              '## ✅ Security/Compliance Summary',
+              '',
+              '### Dependency Vulnerabilities',
+              vulnSummary,
+              '',
+              '### Top Licenses (3-5)',
+              ...licenseLines,
+              '',
+              '_This is a non-blocking summary for visibility._'
+            ].join('\n');
+
+            const { owner, repo } = context.repo;
+            const issue_number = Number('${{ steps.context.outputs.pr_number }}');
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.find(c => typeof c.body === 'string' && c.body.startsWith(header));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }

--- a/scripts/ci/lib/artifact-provenance.mjs
+++ b/scripts/ci/lib/artifact-provenance.mjs
@@ -1,0 +1,227 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const ARTIFACT_PROVENANCE_SCHEMA_VERSION = 'ci-artifact-provenance/v1';
+
+const HEX_SHA_RE = /^[0-9a-f]{64}$/;
+
+export function normalizeSubjectPath(subjectPath) {
+  const raw = String(subjectPath ?? '').trim();
+  if (!raw) {
+    throw new Error('subject path must not be empty');
+  }
+  if (path.isAbsolute(raw)) {
+    throw new Error(`subject path must be repository-relative: ${raw}`);
+  }
+  const normalized = path.posix.normalize(raw.replace(/\\/g, '/'));
+  if (normalized === '.' || normalized === '..' || normalized.startsWith('../') || normalized.includes('/../')) {
+    throw new Error(`subject path must stay within the artifact root: ${raw}`);
+  }
+  return normalized;
+}
+
+export function sha256File(filePath) {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest('hex');
+}
+
+function readJsonOptional(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function parsePullRequestEvent(env = process.env) {
+  const eventPath = env.GITHUB_EVENT_PATH;
+  const event = eventPath ? readJsonOptional(eventPath) : undefined;
+  const pr = event?.pull_request;
+  return {
+    prNumber: pr?.number ?? null,
+    headSha: typeof pr?.head?.sha === 'string' ? pr.head.sha : (env.GITHUB_SHA || ''),
+    baseSha: typeof pr?.base?.sha === 'string' ? pr.base.sha : '',
+    headRepository: typeof pr?.head?.repo?.full_name === 'string' ? pr.head.repo.full_name : '',
+    baseRepository: typeof pr?.base?.repo?.full_name === 'string' ? pr.base.repo.full_name : '',
+  };
+}
+
+export function collectSubjects({ root = '.', subjects = [] } = {}) {
+  const rootDir = path.resolve(root);
+  return subjects.map((subject) => {
+    const normalized = normalizeSubjectPath(subject);
+    const fullPath = path.resolve(rootDir, normalized);
+    const relative = path.relative(rootDir, fullPath);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error(`subject path escapes artifact root: ${subject}`);
+    }
+    const stat = fs.statSync(fullPath);
+    if (!stat.isFile()) {
+      throw new Error(`subject path is not a regular file: ${normalized}`);
+    }
+    return {
+      path: normalized,
+      sha256: sha256File(fullPath),
+      size: stat.size,
+    };
+  });
+}
+
+export function buildArtifactProvenance({
+  artifactName,
+  root = '.',
+  subjects = [],
+  env = process.env,
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  const name = String(artifactName ?? '').trim();
+  if (!name) {
+    throw new Error('artifactName is required');
+  }
+  const collectedSubjects = collectSubjects({ root, subjects });
+  if (!collectedSubjects.length) {
+    throw new Error('at least one subject is required');
+  }
+  const pr = parsePullRequestEvent(env);
+  return {
+    schemaVersion: ARTIFACT_PROVENANCE_SCHEMA_VERSION,
+    generatedAt,
+    artifact: {
+      name,
+      subjects: collectedSubjects,
+    },
+    producer: {
+      repository: env.GITHUB_REPOSITORY || '',
+      workflow: env.GITHUB_WORKFLOW || '',
+      workflowRef: env.GITHUB_WORKFLOW_REF || '',
+      runId: String(env.GITHUB_RUN_ID || ''),
+      runAttempt: String(env.GITHUB_RUN_ATTEMPT || ''),
+      eventName: env.GITHUB_EVENT_NAME || '',
+      headSha: pr.headSha || '',
+      baseSha: pr.baseSha || '',
+      prNumber: pr.prNumber,
+      headRepository: pr.headRepository,
+      baseRepository: pr.baseRepository,
+    },
+  };
+}
+
+function maybeCompare(errors, label, actual, expected) {
+  const exp = String(expected ?? '').trim();
+  if (!exp) return;
+  const act = String(actual ?? '').trim();
+  if (act !== exp) {
+    errors.push(`${label} mismatch: expected ${JSON.stringify(exp)}, actual ${JSON.stringify(act)}`);
+  }
+}
+
+export function validateArtifactProvenance({
+  provenance,
+  root = '.',
+  expected = {},
+  requireSubjects = [],
+} = {}) {
+  const errors = [];
+  if (!provenance || typeof provenance !== 'object') {
+    return ['provenance must be a JSON object'];
+  }
+  if (provenance.schemaVersion !== ARTIFACT_PROVENANCE_SCHEMA_VERSION) {
+    errors.push(`schemaVersion mismatch: expected ${ARTIFACT_PROVENANCE_SCHEMA_VERSION}, actual ${JSON.stringify(provenance.schemaVersion)}`);
+  }
+  const artifact = provenance.artifact;
+  const producer = provenance.producer;
+  if (!artifact || typeof artifact !== 'object') {
+    errors.push('artifact object is required');
+  }
+  if (!producer || typeof producer !== 'object') {
+    errors.push('producer object is required');
+  }
+  if (artifact && typeof artifact === 'object') {
+    maybeCompare(errors, 'artifact.name', artifact.name, expected.artifactName);
+  }
+  if (producer && typeof producer === 'object') {
+    maybeCompare(errors, 'producer.repository', producer.repository, expected.repository);
+    maybeCompare(errors, 'producer.workflow', producer.workflow, expected.workflow);
+    maybeCompare(errors, 'producer.workflowRef', producer.workflowRef, expected.workflowRef);
+    maybeCompare(errors, 'producer.runId', producer.runId, expected.runId);
+    maybeCompare(errors, 'producer.runAttempt', producer.runAttempt, expected.runAttempt);
+    maybeCompare(errors, 'producer.eventName', producer.eventName, expected.eventName);
+    maybeCompare(errors, 'producer.headSha', producer.headSha, expected.headSha);
+    maybeCompare(errors, 'producer.baseSha', producer.baseSha, expected.baseSha);
+    if (String(expected.prNumber ?? '').trim()) {
+      const actualPr = producer.prNumber == null ? '' : String(producer.prNumber);
+      maybeCompare(errors, 'producer.prNumber', actualPr, expected.prNumber);
+    }
+  }
+
+  const subjects = Array.isArray(artifact?.subjects) ? artifact.subjects : [];
+  if (!subjects.length) {
+    errors.push('artifact.subjects must contain at least one subject');
+  }
+  const seen = new Set();
+  const rootDir = path.resolve(root);
+  for (const subject of subjects) {
+    if (!subject || typeof subject !== 'object') {
+      errors.push('artifact subject must be an object');
+      continue;
+    }
+    let normalized;
+    try {
+      normalized = normalizeSubjectPath(subject.path);
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+      continue;
+    }
+    if (seen.has(normalized)) {
+      errors.push(`duplicate subject path: ${normalized}`);
+      continue;
+    }
+    seen.add(normalized);
+    if (subject.path !== normalized) {
+      errors.push(`subject path is not normalized: ${JSON.stringify(subject.path)} -> ${normalized}`);
+    }
+    if (typeof subject.sha256 !== 'string' || !HEX_SHA_RE.test(subject.sha256)) {
+      errors.push(`subject ${normalized} has invalid sha256`);
+      continue;
+    }
+    const fullPath = path.resolve(rootDir, normalized);
+    const relative = path.relative(rootDir, fullPath);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      errors.push(`subject path escapes artifact root: ${normalized}`);
+      continue;
+    }
+    if (!fs.existsSync(fullPath)) {
+      errors.push(`subject file is missing: ${normalized}`);
+      continue;
+    }
+    const stat = fs.statSync(fullPath);
+    if (!stat.isFile()) {
+      errors.push(`subject file is not a regular file: ${normalized}`);
+      continue;
+    }
+    const actualSha = sha256File(fullPath);
+    if (actualSha !== subject.sha256) {
+      errors.push(`subject ${normalized} sha256 mismatch: expected ${subject.sha256}, actual ${actualSha}`);
+    }
+    if (typeof subject.size === 'number' && stat.size !== subject.size) {
+      errors.push(`subject ${normalized} size mismatch: expected ${subject.size}, actual ${stat.size}`);
+    }
+  }
+
+  for (const required of requireSubjects) {
+    let normalized;
+    try {
+      normalized = normalizeSubjectPath(required);
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+      continue;
+    }
+    if (!seen.has(normalized)) {
+      errors.push(`required subject missing from provenance: ${normalized}`);
+    }
+  }
+
+  return errors;
+}

--- a/scripts/ci/validate-artifact-provenance.mjs
+++ b/scripts/ci/validate-artifact-provenance.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import { validateArtifactProvenance } from './lib/artifact-provenance.mjs';
+
+const expectedFlagMap = new Map([
+  ['--artifact-name', 'artifactName'],
+  ['--repository', 'repository'],
+  ['--workflow', 'workflow'],
+  ['--workflow-ref', 'workflowRef'],
+  ['--run-id', 'runId'],
+  ['--run-attempt', 'runAttempt'],
+  ['--event-name', 'eventName'],
+  ['--head-sha', 'headSha'],
+  ['--base-sha', 'baseSha'],
+  ['--pr-number', 'prNumber'],
+]);
+
+function parseArgs(argv) {
+  const args = { root: '.', expected: {}, requireSubjects: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      i += 1;
+      if (i >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[i];
+    };
+    if (arg === '--provenance') args.provenancePath = next();
+    else if (arg === '--root') args.root = next();
+    else if (arg === '--require-subject') args.requireSubjects.push(next());
+    else if (expectedFlagMap.has(arg)) args.expected[expectedFlagMap.get(arg)] = next();
+    else if (arg === '--help' || arg === '-h') args.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ci/validate-artifact-provenance.mjs --provenance <file> [--root <dir>] [expected flags] [--require-subject <path> ...]`);
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.provenancePath) throw new Error('--provenance is required');
+  const provenance = JSON.parse(fs.readFileSync(args.provenancePath, 'utf8'));
+  const errors = validateArtifactProvenance({
+    provenance,
+    root: args.root,
+    expected: args.expected,
+    requireSubjects: args.requireSubjects,
+  });
+  if (errors.length) {
+    for (const error of errors) {
+      console.error(`::error::${error}`);
+    }
+    process.exit(1);
+  }
+  console.log(`Validated artifact provenance: ${args.provenancePath}`);
+} catch (error) {
+  console.error(`validate-artifact-provenance: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/scripts/ci/write-artifact-provenance.mjs
+++ b/scripts/ci/write-artifact-provenance.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { buildArtifactProvenance } from './lib/artifact-provenance.mjs';
+
+function parseArgs(argv) {
+  const args = { subjects: [], root: '.' };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = () => {
+      i += 1;
+      if (i >= argv.length) throw new Error(`${arg} requires a value`);
+      return argv[i];
+    };
+    if (arg === '--output') args.output = next();
+    else if (arg === '--artifact-name') args.artifactName = next();
+    else if (arg === '--root') args.root = next();
+    else if (arg === '--subject') args.subjects.push(next());
+    else if (arg === '--help' || arg === '-h') args.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/ci/write-artifact-provenance.mjs --output <file> --artifact-name <name> [--root <dir>] --subject <path> [--subject <path> ...]`);
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (!args.output) throw new Error('--output is required');
+  const provenance = buildArtifactProvenance({
+    artifactName: args.artifactName,
+    root: args.root,
+    subjects: args.subjects,
+  });
+  fs.mkdirSync(path.dirname(args.output), { recursive: true });
+  fs.writeFileSync(args.output, `${JSON.stringify(provenance, null, 2)}\n`, 'utf8');
+  console.log(`Wrote artifact provenance: ${args.output}`);
+} catch (error) {
+  console.error(`write-artifact-provenance: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/tests/unit/ci/artifact-provenance.test.ts
+++ b/tests/unit/ci/artifact-provenance.test.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ARTIFACT_PROVENANCE_SCHEMA_VERSION,
+  buildArtifactProvenance,
+  normalizeSubjectPath,
+  validateArtifactProvenance,
+} from '../../../scripts/ci/lib/artifact-provenance.mjs';
+
+const tmpDirs: string[] = [];
+
+const makeTmpDir = () => {
+  const base = path.join(process.cwd(), 'artifacts', 'tmp', 'unit-tests');
+  fs.mkdirSync(base, { recursive: true });
+  const dir = fs.mkdtempSync(path.join(base, 'ae-artifact-provenance-'));
+  tmpDirs.push(dir);
+  return dir;
+};
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('artifact provenance helpers', () => {
+  it('writes and validates provenance bound to workflow and subject digest', () => {
+    const root = makeTmpDir();
+    fs.mkdirSync(path.join(root, 'summary'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'summary', 'PR_SUMMARY.md'), 'trusted publisher input\n');
+    const eventPath = path.join(root, 'event.json');
+    fs.writeFileSync(eventPath, JSON.stringify({
+      pull_request: {
+        number: 3464,
+        head: { sha: 'a'.repeat(40), repo: { full_name: 'itdojp/ae-framework' } },
+        base: { sha: 'b'.repeat(40), repo: { full_name: 'itdojp/ae-framework' } },
+      },
+    }));
+
+    const provenance = buildArtifactProvenance({
+      artifactName: 'pr-summary-publish-pr-3464',
+      root,
+      subjects: ['summary/PR_SUMMARY.md'],
+      generatedAt: '2026-06-07T00:00:00.000Z',
+      env: {
+        GITHUB_REPOSITORY: 'itdojp/ae-framework',
+        GITHUB_WORKFLOW: 'PR Maintenance',
+        GITHUB_WORKFLOW_REF: 'itdojp/ae-framework/.github/workflows/pr-ci-status-comment.yml@refs/pull/3464/merge',
+        GITHUB_RUN_ID: '123456789',
+        GITHUB_RUN_ATTEMPT: '2',
+        GITHUB_EVENT_NAME: 'pull_request',
+        GITHUB_SHA: 'c'.repeat(40),
+        GITHUB_EVENT_PATH: eventPath,
+      } as any,
+    });
+
+    expect(provenance.schemaVersion).toBe(ARTIFACT_PROVENANCE_SCHEMA_VERSION);
+    expect(provenance.producer.headSha).toBe('a'.repeat(40));
+    expect(provenance.producer.baseSha).toBe('b'.repeat(40));
+    expect(provenance.producer.prNumber).toBe(3464);
+    expect(provenance.artifact.subjects).toHaveLength(1);
+
+    expect(validateArtifactProvenance({
+      provenance,
+      root,
+      expected: {
+        artifactName: 'pr-summary-publish-pr-3464',
+        repository: 'itdojp/ae-framework',
+        workflow: 'PR Maintenance',
+        runId: '123456789',
+        runAttempt: '2',
+        eventName: 'pull_request',
+        headSha: 'a'.repeat(40),
+        baseSha: 'b'.repeat(40),
+        prNumber: '3464',
+      },
+      requireSubjects: ['summary/PR_SUMMARY.md'],
+    })).toEqual([]);
+  });
+
+  it('fails validation when a subject is changed after provenance is written', () => {
+    const root = makeTmpDir();
+    fs.writeFileSync(path.join(root, 'artifact.json'), '{"ok":true}\n');
+    const provenance = buildArtifactProvenance({
+      artifactName: 'quality-gates-report',
+      root,
+      subjects: ['artifact.json'],
+      env: {
+        GITHUB_REPOSITORY: 'itdojp/ae-framework',
+        GITHUB_WORKFLOW: 'Quality Gates',
+        GITHUB_RUN_ID: '42',
+        GITHUB_RUN_ATTEMPT: '1',
+        GITHUB_EVENT_NAME: 'pull_request',
+        GITHUB_SHA: 'd'.repeat(40),
+      } as any,
+    });
+
+    fs.writeFileSync(path.join(root, 'artifact.json'), '{"ok":false}\n');
+    const errors = validateArtifactProvenance({
+      provenance,
+      root,
+      expected: { artifactName: 'quality-gates-report', runId: '42' },
+      requireSubjects: ['artifact.json'],
+    });
+
+    expect(errors.join('\n')).toContain('sha256 mismatch');
+  });
+
+  it('rejects absolute and parent-traversal subject paths', () => {
+    expect(() => normalizeSubjectPath('/tmp/report.json')).toThrow(/repository-relative/);
+    expect(() => normalizeSubjectPath('../report.json')).toThrow(/artifact root/);
+    expect(() => normalizeSubjectPath('safe/../../report.json')).toThrow(/artifact root/);
+  });
+});

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -307,12 +307,14 @@ describe('workflow permission boundaries', () => {
     expect(rawWorkflow).toContain('environment:\n      name: branch-protection-admin');
   });
 
-  it('pr-maintenance renders PR summary read-only and publishes from a checkout-free writer job', () => {
+  it('pr-maintenance renders PR summary read-only and publishes through a trusted workflow-run publisher', () => {
     const workflow = readWorkflow('pr-ci-status-comment.yml');
     const parsed = parseWorkflow('pr-ci-status-comment.yml');
     const summarize = extractJobBlock(workflow, 'summarize');
     const validateChangePackage = extractJobBlock(workflow, 'validate-change-package');
-    const publishSummary = extractJobBlock(workflow, 'publish-summary');
+    const publisher = parseWorkflow('pr-summary-publisher.yml');
+    const publisherRaw = readWorkflow('pr-summary-publisher.yml');
+    const publisherJob = extractJobBlock(publisherRaw, 'publish');
     const enableAutoMerge = extractJobBlock(workflow, 'enable-auto-merge');
 
     expect(workflowPermission(parsed, 'issues')).toBeUndefined();
@@ -335,14 +337,18 @@ describe('workflow permission boundaries', () => {
       actions: 'read',
       contents: 'read',
     });
-    expect(parsed.jobs?.['publish-summary']?.needs).toEqual(['summarize', 'validate-change-package']);
-    expect(parsed.jobs?.['publish-summary']?.permissions).toEqual({
+    expect(parsed.jobs?.['publish-summary']).toBeUndefined();
+    expect(publisher.on?.workflow_run?.workflows).toContain('PR Maintenance');
+    expect(publisher.permissions).toEqual({
       actions: 'read',
       checks: 'write',
+      contents: 'read',
       issues: 'write',
-      'pull-requests': 'write',
+      'pull-requests': 'read',
     });
     expect(summarize).toContain('Upload PR summary publish artifact');
+    expect(summarize).toContain('Write PR summary publish provenance');
+    expect(summarize).toContain('pr-summary-publish.provenance.json');
     expect(summarize).toContain('artifacts/change-package/change-package.json');
     expect(validateChangePackage).toContain('ref: ${{ github.event.pull_request.base.sha }}');
     expect(validateChangePackage).toContain('Install trusted validation dependencies');
@@ -354,34 +360,41 @@ describe('workflow permission boundaries', () => {
     expect(validateChangePackage).toContain("source: 'base-ref-code'");
     expect(summarize).not.toContain('issues.createComment');
     expect(summarize).not.toContain('issues.updateComment');
-    expect(publishSummary).not.toContain('actions/checkout@v4');
-    expect(publishSummary).toContain('Download PR summary publish artifact');
-    expect(publishSummary).toContain('Download trusted Change Package validation artifact');
-    expect(publishSummary).toContain("const trustedArtifactRoot = 'artifacts/publish/trusted-change-package'");
-    expect(publishSummary).toContain("readText('summary/PR_SUMMARY.md')");
-    expect(publishSummary).toContain("readText('progress/PR_PROGRESS.md')");
-    expect(publishSummary).toContain("readJson('change-package-validation.json', trustedArtifactRoot)");
-    expect(publishSummary).toContain('const truncateUtf8 = (text, maxBytes) =>');
-    expect(publishSummary).toContain('MAX_COMMENT_BYTES - Buffer.byteLength(notice');
-    expect(publishSummary).toContain('availableBytes');
-    expect(publishSummary).toContain('const listAllIssueComments = async () =>');
-    expect(publishSummary).toContain('page += 1');
-    expect(publishSummary).toContain('let issueCommentsCache = null;');
-    expect(publishSummary).toContain('const getIssueComments = async () =>');
-    expect(publishSummary).toContain('issueCommentsCache = await listAllIssueComments();');
-    expect(publishSummary).toContain('const isTrustedAutomationComment = (comment, marker) =>');
-    expect(publishSummary).toContain("login === 'github-actions' || login === 'github-actions[bot]'");
-    expect(publishSummary).toContain('body.startsWith(marker)');
-    expect(publishSummary).toContain('const markerDisplayLabel = (marker) =>');
-    expect(publishSummary).toContain("return label || 'PR comment';");
-    expect(publishSummary).toContain('limitComment(`${marker}\\n\\n${body}`, markerDisplayLabel(marker))');
-    expect(publishSummary).toContain('const comments = await getIssueComments();');
-    expect(publishSummary).toContain('const existing = [...comments].reverse().find((comment) => isTrustedAutomationComment(comment, marker))');
-    expect(publishSummary).toContain('Progress summary JSON omitted because it would exceed the PR comment size cap.');
-    expect(publishSummary).toContain('Progress summary JSON could not be parsed; publishing Markdown without embedded JSON');
-    expect(publishSummary).toContain('could not be parsed; treating as missing structured JSON');
-    expect(publishSummary).toContain("name: 'Change Package Validation'");
-    expect(publishSummary).toContain('head_sha: headSha');
+    expect(publisherJob).toContain('ref: ${{ github.event.repository.default_branch }}');
+    expect(publisherJob).toContain('Download PR summary publish artifact');
+    expect(publisherJob).toContain('Download trusted Change Package validation artifact');
+    expect(publisherJob).toContain('Validate PR summary artifact provenance');
+    expect(publisherJob).toContain('validate-artifact-provenance.mjs');
+    expect(publisherJob).toContain('--workflow "PR Maintenance"');
+    expect(publisherJob).toContain('--require-subject summary/PR_SUMMARY.md');
+    expect(publisherJob).toContain("const trustedArtifactRoot = 'artifacts/publish/trusted-change-package'");
+    expect(publisherJob).toContain("readText('summary/PR_SUMMARY.md')");
+    expect(publisherJob).toContain("readText('progress/PR_PROGRESS.md')");
+    expect(publisherJob).toContain("readJson('change-package-validation.json', trustedArtifactRoot)");
+    expect(publisherJob).toContain("trusted.source !== 'base-ref-code'");
+    expect(publisherJob).toContain("String(trusted.headSha || '') !== headSha");
+    expect(publisherJob).toContain("String(trusted.workflowRunId || '') !== sourceRunId");
+    expect(publisherJob).toContain('const truncateUtf8 = (text, maxBytes) =>');
+    expect(publisherJob).toContain('MAX_COMMENT_BYTES - Buffer.byteLength(notice');
+    expect(publisherJob).toContain('availableBytes');
+    expect(publisherJob).toContain('const listAllIssueComments = async () =>');
+    expect(publisherJob).toContain('page += 1');
+    expect(publisherJob).toContain('let issueCommentsCache = null;');
+    expect(publisherJob).toContain('const getIssueComments = async () =>');
+    expect(publisherJob).toContain('issueCommentsCache = await listAllIssueComments();');
+    expect(publisherJob).toContain('const isTrustedAutomationComment = (comment, marker) =>');
+    expect(publisherJob).toContain("login === 'github-actions' || login === 'github-actions[bot]'");
+    expect(publisherJob).toContain('body.startsWith(marker)');
+    expect(publisherJob).toContain('const markerDisplayLabel = (marker) =>');
+    expect(publisherJob).toContain("return label || 'PR comment';");
+    expect(publisherJob).toContain('limitComment(`${marker}\\n\\n${body}`, markerDisplayLabel(marker))');
+    expect(publisherJob).toContain('const comments = await getIssueComments();');
+    expect(publisherJob).toContain('const existing = [...comments].reverse().find((comment) => isTrustedAutomationComment(comment, marker))');
+    expect(publisherJob).toContain('Progress summary JSON omitted because it would exceed the PR comment size cap.');
+    expect(publisherJob).toContain('Progress summary JSON could not be parsed; publishing Markdown without embedded JSON');
+    expect(publisherJob).toContain('could not be parsed; treating as missing structured JSON');
+    expect(publisherJob).toContain("name: 'Change Package Validation'");
+    expect(publisherJob).toContain('head_sha: headSha');
     expect(enableAutoMerge).not.toContain("github.event_name == 'pull_request'");
   });
 
@@ -445,8 +458,28 @@ describe('workflow permission boundaries', () => {
   it('keeps pull-request DoD report-only while preserving push/main enforcement', () => {
     const workflow = readWorkflow('quality-gates-centralized.yml');
     const dod = extractJobBlock(workflow, 'dod');
+    const publisher = parseWorkflow('quality-gates-publisher.yml');
+    const publisherRaw = readWorkflow('quality-gates-publisher.yml');
+    const publisherJob = extractJobBlock(publisherRaw, 'publish');
     expect(dod).toContain("continue-on-error: ${{ github.event_name == 'pull_request' }}");
     expect(dod).toContain('run: pnpm run quality:run -- --env=testing --gates=dod --sequential');
+    expect(dod).toContain('Write quality report provenance');
+    expect(dod).toContain('write-artifact-provenance.mjs');
+    expect(workflow).not.toContain('  pr-quality-comment:');
+    expect(publisher.on?.workflow_run?.workflows).toContain('Quality Gates');
+    expect(publisher.permissions).toEqual({
+      actions: 'read',
+      contents: 'read',
+      issues: 'write',
+      'pull-requests': 'read',
+    });
+    expect(publisherJob).toContain('ref: ${{ github.event.repository.default_branch }}');
+    expect(publisherJob).toContain('Validate quality report provenance');
+    expect(publisherJob).toContain('--workflow "Quality Gates"');
+    expect(publisherJob).toContain('validate-artifact-provenance.mjs');
+    expect(publisherJob).toContain('render-quality-pr-comment.mjs');
+    expect(publisherJob).toContain('gh api -X PATCH');
+    expect(publisherJob).toContain('gh api -X POST');
   });
 
   it('copilot-review-gate delegates fork-safe behavior to trusted script with explicit actor env', () => {
@@ -691,18 +724,27 @@ describe('workflow permission boundaries', () => {
       'persist-credentials': false,
     });
 
-    const commentJob = sbom.jobs?.['security-summary-comment'];
-    const commentSteps = Array.isArray(commentJob?.steps) ? commentJob.steps : [];
-    expect(commentJob?.permissions).toMatchObject({
+    expect(sbom.jobs?.['security-summary-comment']).toBeUndefined();
+    expect(generationSteps.some((step: any) => step?.name === 'Write SBOM provenance')).toBe(true);
+    expect(generationSteps.some((step: any) => step?.name === 'Write security scan provenance')).toBe(true);
+
+    const publisher = parseWorkflow('sbom-security-publisher.yml');
+    const publisherRaw = readWorkflow('sbom-security-publisher.yml');
+    const publisherJob = extractJobBlock(publisherRaw, 'publish');
+    expect(publisher.on?.workflow_run?.workflows).toContain('SBOM Generation and Security Scanning');
+    expect(publisher.permissions).toMatchObject({
       contents: 'read',
       actions: 'read',
       issues: 'write',
       'pull-requests': 'read',
     });
-    expect(commentSteps.some((step: any) => step?.uses === 'actions/checkout@v4')).toBe(false);
-    expect(commentSteps.some((step: any) => String(step?.uses ?? '').startsWith('./'))).toBe(false);
-    expect(commentSteps.some((step: any) => String(step?.run ?? '').includes('pnpm'))).toBe(false);
-    expect(commentSteps.filter((step: any) => step?.uses === 'actions/github-script@v7')).toHaveLength(1);
+    expect(publisherJob).toContain('ref: ${{ github.event.repository.default_branch }}');
+    expect(publisherJob).toContain('Validate SBOM and security scan provenance');
+    expect(publisherJob).toContain('validate-artifact-provenance.mjs');
+    expect(publisherJob).toContain('--workflow "SBOM Generation and Security Scanning"');
+    expect(publisherJob).toContain('--require-subject sbom.json');
+    expect(publisherJob).toContain('--require-subject audit-results.json');
+    expect(publisherJob).toContain('Post Security/Compliance summary');
   });
 
   it('security analyzer pull request runs stay read-only and isolate security-events writes', () => {
@@ -776,13 +818,17 @@ describe('workflow permission boundaries', () => {
     expect(publisher.on?.workflow_run?.workflows).toContain('Formal Verify');
     expect(publisher.permissions).toMatchObject({
       actions: 'read',
+      contents: 'read',
       issues: 'write',
       'pull-requests': 'read',
     });
-    expect(jobSteps(publisher, 'publish').some((step) => step?.uses === 'actions/checkout@v4')).toBe(false);
+    expect(jobSteps(publisher, 'publish').some((step) => step?.uses === 'actions/checkout@v4')).toBe(true);
+    expect(publisherJob).toContain('ref: ${{ github.event.repository.default_branch }}');
     expect(jobSteps(publisher, 'publish').some((step) => String(step?.uses ?? '').startsWith('./'))).toBe(false);
     expect(publisher.on?.workflow_dispatch?.inputs?.pr_head_sha?.required).toBe(true);
+    expect(publisher.on?.workflow_dispatch?.inputs?.source_run_attempt?.required).toBe(false);
     expect(publisherJob).toContain("workflowRun.head_sha");
+    expect(publisherJob).toContain("workflowRun.run_attempt");
     expect(publisherJob).toContain('/^[0-9a-f]{40}$/i.test(expectedHeadSha)');
     expect(publisherJob).toContain('Invalid or missing PR head SHA');
     expect(publisherJob).toContain('workflowHeadRepository !== `${owner}/${repo}`');
@@ -791,6 +837,10 @@ describe('workflow permission boundaries', () => {
     expect(publisherJob).toContain("labels.has('run-formal')");
     expect(publisherJob).toContain('actions/download-artifact@v4');
     expect(publisherJob).toContain('run-id: ${{ steps.context.outputs.source_run_id }}');
+    expect(publisherJob).toContain('Validate formal aggregate provenance');
+    expect(publisherJob).toContain('validate-artifact-provenance.mjs');
+    expect(publisherJob).toContain('--workflow "Formal Verify"');
+    expect(publisherJob).toContain('--require-subject formal-aggregate.md');
     expect(publisherJob).toContain('FORMAL_AGGREGATE_MARKER');
     expect(publisherJob).toContain('MAX_COMMENT_BYTES');
     expect(publisherJob).toContain('sanitizeAggregateMarkdown');

--- a/tests/unit/ci/workflow-permission-boundary.test.ts
+++ b/tests/unit/ci/workflow-permission-boundary.test.ts
@@ -475,6 +475,8 @@ describe('workflow permission boundaries', () => {
     });
     expect(publisherJob).toContain('ref: ${{ github.event.repository.default_branch }}');
     expect(publisherJob).toContain('Validate quality report provenance');
+    expect(publisherJob).not.toContain("sourceConclusion !== 'success'");
+    expect(publisherJob).toContain('gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments"');
     expect(publisherJob).toContain('--workflow "Quality Gates"');
     expect(publisherJob).toContain('validate-artifact-provenance.mjs');
     expect(publisherJob).toContain('render-quality-pr-comment.mjs');
@@ -745,6 +747,7 @@ describe('workflow permission boundaries', () => {
     expect(publisherJob).toContain('--require-subject sbom.json');
     expect(publisherJob).toContain('--require-subject audit-results.json');
     expect(publisherJob).toContain('Post Security/Compliance summary');
+    expect(publisherJob).toContain('github.paginate(github.rest.issues.listComments');
   });
 
   it('security analyzer pull request runs stay read-only and isolate security-events writes', () => {


### PR DESCRIPTION
## Summary

Fixes #3464.

This PR moves representative write-token CI publishers away from PR-head execution and adds artifact provenance validation before publication:

- Adds shared `ci-artifact-provenance/v1` writer/validator scripts with SHA-256 subject binding.
- Splits Quality Gates PR comments into a trusted `workflow_run` publisher.
- Splits PR summary / progress / Change Package check publication into a trusted `workflow_run` publisher.
- Adds provenance to Formal Aggregate artifacts and validates it in the trusted publisher.
- Splits SBOM/security summary comments into a trusted `workflow_run` publisher with SBOM and audit-result provenance checks.
- Keeps producer jobs read-only and preserves the existing auto-fix trusted-base execution boundary through workflow-boundary tests.

## Acceptance

- Write-token publisher jobs for Quality Gates, PR Summary, Formal Aggregate, and SBOM/Security Summary do not execute repository scripts from PR-head checkouts.
- Publisher workflows run from trusted `workflow_run` / protected default-branch code and check current PR head before publishing.
- Published artifacts include provenance sidecars with producer workflow/run/head metadata and SHA-256 subject digests.
- Representative PR summary, formal aggregate, SBOM/security analyzer, and auto-fix workflow boundaries are covered by regression tests.

## Verification

- `pnpm -s exec vitest run tests/unit/ci/artifact-provenance.test.ts tests/unit/ci/workflow-permission-boundary.test.ts --reporter dot`
- `node --check scripts/ci/lib/artifact-provenance.mjs`
- `node --check scripts/ci/write-artifact-provenance.mjs`
- `node --check scripts/ci/validate-artifact-provenance.mjs`
- `pnpm -s exec eslint --quiet scripts/ci/lib/artifact-provenance.mjs scripts/ci/write-artifact-provenance.mjs scripts/ci/validate-artifact-provenance.mjs tests/unit/ci/artifact-provenance.test.ts tests/unit/ci/workflow-permission-boundary.test.ts`
- `ACTIONLINT_BIN=/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint/actionlint pnpm -s run lint:actions` — existing unrelated findings remain in `hermetic-ci.yml` and `verify-lite.yml`.
- `/home/devuser/work/CodeX/ae-frameworkA/.codex-local/bin/actionlint/actionlint .github/workflows/quality-gates-centralized.yml .github/workflows/quality-gates-publisher.yml .github/workflows/pr-ci-status-comment.yml .github/workflows/pr-summary-publisher.yml .github/workflows/formal-aggregate.yml .github/workflows/formal-aggregate-publisher.yml .github/workflows/sbom-generation.yml .github/workflows/sbom-security-publisher.yml`
- `pnpm -s run check:schemas`
- `node scripts/ci/validate-json.mjs`
- `pnpm -s run types:check`
- `pnpm -s run check:doc-consistency`
- `pnpm -s run build`
- `git diff --check`

## Rollback

Revert this PR to restore same-workflow PR publishers. The producer jobs and artifacts are isolated by workflow file, so rollback is a normal git revert if publisher behavior regresses.
