### PR TITLE
fix(security): unify telemetry redaction boundaries

### DIFF
--- a/src/cli/discovery-cli.ts
+++ b/src/cli/discovery-cli.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { Command } from 'commander';
 
 import { safeExit } from '../utils/safe-exit.js';
+import { createHighImpactChildEnv } from '../utils/high-impact-action-policy.js';
 
 // Traceability anchors for #2732:
 // REQ-UCP-001 REQ-UCP-003 REQ-UCP-005 REQ-UCP-006 REQ-UCP-007
@@ -104,7 +105,7 @@ const runNodeScript = (scriptPath: string, args: string[]) => {
   const result = spawnSync(process.execPath, [scriptPath, ...args], {
     cwd: process.cwd(),
     encoding: 'utf8',
-    env: process.env,
+    env: createHighImpactChildEnv(process.env),
   });
 
   if (result.stdout) {

--- a/src/cli/entry-runner-cli.ts
+++ b/src/cli/entry-runner-cli.ts
@@ -9,6 +9,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { safeExit } from '../utils/safe-exit.js';
+import { createHighImpactChildEnv } from '../utils/high-impact-action-policy.js';
 
 type RunnerKey = 'test' | 'quality' | 'verify' | 'flake' | 'security';
 
@@ -72,7 +73,7 @@ export function createEntryRunnerCommand(): Command {
 
       const result = spawnSync(process.execPath, args, {
         stdio: 'inherit',
-        env: process.env,
+        env: createHighImpactChildEnv(process.env),
         cwd: root,
       });
 

--- a/src/cli/help-cli.ts
+++ b/src/cli/help-cli.ts
@@ -9,6 +9,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { safeExit } from '../utils/safe-exit.js';
+import { createHighImpactChildEnv } from '../utils/high-impact-action-policy.js';
 
 export function createHelpCommand(): Command {
   const help = new Command('help');
@@ -27,7 +28,7 @@ export function createHelpCommand(): Command {
 
       const result = spawnSync(process.execPath, [scriptPath], {
         stdio: 'inherit',
-        env: process.env,
+        env: createHighImpactChildEnv(process.env),
         cwd: root,
       });
 

--- a/src/commands/agent/complete.ts
+++ b/src/commands/agent/complete.ts
@@ -62,10 +62,11 @@ export async function agentComplete(prompt: string, system?: string, flags?: { r
     const llmOpts: { prompt: string; system?: string } = { prompt };
     if (system) llmOpts.system = system;
     const output = await llm.complete(llmOpts);
+    const redactedOutput = redactSensitiveString(output);
     
     // End execution log with character count
     console.log(`[ae][agent] Completed: ${output.length} characters`);
-    console.log(`[${llm.name}]`, output);
+    console.log(`[${llm.name}]`, redactedOutput);
   } catch (error) {
     const appError = toExecAppError('agent.complete', error);
     console.error(`[ae][agent] ${formatAppError(appError)}`);

--- a/src/health/health-endpoint.ts
+++ b/src/health/health-endpoint.ts
@@ -12,6 +12,7 @@ import {
   type AdminDiagnosticsAuthOptions,
   requireAdminDiagnosticsAuth,
 } from '../security/admin-diagnostics-auth.js';
+import { redactSensitiveString } from '../security/sensitive-redaction.js';
 
 // Read version from package.json at startup
 const __filename = fileURLToPath(import.meta.url);
@@ -128,7 +129,7 @@ async function getHealthStatus(): Promise<HealthStatus> {
     }
   } catch (error) {
     telemetryStatus = 'error';
-    telemetryMessage = `Telemetry error: ${error instanceof Error ? error.message : 'Unknown error'}`;
+    telemetryMessage = `Telemetry error: ${error instanceof Error ? redactSensitiveString(error.message) : 'Unknown error'}`;
   }
 
   const systemStatus = 'ok'; // Basic system check

--- a/src/security/sensitive-redaction.ts
+++ b/src/security/sensitive-redaction.ts
@@ -80,3 +80,39 @@ export function safeErrorForLogging(error: unknown): unknown {
 export function safeStringForCassette(value: string): string {
   return redactSensitiveString(value);
 }
+
+export type SafeTelemetryAttributeValue = string | number | boolean;
+
+export function sanitizeTelemetryAttributes(
+  attributes: Record<string, unknown> | undefined,
+): Record<string, SafeTelemetryAttributeValue> | undefined {
+  if (attributes === undefined) {
+    return undefined;
+  }
+
+  const safeAttributes: Record<string, SafeTelemetryAttributeValue> = {};
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (isSensitiveKey(key)) {
+      safeAttributes[key] = REDACTED_VALUE;
+      continue;
+    }
+    if (typeof value === 'string') {
+      safeAttributes[key] = redactSensitiveString(value);
+      continue;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      safeAttributes[key] = value;
+      continue;
+    }
+    try {
+      safeAttributes[key] = JSON.stringify(redactSensitiveData(value));
+    } catch {
+      safeAttributes[key] = '[Unserializable payload]';
+    }
+  }
+
+  return safeAttributes;
+}

--- a/src/telemetry/enhanced-telemetry.ts
+++ b/src/telemetry/enhanced-telemetry.ts
@@ -16,6 +16,7 @@ import { toMessage } from '../utils/error-utils.js';
 import type { logs } from '@opentelemetry/api-logs';
 import * as os from 'os';
 import * as process from 'process';
+import { redactSensitiveString, sanitizeTelemetryAttributes } from '../security/sensitive-redaction.js';
 
 // Enhanced configuration with standardized attributes
 export interface TelemetryConfig {
@@ -250,7 +251,7 @@ export class EnhancedTelemetry {
         console.log(`   OTLP: ${this.config.otlpEndpoint ? '✅' : '❌'}`);
       }
     } catch (error: unknown) {
-      console.error('❌ Failed to initialize Enhanced OpenTelemetry:', toMessage(error));
+      console.error('❌ Failed to initialize Enhanced OpenTelemetry:', redactSensitiveString(toMessage(error)));
     }
   }
 
@@ -264,7 +265,7 @@ export class EnhancedTelemetry {
       }
       console.log('📊 Enhanced OpenTelemetry shutdown complete');
     } catch (error: unknown) {
-      console.error('❌ Error during Enhanced OpenTelemetry shutdown:', toMessage(error));
+      console.error('❌ Error during Enhanced OpenTelemetry shutdown:', redactSensitiveString(toMessage(error)));
     }
   }
 
@@ -279,7 +280,7 @@ export class EnhancedTelemetry {
             description: `Duration of ${name} operation`,
             unit: 'ms',
           });
-          histogram.record(duration, { ...attributes, ...additionalAttributes });
+          histogram.record(duration, sanitizeTelemetryAttributes({ ...attributes, ...additionalAttributes }));
         }
         return duration;
       },
@@ -291,7 +292,7 @@ export class EnhancedTelemetry {
       const counter: Counter = this.meter.createCounter(name, {
         description: `Counter for ${name}`,
       });
-      counter.add(value, attributes);
+      counter.add(value, sanitizeTelemetryAttributes(attributes));
     }
   }
 
@@ -300,7 +301,7 @@ export class EnhancedTelemetry {
       const gauge: UpDownCounter = this.meter.createUpDownCounter(name, {
         description: `Gauge for ${name}`,
       });
-      gauge.add(value, attributes);
+      gauge.add(value, sanitizeTelemetryAttributes(attributes));
     }
   }
 
@@ -311,25 +312,22 @@ export class EnhancedTelemetry {
     severity: 'low' | 'medium' | 'high' | 'critical',
     attributes?: Record<string, any>
   ) {
-    this.recordCounter('contract.violations.total', 1, {
+    const violationAttributes = sanitizeTelemetryAttributes({
       [TELEMETRY_ATTRIBUTES.ERROR_TYPE]: violationType,
       contract_id: contractId,
       severity,
       ...attributes,
-    });
+    }) ?? {};
+
+    this.recordCounter('contract.violations.total', 1, violationAttributes);
 
     // Create a span for contract violation
     const tracer = trace.getTracer(this.config.serviceName);
     const span = tracer.startSpan('contract.violation', {
-      attributes: {
-        [TELEMETRY_ATTRIBUTES.ERROR_TYPE]: violationType,
-        contract_id: contractId,
-        severity,
-        ...attributes,
-      },
+      attributes: violationAttributes,
     });
     
-    span.recordException(new Error(`Contract violation: ${violationType}`));
+    span.recordException(new Error(redactSensitiveString(`Contract violation: ${violationType}`)));
     span.end();
   }
 

--- a/src/telemetry/telemetry-service.ts
+++ b/src/telemetry/telemetry-service.ts
@@ -8,6 +8,7 @@ import { trace, metrics } from '@opentelemetry/api';
 import type { Tracer, Meter } from '@opentelemetry/api';
 import { logs } from '@opentelemetry/api-logs';
 import type { Logger } from '@opentelemetry/api-logs';
+import { sanitizeTelemetryAttributes } from '../security/sensitive-redaction.js';
 
 export enum PhaseType {
   INTENT_ANALYSIS = 'intent_analysis',
@@ -131,17 +132,17 @@ export class TelemetryService {
   ): Promise<void> {
     // Create trace span
     const span = this.tracer.startSpan(`phase_${phase}_execution`);
-    span.setAttributes({
+    span.setAttributes(sanitizeTelemetryAttributes({
       'phase.type': phase,
       'phase.success': success,
       'phase.duration': duration
-    });
+    }) ?? {});
 
     // Record metrics
-    this.phaseExecutionHistogram.record(duration, {
+    this.phaseExecutionHistogram.record(duration, sanitizeTelemetryAttributes({
       phase: phase,
       success: success.toString()
-    });
+    }));
 
     if (qualityMetrics) {
       // Quality metrics are recorded via ObservableGauge callback
@@ -149,23 +150,23 @@ export class TelemetryService {
     }
 
     if (!success) {
-      this.errorRateCounter.add(1, {
+      this.errorRateCounter.add(1, sanitizeTelemetryAttributes({
         phase: phase,
         error_type: 'execution_failure'
-      });
+      }));
     }
 
     span.end();
   }
 
   recordCegisFix(confidence: number, strategy: string): void {
-    this.cegisFixCounter.add(1, {
+    this.cegisFixCounter.add(1, sanitizeTelemetryAttributes({
       strategy: strategy
-    });
+    }));
 
-    this.cegisConfidenceHistogram.record(confidence, {
+    this.cegisConfidenceHistogram.record(confidence, sanitizeTelemetryAttributes({
       strategy: strategy
-    });
+    }));
   }
 
   recordConformanceViolation(
@@ -173,15 +174,15 @@ export class TelemetryService {
     direction: 'input' | 'output',
     duration: number
   ): void {
-    this.conformanceViolationCounter.add(1, {
+    this.conformanceViolationCounter.add(1, sanitizeTelemetryAttributes({
       schema_name: schemaName,
       direction: direction
-    });
+    }));
 
-    this.conformanceLatencyHistogram.record(duration, {
+    this.conformanceLatencyHistogram.record(duration, sanitizeTelemetryAttributes({
       schema_name: schemaName,
       direction: direction
-    });
+    }));
   }
 
   private getLatestQualityScore(): number {

--- a/tests/cli/entry-runner-cli.test.ts
+++ b/tests/cli/entry-runner-cli.test.ts
@@ -58,6 +58,7 @@ describe('entry runner CLI', () => {
 
     spawnSyncMock.mockReturnValueOnce({ status: 0, error: null });
 
+    let childEnvSnapshot: NodeJS.ProcessEnv = {};
     try {
       const command = createEntryRunnerCommand();
       await command.parseAsync([
@@ -70,6 +71,8 @@ describe('entry runner CLI', () => {
         'fast',
         '--dry-run',
       ]);
+      const spawnOptions = spawnSyncMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      childEnvSnapshot = { ...(spawnOptions?.env ?? {}) };
     } finally {
       if (previousToken === undefined) {
         delete process.env['GITHUB_TOKEN'];
@@ -78,15 +81,14 @@ describe('entry runner CLI', () => {
       }
     }
 
+    expect(childEnvSnapshot).not.toHaveProperty('GITHUB_TOKEN');
     expect(spawnSyncMock).toHaveBeenCalledWith(
       process.execPath,
       [runnerPath, '--profile', 'fast', '--dry-run'],
       expect.objectContaining({
         cwd: root,
         stdio: 'inherit',
-        env: expect.not.objectContaining({
-          GITHUB_TOKEN: 'raw-entry-token',
-        }),
+        env: expect.any(Object),
       })
     );
     expect(safeExitMock).toHaveBeenCalledWith(0);

--- a/tests/cli/entry-runner-cli.test.ts
+++ b/tests/cli/entry-runner-cli.test.ts
@@ -53,20 +53,30 @@ describe('entry runner CLI', () => {
     const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const root = process.cwd();
     const runnerPath = path.join(root, 'scripts', 'test', 'run.mjs');
+    const previousToken = process.env['GITHUB_TOKEN'];
+    process.env['GITHUB_TOKEN'] = 'raw-entry-token';
 
     spawnSyncMock.mockReturnValueOnce({ status: 0, error: null });
 
-    const command = createEntryRunnerCommand();
-    await command.parseAsync([
-      'node',
-      'cli',
-      'test',
-      '--root',
-      root,
-      '--profile',
-      'fast',
-      '--dry-run',
-    ]);
+    try {
+      const command = createEntryRunnerCommand();
+      await command.parseAsync([
+        'node',
+        'cli',
+        'test',
+        '--root',
+        root,
+        '--profile',
+        'fast',
+        '--dry-run',
+      ]);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env['GITHUB_TOKEN'];
+      } else {
+        process.env['GITHUB_TOKEN'] = previousToken;
+      }
+    }
 
     expect(spawnSyncMock).toHaveBeenCalledWith(
       process.execPath,
@@ -74,7 +84,9 @@ describe('entry runner CLI', () => {
       expect.objectContaining({
         cwd: root,
         stdio: 'inherit',
-        env: process.env,
+        env: expect.not.objectContaining({
+          GITHUB_TOKEN: 'raw-entry-token',
+        }),
       })
     );
     expect(safeExitMock).toHaveBeenCalledWith(0);
@@ -96,7 +108,7 @@ describe('entry runner CLI', () => {
       expect.objectContaining({
         cwd: root,
         stdio: 'inherit',
-        env: process.env,
+        env: expect.any(Object),
       })
     );
     expect(safeExitMock).toHaveBeenCalledWith(5);

--- a/tests/cli/help-cli.test.ts
+++ b/tests/cli/help-cli.test.ts
@@ -41,11 +41,21 @@ describe('help CLI', () => {
   it('runs help script from the provided root', async () => {
     const root = process.cwd();
     const scriptPath = path.join(root, 'scripts', 'project', 'help.mjs');
+    const previousToken = process.env['GITHUB_TOKEN'];
+    process.env['GITHUB_TOKEN'] = 'raw-help-token';
 
     spawnSyncMock.mockReturnValueOnce({ status: 0, error: null });
 
-    const command = createHelpCommand();
-    await command.parseAsync(['node', 'cli', '--root', root]);
+    try {
+      const command = createHelpCommand();
+      await command.parseAsync(['node', 'cli', '--root', root]);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env['GITHUB_TOKEN'];
+      } else {
+        process.env['GITHUB_TOKEN'] = previousToken;
+      }
+    }
 
     expect(spawnSyncMock).toHaveBeenCalledWith(
       process.execPath,
@@ -53,7 +63,9 @@ describe('help CLI', () => {
       expect.objectContaining({
         cwd: root,
         stdio: 'inherit',
-        env: process.env,
+        env: expect.not.objectContaining({
+          GITHUB_TOKEN: 'raw-help-token',
+        }),
       })
     );
     expect(safeExitMock).toHaveBeenCalledWith(0);

--- a/tests/cli/help-cli.test.ts
+++ b/tests/cli/help-cli.test.ts
@@ -46,9 +46,12 @@ describe('help CLI', () => {
 
     spawnSyncMock.mockReturnValueOnce({ status: 0, error: null });
 
+    let childEnvSnapshot: NodeJS.ProcessEnv = {};
     try {
       const command = createHelpCommand();
       await command.parseAsync(['node', 'cli', '--root', root]);
+      const spawnOptions = spawnSyncMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      childEnvSnapshot = { ...(spawnOptions?.env ?? {}) };
     } finally {
       if (previousToken === undefined) {
         delete process.env['GITHUB_TOKEN'];
@@ -57,15 +60,14 @@ describe('help CLI', () => {
       }
     }
 
+    expect(childEnvSnapshot).not.toHaveProperty('GITHUB_TOKEN');
     expect(spawnSyncMock).toHaveBeenCalledWith(
       process.execPath,
       [scriptPath],
       expect.objectContaining({
         cwd: root,
         stdio: 'inherit',
-        env: expect.not.objectContaining({
-          GITHUB_TOKEN: 'raw-help-token',
-        }),
+        env: expect.any(Object),
       })
     );
     expect(safeExitMock).toHaveBeenCalledWith(0);

--- a/tests/commands/agent-complete-redaction.test.ts
+++ b/tests/commands/agent-complete-redaction.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LLM } from '../../src/providers/index.js';
+
+const completeMock = vi.fn();
+const safeExitMock = vi.fn();
+
+vi.mock('../../src/providers/index.js', () => ({
+  loadLLM: vi.fn(async (): Promise<LLM> => ({
+    name: 'mock-llm',
+    complete: completeMock,
+  })),
+}));
+
+vi.mock('../../src/utils/safe-exit.js', () => ({
+  safeExit: (...args: unknown[]) => safeExitMock(...args),
+}));
+
+const { agentComplete } = await import('../../src/commands/agent/complete.js');
+
+describe('agentComplete redaction boundary', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    completeMock.mockReset();
+    safeExitMock.mockReset();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('TGT-009-F001: redacts prompt and response-like secrets before writing agent logs', async () => {
+    completeMock.mockResolvedValueOnce(
+      'provider answer Bearer raw-output-token password=raw-output-password',
+    );
+
+    await agentComplete('prompt token=raw-prompt-token and api_key=raw-prompt-key');
+
+    const serializedLogs = JSON.stringify(logSpy.mock.calls);
+
+    expect(serializedLogs).toContain('[REDACTED]');
+    expect(serializedLogs).not.toContain('raw-prompt-token');
+    expect(serializedLogs).not.toContain('raw-prompt-key');
+    expect(serializedLogs).not.toContain('raw-output-token');
+    expect(serializedLogs).not.toContain('raw-output-password');
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(safeExitMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/cli/discovery-cli-child-env.test.ts
+++ b/tests/unit/cli/discovery-cli-child-env.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnSyncMock = vi.fn();
+const safeExitMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
+}));
+
+vi.mock('../../../src/utils/safe-exit.js', () => ({
+  safeExit: (...args: unknown[]) => safeExitMock(...args),
+}));
+
+let createDiscoveryCommand: () => any;
+
+beforeAll(async () => {
+  ({ createDiscoveryCommand } = await import('../../../src/cli/discovery-cli.js'));
+});
+
+beforeEach(() => {
+  spawnSyncMock.mockReset();
+  safeExitMock.mockReset();
+});
+
+describe('discovery CLI child process environment', () => {
+  it('does not forward ambient GitHub tokens to discovery scripts', async () => {
+    const previousToken = process.env['GITHUB_TOKEN'];
+    process.env['GITHUB_TOKEN'] = 'raw-discovery-token';
+    spawnSyncMock.mockReturnValueOnce({ status: 0, error: null });
+
+    try {
+      const command = createDiscoveryCommand();
+      await command.parseAsync([
+        'node',
+        'cli',
+        'validate',
+        '--format',
+        'json',
+        '--sources',
+        'docs/**/*.md',
+      ]);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env['GITHUB_TOKEN'];
+      } else {
+        process.env['GITHUB_TOKEN'] = previousToken;
+      }
+    }
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      process.execPath,
+      expect.arrayContaining(['--format', 'json', '--sources', 'docs/**/*.md']),
+      expect.objectContaining({
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: expect.not.objectContaining({
+          GITHUB_TOKEN: 'raw-discovery-token',
+        }),
+      }),
+    );
+    expect(safeExitMock).toHaveBeenCalledWith(0);
+  });
+});

--- a/tests/unit/cli/discovery-cli-child-env.test.ts
+++ b/tests/unit/cli/discovery-cli-child-env.test.ts
@@ -28,6 +28,7 @@ describe('discovery CLI child process environment', () => {
     process.env['GITHUB_TOKEN'] = 'raw-discovery-token';
     spawnSyncMock.mockReturnValueOnce({ status: 0, error: null });
 
+    let childEnvSnapshot: NodeJS.ProcessEnv = {};
     try {
       const command = createDiscoveryCommand();
       await command.parseAsync([
@@ -39,6 +40,8 @@ describe('discovery CLI child process environment', () => {
         '--sources',
         'docs/**/*.md',
       ]);
+      const spawnOptions = spawnSyncMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      childEnvSnapshot = { ...(spawnOptions?.env ?? {}) };
     } finally {
       if (previousToken === undefined) {
         delete process.env['GITHUB_TOKEN'];
@@ -47,15 +50,14 @@ describe('discovery CLI child process environment', () => {
       }
     }
 
+    expect(childEnvSnapshot).not.toHaveProperty('GITHUB_TOKEN');
     expect(spawnSyncMock).toHaveBeenCalledWith(
       process.execPath,
       expect.arrayContaining(['--format', 'json', '--sources', 'docs/**/*.md']),
       expect.objectContaining({
         cwd: process.cwd(),
         encoding: 'utf8',
-        env: expect.not.objectContaining({
-          GITHUB_TOKEN: 'raw-discovery-token',
-        }),
+        env: expect.any(Object),
       }),
     );
     expect(safeExitMock).toHaveBeenCalledWith(0);

--- a/tests/unit/security/sensitive-redaction.test.ts
+++ b/tests/unit/security/sensitive-redaction.test.ts
@@ -4,6 +4,7 @@ import {
   redactSensitiveData,
   redactSensitiveString,
   safeErrorForLogging,
+  sanitizeTelemetryAttributes,
   safeUrlPath,
 } from '../../../src/security/sensitive-redaction.js';
 
@@ -67,5 +68,31 @@ describe('sensitive redaction policy', () => {
     expect(value).not.toContain('raw-dsn-secret');
     expect(value).not.toContain('raw-api-key');
     expect(value).toContain('[REDACTED]');
+  });
+
+  it('TGT-015-F001: sanitizes telemetry attributes through the shared redaction pipeline', () => {
+    const attributes = sanitizeTelemetryAttributes({
+      endpoint: '/callback?token=raw-query-token',
+      authorization: 'Bearer raw-bearer-token',
+      details: {
+        password: 'raw-password-secret',
+        nested: 'api_key=raw-api-key',
+      },
+      status_code: 500,
+      sampled: true,
+    });
+
+    const serialized = JSON.stringify(attributes);
+
+    expect(attributes).toMatchObject({
+      authorization: REDACTED_VALUE,
+      status_code: 500,
+      sampled: true,
+    });
+    expect(serialized).toContain('[REDACTED]');
+    expect(serialized).not.toContain('raw-query-token');
+    expect(serialized).not.toContain('raw-bearer-token');
+    expect(serialized).not.toContain('raw-password-secret');
+    expect(serialized).not.toContain('raw-api-key');
   });
 });


### PR DESCRIPTION
Fixes #3466

## Summary
- Add shared telemetry attribute sanitization on top of the existing sensitive-redaction pipeline and apply it to enhanced telemetry spans/metrics plus telemetry-service metrics.
- Redact LLM completion output before agent logs and redact telemetry health error messages.
- Minimize ambient child-process environments for discovery, entry-runner, and help CLIs by reusing `createHighImpactChildEnv()`.
- Add regression coverage for telemetry attribute redaction, agent completion log redaction, and child env minimization.

## Acceptance
- [x] Secret-like values are not emitted raw through the updated telemetry/log boundaries.
- [x] Token-bearing outbound URL allowlist behavior remains covered by existing outbound URL policy tests.
- [x] Child process env is minimized for the updated CLI script launchers.
- [x] Health/diagnostic sensitive-field behavior remains covered by diagnostics tests, with telemetry error messages redacted.

## Tests
- `pnpm -s exec vitest run tests/unit/security/sensitive-redaction.test.ts tests/commands/agent-complete-redaction.test.ts tests/cli/entry-runner-cli.test.ts tests/cli/help-cli.test.ts tests/unit/cli/discovery-cli.test.ts tests/unit/cli/discovery-cli-child-env.test.ts tests/telemetry/enhanced-telemetry.test.ts tests/telemetry/telemetry-service.test.ts tests/telemetry/runtime-guards.test.ts tests/providers/recorder.test.ts tests/api/diagnostics-auth.test.ts tests/unit/trace/outbound-url-policy.test.ts tests/utils/installer-manager.test.ts tests/unit/utils/high-impact-action-policy.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet <changed TypeScript files>`
- `pnpm -s exec eslint --quiet tests/commands/agent-complete-redaction.test.ts tests/unit/cli/discovery-cli-child-env.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `git diff --check`

## Rollback
Revert this PR to restore the prior telemetry/log/CLI child-env behavior. No schema or migration changes are included.
