### PR TITLE
fix(security): harden container runtime isolation

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -23,6 +23,9 @@ jobs:
       TARGET_SHA: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.target_sha) || github.sha }}
       REPORT_DIR: reports
       LOG_DIR: logs
+      AE_TEST_POSTGRES_DB: ae_test_${{ github.run_id }}
+      AE_TEST_POSTGRES_USER: ae_test_${{ github.run_id }}
+      AE_TEST_POSTGRES_PASSWORD: ae-test-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout target
         uses: actions/checkout@v4

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -5,7 +5,7 @@ services:
     command: ["npm","run","dev"]
     environment:
       - NODE_ENV=development
-      - DATABASE_URL=postgres://app:app@db:5432/app
+      - DATABASE_URL=postgres://${AE_DEV_POSTGRES_USER:?set AE_DEV_POSTGRES_USER}:${AE_DEV_POSTGRES_PASSWORD:?set AE_DEV_POSTGRES_PASSWORD}@db:5432/${AE_DEV_POSTGRES_DB:?set AE_DEV_POSTGRES_DB}
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
     ports: ["3000:3000"]
     depends_on: [db, otel]
@@ -13,9 +13,9 @@ services:
   db:
     image: docker.io/library/postgres:16-alpine
     environment:
-      - POSTGRES_USER=app
-      - POSTGRES_PASSWORD=app
-      - POSTGRES_DB=app
+      - POSTGRES_USER=${AE_DEV_POSTGRES_USER:?set AE_DEV_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${AE_DEV_POSTGRES_PASSWORD:?set AE_DEV_POSTGRES_PASSWORD}
+      - POSTGRES_DB=${AE_DEV_POSTGRES_DB:?set AE_DEV_POSTGRES_DB}
     ports: ["5432:5432"]
     volumes:
       - pgdata:/var/lib/postgresql/data

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -173,9 +173,9 @@ services:
   test-db:
     image: postgres:15-alpine
     environment:
-      - POSTGRES_DB=ae_framework_test
-      - POSTGRES_USER=test_user
-      - POSTGRES_PASSWORD=test_password
+      - POSTGRES_DB=${AE_TEST_POSTGRES_DB:?set AE_TEST_POSTGRES_DB}
+      - POSTGRES_USER=${AE_TEST_POSTGRES_USER:?set AE_TEST_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${AE_TEST_POSTGRES_PASSWORD:?set AE_TEST_POSTGRES_PASSWORD}
       - POSTGRES_HOST_AUTH_METHOD=trust
     deploy:
       resources:
@@ -190,7 +190,7 @@ services:
     networks:
       - test-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U test_user -d ae_framework_test"]
+      test: ["CMD-SHELL", 'pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,14 +64,14 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_DB=ae_framework
-      - POSTGRES_USER=ae_user
-      - POSTGRES_PASSWORD=ae_password
+      - POSTGRES_DB=${AE_DEV_POSTGRES_DB:?set AE_DEV_POSTGRES_DB}
+      - POSTGRES_USER=${AE_DEV_POSTGRES_USER:?set AE_DEV_POSTGRES_USER}
+      - POSTGRES_PASSWORD=${AE_DEV_POSTGRES_PASSWORD:?set AE_DEV_POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ae_user -d ae_framework"]
+      test: ["CMD-SHELL", 'pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/podman/compose.dev.yaml
+++ b/podman/compose.dev.yaml
@@ -45,15 +45,15 @@ services:
   db:
     image: docker.io/library/postgres:16-alpine
     environment:
-      POSTGRES_USER: app
-      POSTGRES_PASSWORD: app
-      POSTGRES_DB: app
+      POSTGRES_USER: ${AE_DEV_POSTGRES_USER:?set AE_DEV_POSTGRES_USER}
+      POSTGRES_PASSWORD: ${AE_DEV_POSTGRES_PASSWORD:?set AE_DEV_POSTGRES_PASSWORD}
+      POSTGRES_DB: ${AE_DEV_POSTGRES_DB:?set AE_DEV_POSTGRES_DB}
     ports:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data:Z
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U app -d app"]
+      test: ["CMD-SHELL", 'pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/scripts/dev/dev_down.sh
+++ b/scripts/dev/dev_down.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/container.sh
+source "$SCRIPT_DIR/../lib/container.sh"
+
+COMPOSE_FILE="${AE_DEV_COMPOSE_FILE:-podman/compose.dev.yaml}"
+
 echo "Stopping development environment..."
 
-# Check if podman is available, fallback to docker
-if command -v podman &> /dev/null; then
-    COMPOSE_CMD="podman compose"
-elif command -v docker &> /dev/null; then
-    COMPOSE_CMD="docker compose"
-else
-    echo "Error: Neither podman nor docker found!"
-    exit 1
+if ! container::select_engine; then
+  echo "Error: Neither podman nor docker found!" >&2
+  exit 1
+fi
+if ! container::select_compose_command "$CONTAINER_ENGINE_BIN"; then
+  echo "Error: compose command unavailable for $CONTAINER_ENGINE_BIN" >&2
+  exit 1
 fi
 
-# Stop and remove containers
-$COMPOSE_CMD down -v
+container::compose --project-name ae-framework-dev -f "$COMPOSE_FILE" down -v --remove-orphans
 
 echo "Development environment stopped"

--- a/scripts/dev/dev_up.sh
+++ b/scripts/dev/dev_up.sh
@@ -1,22 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Starting development environment..."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/container.sh
+source "$SCRIPT_DIR/../lib/container.sh"
 
-# Check if podman is available, fallback to docker
-if command -v podman &> /dev/null; then
-    COMPOSE_CMD="podman compose"
-elif command -v docker &> /dev/null; then
-    COMPOSE_CMD="docker compose"
-else
-    echo "Error: Neither podman nor docker found!"
-    exit 1
+require_dev_secret_env() {
+  local missing=()
+  for name in AE_DEV_POSTGRES_USER AE_DEV_POSTGRES_PASSWORD AE_DEV_POSTGRES_DB; do
+    if [[ -z "${!name:-}" ]]; then
+      missing+=("$name")
+    fi
+  done
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    printf 'Error: set development compose secret environment variables: %s\n' "${missing[*]}" >&2
+    return 1
+  fi
+}
+
+COMPOSE_FILE="${AE_DEV_COMPOSE_FILE:-podman/compose.dev.yaml}"
+
+echo "Starting development environment..."
+require_dev_secret_env
+
+if ! container::select_engine; then
+  echo "Error: Neither podman nor docker found!" >&2
+  exit 1
+fi
+if ! container::select_compose_command "$CONTAINER_ENGINE_BIN"; then
+  echo "Error: compose command unavailable for $CONTAINER_ENGINE_BIN" >&2
+  exit 1
 fi
 
-# Build and start services
-$COMPOSE_CMD up -d --build
+container::compose --project-name ae-framework-dev -f "$COMPOSE_FILE" up -d --build
 
-echo "Development environment started!"
+echo "Development environment started"
 echo "API: http://localhost:3000"
-echo "Database: postgres://localhost:5432/app"
+echo "Database: postgres://localhost:5432/${AE_DEV_POSTGRES_DB}"
 echo "OpenTelemetry Collector: http://localhost:4317"

--- a/src/services/container/container-engine.ts
+++ b/src/services/container/container-engine.ts
@@ -4,6 +4,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { resolveApprovedVolumeMount } from './container-security-policy.js';
 
 export type ContainerEngineName = 'docker' | 'podman';
 
@@ -325,8 +326,9 @@ export abstract class ContainerEngine extends EventEmitter {
     // Volume mounts
     if (config.volumes) {
       config.volumes.forEach(volume => {
-        let mountStr = `${volume.source}:${volume.target}`;
-        if (volume.readonly) mountStr += ':ro';
+        const approvedVolume = resolveApprovedVolumeMount(volume);
+        let mountStr = `${approvedVolume.source}:${approvedVolume.target}`;
+        if (approvedVolume.readonly) mountStr += ':ro';
         args.push('--volume', mountStr);
       });
     }

--- a/src/services/container/container-engine.ts
+++ b/src/services/container/container-engine.ts
@@ -77,6 +77,8 @@ export interface ContainerConfig {
   environment?: Record<string, string>;
   workingDir?: string;
   volumes?: VolumeMount[];
+  /** Approved host workspace root used to validate bind-mount sources. */
+  volumeWorkspaceRoot?: string;
   ports?: PortMapping[];
   resources?: ResourceLimits;
   network?: ContainerNetworkConfig;
@@ -326,7 +328,10 @@ export abstract class ContainerEngine extends EventEmitter {
     // Volume mounts
     if (config.volumes) {
       config.volumes.forEach(volume => {
-        const approvedVolume = resolveApprovedVolumeMount(volume);
+        const approvedVolume = resolveApprovedVolumeMount(
+          volume,
+          config.volumeWorkspaceRoot !== undefined ? { workspaceRoot: config.volumeWorkspaceRoot } : {},
+        );
         let mountStr = `${approvedVolume.source}:${approvedVolume.target}`;
         if (approvedVolume.readonly) mountStr += ':ro';
         args.push('--volume', mountStr);

--- a/src/services/container/container-manager.ts
+++ b/src/services/container/container-manager.ts
@@ -196,6 +196,7 @@ export class ContainerManager extends EventEmitter {
           ...env.environment
         },
         volumes: env.volumes,
+        ...(this.config.workspaceRoot !== undefined ? { volumeWorkspaceRoot: this.config.workspaceRoot } : {}),
         resources: env.resources,
         security: this.config.securityDefaults ? { ...this.config.securityDefaults, readOnlyRootFilesystem: false } : { readOnlyRootFilesystem: false },
         labels: {
@@ -278,6 +279,7 @@ export class ContainerManager extends EventEmitter {
             type: 'volume'
           }
         ],
+        ...(this.config.workspaceRoot !== undefined ? { volumeWorkspaceRoot: this.config.workspaceRoot } : {}),
         resources: {
           ...this.config.resourceLimits,
           ...environment.resources

--- a/src/services/container/container-security-policy.ts
+++ b/src/services/container/container-security-policy.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
+import { realpathSync } from 'fs';
 import * as path from 'path';
-import type { ImageBuildContext } from './container-engine.js';
+import type { ImageBuildContext, VolumeMount } from './container-engine.js';
 
 export const AE_CONTAINER_MANAGED_LABEL = 'ae-framework.managed';
 export const AE_CONTAINER_MANAGED_LABEL_VALUE = 'true';
@@ -56,6 +57,72 @@ export interface WorkspaceResolutionResult {
   workspaceRoot: string;
   projectPath: string;
 }
+
+
+export interface ApprovedVolumeMountOptions {
+  workspaceRoot?: string;
+}
+
+const namedVolumePattern = /^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/;
+const windowsAbsolutePathPattern = /^[A-Za-z]:[\\/]/;
+
+const isHostPathLikeVolumeSource = (source: string): boolean => path.isAbsolute(source)
+  || windowsAbsolutePathPattern.test(source)
+  || source.startsWith('.')
+  || source.startsWith('~')
+  || source.includes('/')
+  || source.includes('\\');
+
+const resolveExistingPathSync = (candidate: string, errorMessage: string): string => {
+  try {
+    return realpathSync(candidate);
+  } catch {
+    throw new Error(errorMessage);
+  }
+};
+
+export const resolveApprovedVolumeMount = (
+  volume: VolumeMount,
+  { workspaceRoot = process.env['AE_CONTAINER_WORKSPACE_ROOT'] || process.cwd() }: ApprovedVolumeMountOptions = {},
+): VolumeMount => {
+  if (volume.type === 'tmpfs') {
+    return { ...volume };
+  }
+
+  if (typeof volume.source !== 'string' || volume.source.length === 0) {
+    throw new Error('Volume source is required');
+  }
+
+  if (volume.type === 'volume' || !isHostPathLikeVolumeSource(volume.source)) {
+    if (!namedVolumePattern.test(volume.source)) {
+      throw new Error(`Invalid named volume source: ${JSON.stringify(volume.source)}`);
+    }
+    return { ...volume, type: 'volume' };
+  }
+
+  const resolvedRoot = resolveExistingPathSync(path.resolve(workspaceRoot), 'Approved workspace root does not exist');
+  if (isSensitiveHostPath(resolvedRoot)) {
+    throw new Error('Approved workspace root is too broad or sensitive');
+  }
+
+  const candidate = path.isAbsolute(volume.source)
+    ? path.resolve(volume.source)
+    : path.resolve(resolvedRoot, volume.source);
+  const resolvedSource = resolveExistingPathSync(candidate, 'Volume source path does not exist');
+
+  if (!isPathInside(resolvedSource, resolvedRoot)) {
+    throw new Error('Volume source path is outside approved workspace root');
+  }
+  if (isSensitiveHostPath(resolvedSource)) {
+    throw new Error('Volume source path points to a sensitive host directory');
+  }
+
+  return {
+    ...volume,
+    source: resolvedSource,
+    type: 'bind',
+  };
+};
 
 const allowedToolsByLanguage: Record<'rust' | 'elixir' | 'multi', Set<string>> = {
   rust: new Set(['cargo', 'rustc', 'prusti', 'kani', 'miri']),

--- a/src/services/container/docker-engine.ts
+++ b/src/services/container/docker-engine.ts
@@ -3,7 +3,7 @@
  * Phase 3 of Issue #37: Docker container engine implementation for comparison with Podman
  */
 
-import { exec, execFile, spawn } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import { ContainerEngine } from './container-engine.js';
@@ -25,7 +25,7 @@ import {
   splitUsagePair,
   toExecErrorLike
 } from './container-engine-utils.js';
-import { redactBuildArgsInMessage, redactImageBuildContext } from './container-security-policy.js';
+import { AE_CONTAINER_LABEL_FILTER, redactBuildArgsInMessage, redactImageBuildContext } from './container-security-policy.js';
 import type {
   DockerContainerListEntry,
   DockerImageListEntry,
@@ -33,7 +33,6 @@ import type {
   DockerVolumeListEntry
 } from './container-engine-output-types.js';
 
-const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 const getErrorMessage = (error: unknown): string => toExecErrorLike(error).message;
 
@@ -68,7 +67,7 @@ export class DockerEngine extends ContainerEngine {
     try {
       const checkTimeout = process.env['CI'] ? 2000 : 5000;
       // Check if docker is available
-      const versionResult = await execAsync(`${this.dockerPath} --version`, { timeout: checkTimeout });
+      const versionResult = await execFileAsync(this.dockerPath, ['--version'], { timeout: checkTimeout });
       const versionMatch = versionResult.stdout.match(/Docker version (\d+\.\d+\.\d+)/);
       
       if (!versionMatch) {
@@ -81,7 +80,7 @@ export class DockerEngine extends ContainerEngine {
       // Keep this bounded with a timeout to avoid hanging in CI.
       let info: DockerInfoResponse = {};
       try {
-        const infoResult = await execAsync(`${this.dockerPath} info --format json`, { timeout: checkTimeout });
+        const infoResult = await execFileAsync(this.dockerPath, ['info', '--format', 'json'], { timeout: checkTimeout });
         info = JSON.parse(infoResult.stdout) as DockerInfoResponse;
       } catch {
         this.engineInfo.available = false;
@@ -92,14 +91,14 @@ export class DockerEngine extends ContainerEngine {
 
       // Check for docker-compose
       try {
-        await execAsync('docker-compose --version', { timeout: checkTimeout });
+        await execFileAsync('docker-compose', ['--version'], { timeout: checkTimeout });
         this.engineInfo.composeCommand = 'docker-compose';
         this.engineInfo.capabilities.compose = true;
         this.composePath = 'docker-compose';
       } catch {
         // Check for docker compose (newer syntax)
         try {
-          await execAsync(`${this.dockerPath} compose version`, { timeout: checkTimeout });
+          await execFileAsync(this.dockerPath, ['compose', 'version'], { timeout: checkTimeout });
           this.engineInfo.composeCommand = 'docker compose';
           this.engineInfo.capabilities.compose = true;
           this.composePath = 'docker compose';
@@ -110,7 +109,7 @@ export class DockerEngine extends ContainerEngine {
 
       // Check for buildx
       try {
-        await execAsync(`${this.dockerPath} buildx version`, { timeout: checkTimeout });
+        await execFileAsync(this.dockerPath, ['buildx', 'version'], { timeout: checkTimeout });
         this.engineInfo.capabilities.buildx = true;
       } catch {
         // Buildx not available
@@ -152,7 +151,7 @@ export class DockerEngine extends ContainerEngine {
     if (config.args) args.push(...config.args);
 
     try {
-      const result = await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      const result = await execFileAsync(this.dockerPath, args);
       const containerId = result.stdout.trim();
       
       this.emit('containerCreated', {
@@ -178,7 +177,7 @@ export class DockerEngine extends ContainerEngine {
       if (options?.capture) args.push('--attach');
       args.push(containerId);
 
-      await execAsync(`${this.dockerPath} ${args.join(' ')}`, {
+      await execFileAsync(this.dockerPath, args, {
         timeout: (options?.timeout || 60) * 1000
       });
 
@@ -195,7 +194,7 @@ export class DockerEngine extends ContainerEngine {
 
   async stopContainer(containerId: string, timeout: number = 10): Promise<void> {
     try {
-      await execAsync(`${this.dockerPath} stop --time ${timeout} ${containerId}`);
+      await execFileAsync(this.dockerPath, ['stop', '--time', String(timeout), containerId]);
       
       this.emit('containerStopped', { containerId });
     } catch (error: unknown) {
@@ -214,7 +213,7 @@ export class DockerEngine extends ContainerEngine {
       if (force) args.push('--force');
       args.push(containerId);
 
-      await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      await execFileAsync(this.dockerPath, args);
       
       this.emit('containerRemoved', { containerId, force });
     } catch (error: unknown) {
@@ -229,7 +228,7 @@ export class DockerEngine extends ContainerEngine {
 
   async restartContainer(containerId: string): Promise<void> {
     try {
-      await execAsync(`${this.dockerPath} restart ${containerId}`);
+      await execFileAsync(this.dockerPath, ['restart', containerId]);
       
       this.emit('containerRestarted', { containerId });
     } catch (error: unknown) {
@@ -332,7 +331,7 @@ export class DockerEngine extends ContainerEngine {
     args.push(...command);
 
     try {
-      const result = await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      const result = await execFileAsync(this.dockerPath, args);
       
       const logs: ContainerLogs = {
         stdout: result.stdout,
@@ -363,7 +362,7 @@ export class DockerEngine extends ContainerEngine {
 
   async getContainerStatus(containerId: string): Promise<ContainerStatus> {
     try {
-      const result = await execAsync(`${this.dockerPath} inspect ${containerId} --format json`);
+      const result = await execFileAsync(this.dockerPath, ['inspect', containerId, '--format', 'json']);
       const containerInfo = JSON.parse(result.stdout)[0];
 
       return {
@@ -393,7 +392,7 @@ export class DockerEngine extends ContainerEngine {
         });
       }
 
-      const result = await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      const result = await execFileAsync(this.dockerPath, args);
       
       // Docker returns JSONL (one JSON object per line) instead of a JSON array
       const containers = parseJsonLines<DockerContainerListEntry>(result.stdout);
@@ -428,7 +427,7 @@ export class DockerEngine extends ContainerEngine {
       return this.streamLogs(args);
     } else {
       try {
-        const result = await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+        const result = await execFileAsync(this.dockerPath, args);
         
         return {
           stdout: result.stdout,
@@ -467,7 +466,7 @@ export class DockerEngine extends ContainerEngine {
 
   async getContainerStats(containerId: string): Promise<ContainerStats> {
     try {
-      const result = await execAsync(`${this.dockerPath} stats ${containerId} --no-stream --format json`);
+      const result = await execFileAsync(this.dockerPath, ['stats', containerId, '--no-stream', '--format', 'json']);
       const stats = JSON.parse(result.stdout);
       const [memoryUsageRaw, memoryLimitRaw] = splitUsagePair(stats.MemUsage);
       const [networkRxRaw, networkTxRaw] = splitUsagePair(stats.NetIO);
@@ -557,7 +556,7 @@ export class DockerEngine extends ContainerEngine {
   async pullImage(image: string, tag: string = 'latest'): Promise<void> {
     try {
       const fullImage = `${image}:${tag}`;
-      await execAsync(`${this.dockerPath} pull ${fullImage}`);
+      await execFileAsync(this.dockerPath, ['pull', fullImage]);
       
       this.emit('imagePulled', { image: fullImage });
     } catch (error: unknown) {
@@ -592,7 +591,7 @@ export class DockerEngine extends ContainerEngine {
       if (force) args.push('--force');
       args.push(image);
 
-      await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      await execFileAsync(this.dockerPath, args);
       
       this.emit('imageRemoved', { image, force });
     } catch (error: unknown) {
@@ -615,7 +614,7 @@ export class DockerEngine extends ContainerEngine {
         });
       }
 
-      const result = await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      const result = await execFileAsync(this.dockerPath, args);
       
       // Docker returns JSONL format
       const images = parseJsonLines<DockerImageListEntry>(result.stdout);
@@ -634,7 +633,7 @@ export class DockerEngine extends ContainerEngine {
 
   async tagImage(sourceImage: string, targetImage: string): Promise<void> {
     try {
-      await execAsync(`${this.dockerPath} tag ${sourceImage} ${targetImage}`);
+      await execFileAsync(this.dockerPath, ['tag', sourceImage, targetImage]);
       
       this.emit('imageTagged', { sourceImage, targetImage });
     } catch (error: unknown) {
@@ -661,7 +660,7 @@ export class DockerEngine extends ContainerEngine {
       
       args.push(name);
 
-      await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      await execFileAsync(this.dockerPath, args);
       
       this.emit('volumeCreated', { name, labels });
     } catch (error: unknown) {
@@ -680,7 +679,7 @@ export class DockerEngine extends ContainerEngine {
       if (force) args.push('--force');
       args.push(name);
 
-      await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      await execFileAsync(this.dockerPath, args);
       
       this.emit('volumeRemoved', { name, force });
     } catch (error: unknown) {
@@ -701,7 +700,7 @@ export class DockerEngine extends ContainerEngine {
     size?: number;
   }>> {
     try {
-      const result = await execAsync(`${this.dockerPath} volume ls --format json`);
+      const result = await execFileAsync(this.dockerPath, ['volume', 'ls', '--format', 'json']);
       
       // Docker returns JSONL format
       const volumes = parseJsonLines<DockerVolumeListEntry>(result.stdout);
@@ -737,7 +736,7 @@ export class DockerEngine extends ContainerEngine {
       
       args.push(name);
 
-      await execAsync(`${this.dockerPath} ${args.join(' ')}`);
+      await execFileAsync(this.dockerPath, args);
       
       this.emit('networkCreated', { name, options });
     } catch (error: unknown) {
@@ -752,7 +751,7 @@ export class DockerEngine extends ContainerEngine {
 
   async removeNetwork(name: string): Promise<void> {
     try {
-      await execAsync(`${this.dockerPath} network rm ${name}`);
+      await execFileAsync(this.dockerPath, ['network', 'rm', name]);
       
       this.emit('networkRemoved', { name });
     } catch (error: unknown) {
@@ -774,7 +773,7 @@ export class DockerEngine extends ContainerEngine {
     labels?: Record<string, string>;
   }>> {
     try {
-      const result = await execAsync(`${this.dockerPath} network ls --format json`);
+      const result = await execFileAsync(this.dockerPath, ['network', 'ls', '--format', 'json']);
       
       // Docker returns JSONL format
       const networks = parseJsonLines<DockerNetworkListEntry>(result.stdout);
@@ -787,6 +786,17 @@ export class DockerEngine extends ContainerEngine {
     } catch (error: unknown) {
       throw new Error(`Failed to list networks: ${getErrorMessage(error)}`);
     }
+  }
+
+  private getComposeInvocation(): { command: string; argsPrefix: string[] } {
+    if (!this.composePath) {
+      throw new Error('Compose command is not configured');
+    }
+    const [command, ...argsPrefix] = this.composePath.split(' ');
+    if (!command) {
+      throw new Error('Compose command is not configured');
+    }
+    return { command, argsPrefix };
   }
 
   // Compose operations
@@ -814,7 +824,8 @@ export class DockerEngine extends ContainerEngine {
       if (options?.detached !== false) args.push('-d');
 
       const env = { ...process.env, ...options?.environment };
-      await execAsync(`${this.composePath} ${args.join(' ')}`, { env });
+      const compose = this.getComposeInvocation();
+      await execFileAsync(compose.command, [...compose.argsPrefix, ...args], { env });
       
       this.emit('composeUp', { composeFile, options });
     } catch (error: unknown) {
@@ -841,7 +852,8 @@ export class DockerEngine extends ContainerEngine {
       
       args.push('down');
 
-      await execAsync(`${this.composePath} ${args.join(' ')}`);
+      const compose = this.getComposeInvocation();
+      await execFileAsync(compose.command, [...compose.argsPrefix, ...args]);
       
       this.emit('composeDown', { composeFile, projectName });
     } catch (error: unknown) {
@@ -878,10 +890,13 @@ export class DockerEngine extends ContainerEngine {
     };
 
     try {
+      const scopedLabelFilters = options?.labelFilters && options.labelFilters.length > 0
+        ? options.labelFilters
+        : [AE_CONTAINER_LABEL_FILTER];
       const pruneArgs = (resource: 'container' | 'image' | 'volume' | 'network') => {
         const args = [resource, 'prune'];
         if (options?.force) args.push('--force');
-        for (const filter of options?.labelFilters ?? []) {
+        for (const filter of scopedLabelFilters) {
           args.push('--filter', filter);
         }
         args.push('--format', 'json');

--- a/src/services/container/podman-engine.ts
+++ b/src/services/container/podman-engine.ts
@@ -3,7 +3,7 @@
  * Phase 3 of Issue #37: Podman-specific container engine implementation
  */
 
-import { exec, execFile, spawn } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import type * as fs from 'fs/promises';
@@ -25,7 +25,7 @@ import {
   splitUsagePair,
   toExecErrorLike
 } from './container-engine-utils.js';
-import { redactBuildArgsInMessage, redactImageBuildContext } from './container-security-policy.js';
+import { AE_CONTAINER_LABEL_FILTER, redactBuildArgsInMessage, redactImageBuildContext } from './container-security-policy.js';
 import type {
   PodmanContainerListEntry,
   PodmanImageListEntry,
@@ -33,7 +33,6 @@ import type {
   PodmanVolumeListEntry
 } from './container-engine-output-types.js';
 
-const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 const getErrorMessage = (error: unknown): string => toExecErrorLike(error).message;
 
@@ -72,7 +71,7 @@ export class PodmanEngine extends ContainerEngine {
     try {
       const checkTimeout = process.env['CI'] ? 2000 : 5000;
       // Check if podman is available
-      const versionResult = await execAsync(`${this.podmanPath} --version`, { timeout: checkTimeout });
+      const versionResult = await execFileAsync(this.podmanPath, ['--version'], { timeout: checkTimeout });
       const versionMatch = versionResult.stdout.match(/podman version (\d+\.\d+\.\d+)/);
       
       if (!versionMatch) {
@@ -85,7 +84,7 @@ export class PodmanEngine extends ContainerEngine {
       // Keep this bounded with a timeout to avoid hanging in CI.
       let info: PodmanInfoResponse = {};
       try {
-        const infoResult = await execAsync(`${this.podmanPath} info --format json`, { timeout: checkTimeout });
+        const infoResult = await execFileAsync(this.podmanPath, ['info', '--format', 'json'], { timeout: checkTimeout });
         info = JSON.parse(infoResult.stdout) as PodmanInfoResponse;
       } catch {
         this.engineInfo.available = false;
@@ -96,14 +95,14 @@ export class PodmanEngine extends ContainerEngine {
 
       // Check for podman-compose
       try {
-        await execAsync('podman-compose --version', { timeout: checkTimeout });
+        await execFileAsync('podman-compose', ['--version'], { timeout: checkTimeout });
         this.engineInfo.composeCommand = 'podman-compose';
         this.engineInfo.capabilities.compose = true;
         this.composePath = 'podman-compose';
       } catch {
         // Check for docker-compose with podman
         try {
-          await execAsync('docker-compose --version', { timeout: checkTimeout });
+          await execFileAsync('docker-compose', ['--version'], { timeout: checkTimeout });
           this.engineInfo.composeCommand = 'docker-compose';
           this.engineInfo.capabilities.compose = true;
           this.composePath = 'docker-compose';
@@ -148,7 +147,7 @@ export class PodmanEngine extends ContainerEngine {
     if (config.args) args.push(...config.args);
 
     try {
-      const result = await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      const result = await execFileAsync(this.podmanPath, args);
       const containerId = result.stdout.trim();
       
       this.emit('containerCreated', {
@@ -174,7 +173,7 @@ export class PodmanEngine extends ContainerEngine {
       if (options?.capture) args.push('--attach');
       args.push(containerId);
 
-      await execAsync(`${this.podmanPath} ${args.join(' ')}`, {
+      await execFileAsync(this.podmanPath, args, {
         timeout: (options?.timeout || 60) * 1000
       });
 
@@ -191,7 +190,7 @@ export class PodmanEngine extends ContainerEngine {
 
   async stopContainer(containerId: string, timeout: number = 10): Promise<void> {
     try {
-      await execAsync(`${this.podmanPath} stop --time ${timeout} ${containerId}`);
+      await execFileAsync(this.podmanPath, ['stop', '--time', String(timeout), containerId]);
       
       this.emit('containerStopped', { containerId });
     } catch (error: unknown) {
@@ -210,7 +209,7 @@ export class PodmanEngine extends ContainerEngine {
       if (force) args.push('--force');
       args.push(containerId);
 
-      await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      await execFileAsync(this.podmanPath, args);
       
       this.emit('containerRemoved', { containerId, force });
     } catch (error: unknown) {
@@ -225,7 +224,7 @@ export class PodmanEngine extends ContainerEngine {
 
   async restartContainer(containerId: string): Promise<void> {
     try {
-      await execAsync(`${this.podmanPath} restart ${containerId}`);
+      await execFileAsync(this.podmanPath, ['restart', containerId]);
       
       this.emit('containerRestarted', { containerId });
     } catch (error: unknown) {
@@ -328,7 +327,7 @@ export class PodmanEngine extends ContainerEngine {
     args.push(...command);
 
     try {
-      const result = await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      const result = await execFileAsync(this.podmanPath, args);
       
       const logs: ContainerLogs = {
         stdout: result.stdout,
@@ -359,7 +358,7 @@ export class PodmanEngine extends ContainerEngine {
 
   async getContainerStatus(containerId: string): Promise<ContainerStatus> {
     try {
-      const result = await execAsync(`${this.podmanPath} inspect ${containerId} --format json`);
+      const result = await execFileAsync(this.podmanPath, ['inspect', containerId, '--format', 'json']);
       const containerInfo = JSON.parse(result.stdout)[0];
 
       return {
@@ -389,7 +388,7 @@ export class PodmanEngine extends ContainerEngine {
         });
       }
 
-      const result = await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      const result = await execFileAsync(this.podmanPath, args);
       const containers = JSON.parse(result.stdout) as PodmanContainerListEntry[];
       return containers.map(container => ({
         id: container.Id,
@@ -422,7 +421,7 @@ export class PodmanEngine extends ContainerEngine {
       return this.streamLogs(args);
     } else {
       try {
-        const result = await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+        const result = await execFileAsync(this.podmanPath, args);
         
         return {
           stdout: result.stdout,
@@ -461,7 +460,7 @@ export class PodmanEngine extends ContainerEngine {
 
   async getContainerStats(containerId: string): Promise<ContainerStats> {
     try {
-      const result = await execAsync(`${this.podmanPath} stats ${containerId} --no-stream --format json`);
+      const result = await execFileAsync(this.podmanPath, ['stats', containerId, '--no-stream', '--format', 'json']);
       const stats = JSON.parse(result.stdout);
       const [memoryUsageRaw, memoryLimitRaw] = splitUsagePair(stats.MemUsage);
       const [networkRxRaw, networkTxRaw] = splitUsagePair(stats.NetIO);
@@ -551,7 +550,7 @@ export class PodmanEngine extends ContainerEngine {
   async pullImage(image: string, tag: string = 'latest'): Promise<void> {
     try {
       const fullImage = `${image}:${tag}`;
-      await execAsync(`${this.podmanPath} pull ${fullImage}`);
+      await execFileAsync(this.podmanPath, ['pull', fullImage]);
       
       this.emit('imagePulled', { image: fullImage });
     } catch (error: unknown) {
@@ -586,7 +585,7 @@ export class PodmanEngine extends ContainerEngine {
       if (force) args.push('--force');
       args.push(image);
 
-      await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      await execFileAsync(this.podmanPath, args);
       
       this.emit('imageRemoved', { image, force });
     } catch (error: unknown) {
@@ -609,7 +608,7 @@ export class PodmanEngine extends ContainerEngine {
         });
       }
 
-      const result = await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      const result = await execFileAsync(this.podmanPath, args);
       const images = JSON.parse(result.stdout) as PodmanImageListEntry[];
       return images.map(image => ({
         id: image.Id,
@@ -627,7 +626,7 @@ export class PodmanEngine extends ContainerEngine {
 
   async tagImage(sourceImage: string, targetImage: string): Promise<void> {
     try {
-      await execAsync(`${this.podmanPath} tag ${sourceImage} ${targetImage}`);
+      await execFileAsync(this.podmanPath, ['tag', sourceImage, targetImage]);
       
       this.emit('imageTagged', { sourceImage, targetImage });
     } catch (error: unknown) {
@@ -654,7 +653,7 @@ export class PodmanEngine extends ContainerEngine {
       
       args.push(name);
 
-      await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      await execFileAsync(this.podmanPath, args);
       
       this.emit('volumeCreated', { name, labels });
     } catch (error: unknown) {
@@ -673,7 +672,7 @@ export class PodmanEngine extends ContainerEngine {
       if (force) args.push('--force');
       args.push(name);
 
-      await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      await execFileAsync(this.podmanPath, args);
       
       this.emit('volumeRemoved', { name, force });
     } catch (error: unknown) {
@@ -694,7 +693,7 @@ export class PodmanEngine extends ContainerEngine {
     size?: number;
   }>> {
     try {
-      const result = await execAsync(`${this.podmanPath} volume ls --format json`);
+      const result = await execFileAsync(this.podmanPath, ['volume', 'ls', '--format', 'json']);
       const volumes = JSON.parse(result.stdout) as PodmanVolumeListEntry[];
       return volumes.map(volume => ({
         name: volume.Name,
@@ -728,7 +727,7 @@ export class PodmanEngine extends ContainerEngine {
       
       args.push(name);
 
-      await execAsync(`${this.podmanPath} ${args.join(' ')}`);
+      await execFileAsync(this.podmanPath, args);
       
       this.emit('networkCreated', { name, options });
     } catch (error: unknown) {
@@ -743,7 +742,7 @@ export class PodmanEngine extends ContainerEngine {
 
   async removeNetwork(name: string): Promise<void> {
     try {
-      await execAsync(`${this.podmanPath} network rm ${name}`);
+      await execFileAsync(this.podmanPath, ['network', 'rm', name]);
       
       this.emit('networkRemoved', { name });
     } catch (error: unknown) {
@@ -765,7 +764,7 @@ export class PodmanEngine extends ContainerEngine {
     labels?: Record<string, string>;
   }>> {
     try {
-      const result = await execAsync(`${this.podmanPath} network ls --format json`);
+      const result = await execFileAsync(this.podmanPath, ['network', 'ls', '--format', 'json']);
       const networks = JSON.parse(result.stdout) as PodmanNetworkListEntry[];
       return networks.map(network => ({
         id: network.NetworkID,
@@ -776,6 +775,17 @@ export class PodmanEngine extends ContainerEngine {
     } catch (error: unknown) {
       throw new Error(`Failed to list networks: ${getErrorMessage(error)}`);
     }
+  }
+
+  private getComposeInvocation(): { command: string; argsPrefix: string[] } {
+    if (!this.composePath) {
+      throw new Error('Compose command is not configured');
+    }
+    const [command, ...argsPrefix] = this.composePath.split(' ');
+    if (!command) {
+      throw new Error('Compose command is not configured');
+    }
+    return { command, argsPrefix };
   }
 
   // Compose operations
@@ -803,7 +813,8 @@ export class PodmanEngine extends ContainerEngine {
       if (options?.detached !== false) args.push('-d');
 
       const env = { ...process.env, ...options?.environment };
-      await execAsync(`${this.composePath} ${args.join(' ')}`, { env });
+      const compose = this.getComposeInvocation();
+      await execFileAsync(compose.command, [...compose.argsPrefix, ...args], { env });
       
       this.emit('composeUp', { composeFile, options });
     } catch (error: unknown) {
@@ -830,7 +841,8 @@ export class PodmanEngine extends ContainerEngine {
       
       args.push('down');
 
-      await execAsync(`${this.composePath} ${args.join(' ')}`);
+      const compose = this.getComposeInvocation();
+      await execFileAsync(compose.command, [...compose.argsPrefix, ...args]);
       
       this.emit('composeDown', { composeFile, projectName });
     } catch (error: unknown) {
@@ -867,10 +879,13 @@ export class PodmanEngine extends ContainerEngine {
     };
 
     try {
+      const scopedLabelFilters = options?.labelFilters && options.labelFilters.length > 0
+        ? options.labelFilters
+        : [AE_CONTAINER_LABEL_FILTER];
       const pruneArgs = (resource: 'container' | 'image' | 'volume' | 'network') => {
         const args = [resource, 'prune'];
         if (options?.force) args.push('--force');
-        for (const filter of options?.labelFilters ?? []) {
+        for (const filter of scopedLabelFilters) {
           args.push('--filter', filter);
         }
         args.push('--format', 'json');

--- a/tests/unit/container/container-engine-security-boundary.test.ts
+++ b/tests/unit/container/container-engine-security-boundary.test.ts
@@ -12,21 +12,56 @@ const methodBody = (source: string, signature: string) => {
 };
 
 describe('container engine security boundaries', () => {
-  for (const [file, executable] of [
-    ['docker-engine.ts', 'this.dockerPath'],
-    ['podman-engine.ts', 'this.podmanPath'],
+  for (const file of [
+    'docker-engine.ts',
+    'podman-engine.ts',
   ] as const) {
     it(`${file} uses argv-safe execution for caller-influenced run/build/push/cleanup paths`, () => {
       const source = readSource(file);
       expect(source).toContain('execFileAsync');
+      expect(source).not.toContain('execAsync');
+      expect(source).not.toContain('promisify(exec)');
+      expect(source).not.toMatch(/args\.join\(' '\)/);
 
-      for (const signature of ['async runContainer', 'async buildImage', 'async pushImage', 'async cleanup']) {
+      for (const signature of [
+        'async createContainer',
+        'async startContainer',
+        'async stopContainer',
+        'async removeContainer',
+        'async restartContainer',
+        'async runContainer',
+        'async executeInContainer',
+        'async getContainerStatus',
+        'async listContainers',
+        'async getContainerStats',
+        'async buildImage',
+        'async pullImage',
+        'async pushImage',
+        'async removeImage',
+        'async listImages',
+        'async tagImage',
+        'async createVolume',
+        'async removeVolume',
+        'async listVolumes',
+        'async createNetwork',
+        'async removeNetwork',
+        'async listNetworks',
+        'async runCompose',
+        'async stopCompose',
+        'async cleanup',
+      ]) {
         const body = methodBody(source, signature);
-        expect(body).toContain(`execFileAsync(${executable}`);
-        expect(body).not.toMatch(/execAsync\(`\$\{this\.(?:dockerPath|podmanPath)\} \$\{args\.join\(' '\)\}`/);
-        expect(body).not.toMatch(/execAsync\(`\$\{this\.(?:dockerPath|podmanPath)\} push/);
+        expect(body).toContain('execFileAsync(');
+        expect(body).not.toMatch(/execAsync\(`\$\{this\.(?:dockerPath|podmanPath)\}/);
         expect(body).not.toMatch(/(?:container|image|volume|network) prune \$\{/);
       }
+    });
+
+    it(`${file} defaults cleanup prune filters to ae-framework-managed resources`, () => {
+      const body = methodBody(readSource(file), 'async cleanup');
+      expect(body).toContain('AE_CONTAINER_LABEL_FILTER');
+      expect(body).toContain('scopedLabelFilters');
+      expect(body).toContain("[AE_CONTAINER_LABEL_FILTER]");
     });
 
     it(`${file} redacts build args from build-image events and errors`, () => {

--- a/tests/unit/container/container-engine-security-boundary.test.ts
+++ b/tests/unit/container/container-engine-security-boundary.test.ts
@@ -1,8 +1,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { DockerEngine } from '../../../src/services/container/docker-engine.js';
+import type { ContainerConfig } from '../../../src/services/container/container-engine.js';
 
 const readSource = (name: string) => fs.readFileSync(path.resolve(process.cwd(), 'src/services/container', name), 'utf8');
+const readContainerManagerSource = () => fs.readFileSync(path.resolve(process.cwd(), 'src/services/container/container-manager.ts'), 'utf8');
 
 const methodBody = (source: string, signature: string) => {
   const start = source.indexOf(signature);
@@ -70,4 +73,44 @@ describe('container engine security boundaries', () => {
       expect(body).not.toContain('buildContext\n');
     });
   }
+
+  it('TGT-004-F003: honors configured workspaceRoot when approving container bind mounts', () => {
+    const sandboxParent = path.resolve(process.cwd(), '..', '.codex-local/tmp');
+    fs.mkdirSync(sandboxParent, { recursive: true });
+    const sandboxRoot = fs.mkdtempSync(path.join(sandboxParent, 'container-engine-volume-root-'));
+
+    try {
+      const workspaceRoot = path.join(sandboxRoot, 'approved-workspace');
+      const projectPath = path.join(workspaceRoot, 'project');
+      fs.mkdirSync(projectPath, { recursive: true });
+
+      const engine = new DockerEngine() as unknown as {
+        buildCommandArgs(config: ContainerConfig): string[];
+      };
+      const config: ContainerConfig = {
+        name: 'ae-verify-test',
+        image: 'node:22-alpine',
+        volumes: [{
+          source: projectPath,
+          target: '/workspace',
+          readonly: true,
+        }],
+      };
+
+      expect(() => engine.buildCommandArgs(config)).toThrow(/^Volume source path is outside approved workspace root$/);
+      const args = engine.buildCommandArgs({
+        ...config,
+        volumeWorkspaceRoot: workspaceRoot,
+      });
+
+      expect(args).toContain(`${fs.realpathSync(projectPath)}:/workspace:ro`);
+    } finally {
+      fs.rmSync(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('container manager propagates its workspaceRoot to volume approval', () => {
+    const source = readContainerManagerSource();
+    expect(source).toContain('volumeWorkspaceRoot: this.config.workspaceRoot');
+  });
 });

--- a/tests/unit/container/container-security-policy.test.ts
+++ b/tests/unit/container/container-security-policy.test.ts
@@ -15,6 +15,7 @@ import {
   assertPushPolicy,
   redactBuildArgsInMessage,
   redactImageBuildContext,
+  resolveApprovedVolumeMount,
   resolveApprovedWorkspacePath,
   validateBuildArgs,
   validateContainerTools,
@@ -160,6 +161,38 @@ describe('container security policy', () => {
     expect(() => assertCleanupConfirmation({ dryRun: false, force: true, confirm: CONTAINER_CLEANUP_CONFIRM })).toThrow(CONTAINER_FORCE_CLEANUP_CONFIRM);
     expect(assertCleanupConfirmation({ dryRun: false, confirm: CONTAINER_CLEANUP_CONFIRM })).toEqual({ dryRun: false });
     expect(assertCleanupConfirmation({ dryRun: false, force: true, confirm: CONTAINER_FORCE_CLEANUP_CONFIRM })).toEqual({ dryRun: false });
+  });
+
+
+  it('TGT-004-F003: resolves bind mounts under the approved workspace and rejects arbitrary host paths', async () => {
+    const workspace = path.join(sandboxRoot, 'workspace');
+    const project = path.join(workspace, 'project');
+    const outside = path.join(sandboxRoot, 'outside');
+    await fs.mkdir(project, { recursive: true });
+    await fs.mkdir(outside, { recursive: true });
+
+    expect(resolveApprovedVolumeMount(
+      { source: project, target: '/workspace', readonly: true },
+      { workspaceRoot: workspace },
+    )).toMatchObject({ source: await fs.realpath(project), target: '/workspace', readonly: true, type: 'bind' });
+
+    expect(resolveApprovedVolumeMount(
+      { source: 'ae-verify-output', target: '/output', type: 'volume' },
+      { workspaceRoot: workspace },
+    )).toMatchObject({ source: 'ae-verify-output', target: '/output', type: 'volume' });
+
+    expect(() => resolveApprovedVolumeMount(
+      { source: outside, target: '/host' },
+      { workspaceRoot: workspace },
+    )).toThrow(/^Volume source path is outside approved workspace root$/);
+    expect(() => resolveApprovedVolumeMount(
+      { source: '../outside', target: '/host' },
+      { workspaceRoot: workspace },
+    )).toThrow(/^Volume source path is outside approved workspace root$/);
+    expect(() => resolveApprovedVolumeMount(
+      { source: '../outside', target: '/host', type: 'volume' },
+      { workspaceRoot: workspace },
+    )).toThrow(/^Invalid named volume source/);
   });
 
   it('resolves project paths under the approved workspace and rejects symlink escapes', async () => {

--- a/tests/unit/scripts/dev-compose-scope.test.ts
+++ b/tests/unit/scripts/dev-compose-scope.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('development compose scripts', () => {
+  it('TGT-004-F002: scopes compose cleanup to the ae-framework-dev project without global prune', () => {
+    const up = readFileSync('scripts/dev/dev_up.sh', 'utf8');
+    const down = readFileSync('scripts/dev/dev_down.sh', 'utf8');
+
+    expect(up).toContain('container::compose --project-name ae-framework-dev -f "$COMPOSE_FILE" up -d --build');
+    expect(down).toContain('container::compose --project-name ae-framework-dev -f "$COMPOSE_FILE" down -v --remove-orphans');
+    expect(`${up}\n${down}`).not.toMatch(/\b(?:docker|podman)\s+system\s+prune\b/);
+    expect(`${up}\n${down}`).not.toMatch(/\b(?:docker|podman)\s+(?:container|image|volume|network)\s+prune\b/);
+  });
+
+  it('TGT-017-F001: requires dev database credentials through environment injection', () => {
+    const up = readFileSync('scripts/dev/dev_up.sh', 'utf8');
+    expect(up).toContain('AE_DEV_POSTGRES_USER');
+    expect(up).toContain('AE_DEV_POSTGRES_PASSWORD');
+    expect(up).toContain('AE_DEV_POSTGRES_DB');
+    expect(up).toContain('require_dev_secret_env');
+  });
+});

--- a/tests/unit/security/compose-runtime-isolation.test.ts
+++ b/tests/unit/security/compose-runtime-isolation.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import YAML from 'yaml';
+
+const COMPOSE_FILES = [
+  'docker/docker-compose.yml',
+  'docker/docker-compose.test.yml',
+  'docker/compose.yaml',
+  'podman/compose.dev.yaml',
+  'podman/compose.prod.yaml',
+  'infra/podman/unit-compose.yml',
+] as const;
+
+type ComposeService = {
+  environment?: Record<string, unknown> | string[];
+  volumes?: Array<string | { type?: string; source?: string; target?: string }>;
+};
+
+type ComposeFile = {
+  services?: Record<string, ComposeService>;
+};
+
+const readCompose = (filePath: string): ComposeFile => YAML.parse(readFileSync(filePath, 'utf8')) as ComposeFile;
+
+const environmentEntries = (environment: ComposeService['environment']): Array<[string, string]> => {
+  if (!environment) return [];
+  if (Array.isArray(environment)) {
+    return environment.map((entry) => {
+      const [key, ...valueParts] = String(entry).split('=');
+      return [key, valueParts.join('=')];
+    });
+  }
+  return Object.entries(environment).map(([key, value]) => [key, String(value)]);
+};
+
+const volumeSource = (volume: string | { source?: string }): string | undefined => {
+  if (typeof volume === 'object') return volume.source;
+  const [source] = volume.split(':');
+  return source;
+};
+
+const isSensitiveHostSource = (source: string): boolean => source.startsWith('/')
+  || source.startsWith('~')
+  || source === '..'
+  || source.startsWith('/etc')
+  || source.startsWith('/root')
+  || source.startsWith('/var/run')
+  || source.startsWith('/var/lib/docker')
+  || source.startsWith('/var/lib/containers');
+
+const isNamedVolumeSource = (source: string): boolean => /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(source);
+
+const isRepoContainedSource = (filePath: string, source: string): boolean => {
+  if (isNamedVolumeSource(source)) return true;
+  if (path.isAbsolute(source) || source.startsWith('~')) return false;
+  const repoRoot = process.cwd();
+  const composeDir = path.dirname(path.resolve(repoRoot, filePath));
+  const resolvedSource = path.resolve(composeDir, source);
+  const relative = path.relative(repoRoot, resolvedSource);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
+describe('compose runtime isolation', () => {
+  it('TGT-017-F001: does not keep literal database credentials in compose manifests', () => {
+    const credentialKey = /(?:POSTGRES_(?:USER|PASSWORD|DB)|DATABASE_URL|.*(?:PASSWORD|SECRET|TOKEN|API_KEY).*)/i;
+
+    for (const filePath of COMPOSE_FILES) {
+      const compose = readCompose(filePath);
+      for (const [serviceName, service] of Object.entries(compose.services ?? {})) {
+        for (const [key, value] of environmentEntries(service.environment)) {
+          if (!credentialKey.test(key)) continue;
+          expect(value, `${filePath}:${serviceName}.${key} must use environment injection`).toContain('${');
+        }
+      }
+    }
+  });
+
+  it('TGT-004-F003: avoids sensitive or absolute host-root bind mounts in compose manifests', () => {
+    for (const filePath of COMPOSE_FILES) {
+      const compose = readCompose(filePath);
+      for (const [serviceName, service] of Object.entries(compose.services ?? {})) {
+        for (const volume of service.volumes ?? []) {
+          const source = volumeSource(volume);
+          if (!source || isNamedVolumeSource(source)) continue;
+          expect(isSensitiveHostSource(source), `${filePath}:${serviceName} mounts sensitive host source ${source}`).toBe(false);
+          expect(isRepoContainedSource(filePath, source), `${filePath}:${serviceName} host source ${source} must stay inside the repository workspace`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it('parses modified compose manifests as YAML', () => {
+    for (const filePath of COMPOSE_FILES) {
+      expect(() => readCompose(filePath), `${filePath} must be valid YAML`).not.toThrow();
+    }
+  });
+
+  it('TGT-017-F001: injects test compose credentials in docker-tests workflow without static secrets', () => {
+    const workflow = readFileSync('.github/workflows/docker-tests.yml', 'utf8');
+    expect(workflow).toContain('AE_TEST_POSTGRES_DB: ae_test_${{ github.run_id }}');
+    expect(workflow).toContain('AE_TEST_POSTGRES_USER: ae_test_${{ github.run_id }}');
+    expect(workflow).toContain('AE_TEST_POSTGRES_PASSWORD: ae-test-${{ github.run_id }}-${{ github.run_attempt }}');
+    expect(workflow).not.toContain('AE_TEST_POSTGRES_PASSWORD: test_password');
+  });
+});

--- a/tests/unit/security/compose-runtime-isolation.test.ts
+++ b/tests/unit/security/compose-runtime-isolation.test.ts
@@ -36,11 +36,47 @@ const environmentEntries = (environment: ComposeService['environment']): Array<[
 
 const volumeSource = (volume: string | { source?: string }): string | undefined => {
   if (typeof volume === 'object') return volume.source;
-  const [source] = volume.split(':');
-  return source;
+  let expansionDepth = 0;
+  for (let index = 0; index < volume.length; index += 1) {
+    const char = volume[index];
+    if (char === '$' && volume[index + 1] === '{') {
+      expansionDepth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === '}' && expansionDepth > 0) {
+      expansionDepth -= 1;
+      continue;
+    }
+    const isWindowsDriveSeparator = index === 1
+      && /^[A-Za-z]$/.test(volume[0] ?? '')
+      && (volume[2] === '\\' || volume[2] === '/');
+    if (char === ':' && expansionDepth === 0 && !isWindowsDriveSeparator) {
+      return volume.slice(0, index);
+    }
+  }
+  return volume;
+};
+
+const variableExpansionPattern = /^\$\{[A-Z0-9_]+(?::[-?][^}]*)?\}$/;
+const variableDefaultPattern = /^\$\{[A-Z0-9_]+:-(.+)\}$/;
+const windowsAbsolutePathPattern = /^[A-Za-z]:[\\/]/;
+
+const isVariableExpansion = (value: string): boolean => variableExpansionPattern.test(value);
+
+const staticallyValidatedVolumeSources = (source: string): string[] => {
+  const defaultMatch = source.match(variableDefaultPattern);
+  if (defaultMatch?.[1]) {
+    return [defaultMatch[1]];
+  }
+  if (source.includes('${')) {
+    return [];
+  }
+  return [source];
 };
 
 const isSensitiveHostSource = (source: string): boolean => source.startsWith('/')
+  || windowsAbsolutePathPattern.test(source)
   || source.startsWith('~')
   || source === '..'
   || source.startsWith('/etc')
@@ -53,7 +89,7 @@ const isNamedVolumeSource = (source: string): boolean => /^[A-Za-z0-9][A-Za-z0-9
 
 const isRepoContainedSource = (filePath: string, source: string): boolean => {
   if (isNamedVolumeSource(source)) return true;
-  if (path.isAbsolute(source) || source.startsWith('~')) return false;
+  if (path.isAbsolute(source) || windowsAbsolutePathPattern.test(source) || source.startsWith('~')) return false;
   const repoRoot = process.cwd();
   const composeDir = path.dirname(path.resolve(repoRoot, filePath));
   const resolvedSource = path.resolve(composeDir, source);
@@ -62,6 +98,22 @@ const isRepoContainedSource = (filePath: string, source: string): boolean => {
 };
 
 describe('compose runtime isolation', () => {
+  it('parses compose volume sources with interpolation defaults and Windows drive prefixes', () => {
+    const interpolatedSource = '${AE_HOST_STORE:-../../.pnpm-store}';
+    expect(volumeSource(`${interpolatedSource}:/root/.local/share/pnpm/store/v3:Z`)).toBe(interpolatedSource);
+    expect(staticallyValidatedVolumeSources(interpolatedSource)).toEqual(['../../.pnpm-store']);
+    expect(isRepoContainedSource('infra/podman/unit-compose.yml', '../../.pnpm-store')).toBe(true);
+
+    expect(volumeSource('C:\\cache:/cache:ro')).toBe('C:\\cache');
+    expect(isSensitiveHostSource('C:\\cache')).toBe(true);
+    expect(isRepoContainedSource('docker/compose.yaml', 'C:\\cache')).toBe(false);
+  });
+
+  it('requires credential variables to be full compose expansions except assembled URLs', () => {
+    expect(isVariableExpansion('${AE_DEV_POSTGRES_PASSWORD:?set AE_DEV_POSTGRES_PASSWORD}')).toBe(true);
+    expect(isVariableExpansion('static-${AE_DEV_POSTGRES_PASSWORD}')).toBe(false);
+  });
+
   it('TGT-017-F001: does not keep literal database credentials in compose manifests', () => {
     const credentialKey = /(?:POSTGRES_(?:USER|PASSWORD|DB)|DATABASE_URL|.*(?:PASSWORD|SECRET|TOKEN|API_KEY).*)/i;
 
@@ -70,7 +122,11 @@ describe('compose runtime isolation', () => {
       for (const [serviceName, service] of Object.entries(compose.services ?? {})) {
         for (const [key, value] of environmentEntries(service.environment)) {
           if (!credentialKey.test(key)) continue;
-          expect(value, `${filePath}:${serviceName}.${key} must use environment injection`).toContain('${');
+          if (key === 'DATABASE_URL') {
+            expect(value, `${filePath}:${serviceName}.${key} must use environment injection`).toContain('${');
+            continue;
+          }
+          expect(isVariableExpansion(value), `${filePath}:${serviceName}.${key} must use a full compose variable expansion`).toBe(true);
         }
       }
     }
@@ -83,8 +139,13 @@ describe('compose runtime isolation', () => {
         for (const volume of service.volumes ?? []) {
           const source = volumeSource(volume);
           if (!source || isNamedVolumeSource(source)) continue;
-          expect(isSensitiveHostSource(source), `${filePath}:${serviceName} mounts sensitive host source ${source}`).toBe(false);
-          expect(isRepoContainedSource(filePath, source), `${filePath}:${serviceName} host source ${source} must stay inside the repository workspace`).toBe(true);
+          const candidates = staticallyValidatedVolumeSources(source);
+          expect(candidates, `${filePath}:${serviceName} host source ${source} must be statically validated`).not.toHaveLength(0);
+          for (const candidate of candidates) {
+            if (isNamedVolumeSource(candidate)) continue;
+            expect(isSensitiveHostSource(candidate), `${filePath}:${serviceName} mounts sensitive host source ${candidate}`).toBe(false);
+            expect(isRepoContainedSource(filePath, candidate), `${filePath}:${serviceName} host source ${candidate} must stay inside the repository workspace`).toBe(true);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- Replace Docker/Podman string-interpolated container commands with argv-safe `execFile` calls, including compose invocations.
- Restrict runtime bind mounts to an approved workspace boundary and treat non-path sources as validated named volumes.
- Scope cleanup pruning to `ae-framework.managed=true` resources by default instead of running unfiltered prune operations.
- Remove hardcoded compose database credentials and inject dev/test credentials through explicit environment variables, including Docker Tests workflow values.

## Acceptance

- [x] shell interpolation を使わず container commands を実行する。
- [x] global prune が default で実行されない。
- [x] arbitrary host path mount が拒否される。
- [x] compose hardcoded credential がなくなる。

## Verification

- `pnpm -s exec vitest run tests/unit/container/container-engine-security-boundary.test.ts tests/unit/container/container-security-policy.test.ts tests/unit/security/compose-runtime-isolation.test.ts tests/unit/security/production-compose-security.test.ts tests/docker/optimization.test.ts tests/unit/scripts/dev-compose-scope.test.ts --reporter dot`
- `pnpm -s exec vitest run tests/unit/container/container-engine-security-boundary.test.ts tests/unit/security/compose-runtime-isolation.test.ts --reporter dot`
- `pnpm -s exec eslint --quiet src/services/container/container-engine.ts src/services/container/container-security-policy.ts src/services/container/docker-engine.ts src/services/container/podman-engine.ts tests/unit/container/container-engine-security-boundary.test.ts tests/unit/container/container-security-policy.test.ts tests/unit/security/compose-runtime-isolation.test.ts tests/unit/scripts/dev-compose-scope.test.ts`
- `pnpm -s exec eslint --quiet tests/unit/container/container-engine-security-boundary.test.ts tests/unit/security/compose-runtime-isolation.test.ts`
- `pnpm -s run types:check`
- `pnpm -s run build`
- `pnpm -s run check:schemas`
- `git diff --check`
- `bash -n scripts/dev/dev_up.sh scripts/dev/dev_down.sh scripts/docker/run-unit.sh scripts/docker/analyze-optimization.sh scripts/lib/container.sh`

## Rollback

Revert this PR. The rollback restores the previous container command execution, compose credential defaults, dev script compose behavior, and cleanup filtering behavior.

Fixes #3467
